### PR TITLE
fix: keep completed notification visible for 30s grace period

### DIFF
--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -375,12 +375,20 @@ public extension AgentSession {
         attachmentState.isLive
     }
 
+    /// Grace period after completion before the session becomes invisible.
+    /// Keeps the completed notification card visible long enough for the user to see it.
+    private static let completedVisibilityGrace: TimeInterval = 30
+
     /// New visibility rule based on process liveness (Phase 1: parallel, not yet driving UI).
     /// Will replace `isAttachedToTerminal` in Phase 3.
     var isVisibleInIsland: Bool {
         if isDemoSession { return true }
         if phase.requiresAttention { return true }
         if isProcessAlive { return true }
+        if phase == .completed,
+           Date.now.timeIntervalSince(updatedAt) < Self.completedVisibilityGrace {
+            return true
+        }
         return false
     }
 


### PR DESCRIPTION
## Summary
- Completed sessions were being removed by `removeInvisibleSessions()` during process monitoring cycles (every few seconds), causing the completion notification card to vanish before the 10s auto-collapse timer could fire
- Added a 30s grace period in `isVisibleInIsland` so completed sessions remain visible long enough for the notification to display and auto-collapse naturally

## Test plan
- [x] `swift build` passes
- [x] All 118 tests pass
- [ ] Manual: trigger a session completion and verify the notification stays visible for ~10s before auto-collapsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)