### PR TITLE
perf: conditional drawingGroup and hover guard

### DIFF
--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -35,6 +35,18 @@ private struct ClosedPresenceKey: Equatable {
     var width: CGFloat
 }
 
+private struct ConditionalDrawingGroup: ViewModifier {
+    let enabled: Bool
+
+    func body(content: Content) -> some View {
+        if enabled {
+            content.drawingGroup()
+        } else {
+            content
+        }
+    }
+}
+
 // MARK: - Main island view
 
 struct IslandPanelView: View {
@@ -406,6 +418,8 @@ struct IslandPanelView: View {
                             session: session,
                             referenceDate: context.date,
                             isActionable: session.id == actionableSessionID,
+                            useDrawingGroup: model.notchStatus == .opened,
+                            isInteractive: model.notchStatus == .opened,
                             onApprove: { model.approvePermission(for: session.id, mode: $0) },
                             onAnswer: { model.answerQuestion(for: session.id, answer: $0) },
                             onJump: { model.jumpToSession(session) }
@@ -872,6 +886,8 @@ private struct IslandSessionRow: View {
     let session: AgentSession
     let referenceDate: Date
     var isActionable: Bool = false
+    var useDrawingGroup: Bool = true
+    var isInteractive: Bool = true
     var onApprove: ((ClaudePermissionMode?) -> Void)?
     var onAnswer: ((QuestionPromptResponse) -> Void)?
     let onJump: () -> Void
@@ -988,10 +1004,11 @@ private struct IslandSessionRow: View {
             },
             alignment: .bottom
         )
-        .drawingGroup()
+        .modifier(ConditionalDrawingGroup(enabled: useDrawingGroup))
         .contentShape(RoundedRectangle(cornerRadius: isActionable ? 24 : 22, style: .continuous))
         .onTapGesture(perform: handlePrimaryTap)
         .onHover { hovering in
+            guard isInteractive else { return }
             withAnimation(.easeInOut(duration: 0.15)) {
                 isHighlighted = hovering
             }


### PR DESCRIPTION
## Summary
- `.drawingGroup()` 改为条件化：仅在 panel 已展开（settled）时启用 Metal 光栅化，过渡动画期间跳过
- 新增 `ConditionalDrawingGroup` ViewModifier 和 `useDrawingGroup` / `isInteractive` 参数
- 过渡动画期间禁用 session row 的 hover 高亮动画，避免不必要的渲染开销

## Test plan
- [ ] 展开/折叠动画帧率应有提升（减少每帧 GPU 光栅化）
- [ ] 展开后 hover session row 仍有平滑高亮效果
- [ ] 多 session 场景（1/3/6 个）展开动画流畅
- [ ] Instruments Animation Hitches 对比优化前后

🤖 Generated with [Claude Code](https://claude.com/claude-code)