### PR TITLE
perf: unify AppKit/SwiftUI animation curves

### DIFF
--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -149,9 +149,17 @@ final class OverlayPanelController {
 
         let windowFrame = panelFrame(for: model, on: screen)
         if animated {
+            let status = model?.notchStatus
             NSAnimationContext.runAnimationGroup { context in
-                context.duration = panelAnimationDuration(for: model?.notchStatus)
-                context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+                switch status {
+                case .opened:
+                    context.duration = 0.50
+                case .closed, .popping:
+                    context.duration = 0.42
+                case nil:
+                    context.duration = 0
+                }
+                context.timingFunction = CAMediaTimingFunction(controlPoints: 0.22, 1.0, 0.36, 1.0)
                 context.allowsImplicitAnimation = true
                 panel.animator().setFrame(windowFrame, display: true)
             }
@@ -164,17 +172,6 @@ final class OverlayPanelController {
             preferredScreenID: preferredScreenID,
             panelSize: panel.frame.size
         )
-    }
-
-    private func panelAnimationDuration(for status: NotchStatus?) -> TimeInterval {
-        switch status {
-        case .opened:
-            0.36
-        case .closed, .popping:
-            0.30
-        case nil:
-            0
-        }
     }
 
     private func presentPanel(_ panel: NSPanel, activates: Bool) {

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -205,8 +205,8 @@ struct IslandPanelView: View {
         .padding(.horizontal, panelShadowHorizontalInset)
         .padding(.bottom, panelShadowBottomInset)
         .animation(isOpened ? openAnimation : closeAnimation, value: model.notchStatus)
-        .animation(.smooth, value: closedPresenceAnimationKey)
-        .animation(popAnimation, value: isPopping)
+        .animation(isOpened ? nil : .smooth, value: closedPresenceAnimationKey)
+        .animation(isOpened ? nil : popAnimation, value: isPopping)
         .contentShape(Rectangle())
         .onHover { hovering in
             withAnimation(.spring(response: 0.38, dampingFraction: 0.8)) {


### PR DESCRIPTION
## Summary
- NSPanel frame 动画改用贝塞尔曲线近似 SwiftUI spring 曲线，统一容器与内容的运动节奏
- opened 时长 0.36s → 0.50s，closed 时长 0.30s → 0.42s，匹配 spring settling time
- 隔离 `.animation()` modifier：closedPresenceAnimationKey 和 popAnimation 在 opened 状态下设为 nil，防止干扰主 spring 动画

## Test plan
- [ ] 展开/折叠动画：容器和内容应同步运动，无"容器先到内容还在飘"
- [ ] Pop 动画：closed 状态下收到通知的弹跳效果不受影响
- [ ] Closed presence 展开：新 session 出现时 notch 横向扩展动画正常
- [ ] Instruments Animation Hitches 对比优化前后

🤖 Generated with [Claude Code](https://claude.com/claude-code)