### PR TITLE
fix: notification panel auto-sizes to content

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -38,6 +38,11 @@
 如果你想现在就开始做贡献，可以先加入微信群：
 
 <img src="docs/images/wechat-group.jpg" alt="Open Island 微信群二维码" width="360">
+  
+## 路线图
+
+4.6 发布测试版
+
 
 ## Agent Parts
 
@@ -152,13 +157,6 @@ swift run OpenIslandSetup uninstall
 - 更少的标签页来回寻找
 - 更少的会话感知摩擦
 - 更快地回到当前活跃 agent session
-
-## 路线图
-
-1. 先交付一个扎实的单 agent macOS MVP
-2. 强化 approvals 和 jump-back behavior
-3. 改进 multi-session handling
-4. 再逐步扩展到更多 agent integrations
 
 ## 贡献
 

--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -456,7 +456,7 @@ final class OverlayPanelController {
         if isNotificationMode {
             // Use SwiftUI-measured height when available (accurate after first render).
             if model.measuredNotificationContentHeight > 0 {
-                return model.measuredNotificationContentHeight + 8
+                return model.measuredNotificationContentHeight + 28
             }
             // First render: use generous height so content isn't clipped.
             // SwiftUI will measure actual height and trigger a resize.

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -469,13 +469,33 @@ struct IslandPanelView: View {
 
     private var sessionList: some View {
         TimelineView(.periodic(from: .now, by: 30)) { context in
-            ScrollView(.vertical) {
+            if isNotificationMode {
+                // Notification mode: NO ScrollView — content sizes naturally
                 sessionListContent(context: context)
+                    .padding(.vertical, 2)
+                    .background(
+                        GeometryReader { geo in
+                            Color.clear.preference(
+                                key: NotificationContentHeightKey.self,
+                                value: geo.size.height
+                            )
+                        }
+                    )
+                    .onPreferenceChange(NotificationContentHeightKey.self) { height in
+                        if height > 0 {
+                            model.measuredNotificationContentHeight = height
+                        }
+                    }
+            } else {
+                // List mode: scrollable
+                ScrollView(.vertical) {
+                    sessionListContent(context: context)
+                }
+                .scrollIndicators(.automatic, axes: .vertical)
+                .scrollContentBackground(.hidden)
+                .frame(maxHeight: Self.maxSessionListHeight)
+                .padding(.vertical, 2)
             }
-            .scrollIndicators(.automatic, axes: .vertical)
-            .scrollContentBackground(.hidden)
-            .frame(maxHeight: Self.maxSessionListHeight)
-            .padding(.vertical, 2)
         }
     }
 


### PR DESCRIPTION
通知模式从 ScrollView 中取出，内容自然撑高。GeometryReader 测量实际高度触发面板 resize。

🤖 Generated with [Claude Code](https://claude.com/claude-code)