### PR TITLE
feat: add notification sound selection in settings

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -84,6 +84,12 @@ final class AppModel {
                 : "Island sound notifications enabled."
         }
     }
+    var selectedSoundName: String = NotificationSoundService.defaultSoundName {
+        didSet {
+            guard selectedSoundName != oldValue else { return }
+            NotificationSoundService.selectedSoundName = selectedSoundName
+        }
+    }
     var overlayDisplaySelectionID = OverlayDisplayOption.automaticID {
         didSet {
             guard overlayDisplaySelectionID != oldValue else {
@@ -188,6 +194,7 @@ final class AppModel {
             forKey: Self.overlayDisplayPreferenceDefaultsKey
         ) ?? OverlayDisplayOption.automaticID
         isSoundMuted = UserDefaults.standard.bool(forKey: Self.soundMutedDefaultsKey)
+        selectedSoundName = NotificationSoundService.selectedSoundName
 
         codexRolloutWatcher.eventHandler = { [weak self] event in
             Task { @MainActor [weak self] in
@@ -1300,6 +1307,7 @@ final class AppModel {
             return
         }
 
+        NotificationSoundService.playNotification(isMuted: isSoundMuted)
         notchOpen(reason: .notification, surface: surface)
     }
 

--- a/Sources/OpenIslandApp/NotificationSoundService.swift
+++ b/Sources/OpenIslandApp/NotificationSoundService.swift
@@ -1,0 +1,46 @@
+import AppKit
+
+/// Manages notification sound playback using macOS system sounds.
+@MainActor
+struct NotificationSoundService {
+    private static let soundsDirectory = "/System/Library/Sounds"
+    private static let defaultsKey = "notification.sound.name"
+    static let defaultSoundName = "Blow"
+
+    /// Returns the list of available system sound names (without file extension).
+    static func availableSounds() -> [String] {
+        let fm = FileManager.default
+        guard let contents = try? fm.contentsOfDirectory(atPath: soundsDirectory) else {
+            return []
+        }
+        return contents
+            .filter { $0.hasSuffix(".aiff") }
+            .map { ($0 as NSString).deletingPathExtension }
+            .sorted()
+    }
+
+    /// The currently selected sound name, persisted in UserDefaults.
+    static var selectedSoundName: String {
+        get {
+            UserDefaults.standard.string(forKey: defaultsKey) ?? defaultSoundName
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: defaultsKey)
+        }
+    }
+
+    /// Plays a system sound by name.
+    static func play(_ name: String) {
+        guard let sound = NSSound(named: NSSound.Name(name)) else {
+            return
+        }
+        sound.stop()
+        sound.play()
+    }
+
+    /// Plays the user-selected notification sound, respecting the mute setting.
+    static func playNotification(isMuted: Bool) {
+        guard !isMuted else { return }
+        play(selectedSoundName)
+    }
+}

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -242,6 +242,10 @@ struct DisplaySettingsPane: View {
 struct SoundSettingsPane: View {
     var model: AppModel
 
+    private var availableSounds: [String] {
+        NotificationSoundService.availableSounds()
+    }
+
     var body: some View {
         Form {
             Section("通知音效") {
@@ -249,6 +253,28 @@ struct SoundSettingsPane: View {
                     get: { model.isSoundMuted },
                     set: { _ in model.toggleSoundMuted() }
                 ))
+            }
+
+            Section("选择音效") {
+                List(availableSounds, id: \.self) { name in
+                    Button {
+                        model.selectedSoundName = name
+                        NotificationSoundService.play(name)
+                    } label: {
+                        HStack {
+                            Text(name)
+                                .foregroundStyle(.primary)
+                            Spacer()
+                            if name == model.selectedSoundName {
+                                Image(systemName: "checkmark")
+                                    .foregroundStyle(.blue)
+                                    .fontWeight(.semibold)
+                            }
+                        }
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
             }
         }
         .formStyle(.grouped)


### PR DESCRIPTION
## Summary
- 新增 `NotificationSoundService`，使用 `NSSound` 播放 macOS 系统音效
- 设置页声音 tab 新增音效选择列表，点击即可预览试听，选中项蓝色对勾高亮
- 通知触发时自动播放用户选择的音效，尊重静音开关
- 用户选择通过 UserDefaults 持久化，默认音效 `Blow`

## Changes
- `NotificationSoundService.swift` — 扫描 `/System/Library/Sounds/`，提供播放和列表 API
- `AppModel.swift` — 新增 `selectedSoundName` 属性，`presentNotificationSurface()` 集成音效播放
- `SettingsView.swift` — `SoundSettingsPane` 新增音效选择 UI

## Test plan
- [ ] 打开设置 → 声音 tab，确认系统音效列表正确显示
- [ ] 点击任意音效，确认立即播放预览且选中状态更新
- [ ] 触发通知（权限请求/问题/完成），确认播放选中的音效
- [ ] 开启静音，确认通知不播放音效
- [ ] 重启应用，确认音效选择持久化

🤖 Generated with [Claude Code](https://claude.com/claude-code)