### PR TITLE
fix: process liveness tolerance for completed notification

### DIFF
--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -3,7 +3,7 @@ import OpenIslandCore
 
 struct ActiveAgentProcessDiscovery {
     private static let processCommandTimeout: TimeInterval = 0.5
-    private static let lsofCommandTimeout: TimeInterval = 0.2
+    private static let lsofCommandTimeout: TimeInterval = 0.5
 
     private final class OutputBox: @unchecked Sendable {
         var data = Data()

--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -273,8 +273,8 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
     public var isProcessAlive: Bool = false
 
     /// Number of consecutive reconciliation polls where the process was not found.
-    /// Reset to 0 when the process is found. When >= 2 (~6 seconds), the session
-    /// is considered gone. This prevents flicker from momentary `ps` gaps.
+    /// Reset to 0 when the process is found. When >= 3 (~9 seconds), the session
+    /// is considered gone. This prevents flicker from momentary `lsof`/`ps` gaps.
     public var processNotSeenCount: Int = 0
 
     public init(

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -285,7 +285,7 @@ public struct SessionState: Equatable, Sendable {
                 session.processNotSeenCount = 0
             } else {
                 session.processNotSeenCount += 1
-                session.isProcessAlive = session.processNotSeenCount < 1
+                session.isProcessAlive = session.processNotSeenCount < 3
             }
 
             if session.isProcessAlive != wasAlive {


### PR DESCRIPTION
## Summary
- `processNotSeenCount < 1` 导致一次 `lsof` 超时就判定进程死亡，实际上注释写的是 `>= 2` 才判死，代码和注释不一致
- 将阈值改为 `< 3`，需要连续 3 次匹配失败（~9 秒）才判定进程死亡
- 将 `lsof` 超时从 0.2s 提高到 0.5s，与 `ps` 超时一致，减少系统繁忙时的误判

## Root cause
这是一个**偶现问题**，取决于系统负载。Completed notification 快速消失是因��：`lsof` 在��统繁忙时偶尔超时 → 进程匹配���败 → `isProcessAlive` 立刻变 false → `removeInvisibleSessions()` 删除 session → notification card 找不到 session 关闭

## Test plan
- [x] `swift build` passes
- [x] All 118 tests pass
- [ ] Manual: 触发 session complete，确认 notification 稳定展示 10 秒后自动收起

Closes #53 (replaced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)