### PR TITLE
fix: notification mode — single session view with expand footer

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -624,6 +624,15 @@ final class AppModel {
     func showOverlay() { notchOpen(reason: .click, surface: .sessionList()) }
     func hideOverlay() { notchClose() }
 
+    /// Transition from notification mode (single session) to full session list.
+    func expandNotificationToSessionList() {
+        islandSurface = .sessionList()
+        notchOpenReason = .click
+        notificationAutoCollapseTask?.cancel()
+        notificationAutoCollapseTask = nil
+        refreshOverlayPlacementIfVisible()
+    }
+
     func refreshOverlayDisplayConfiguration() {
         overlayDisplayOptions = overlayPanelController.availableDisplayOptions()
 

--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -451,6 +451,19 @@ final class OverlayPanelController {
         }
 
         let actionableID = model.islandSurface.sessionID
+        let isNotificationMode = model.notchOpenReason == .notification && actionableID != nil
+
+        if isNotificationMode {
+            // Notification mode: only the actionable session + footer
+            guard let session = model.activeIslandCardSession else {
+                return Self.openedEmptyStateHeight
+            }
+            let rowHeight = session.estimatedIslandRowHeight(at: now)
+                + actionableBodyHeight(for: session, model: model)
+            let footerHeight: CGFloat = model.allSessions.count > 1 ? 28 : 0
+            return rowHeight + footerHeight + Self.openedContentVerticalInsets
+        }
+
         let rowHeights = visibleSessions.map { session -> CGFloat in
             if session.id == actionableID {
                 return session.estimatedIslandRowHeight(at: now)
@@ -502,7 +515,9 @@ final class OverlayPanelController {
         )
 
         let estimatedHeight = Self.completionCardChromeHeight + ceil(textSize.height)
-        return min(Self.completionCardMaxHeight, max(Self.completionCardMinHeight, estimatedHeight))
+        // Use a smaller minimum to avoid blank space when content is short
+        let minHeight: CGFloat = Self.completionCardChromeHeight + 20
+        return min(Self.completionCardMaxHeight, max(minHeight, estimatedHeight))
     }
 
     private func openedVisibleSessions(sessions: [AgentSession]) -> [AgentSession] {

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -409,36 +409,72 @@ struct IslandPanelView: View {
         model.islandSurface.sessionID
     }
 
+    /// Whether the panel was opened by a notification (show only actionable session + footer).
+    private var isNotificationMode: Bool {
+        model.notchOpenReason == .notification && actionableSessionID != nil
+    }
+
     private var sessionList: some View {
         TimelineView(.periodic(from: .now, by: 30)) { context in
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(spacing: 4) {
-                    ForEach(displayedSessions) { session in
-                        IslandSessionRow(
-                            session: session,
-                            referenceDate: context.date,
-                            isActionable: session.id == actionableSessionID,
-                            useDrawingGroup: model.notchStatus == .opened,
-                            isInteractive: model.notchStatus == .opened,
-                            onApprove: { model.approvePermission(for: session.id, mode: $0) },
-                            onAnswer: { model.answerQuestion(for: session.id, answer: $0) },
-                            onJump: { model.jumpToSession(session) }
-                        )
-                    }
-
-                    if totalSessionCount > displayedSessions.count {
-                        Button {
-                            model.showsAllSessions.toggle()
-                        } label: {
-                            Text(model.showsAllSessions
-                                ? "收起列表"
-                                : "显示全部 \(totalSessionCount) 个会话")
-                                .font(.system(size: 11, weight: .medium))
-                                .foregroundStyle(.white.opacity(0.45))
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, 8)
+                    if isNotificationMode {
+                        // Notification mode: only show the actionable session
+                        if let session = model.activeIslandCardSession {
+                            IslandSessionRow(
+                                session: session,
+                                referenceDate: context.date,
+                                isActionable: true,
+                                useDrawingGroup: model.notchStatus == .opened,
+                                isInteractive: model.notchStatus == .opened,
+                                onApprove: { model.approvePermission(for: session.id, mode: $0) },
+                                onAnswer: { model.answerQuestion(for: session.id, answer: $0) },
+                                onJump: { model.jumpToSession(session) }
+                            )
                         }
-                        .buttonStyle(.plain)
+
+                        // Footer to expand to full list
+                        if totalSessionCount > 1 {
+                            Button {
+                                model.expandNotificationToSessionList()
+                            } label: {
+                                Text("显示全部 \(totalSessionCount) 个会话")
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundStyle(.white.opacity(0.45))
+                                    .frame(maxWidth: .infinity)
+                                    .padding(.vertical, 8)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    } else {
+                        // List mode: show all sessions
+                        ForEach(displayedSessions) { session in
+                            IslandSessionRow(
+                                session: session,
+                                referenceDate: context.date,
+                                isActionable: session.id == actionableSessionID,
+                                useDrawingGroup: model.notchStatus == .opened,
+                                isInteractive: model.notchStatus == .opened,
+                                onApprove: { model.approvePermission(for: session.id, mode: $0) },
+                                onAnswer: { model.answerQuestion(for: session.id, answer: $0) },
+                                onJump: { model.jumpToSession(session) }
+                            )
+                        }
+
+                        if totalSessionCount > displayedSessions.count {
+                            Button {
+                                model.showsAllSessions.toggle()
+                            } label: {
+                                Text(model.showsAllSessions
+                                    ? "收起列表"
+                                    : "显示全部 \(totalSessionCount) 个会话")
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundStyle(.white.opacity(0.45))
+                                    .frame(maxWidth: .infinity)
+                                    .padding(.vertical, 8)
+                            }
+                            .buttonStyle(.plain)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- 通知模式下只展示一个 actionable session，不再显示完整列表
- 底部添加 "显示全部 N 个会话" 按钮，点击后切换到完整列表模式
- 修复 completion 通知的大片空白（移除 210pt 最小高度限制，改为内容自适应）

## Test plan
- [x] `swift build` 编译通过
- [x] `swift test` 全部 118 个测试通过
- [ ] 手动验证 completion 通知只显示一个 session + footer
- [ ] 手动验证点击 "显示全部" 后展开完整列表
- [ ] 手动验证无多余空白

🤖 Generated with [Claude Code](https://claude.com/claude-code)