### PR TITLE
refactor: rename DemoBridgeServer to BridgeServer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,10 +21,10 @@ Four targets in one Swift package (`OpenIsland`):
 ## Key data flow
 
 ### Codex path
-Codex → hooks.json → OpenIslandHooks (stdin/stdout) → Unix socket → DemoBridgeServer → AppModel → UI
+Codex → hooks.json → OpenIslandHooks (stdin/stdout) → Unix socket → BridgeServer → AppModel → UI
 
 ### Claude Code path
-Claude Code → settings.json hooks → OpenIslandHooks (stdin/stdout) → Unix socket → DemoBridgeServer.handleClaudeHook → AppModel → UI
+Claude Code → settings.json hooks → OpenIslandHooks (stdin/stdout) → Unix socket → BridgeServer.handleClaudeHook → AppModel → UI
 
 ### Session discovery (on launch)
 Restore cached sessions from registry → discover recent JSONL transcripts (`~/.claude/projects/`) → reconcile with active terminal processes → start live bridge.
@@ -120,7 +120,7 @@ Open `Package.swift` in Xcode for the app target. Requires macOS 14+, Swift 6.2.
 - `Sources/OpenIslandCore/AgentSession.swift` — Core session model and related types
 - `Sources/OpenIslandCore/AgentEvent.swift` — Event enum driving all state transitions
 - `Sources/OpenIslandCore/BridgeTransport.swift` — Unix socket protocol, codec, envelope types
-- `Sources/OpenIslandCore/DemoBridgeServer.swift` — Bridge server handling hook payloads
+- `Sources/OpenIslandCore/BridgeServer.swift` — Bridge server handling hook payloads
 - `Sources/OpenIslandCore/ClaudeHooks.swift` — Claude Code hook payload model and terminal detection
 - `Sources/OpenIslandCore/ClaudeTranscriptDiscovery.swift` — Discovers sessions from `~/.claude/projects/` JSONL files
 - `Sources/OpenIslandCore/ClaudeSessionRegistry.swift` — Persists/restores Claude sessions across app launches

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -119,7 +119,7 @@ final class AppModel {
     private let overlayPanelController = OverlayPanelController()
 
     @ObservationIgnored
-    private let bridgeServer = DemoBridgeServer()
+    private let bridgeServer = BridgeServer()
 
     @ObservationIgnored
     private let bridgeClient = LocalBridgeClient()

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -2,7 +2,7 @@ import Dispatch
 import Darwin
 import Foundation
 
-public final class DemoBridgeServer: @unchecked Sendable {
+public final class BridgeServer: @unchecked Sendable {
     private struct ClientConnection {
         let id: UUID
         let fileDescriptor: Int32

--- a/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
@@ -157,7 +157,7 @@ struct ClaudeHooksTests {
     @Test
     func claudePermissionRequestReturnsAllowDirectiveAfterApproval() async throws {
         let socketURL = BridgeSocketLocation.uniqueTestURL()
-        let server = DemoBridgeServer(socketURL: socketURL)
+        let server = BridgeServer(socketURL: socketURL)
         try server.start()
         defer { server.stop() }
 
@@ -219,7 +219,7 @@ struct ClaudeHooksTests {
     @Test
     func claudeAskUserQuestionReturnsUpdatedAnswers() async throws {
         let socketURL = BridgeSocketLocation.uniqueTestURL()
-        let server = DemoBridgeServer(socketURL: socketURL)
+        let server = BridgeServer(socketURL: socketURL)
         try server.start()
         defer { server.stop() }
 

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -283,7 +283,7 @@ struct SessionStateTests {
     @Test
     func bridgeQuestionCommandEmitsQuestionEventForExistingSession() async throws {
         let socketURL = BridgeSocketLocation.uniqueTestURL()
-        let server = DemoBridgeServer(socketURL: socketURL)
+        let server = BridgeServer(socketURL: socketURL)
         try server.start()
         defer { server.stop() }
 
@@ -322,7 +322,7 @@ struct SessionStateTests {
     @Test
     func codexPreToolUseWaitsForApprovalAndReturnsDenyDirective() async throws {
         let socketURL = BridgeSocketLocation.uniqueTestURL()
-        let server = DemoBridgeServer(socketURL: socketURL)
+        let server = BridgeServer(socketURL: socketURL)
         try server.start()
         defer { server.stop() }
 
@@ -362,7 +362,7 @@ struct SessionStateTests {
     @Test
     func codexPreToolUseStillRequiresResolutionWhenHookArrivesInDontAskMode() async throws {
         let socketURL = BridgeSocketLocation.uniqueTestURL()
-        let server = DemoBridgeServer(socketURL: socketURL)
+        let server = BridgeServer(socketURL: socketURL)
         try server.start()
         defer { server.stop() }
 
@@ -407,7 +407,7 @@ struct SessionStateTests {
     @Test
     func codexHookUpdatesJumpTargetWhenLaterHooksLearnMoreAboutTheTerminal() async throws {
         let socketURL = BridgeSocketLocation.uniqueTestURL()
-        let server = DemoBridgeServer(socketURL: socketURL)
+        let server = BridgeServer(socketURL: socketURL)
         try server.start()
         defer { server.stop() }
 

--- a/docs/session-state-refactor.md
+++ b/docs/session-state-refactor.md
@@ -158,7 +158,7 @@ After refactoring, AppleScript is used ONLY for jump precision (#2). This is ext
   5. Run jump target resolver for Ghostty/Terminal precision
 - Rewrite `computeSessionBuckets()` (~35 lines → ~10 lines): filter by `isVisibleInIsland`, sort by attention > running > updatedAt
 
-### Modify: `Sources/OpenIslandCore/DemoBridgeServer.swift`
+### Modify: `Sources/OpenIslandCore/BridgeServer.swift`
 - Minimal changes. SessionEnd handler can set `phase = .completed` as before. Hooks continue to create and update sessions as they do now.
 
 ## 7. Migration Phases


### PR DESCRIPTION
## Summary
- Rename `DemoBridgeServer` class and file to `BridgeServer` — the class is the production bridge server, not a demo artifact
- Update all references in code (AppModel, tests) and documentation (CLAUDE.md, session-state-refactor.md)

## Test plan
- [x] `swift build` passes
- [x] All 114 tests pass (`swift test`)
- [x] Grep confirms zero remaining `DemoBridgeServer` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)