### PR TITLE
feat: individual subagent detail display

### DIFF
--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -13,7 +13,10 @@ extension AgentSession {
         guard presence != .inactive else { return height }
         if spotlightPromptLineText != nil { height += 22 }   // spacing (6) + text (16)
         if spotlightActivityLineText != nil { height += 20 }  // spacing (6) + text (14)
-        if spotlightSubagentLabel != nil { height += 20 }     // spacing (6) + text (14)
+        if let subagents = claudeMetadata?.activeSubagents, !subagents.isEmpty {
+            height += 20  // spacing (6) + header (14)
+            height += CGFloat(subagents.count) * 18  // each subagent row (spacing 4 + text 14)
+        }
         return height
     }
 }
@@ -904,14 +907,37 @@ private struct IslandSessionRow: View {
                     }
 
                     if showsExpandedContent,
-                       let subagentLabel = session.spotlightSubagentLabel {
-                        HStack(spacing: 5) {
-                            Image(systemName: "arrow.triangle.branch")
-                                .font(.system(size: 9, weight: .medium))
-                            Text(subagentLabel)
-                                .font(.system(size: 10.5, weight: .medium))
+                       let subagents = session.claudeMetadata?.activeSubagents,
+                       !subagents.isEmpty {
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack(spacing: 5) {
+                                Image(systemName: "arrow.triangle.branch")
+                                    .font(.system(size: 9, weight: .medium))
+                                Text("Subagents (\(subagents.count))")
+                                    .font(.system(size: 10.5, weight: .medium))
+                            }
+                            .foregroundStyle(.cyan.opacity(0.8))
+
+                            ForEach(subagents, id: \.agentID) { sub in
+                                HStack(spacing: 6) {
+                                    Circle()
+                                        .fill(sub.summary != nil
+                                            ? Color(red: 0.29, green: 0.86, blue: 0.46)
+                                            : Color(red: 0.34, green: 0.61, blue: 0.99))
+                                        .frame(width: 6, height: 6)
+                                    Text(sub.agentType ?? sub.agentID)
+                                        .font(.system(size: 11, weight: .medium))
+                                        .foregroundStyle(.white.opacity(0.8))
+                                        .lineLimit(1)
+                                    if let summary = sub.summary {
+                                        Text(summary)
+                                            .font(.system(size: 10.5))
+                                            .foregroundStyle(.white.opacity(0.45))
+                                            .lineLimit(1)
+                                    }
+                                }
+                            }
                         }
-                        .foregroundStyle(.cyan.opacity(0.8))
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- 将 "Subagents (N)" 计数标签替换为详细列表，每个 subagent 独立一行
- 状态圆点：绿色=已完成（有 summary），蓝色=运行中（无 summary）
- 显示 subagent 名称 + 完成摘要
- 更新行高估算以适配展开的列表

## Test plan
- [x] `swift build` 编译通过
- [x] `swift test` 全部 118 个测试通过
- [ ] 手动验证有 subagent 的 session 显示详情列表

🤖 Generated with [Claude Code](https://claude.com/claude-code)