### PR TITLE
perf: reduce hover open delay to 0.35s

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -31,7 +31,7 @@ final class AppModel {
     private static let liveSessionStalenessWindow: TimeInterval = 15 * 60
     private static let notificationSurfaceAutoCollapseDelay: TimeInterval = 10
     private static let jumpOverlayDismissLeadTime: Duration = .milliseconds(20)
-    static let hoverOpenDelay: TimeInterval = 0.7
+    static let hoverOpenDelay: TimeInterval = 0.35
     typealias ActiveProcessSnapshot = ActiveAgentProcessDiscovery.ProcessSnapshot
 
     struct AcceptanceStep: Identifiable {


### PR DESCRIPTION
## Summary
- Hover 展开延迟从 0.7s 缩短到 0.35s，响应更灵敏

## Test plan
- [ ] hover notch 后约 0.35s 即展开，体感明显更快
- [ ] 鼠标快速划过 notch 不会误触发展开（0.35s 仍有足够的防抖）

🤖 Generated with [Claude Code](https://claude.com/claude-code)