### PR TITLE
fix: hook status detection false positive on JSON format mismatch

### DIFF
--- a/Sources/OpenIslandCore/ClaudeHookInstallationManager.swift
+++ b/Sources/OpenIslandCore/ClaudeHookInstallationManager.swift
@@ -61,7 +61,7 @@ public final class ClaudeHookInstallationManager: @unchecked Sendable {
             settingsURL: settingsURL,
             manifestURL: manifestURL,
             hooksBinaryURL: resolvedHooksBinaryURL,
-            managedHooksPresent: uninstallMutation.changed,
+            managedHooksPresent: uninstallMutation.managedHooksPresent,
             hasClaudeIslandHooks: uninstallMutation.hasClaudeIslandHooks,
             manifest: manifest
         )

--- a/Sources/OpenIslandCore/ClaudeHookInstaller.swift
+++ b/Sources/OpenIslandCore/ClaudeHookInstaller.swift
@@ -143,7 +143,7 @@ public enum ClaudeHookInstaller {
         return ClaudeHookFileMutation(
             contents: contents,
             changed: mutated || contents != existingData,
-            managedHooksPresent: false,
+            managedHooksPresent: mutated,
             hasClaudeIslandHooks: containsClaudeIslandHook(in: hooksObject)
         )
     }


### PR DESCRIPTION
## Summary

- `ClaudeHookInstallationManager.status()` 使用 `uninstallMutation.changed` 判断 hooks 是否已安装
- `changed` 包含了 JSON 重新序列化的格式差异（如外部工具编辑后缩进/排序不同），导致即使 hooks 条目已清除，仍误报为"已安装"
- 改为使用 `uninstallMutation.managedHooksPresent`，仅当确实存在 managed hook 条目时才报告已安装

## Test plan

- [x] `ClaudeHooksTests` 全部 6 个测试通过
- [x] 本地验证：清除 settings.json 中的 hooks 后，app 应正确显示"未安装"

🤖 Generated with [Claude Code](https://claude.com/claude-code)