### PR TITLE
fix: headline shows initial prompt, prompt line shows latest

### DIFF
--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -162,15 +162,9 @@ extension AgentSession {
     }
 
     var spotlightHeadlinePromptText: String? {
-        if let prompt = spotlightPromptText {
-            return prompt
-        }
-
-        if let prompt = initialPromptText {
-            return prompt
-        }
-
-        return spotlightPromptText
+        // Headline shows the initial prompt (session topic), not the latest.
+        // The latest prompt is shown separately in the "You:" line.
+        initialPromptText ?? latestPromptText
     }
 
     var spotlightPromptText: String? {

--- a/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
+++ b/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
@@ -123,13 +123,13 @@ struct AgentSessionPresentationTests {
             )
         )
 
-        #expect(session.spotlightHeadlineText == "worktree · Now make the overlay height fit the content.")
-        // Prompt line always shows when detail lines are visible, even if duplicated in headline
+        // Headline uses initial prompt (session topic), prompt line uses latest
+        #expect(session.spotlightHeadlineText == "worktree · Start by fixing the island hover behavior.")
         #expect(session.spotlightPromptLineText == "You: Now make the overlay height fit the content.")
     }
 
     @Test
-    func detachedSessionHeadlineShowsLatestPrompt() {
+    func detachedSessionHeadlineShowsInitialPrompt() {
         let session = AgentSession(
             id: "session-1",
             title: "Codex · worktree",
@@ -146,12 +146,12 @@ struct AgentSessionPresentationTests {
             )
         )
 
-        #expect(session.spotlightHeadlineText == "worktree · Now make the overlay height fit the content.")
+        #expect(session.spotlightHeadlineText == "worktree · Start by fixing the island hover behavior.")
         #expect(session.spotlightPromptLineText == "You: Now make the overlay height fit the content.")
     }
 
     @Test
-    func completedSessionAlwaysShowsPromptLine() {
+    func completedSessionShowsDifferentHeadlineAndPrompt() {
         let now = Date.now
         let session = AgentSession(
             id: "session-1",
@@ -176,9 +176,8 @@ struct AgentSessionPresentationTests {
             )
         )
 
-        #expect(session.spotlightHeadlineText == "worktree · Also confirm the worktree status.")
+        #expect(session.spotlightHeadlineText == "worktree · Commit the README change.")
         #expect(session.spotlightPromptLineText == "You: Also confirm the worktree status.")
-        // Completed sessions don't show prompt in notification header
         #expect(session.notificationHeaderPromptLineText == nil)
     }
 }


### PR DESCRIPTION
## Summary
- Headline 用 `initialPromptText`（session 主题），prompt 行用 `latestPromptText`（最新 prompt）
- 修复两行内容完全重复的问题

## Test plan
- [x] `swift test` 118 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)