### PR TITLE
fix: remove duplicate display picker entries

### DIFF
--- a/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
+++ b/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
@@ -62,7 +62,7 @@ enum OverlayDisplayResolver {
     static func availableDisplayOptions() -> [OverlayDisplayOption] {
         let automatic = OverlayDisplayOption(
             id: OverlayDisplayOption.automaticID,
-            title: "Automatic",
+            title: "自动",
             subtitle: "Prefer the built-in notched display, otherwise use the current main display."
         )
 

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -150,7 +150,6 @@ struct GeneralSettingsPane: View {
                     get: { model.overlayDisplaySelectionID },
                     set: { model.overlayDisplaySelectionID = $0 }
                 )) {
-                    Text("自动").tag(OverlayDisplayOption.automaticID)
                     ForEach(model.overlayDisplayOptions) { option in
                         Text(option.title).tag(option.id)
                     }
@@ -218,7 +217,6 @@ struct DisplaySettingsPane: View {
                     get: { model.overlayDisplaySelectionID },
                     set: { model.overlayDisplaySelectionID = $0 }
                 )) {
-                    Text("自动").tag(OverlayDisplayOption.automaticID)
                     ForEach(model.overlayDisplayOptions) { option in
                         Text(option.title).tag(option.id)
                     }


### PR DESCRIPTION
## Summary
- 设置中显示器选择器出现了4个选项（"自动" + "Automatic" + 两个显示器），实际应为3个
- 原因：`SettingsView` 手动添加了"自动"选项，但 `overlayDisplayOptions` 已经包含了 `availableDisplayOptions()` 返回的 "Automatic" 选项
- 移除 `SettingsView` 中手动添加的"自动"条目，将 `OverlayDisplayConfiguration` 中的 title 从 "Automatic" 改为 "自动"

## Test plan
- [ ] 打开设置，确认显示器 Picker 只显示3个选项：自动 + 各显示器
- [ ] 确认选择"自动"后功能正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)