### PR TITLE
refactor: rename DemoBridgeServer to BridgeServer

### DIFF
--- a/Sources/VibeIslandApp/AppModel.swift
+++ b/Sources/VibeIslandApp/AppModel.swift
@@ -32,7 +32,7 @@ final class AppModel {
     private weak var controlCenterWindowController: ControlCenterWindowController?
 
     @ObservationIgnored
-    private let bridgeServer = DemoBridgeServer()
+    private let bridgeServer = BridgeServer()
 
     @ObservationIgnored
     private let bridgeClient = LocalBridgeClient()

--- a/Sources/VibeIslandCore/BridgeServer.swift
+++ b/Sources/VibeIslandCore/BridgeServer.swift
@@ -2,7 +2,7 @@ import Dispatch
 import Darwin
 import Foundation
 
-public final class DemoBridgeServer: @unchecked Sendable {
+public final class BridgeServer: @unchecked Sendable {
     private struct ClientConnection {
         let id: UUID
         let fileDescriptor: Int32

--- a/Tests/VibeIslandCoreTests/SessionStateTests.swift
+++ b/Tests/VibeIslandCoreTests/SessionStateTests.swift
@@ -131,7 +131,7 @@ struct SessionStateTests {
     @Test
     func localBridgeAcceptsResetDemoCommand() async throws {
         let socketURL = BridgeSocketLocation.uniqueTestURL()
-        let server = DemoBridgeServer(socketURL: socketURL)
+        let server = BridgeServer(socketURL: socketURL)
         try server.start()
         defer { server.stop() }
 
@@ -158,7 +158,7 @@ struct SessionStateTests {
     @Test
     func codexPreToolUseWaitsForApprovalAndReturnsDenyDirective() async throws {
         let socketURL = BridgeSocketLocation.uniqueTestURL()
-        let server = DemoBridgeServer(socketURL: socketURL, approvalTimeout: 5)
+        let server = BridgeServer(socketURL: socketURL, approvalTimeout: 5)
         try server.start()
         defer { server.stop() }
 


### PR DESCRIPTION
## Summary
- Rename `DemoBridgeServer` class and file to `BridgeServer` — the class is the production bridge server, not a demo artifact
- Update all references in AppModel and tests

## Test plan
- [x] `swift build` passes
- [x] All 11 tests pass (`swift test`)
- [x] Grep confirms zero remaining `DemoBridge` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)