### PR TITLE
fix: click-to-expand inactive rows + completion card blank space

### DIFF
--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -931,8 +931,11 @@ private struct IslandSessionRow: View {
     var onApprove: ((ClaudePermissionMode?) -> Void)?
     var onAnswer: ((QuestionPromptResponse) -> Void)?
     let onJump: () -> Void
+    /// Called when an inactive row is tapped to expand it.
+    var onExpand: (() -> Void)?
 
     @State private var isHighlighted = false
+    @State private var isManuallyExpanded = false
 
     var body: some View {
         rowBody(referenceDate: referenceDate)
@@ -940,7 +943,7 @@ private struct IslandSessionRow: View {
 
     private func rowBody(referenceDate: Date) -> some View {
         let presence = session.islandPresence(at: referenceDate)
-        let showsExpandedContent = presence != .inactive
+        let showsExpandedContent = presence != .inactive || isManuallyExpanded
         return VStack(alignment: .leading, spacing: 0) {
             HStack(alignment: .top, spacing: 14) {
                 statusDot(for: presence)
@@ -1194,26 +1197,28 @@ private struct IslandSessionRow: View {
 
                 Spacer(minLength: 8)
 
-                Text("Done")
+                Text("完成")
                     .font(.system(size: 11, weight: .bold))
                     .foregroundStyle(Color(red: 0.29, green: 0.86, blue: 0.46).opacity(0.96))
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 12)
 
-            Rectangle()
-                .fill(.white.opacity(0.04))
-                .frame(height: 1)
+            if !completionMessageText.isEmpty {
+                Rectangle()
+                    .fill(.white.opacity(0.04))
+                    .frame(height: 1)
 
-            ScrollView(.vertical) {
-                Markdown(completionMessageText)
-                    .markdownTheme(.completionCard)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 14)
-                    .padding(.vertical, 14)
+                ScrollView(.vertical) {
+                    Markdown(completionMessageText)
+                        .markdownTheme(.completionCard)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 14)
+                }
+                .scrollIndicators(.visible)
+                .frame(maxHeight: 260)
             }
-            .scrollIndicators(.visible)
-            .frame(maxHeight: 260)
         }
         .background(
             RoundedRectangle(cornerRadius: 18, style: .continuous)
@@ -1311,7 +1316,16 @@ private struct IslandSessionRow: View {
     }
 
     private func handlePrimaryTap() {
-        onJump()
+        let presence = session.islandPresence(at: referenceDate)
+        if presence == .inactive && !isManuallyExpanded {
+            // First click on inactive row: expand to show details
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isManuallyExpanded = true
+            }
+        } else {
+            // Already expanded (or active/running): jump to terminal
+            onJump()
+        }
     }
 
     private func compactBadge(


### PR DESCRIPTION
## Summary
1. **点击交互**：灰色（inactive）行第一次点击展开详情，第二次点击跳转终端。活跃行直接跳转。
2. **Completion 卡片空白修复**：无助手回复时隐藏空的 markdown ScrollView，消除大片黑色空白。
3. "Done" 改为 "完成"。

## Dependencies
基于 PR #38

## Test plan
- [x] `swift build` + `swift test` 118 tests passed
- [ ] 手动验证灰色行点击展开再点击跳转
- [ ] 手动验证 completion 通知无多余空白

🤖 Generated with [Claude Code](https://claude.com/claude-code)