### PR TITLE
fix: add cmux to supported terminal app list

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -2347,6 +2347,8 @@ final class AppModel {
             return "Ghostty"
         case "terminal", "apple_terminal":
             return "Terminal"
+        case "cmux":
+            return "cmux"
         default:
             return nil
         }


### PR DESCRIPTION
## Summary
- Add `"cmux"` case to `supportedTerminalApp(for:)` in `AppModel.swift` so that cmux-hosted Claude Code sessions are recognized and displayed in the island UI
- Without this fix, process discovery correctly identifies cmux but `supportedTerminalApp()` returns `nil`, causing sessions to get `terminalApp: "Unknown"` and fail to appear

## Test plan
- [ ] Launch Open Island, start a Claude Code session inside cmux
- [ ] Verify the session appears in the notch/overlay UI with `terminalApp: "cmux"`
- [ ] Verify existing Ghostty and Terminal.app sessions still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)