### PR TITLE
fix: remove duplicate Automatic entry from display picker

### DIFF
--- a/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
+++ b/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
@@ -60,21 +60,13 @@ enum OverlayDisplayResolver {
     static let defaultPanelSize = NSSize(width: 708, height: 514)
 
     static func availableDisplayOptions() -> [OverlayDisplayOption] {
-        let automatic = OverlayDisplayOption(
-            id: OverlayDisplayOption.automaticID,
-            title: "Automatic",
-            subtitle: "Prefer the built-in notched display, otherwise use the current main display."
-        )
-
-        let displays = NSScreen.screens.map { screen in
+        NSScreen.screens.map { screen in
             OverlayDisplayOption(
                 id: screenID(for: screen),
                 title: screen.localizedName,
                 subtitle: "\(screenKindDescription(for: screen)) · \(Int(screen.frame.width))×\(Int(screen.frame.height))"
             )
         }
-
-        return [automatic] + displays
     }
 
     static func diagnostics(preferredScreenID: String?, panelSize: NSSize) -> OverlayPlacementDiagnostics? {


### PR DESCRIPTION
## Summary
- 设置中显示器 Picker 出现4个选项（"自动" + "Automatic" + 显示器列表），应为3个
- 原因：`SettingsView` 已通过 `lang.t("settings.general.automatic")` 添加了国际化的"自动"选项，但 `availableDisplayOptions()` 仍返回一个硬编码的 "Automatic" 选项
- 修复：从 `availableDisplayOptions()` 移除冗余的 automatic 条目，仅返回实际显示器列表

## Test plan
- [ ] 打开设置，确认显示器 Picker 只有3个选项：自动 + 各显示器
- [ ] 切换语言，确认"自动"选项随语言切换正确显示（中文"自动" / 英文"Automatic"）

🤖 Generated with [Claude Code](https://claude.com/claude-code)