### PR TITLE
docs: add feature status tables and issue template to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,83 @@ This app may install hooks for Claude Code or Codex, so you may see hook-related
 
 TBD
 
+### Feature Status
+
+#### Supported Code Agents
+
+| Agent | Status | Description |
+|---|---|---|
+| **Claude Code** | Supported | Hook integration, JSONL session discovery, status line bridge, usage tracking |
+| **Codex** | Supported | Full hook integration (SessionStart, UserPromptSubmit, Stop), usage tracking |
+| **Cursor** | Planned | — |
+| **Windsurf** | Planned | — |
+
+#### Supported Terminals
+
+| Terminal | Status | Description |
+|---|---|---|
+| **Terminal.app** | Full Support | Jump-back with TTY targeting |
+| **Ghostty** | Full Support | Jump-back with ID matching |
+| **cmux** | Full Support | Jump-back via Unix socket API |
+| **iTerm2** | Partial | AppleScript session targeting |
+| **Warp** | Planned | Fallback detection only |
+| **WezTerm** | Planned | Fallback detection only |
+
+#### Other Features
+
+| Feature | Status | Description |
+|---|---|---|
+| Notch / Top-bar overlay | Supported | Notch area on notch Macs, top-center bar on others |
+| Control center | Supported | Hook status, usage dashboard |
+| Settings | Supported | General, Display, Sound, Shortcuts, Lab, About |
+| Notification mode | Supported | Auto-height panel for permission requests and session events |
+| Notification sounds | Supported | Configurable system sounds, mute toggle |
+| i18n | Supported | English, Simplified Chinese |
+| Session discovery | Supported | Auto-discover from local transcripts, persist across launches |
+| Process discovery | Supported | Match active agents via `ps`/`lsof` |
+| DMG packaging | Supported | Signing, notarization, GitHub Actions release workflow |
+| Auto-update | Planned | — |
+
 ## Community
 
 The project is still at an early stage — you may encounter issues along the way. Join the WeChat group or Discord for faster feedback and higher resolution priority.
 Issues and pull requests are always welcome. We are also looking for additional maintainers — Open Island is just the beginning. Come join us:
 
 <img src="docs/images/wechat-group.jpg" alt="Open Island WeChat group QR code" width="360">
+
+### Report a Bug via Your Code Agent
+
+If you run into a problem, copy the prompt below into your code agent (Claude Code, Codex, etc.) and it will automatically collect environment info and create a well-structured issue for you.
+
+<details>
+<summary>Click to expand the prompt</summary>
+
+```
+I'm having an issue with Open Island (https://github.com/Octane0411/open-vibe-island).
+
+Please help me file a GitHub issue. Do the following:
+
+1. Collect my environment info:
+   - Run `sw_vers` to get macOS version
+   - Run `swift --version` to get Swift version
+   - Check if Open Island is running: `ps aux | grep -i "open.island\|OpenIslandApp" | grep -v grep`
+   - Get the app version: `defaults read ~/Applications/Open\ Island\ Dev.app/Contents/Info.plist CFBundleShortVersionString 2>/dev/null || echo "unknown"`
+   - Check which terminal I'm using
+
+2. Ask me to describe:
+   - What I expected to happen
+   - What actually happened
+   - Steps to reproduce
+
+3. Create the issue on GitHub using `gh issue create` with this format:
+   - Title: concise summary
+   - Body with sections: **Environment**, **Description**, **Steps to Reproduce**, **Expected vs Actual Behavior**
+   - Add label "bug" if applicable
+
+Repository: Octane0411/open-vibe-island
+```
+
+</details>
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -48,17 +48,87 @@
 
 待补充
 
+### 功能状态
+
+#### 支持的 Code Agents
+
+| Agent | 状态 | 说明 |
+|---|---|---|
+| **Claude Code** | 已支持 | Hook 集成、JSONL 会话发现、status line bridge、用量追踪 |
+| **Codex** | 已支持 | 完整 hook 集成（SessionStart、UserPromptSubmit、Stop）、用量追踪 |
+| **opencode** | 规划中 | — |
+| **gemini cli** | 规划中 | — |
+
+#### 支持的终端
+
+| 终端 | 状态 | 说明 |
+|---|---|---|
+| **Terminal.app** | 完整支持 | Jump-back，TTY 定位 |
+| **Ghostty** | 完整支持 | Jump-back，ID 匹配 |
+| **cmux** | 完整支持 | Jump-back，Unix socket API |
+| **iTerm2** | 部分支持 | AppleScript 会话定位 |
+| **Warp** | 规划中 | 仅降级检测 |
+| **WezTerm** | 规划中 | 仅降级检测 |
+
+#### 其他功能
+
+| 功能 | 状态 | 说明 |
+|---|---|---|
+| 刘海 / 顶部栏覆盖层 | 已支持 | 刘海 Mac 在刘海区域，其他 Mac 顶部居中栏 |
+| 控制中心 | 已支持 | Hook 状态、用量仪表盘 |
+| 设置 | 已支持 | 通用、显示、声音、快捷键、实验室、关于 |
+| 完成通知 | 已支持 | 已支持claude code, codex |
+| 权限通知 | 已支持 | 已支持claude code, codex |
+| askUserQuestion通知 | 已支持 | 已支持claude code |
+| 通知音效 | 已支持 | 可配置系统音效、静音切换 |
+| 国际化 | 已支持 | English、简体中文 |
+| 自动更新 | 规划中 | — |
+
 ## 社区
 
 目前项目还在早期阶段，在体验中可能会出现任何问题，加入微信群/discord以获得更快的反馈和更高的解决优先级
-同时欢迎任意 issue 和 pull request，我们也在寻找其他maintainer，open island只是个开始，欢迎加入微信群：
+
+同时欢迎任意 issue 和 pull request，我们也在寻找其他maintainer，open island只是个开始，微信群：
 
 <img src="docs/images/wechat-group.jpg" alt="Open Island 微信群二维码" width="360">
-  
+
+### 通过 Code Agent 提交 Bug
+
+遇到问题？把下面的 prompt 复制到你的 code agent（Claude Code、Codex 等）中，它会自动收集环境信息并帮你创建一个规范的 issue。
+
+<details>
+<summary>点击展开 prompt</summary>
+
+```
+我在使用 Open Island (https://github.com/Octane0411/open-vibe-island) 时遇到了问题。
+
+请帮我提交一个 GitHub issue，按以下步骤操作：
+
+1. 收集我的环境信息：
+   - 运行 `sw_vers` 获取 macOS 版本
+   - 运行 `swift --version` 获取 Swift 版本
+   - 检查 Open Island 是否在运行：`ps aux | grep -i "open.island\|OpenIslandApp" | grep -v grep`
+   - 获取 app 版本：`defaults read ~/Applications/Open\ Island\ Dev.app/Contents/Info.plist CFBundleShortVersionString 2>/dev/null || echo "unknown"`
+   - 检查我当前使用的终端
+
+2. 询问我：
+   - 期望的行为是什么
+   - 实际发生了什么
+   - 复现步骤
+
+3. 使用 `gh issue create` 在 GitHub 上创建 issue，格式如下：
+   - 标题：简洁的问题概述
+   - 正文包含以下部分：**环境信息**、**问题描述**、**复现步骤**、**期望行为 vs 实际行为**
+   - 如果是 bug 请添加 "bug" 标签
+
+仓库：Octane0411/open-vibe-island
+```
+
+</details>
+
 ## 路线图
 
 4.6 发布测试版
-
 
 ---
 


### PR DESCRIPTION
## Summary
- 在中英文 README 中添加功能状态表格（支持的 Code Agents、终端、其他功能）
- 在社区部分添加 code agent issue 提交模板，用户复制 prompt 到 agent 中即可自动收集环境信息并创建规范 issue

## Test plan
- [ ] GitHub 上预览两个 README 表格渲染正常
- [ ] 确认 `<details>` 折叠块可展开

🤖 Generated with [Claude Code](https://claude.com/claude-code)