### PR TITLE
docs: replace mandatory subagent requirement with EnterWorktree workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,43 +46,17 @@ swift build -c release --product OpenIslandHooks   # build hook binary
 
 Open `Package.swift` in Xcode for the app target. Requires macOS 14+, Swift 6.2.
 
-## Required Workflow — MANDATORY
+## Required Workflow
 
-> **⚠️ CRITICAL: NEVER edit files directly in the main worktree. ALL code changes MUST be made inside a worktree-isolated Agent.**
+> **⚠️ NEVER edit files directly in the main worktree.** Use `EnterWorktree` or `git worktree` to work in an isolated copy.
 
-When the user requests any task that involves file modifications, **the very first step** MUST be spawning an isolated Agent:
-
-```
-Agent(
-  subagent_type: "general-purpose",
-  isolation: "worktree",
-  prompt: "task description...",
-  description: "short summary"
-)
-```
-
-### Allowed in main conversation (main worktree):
-- Read files (Read, Grep, Glob)
-- Run read-only git commands (git status, git log, git diff)
-- Research and planning (no file mutations)
-- Spawn Agent sub-tasks
-
-### FORBIDDEN in main conversation:
-- Using Edit / Write tools to modify any source file
-- Running `git commit`, `git checkout -b`, or any write operations
-- Creating branches or commits directly in the main worktree
-
-### Workflow inside the worktree Agent:
-1. Check repository state with `git status -sb`
-2. Confirm you are on the correct feature branch (worktree Agent auto-creates a branch)
-3. Read relevant files before editing — do not guess
-4. Keep each round focused on a single coherent change
-5. Run the most relevant verification after changes (`swift build`, `swift test`, etc.)
-6. Summarize what changed
-7. Commit and push to remote
-
-### After Agent completes:
-Create a PR from the main conversation to merge the branch into main.
+1. Start each round by checking the current repository state with `git status -sb`.
+2. **Enter a worktree** before making any edits — use `EnterWorktree` (preferred) or `git worktree add` to create an isolated working copy based on `main`.
+3. Read the relevant files before editing. Do not guess repository structure or behavior.
+4. Keep each round focused on a single coherent change.
+5. After making changes, run the most relevant verification available for that round.
+6. Summarize what changed, including any verification gaps.
+7. Commit, push to remote, exit the worktree (`ExitWorktree`), and create a PR to merge into `main`.
 
 ## Commit Policy
 
@@ -104,9 +78,9 @@ Create a PR from the main conversation to merge the branch into main.
 - `main` is a protected branch (GitHub branch protection enabled). **NEVER commit or push directly to `main`.**
 - All changes MUST go through a Pull Request to merge into `main`. Direct pushes are rejected.
 - All feature branches must be created from the latest local `main`.
-- **You MUST use the Agent tool with `isolation: "worktree"`** for all development work. This is NOT optional — it is a hard requirement.
 - Each agent or workstream should work on its own branch, named to match the topic (e.g. `feat/<topic>`, `fix/<topic>`).
-- Standard flow: **Agent(worktree) develop → push → create PR → review/merge**.
+- Standard flow: **EnterWorktree → develop → commit → push → ExitWorktree → create PR → merge**.
+- For parallel Agent sub-tasks, use `Agent(isolation: "worktree")` to give each agent its own isolated copy.
 
 ## App Targets And Naming
 


### PR DESCRIPTION
## Summary
- 移除了强制使用 `Agent(isolation: "worktree")` subagent 的要求
- 改为使用 `EnterWorktree`/`ExitWorktree` 在主会话中进行 worktree 隔离开发
- `Agent(isolation: "worktree")` 仅保留用于并行子任务场景

## Why
之前的规范把"worktree 隔离"和"subagent 委托"绑定在一起，导致每次编辑都必须 spawn subagent，增加了不必要的复杂度。实际意图是不在 main 上直接编辑，而非必须用 subagent。

## Test plan
- [x] `swift build` 通过
- [ ] 验证新会话中 Claude Code 不再强制 spawn subagent 进行编辑

🤖 Generated with [Claude Code](https://claude.com/claude-code)