### PR TITLE
fix: detach completed cmux sessions when process exits

### DIFF
--- a/Sources/OpenIslandApp/TerminalSessionAttachmentProbe.swift
+++ b/Sources/OpenIslandApp/TerminalSessionAttachmentProbe.swift
@@ -228,6 +228,7 @@ struct TerminalSessionAttachmentProbe {
             let isRecentHookSession = !cwdContested
                 && session.origin == .live
                 && now.timeIntervalSince(session.updatedAt) < Self.staleGraceWindow
+                && session.phase != .completed
             resolutions[session.id] = SessionResolution(
                 attachmentState: (isActiveProcess || isRecentHookSession)
                     ? .attached


### PR DESCRIPTION
## Summary
- Completed cmux Claude Code sessions were staying "attached" in the session list for up to 15 minutes after the Claude process exited, because the `staleGraceWindow` fallback kept them alive.
- Added `session.phase != .completed` guard to `isRecentHookSession` so the grace window only applies to running/waiting sessions.
- Ghostty and Terminal.app are unaffected (they use AppleScript snapshots for precise detection).

## Test plan
- [x] `swift build` passes
- [x] `swift test` passes (114 tests, 16 suites)
- [ ] Manual: start a Claude Code session in cmux, complete it, verify it transitions to detached immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)