### PR TITLE
feat: uninstall hooks button with confirmation in Settings

### DIFF
--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -26,6 +26,12 @@
 "settings.general.cliHooks" = "CLI Hooks";
 "settings.general.activated" = "Activated";
 "settings.general.install" = "Install";
+"settings.general.uninstall" = "Uninstall";
+"settings.general.uninstallConfirmTitle" = "Uninstall Hooks?";
+"settings.general.uninstallConfirmAction" = "Uninstall";
+"settings.general.uninstallConfirmMessage.claude" = "This will remove Open Island hooks from Claude Code. You can reinstall them at any time.";
+"settings.general.uninstallConfirmMessage.codex" = "This will remove Open Island hooks from Codex. You can reinstall them at any time.";
+"settings.general.cancel" = "Cancel";
 "settings.general.language" = "Language";
 "settings.general.languageSystem" = "System";
 "settings.general.languageEnglish" = "English";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -26,6 +26,12 @@
 "settings.general.cliHooks" = "CLI Hooks";
 "settings.general.activated" = "已激活";
 "settings.general.install" = "安装";
+"settings.general.uninstall" = "卸载";
+"settings.general.uninstallConfirmTitle" = "确认卸载 Hooks？";
+"settings.general.uninstallConfirmAction" = "卸载";
+"settings.general.uninstallConfirmMessage.claude" = "这将从 Claude Code 中移除 Open Island 的 hooks。你可以随时重新安装。";
+"settings.general.uninstallConfirmMessage.codex" = "这将从 Codex 中移除 Open Island 的 hooks。你可以随时重新安装。";
+"settings.general.cancel" = "取消";
 "settings.general.language" = "语言";
 "settings.general.languageSystem" = "跟随系统";
 "settings.general.languageEnglish" = "English";

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -142,6 +142,8 @@ struct GeneralSettingsPane: View {
     var model: AppModel
 
     @State private var launchAtLogin = false
+    @State private var confirmingUninstallClaude = false
+    @State private var confirmingUninstallCodex = false
 
     private var lang: LanguageManager { model.lang }
 
@@ -183,11 +185,18 @@ struct GeneralSettingsPane: View {
                     Text("Claude Code")
                     Spacer()
                     if model.claudeHooksInstalled {
-                        HStack(spacing: 4) {
-                            Image(systemName: "checkmark.circle.fill")
-                                .foregroundStyle(.green)
-                            Text(lang.t("settings.general.activated"))
-                                .foregroundStyle(.secondary)
+                        HStack(spacing: 8) {
+                            HStack(spacing: 4) {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundStyle(.green)
+                                Text(lang.t("settings.general.activated"))
+                                    .foregroundStyle(.secondary)
+                            }
+                            Button(lang.t("settings.general.uninstall")) {
+                                confirmingUninstallClaude = true
+                            }
+                            .foregroundStyle(.red)
+                            .font(.caption)
                         }
                     } else {
                         Button(lang.t("settings.general.install")) {
@@ -196,16 +205,31 @@ struct GeneralSettingsPane: View {
                         .disabled(model.hooksBinaryURL == nil)
                     }
                 }
+                .alert(lang.t("settings.general.uninstallConfirmTitle"), isPresented: $confirmingUninstallClaude) {
+                    Button(lang.t("settings.general.uninstallConfirmAction"), role: .destructive) {
+                        model.uninstallClaudeHooks()
+                    }
+                    Button(lang.t("settings.general.cancel"), role: .cancel) {}
+                } message: {
+                    Text(lang.t("settings.general.uninstallConfirmMessage.claude"))
+                }
 
                 HStack {
                     Text("Codex")
                     Spacer()
                     if model.codexHooksInstalled {
-                        HStack(spacing: 4) {
-                            Image(systemName: "checkmark.circle.fill")
-                                .foregroundStyle(.green)
-                            Text(lang.t("settings.general.activated"))
-                                .foregroundStyle(.secondary)
+                        HStack(spacing: 8) {
+                            HStack(spacing: 4) {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundStyle(.green)
+                                Text(lang.t("settings.general.activated"))
+                                    .foregroundStyle(.secondary)
+                            }
+                            Button(lang.t("settings.general.uninstall")) {
+                                confirmingUninstallCodex = true
+                            }
+                            .foregroundStyle(.red)
+                            .font(.caption)
                         }
                     } else {
                         Button(lang.t("settings.general.install")) {
@@ -213,6 +237,14 @@ struct GeneralSettingsPane: View {
                         }
                         .disabled(model.hooksBinaryURL == nil)
                     }
+                }
+                .alert(lang.t("settings.general.uninstallConfirmTitle"), isPresented: $confirmingUninstallCodex) {
+                    Button(lang.t("settings.general.uninstallConfirmAction"), role: .destructive) {
+                        model.uninstallCodexHooks()
+                    }
+                    Button(lang.t("settings.general.cancel"), role: .cancel) {}
+                } message: {
+                    Text(lang.t("settings.general.uninstallConfirmMessage.codex"))
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Settings → CLI Hooks 已激活状态旁新增红色"卸载"按钮
- 点击卸载弹出确认对话框，防止误操作
- 中英文本地化支持

## Test plan

- [x] 编译通过
- [x] Dev app 验证：卸载按钮显示、确认弹窗、卸载执行均正常
- [x] 验证卸载后 `~/.claude/settings.json` 中 hooks 条目已清除

🤖 Generated with [Claude Code](https://claude.com/claude-code)