### PR TITLE
fix: strip markdown syntax from preview text, use plain Text for completion card

### DIFF
--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -350,6 +350,18 @@ extension AgentSession {
 
 private extension String {
     var trimmedForSurface: String {
-        trimmingCharacters(in: .whitespacesAndNewlines)
+        strippingMarkdownForSurface.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var strippingMarkdownForSurface: String {
+        var s = self
+        s = s.replacingOccurrences(of: "```[^`]*```", with: "", options: .regularExpression)
+        s = s.replacingOccurrences(of: "`([^`]+)`", with: "$1", options: .regularExpression)
+        s = s.replacingOccurrences(of: "\\*{1,3}(.+?)\\*{1,3}", with: "$1", options: .regularExpression)
+        s = s.replacingOccurrences(of: "_{1,3}(.+?)_{1,3}", with: "$1", options: .regularExpression)
+        s = s.replacingOccurrences(of: "(?m)^#{1,6}\\s+", with: "", options: .regularExpression)
+        s = s.replacingOccurrences(of: "\\[([^\\]]+)\\]\\([^)]+\\)", with: "$1", options: .regularExpression)
+        s = s.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+        return s
     }
 }

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1243,8 +1243,9 @@ private struct IslandSessionRow: View {
                 .frame(height: 1)
 
             AutoHeightScrollView(maxHeight: 260) {
-                Markdown(completionMessageText)
-                    .markdownTheme(.completionCard)
+                Text(completionMessageText.strippingMarkdownForPreview)
+                    .font(.system(size: 13.5, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.88))
                     .frame(maxWidth: .infinity, alignment: .topLeading)
                     .padding(.horizontal, 14)
                     .padding(.vertical, 10)
@@ -1566,6 +1567,25 @@ private struct StructuredQuestionPromptView: View {
 private extension String {
     var trimmedForNotificationCard: String {
         trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Strips common markdown syntax so text reads cleanly as plain text.
+    var strippingMarkdownForPreview: String {
+        var s = self
+        // Code blocks (``` ... ```) → remove
+        s = s.replacingOccurrences(of: "```[^`]*```", with: "", options: .regularExpression)
+        // Inline code `text` → text
+        s = s.replacingOccurrences(of: "`([^`]+)`", with: "$1", options: .regularExpression)
+        // Bold/italic markers
+        s = s.replacingOccurrences(of: "\\*{1,3}(.+?)\\*{1,3}", with: "$1", options: .regularExpression)
+        s = s.replacingOccurrences(of: "_{1,3}(.+?)_{1,3}", with: "$1", options: .regularExpression)
+        // Heading markers
+        s = s.replacingOccurrences(of: "(?m)^#{1,6}\\s+", with: "", options: .regularExpression)
+        // Links [text](url) → text
+        s = s.replacingOccurrences(of: "\\[([^\\]]+)\\]\\([^)]+\\)", with: "$1", options: .regularExpression)
+        // Collapse multiple whitespace/newlines
+        s = s.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+        return s.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
 


### PR DESCRIPTION
## Summary
- 完成卡片的 `Markdown()` 渲染替换为普通 `Text`，避免 MarkdownUI 渲染长文本时空白/延迟
- 预览文本和卡片列表活动文本都剥离 markdown 语法（反引号、粗体/斜体标记、标题、链接等），显示为干净的纯文本

## 备注
⚠️ 这是一个**偶现问题**，尚未稳定复现。当前版本大多数情况下正常工作。先保留 PR，等复现后再决定是否合入。

## Test plan
- [ ] 触发一个 Claude Code 会话完成，确认完成卡片正文正常显示
- [ ] 确认反引号 `code` 等 markdown 语法在预览文本中不再原样显示
- [ ] 尝试复现偶现的完成卡片空白问题

🤖 Generated with [Claude Code](https://claude.com/claude-code)