### PR TITLE
fix: correct cmux bundle ID, process detection, and socket path

### DIFF
--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -245,6 +245,10 @@ struct ActiveAgentProcessDiscovery {
     private func recognizedTerminalApp(for command: String) -> String? {
         let lowered = command.lowercased()
 
+        if lowered.contains("/cmux.app/contents/macos/cmux") {
+            return "cmux"
+        }
+
         if lowered.contains("/ghostty.app/contents/macos/ghostty") || lowered.hasSuffix("/ghostty") {
             return "Ghostty"
         }

--- a/Sources/OpenIslandApp/TerminalJumpService.swift
+++ b/Sources/OpenIslandApp/TerminalJumpService.swift
@@ -22,7 +22,7 @@ struct TerminalJumpService {
         ),
         TerminalAppDescriptor(
             displayName: "cmux",
-            bundleIdentifier: "dev.cmux.cmux",
+            bundleIdentifier: "com.cmuxterm.app",
             aliases: ["cmux"]
         ),
         TerminalAppDescriptor(
@@ -89,7 +89,7 @@ struct TerminalJumpService {
                 if try jumpToITermSession(target) {
                     return "Focused the matching iTerm session."
                 }
-            case "dev.cmux.cmux":
+            case "com.cmuxterm.app":
                 if jumpToCmuxTerminal(target) {
                     return "Focused the matching cmux terminal."
                 }
@@ -163,8 +163,7 @@ struct TerminalJumpService {
             return false
         }
 
-        let socketPath = "/tmp/cmux.sock"
-        guard FileManager.default.fileExists(atPath: socketPath) else {
+        guard let socketPath = Self.resolveCmuxSocketPath() else {
             return false
         }
 
@@ -197,9 +196,35 @@ struct TerminalJumpService {
         guard sent > 0 else { return false }
 
         // Best-effort: activate the cmux app window.
-        try? openAction(["-b", "dev.cmux.cmux"])
+        try? openAction(["-b", "com.cmuxterm.app"])
 
         return true
+    }
+
+    private static func resolveCmuxSocketPath() -> String? {
+        let fm = FileManager.default
+
+        // 1. cmux writes the active socket path here on startup.
+        if let redirected = try? String(contentsOfFile: "/tmp/cmux-last-socket-path", encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !redirected.isEmpty,
+           fm.fileExists(atPath: redirected) {
+            return redirected
+        }
+
+        // 2. Standard Application Support location.
+        let appSupportPath = NSHomeDirectory() + "/Library/Application Support/cmux/cmux.sock"
+        if fm.fileExists(atPath: appSupportPath) {
+            return appSupportPath
+        }
+
+        // 3. Legacy fallback.
+        let legacyPath = "/tmp/cmux.sock"
+        if fm.fileExists(atPath: legacyPath) {
+            return legacyPath
+        }
+
+        return nil
     }
 
     private func jumpToGhosttyTerminal(_ target: JumpTarget) throws -> Bool {


### PR DESCRIPTION
## Summary
- Fix cmux bundle identifier from `dev.cmux.cmux` to `com.cmuxterm.app` (app activation and running checks were failing)
- Add cmux process recognition in `ActiveAgentProcessDiscovery` so sessions under cmux are correctly identified via process tree (placed before Ghostty check since cmux paths contain ghostty resources)
- Replace hardcoded `/tmp/cmux.sock` with dynamic resolution: reads `/tmp/cmux-last-socket-path` first, then `~/Library/Application Support/cmux/cmux.sock`, then legacy `/tmp/cmux.sock`

## Test plan
- [ ] Launch Claude Code in cmux terminal, verify session appears in Open Island list
- [ ] Click session to jump — verify cmux window is focused and correct surface is activated
- [ ] Verify Ghostty sessions are still correctly detected (not misidentified as cmux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)