### PR TITLE
fix: clear stale actionable state when permission resolved externally

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1961,6 +1961,8 @@ final class AppModel {
             payload.sessionID
         case let .claudeSessionMetadataUpdated(payload):
             payload.sessionID
+        case let .actionableStateResolved(payload):
+            payload.sessionID
         }
     }
 
@@ -2498,6 +2500,8 @@ final class AppModel {
             }
 
             return payload.claudeMetadata.lastAssistantMessage ?? "Claude session metadata updated."
+        case let .actionableStateResolved(payload):
+            return payload.summary
         }
     }
 

--- a/Sources/OpenIslandCore/AgentEvent.swift
+++ b/Sources/OpenIslandCore/AgentEvent.swift
@@ -155,6 +155,22 @@ public struct ClaudeSessionMetadataUpdated: Equatable, Codable, Sendable {
     }
 }
 
+public struct ActionableStateResolved: Equatable, Codable, Sendable {
+    public var sessionID: String
+    public var summary: String
+    public var timestamp: Date
+
+    public init(
+        sessionID: String,
+        summary: String,
+        timestamp: Date
+    ) {
+        self.sessionID = sessionID
+        self.summary = summary
+        self.timestamp = timestamp
+    }
+}
+
 public enum AgentEvent: Equatable, Codable, Sendable {
     case sessionStarted(SessionStarted)
     case activityUpdated(SessionActivityUpdated)
@@ -164,6 +180,7 @@ public enum AgentEvent: Equatable, Codable, Sendable {
     case jumpTargetUpdated(JumpTargetUpdated)
     case sessionMetadataUpdated(SessionMetadataUpdated)
     case claudeSessionMetadataUpdated(ClaudeSessionMetadataUpdated)
+    case actionableStateResolved(ActionableStateResolved)
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -175,6 +192,7 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case jumpTargetUpdated
         case sessionMetadataUpdated
         case claudeSessionMetadataUpdated
+        case actionableStateResolved
     }
 
     private enum EventType: String, Codable {
@@ -186,6 +204,7 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case jumpTargetUpdated
         case sessionMetadataUpdated
         case claudeSessionMetadataUpdated
+        case actionableStateResolved
     }
 
     public init(from decoder: any Decoder) throws {
@@ -210,6 +229,10 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case .claudeSessionMetadataUpdated:
             self = .claudeSessionMetadataUpdated(
                 try container.decode(ClaudeSessionMetadataUpdated.self, forKey: .claudeSessionMetadataUpdated)
+            )
+        case .actionableStateResolved:
+            self = .actionableStateResolved(
+                try container.decode(ActionableStateResolved.self, forKey: .actionableStateResolved)
             )
         }
     }
@@ -242,6 +265,9 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case let .claudeSessionMetadataUpdated(payload):
             try container.encode(EventType.claudeSessionMetadataUpdated, forKey: .type)
             try container.encode(payload, forKey: .claudeSessionMetadataUpdated)
+        case let .actionableStateResolved(payload):
+            try container.encode(EventType.actionableStateResolved, forKey: .type)
+            try container.encode(payload, forKey: .actionableStateResolved)
         }
     }
 }

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -454,6 +454,7 @@ public final class BridgeServer: @unchecked Sendable {
 
         switch payload.hookEventName {
         case .sessionStart:
+            clearStaleClaudeInteractionIfNeeded(for: payload.sessionID)
             emit(
                 .sessionStarted(
                     SessionStarted(
@@ -472,6 +473,7 @@ public final class BridgeServer: @unchecked Sendable {
             send(.response(.acknowledged), to: clientID)
 
         case .userPromptSubmit:
+            clearStaleClaudeInteractionIfNeeded(for: payload.sessionID)
             ensureClaudeSessionExists(for: payload)
             synchronizeClaudeJumpTarget(for: payload)
             synchronizeClaudeMetadata(for: payload)
@@ -488,6 +490,7 @@ public final class BridgeServer: @unchecked Sendable {
             send(.response(.acknowledged), to: clientID)
 
         case .preToolUse:
+            clearStaleClaudeInteractionIfNeeded(for: payload.sessionID)
             ensureClaudeSessionExists(for: payload)
             synchronizeClaudeJumpTarget(for: payload)
             synchronizeClaudeMetadata(for: payload)
@@ -557,6 +560,7 @@ public final class BridgeServer: @unchecked Sendable {
             }
 
         case .postToolUse:
+            clearStaleClaudeInteractionIfNeeded(for: payload.sessionID)
             ensureClaudeSessionExists(for: payload)
             synchronizeClaudeJumpTarget(for: payload)
             synchronizeClaudeMetadata(for: payload)
@@ -592,6 +596,7 @@ public final class BridgeServer: @unchecked Sendable {
             send(.response(.acknowledged), to: clientID)
 
         case .postToolUseFailure:
+            clearStaleClaudeInteractionIfNeeded(for: payload.sessionID)
             ensureClaudeSessionExists(for: payload)
             synchronizeClaudeJumpTarget(for: payload)
             synchronizeClaudeMetadata(for: payload)
@@ -610,6 +615,7 @@ public final class BridgeServer: @unchecked Sendable {
             send(.response(.acknowledged), to: clientID)
 
         case .permissionDenied:
+            clearStaleClaudeInteractionIfNeeded(for: payload.sessionID)
             ensureClaudeSessionExists(for: payload)
             synchronizeClaudeJumpTarget(for: payload)
             synchronizeClaudeMetadata(for: payload)
@@ -626,6 +632,7 @@ public final class BridgeServer: @unchecked Sendable {
             send(.response(.acknowledged), to: clientID)
 
         case .notification:
+            clearStaleClaudeInteractionIfNeeded(for: payload.sessionID)
             ensureClaudeSessionExists(for: payload)
             synchronizeClaudeJumpTarget(for: payload)
             synchronizeClaudeMetadata(for: payload)
@@ -652,6 +659,7 @@ public final class BridgeServer: @unchecked Sendable {
             send(.response(.acknowledged), to: clientID)
 
         case .stop:
+            clearStaleClaudeInteractionIfNeeded(for: payload.sessionID)
             ensureClaudeSessionExists(for: payload)
             synchronizeClaudeJumpTarget(for: payload)
             synchronizeClaudeMetadata(for: payload)
@@ -669,6 +677,7 @@ public final class BridgeServer: @unchecked Sendable {
             send(.response(.acknowledged), to: clientID)
 
         case .stopFailure:
+            clearStaleClaudeInteractionIfNeeded(for: payload.sessionID)
             ensureClaudeSessionExists(for: payload)
             synchronizeClaudeJumpTarget(for: payload)
             synchronizeClaudeMetadata(for: payload)
@@ -686,6 +695,7 @@ public final class BridgeServer: @unchecked Sendable {
             send(.response(.acknowledged), to: clientID)
 
         case .subagentStart:
+            clearStaleClaudeInteractionIfNeeded(for: payload.sessionID)
             ensureClaudeSessionExists(for: payload)
             synchronizeClaudeJumpTarget(for: payload)
             synchronizeClaudeMetadata(for: payload)
@@ -711,6 +721,7 @@ public final class BridgeServer: @unchecked Sendable {
             send(.response(.acknowledged), to: clientID)
 
         case .subagentStop:
+            clearStaleClaudeInteractionIfNeeded(for: payload.sessionID)
             ensureClaudeSessionExists(for: payload)
             synchronizeClaudeJumpTarget(for: payload)
             synchronizeClaudeMetadata(for: payload)
@@ -735,6 +746,7 @@ public final class BridgeServer: @unchecked Sendable {
             send(.response(.acknowledged), to: clientID)
 
         case .preCompact:
+            clearStaleClaudeInteractionIfNeeded(for: payload.sessionID)
             ensureClaudeSessionExists(for: payload)
             synchronizeClaudeJumpTarget(for: payload)
             synchronizeClaudeMetadata(for: payload)
@@ -752,6 +764,7 @@ public final class BridgeServer: @unchecked Sendable {
             send(.response(.acknowledged), to: clientID)
 
         case .sessionEnd:
+            clearStaleClaudeInteractionIfNeeded(for: payload.sessionID)
             ensureClaudeSessionExists(for: payload)
             synchronizeClaudeJumpTarget(for: payload)
             synchronizeClaudeMetadata(for: payload)
@@ -771,6 +784,22 @@ public final class BridgeServer: @unchecked Sendable {
     }
 
 
+
+    private func clearStaleClaudeInteractionIfNeeded(for sessionID: String) {
+        guard pendingClaudeInteractions.removeValue(forKey: sessionID) != nil else {
+            return
+        }
+
+        emit(
+            .actionableStateResolved(
+                ActionableStateResolved(
+                    sessionID: sessionID,
+                    summary: "Approval was handled outside Open Island.",
+                    timestamp: .now
+                )
+            )
+        )
+    }
 
     private func ensureSessionExists(for payload: CodexHookPayload) {
         guard state.session(id: payload.sessionID) == nil else {
@@ -1316,6 +1345,15 @@ public final class BridgeServer: @unchecked Sendable {
 
         for sessionID in pendingClaudeSessionIDs {
             pendingClaudeInteractions.removeValue(forKey: sessionID)
+            emit(
+                .actionableStateResolved(
+                    ActionableStateResolved(
+                        sessionID: sessionID,
+                        summary: "Hook process disconnected.",
+                        timestamp: .now
+                    )
+                )
+            )
         }
 
         client.readSource.cancel()

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -162,6 +162,22 @@ public struct SessionState: Equatable, Sendable {
             session.claudeMetadata = payload.claudeMetadata.isEmpty ? nil : payload.claudeMetadata
             session.updatedAt = payload.timestamp
             upsert(session)
+
+        case let .actionableStateResolved(payload):
+            guard var session = sessionsByID[payload.sessionID] else {
+                return
+            }
+
+            guard session.phase == .waitingForApproval || session.phase == .waitingForAnswer else {
+                return
+            }
+
+            session.phase = .running
+            session.summary = payload.summary
+            session.permissionRequest = nil
+            session.questionPrompt = nil
+            session.updatedAt = payload.timestamp
+            upsert(session)
         }
     }
 

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -153,6 +153,108 @@ struct SessionStateTests {
     }
 
     @Test
+    func actionableStateResolvedClearsWaitingForApproval() {
+        let startedAt = Date(timeIntervalSince1970: 5_000)
+        var state = SessionState(
+            sessions: [
+                AgentSession(
+                    id: "claude-approval",
+                    title: "Claude · repo",
+                    tool: .claudeCode,
+                    attachmentState: .attached,
+                    phase: .waitingForApproval,
+                    summary: "Wants to edit file",
+                    updatedAt: startedAt,
+                    permissionRequest: PermissionRequest(
+                        title: "Edit file",
+                        summary: "Wants to edit file",
+                        affectedPath: "src/main.ts"
+                    )
+                )
+            ]
+        )
+
+        state.apply(
+            .actionableStateResolved(
+                ActionableStateResolved(
+                    sessionID: "claude-approval",
+                    summary: "Approval was handled outside Open Island.",
+                    timestamp: startedAt.addingTimeInterval(10)
+                )
+            )
+        )
+
+        #expect(state.session(id: "claude-approval")?.phase == .running)
+        #expect(state.session(id: "claude-approval")?.permissionRequest == nil)
+        #expect(state.session(id: "claude-approval")?.summary == "Approval was handled outside Open Island.")
+    }
+
+    @Test
+    func actionableStateResolvedClearsWaitingForAnswer() {
+        let startedAt = Date(timeIntervalSince1970: 5_500)
+        var state = SessionState(
+            sessions: [
+                AgentSession(
+                    id: "claude-question",
+                    title: "Claude · repo",
+                    tool: .claudeCode,
+                    attachmentState: .attached,
+                    phase: .waitingForAnswer,
+                    summary: "Which environment?",
+                    updatedAt: startedAt,
+                    questionPrompt: QuestionPrompt(
+                        title: "Which environment?",
+                        options: ["Production", "Staging"]
+                    )
+                )
+            ]
+        )
+
+        state.apply(
+            .actionableStateResolved(
+                ActionableStateResolved(
+                    sessionID: "claude-question",
+                    summary: "Approval was handled outside Open Island.",
+                    timestamp: startedAt.addingTimeInterval(10)
+                )
+            )
+        )
+
+        #expect(state.session(id: "claude-question")?.phase == .running)
+        #expect(state.session(id: "claude-question")?.questionPrompt == nil)
+    }
+
+    @Test
+    func actionableStateResolvedIsNoOpWhenAlreadyRunning() {
+        let startedAt = Date(timeIntervalSince1970: 6_000)
+        var state = SessionState(
+            sessions: [
+                AgentSession(
+                    id: "claude-running",
+                    title: "Claude · repo",
+                    tool: .claudeCode,
+                    phase: .running,
+                    summary: "Working on it",
+                    updatedAt: startedAt
+                )
+            ]
+        )
+
+        state.apply(
+            .actionableStateResolved(
+                ActionableStateResolved(
+                    sessionID: "claude-running",
+                    summary: "Should not change anything.",
+                    timestamp: startedAt.addingTimeInterval(10)
+                )
+            )
+        )
+
+        #expect(state.session(id: "claude-running")?.phase == .running)
+        #expect(state.session(id: "claude-running")?.summary == "Working on it")
+    }
+
+    @Test
     func preservesLiveSessionOriginFromStartEvent() {
         var state = SessionState()
 


### PR DESCRIPTION
## Summary

- 修复终端手动审批权限后 Island UI 状态卡在 "Needs approval" 的问题
- 新增 `actionableStateResolved` 事件，绕过 `preservesActionableState` 守卫，无条件清除过期的审批/问答状态
- Bridge 层通过两个检测点发出事件：新 hook 事件到达时清理过期 pending interaction，hook client 断开时同步清理

## Test plan

- [x] `swift build` 编译通过
- [x] `swift test` 全部 117 个测试通过
- [x] 新增 3 个单元测试覆盖：清除 waitingForApproval、清除 waitingForAnswer、running 状态下 no-op
- [ ] 手动验证：触发 Claude Code 审批 → 在终端手动审批 → 确认 Island UI 恢复为 running

🤖 Generated with [Claude Code](https://claude.com/claude-code)