### PR TITLE
feat: DMG packaging and GitHub Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and package
+        env:
+          OPEN_ISLAND_VERSION: ${{ steps.version.outputs.version }}
+          OPEN_ISLAND_BUILD_NUMBER: ${{ github.run_number }}
+        run: zsh scripts/package-app.sh
+
+      - name: Verify artifacts
+        run: |
+          test -f "output/package/Open Island.zip"
+          test -f "output/package/Open Island.dmg"
+          ls -lh output/package/
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "Open Island $GITHUB_REF_NAME" \
+            --generate-notes \
+            --notes-start-tag "$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo '')" \
+            --draft \
+            "output/package/Open Island.dmg#Open Island.dmg (macOS, Apple Silicon)" \
+            "output/package/Open Island.zip#Open Island.zip (macOS, Apple Silicon)"
+
+      - name: Append install instructions to release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          existing="$(gh release view "$GITHUB_REF_NAME" --json body -q .body)"
+          gh release edit "$GITHUB_REF_NAME" --notes "$(cat <<EOF
+          ${existing}
+
+          ---
+
+          ## Installation
+
+          1. Download **Open Island.dmg**, open it, and drag **Open Island** to **Applications**.
+          2. First launch: right-click the app → **Open** (macOS Gatekeeper will warn about unsigned apps).
+             - Alternatively, run in Terminal: \`xattr -cr /Applications/Open\ Island.app\`
+          3. Requires **macOS 14+** and **Apple Silicon** (M1/M2/M3/M4).
+
+          > This is an unsigned early-access build. Code signing and notarization will be added once our Apple Developer account is approved.
+          EOF
+          )"

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -15,6 +15,7 @@ build_number="${OPEN_ISLAND_BUILD_NUMBER:-$(git -C "$repo_root" rev-list --count
 package_root="${OPEN_ISLAND_PACKAGE_ROOT:-$repo_root/output/package}"
 bundle_dir="${OPEN_ISLAND_BUNDLE_DIR:-$package_root/$app_name.app}"
 zip_path="${OPEN_ISLAND_ZIP_PATH:-$package_root/$app_name.zip}"
+dmg_path="${OPEN_ISLAND_DMG_PATH:-$package_root/$app_name.dmg}"
 signing_identity="${OPEN_ISLAND_SIGN_IDENTITY:-}"
 notary_profile="${OPEN_ISLAND_NOTARY_PROFILE:-}"
 
@@ -35,7 +36,7 @@ brand_icon="$repo_root/Assets/Brand/OpenIsland.icns"
 
 python3 "$brand_script"
 
-rm -rf "$bundle_dir" "$zip_path"
+rm -rf "$bundle_dir" "$zip_path" "$dmg_path"
 mkdir -p "$bundle_dir/Contents/MacOS" "$bundle_dir/Contents/Helpers" "$bundle_dir/Contents/Resources"
 
 cp "$app_binary" "$bundle_dir/Contents/MacOS/OpenIslandApp"
@@ -115,15 +116,35 @@ fi
 
 ditto -c -k --keepParent "$bundle_dir" "$zip_path"
 
+# --- DMG creation ---
+dmg_staging="$package_root/dmg-staging"
+rm -rf "$dmg_staging"
+mkdir -p "$dmg_staging"
+cp -R "$bundle_dir" "$dmg_staging/"
+ln -s /Applications "$dmg_staging/Applications"
+
+hdiutil create \
+    -volname "$app_name" \
+    -srcfolder "$dmg_staging" \
+    -ov \
+    -format UDZO \
+    "$dmg_path"
+
+rm -rf "$dmg_staging"
+
 if [[ -n "$signing_identity" && -n "$notary_profile" ]]; then
     xcrun notarytool submit "$zip_path" --keychain-profile "$notary_profile" --wait
     xcrun stapler staple -v "$bundle_dir"
     rm -f "$zip_path"
     ditto -c -k --keepParent "$bundle_dir" "$zip_path"
+
+    xcrun notarytool submit "$dmg_path" --keychain-profile "$notary_profile" --wait
+    xcrun stapler staple -v "$dmg_path"
 fi
 
 echo "Bundle: $bundle_dir"
 echo "Archive: $zip_path"
+echo "DMG: $dmg_path"
 if [[ -n "$signing_identity" ]]; then
     echo "Signed with identity: $signing_identity"
 else


### PR DESCRIPTION
## Summary

- `package-app.sh` 新增 DMG 生成（`hdiutil`，含 Applications 快捷方式，拖拽安装）
- 新增 `.github/workflows/release.yml`，push `v*` tag 时自动构建并创建 draft GitHub Release
- Release notes 自动附带 Gatekeeper 绕过说明，适合未签名早期测试版分发

## 使用方式

合并后，打 tag 即可触发发布：

```bash
git tag v0.1.0
git push origin v0.1.0
```

GitHub Actions 会自动构建并创建 draft release，包含 DMG 和 ZIP 两个产物。确认无误后手动 publish。

## Test plan

- [x] 本地运行 `package-app.sh`，DMG 和 ZIP 均成功生成
- [x] `hdiutil verify` 验证 DMG 完整性通过
- [ ] 合并后打 tag 验证 workflow 端到端执行

🤖 Generated with [Claude Code](https://claude.com/claude-code)