### PR TITLE
feat: session list footer with show-all toggle

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -49,6 +49,7 @@ final class AppModel {
     var notchStatus: NotchStatus = .closed
     var notchOpenReason: NotchOpenReason?
     var islandSurface: IslandSurface = .sessionList()
+    var showsAllSessions: Bool = false
     var isOverlayVisible: Bool { notchStatus != .closed }
     let hooks = HookInstallationCoordinator()
     var isCodexSetupBusy: Bool { hooks.isCodexSetupBusy }
@@ -216,6 +217,10 @@ final class AppModel {
 
     var islandListSessions: [AgentSession] {
         surfacedSessions
+    }
+
+    var allSessions: [AgentSession] {
+        state.sessions
     }
 
     var recentSessionCount: Int {

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -408,6 +408,21 @@ struct IslandPanelView: View {
                             onJump: { model.jumpToSession(session) }
                         )
                     }
+
+                    if totalSessionCount > displayedSessions.count {
+                        Button {
+                            model.showsAllSessions.toggle()
+                        } label: {
+                            Text(model.showsAllSessions
+                                ? "收起列表"
+                                : "显示全部 \(totalSessionCount) 个会话")
+                                .font(.system(size: 11, weight: .medium))
+                                .foregroundStyle(.white.opacity(0.45))
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 8)
+                        }
+                        .buttonStyle(.plain)
+                    }
                 }
             }
             .padding(.vertical, 2)
@@ -422,7 +437,11 @@ struct IslandPanelView: View {
     }
 
     private var displayedSessions: [AgentSession] {
-        model.islandListSessions
+        model.showsAllSessions ? model.allSessions : model.islandListSessions
+    }
+
+    private var totalSessionCount: Int {
+        model.allSessions.count
     }
 
     private func sessionListViewportSessions(at referenceDate: Date) -> [AgentSession] {


### PR DESCRIPTION
## Summary
- 列表底部新增 "显示全部 N 个会话" 按钮
- 点击切换 `showsAllSessions` 状态，展开时显示所有 session（含 overflow）
- 展开后按钮文字变为 "收起列表"

## Test plan
- [x] `swift build` 编译通过
- [x] `swift test` 全部 118 个测试通过
- [ ] 手动验证 footer 显示和切换行为

🤖 Generated with [Claude Code](https://claude.com/claude-code)