### PR TITLE
feat: setup guide window on launch when hooks are missing

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -127,6 +127,17 @@ final class AppModel {
     @ObservationIgnored
     var openSettingsWindow: (() -> Void)?
 
+    @ObservationIgnored
+    var openSetupGuideWindow: (() -> Void)?
+
+    /// Whether the setup guide window is currently presented.
+    var isSetupGuidePresented = false
+
+    /// Tracks whether hooks status has been loaded after startup so the
+    /// guide can be shown once the status is known.
+    @ObservationIgnored
+    private var hasCheckedHooksOnStartup = false
+
     var ignoresPointerExitDuringHarness = false
     var disablesOverlayEventMonitoringDuringHarness = false
 
@@ -391,6 +402,16 @@ final class AppModel {
             hooks.startClaudeUsageMonitoringIfNeeded()
             hooks.refreshCodexUsageState()
             hooks.startCodexUsageMonitoringIfNeeded()
+
+            // After hook status is loaded, check whether the setup guide
+            // should be presented. The refresh calls above schedule async
+            // Tasks that will set codexHookStatus / claudeHookStatus, so
+            // we wait briefly for them to settle.
+            Task { @MainActor [weak self] in
+                // Yield twice to let the refresh Tasks enqueue their results.
+                try? await Task.sleep(for: .milliseconds(500))
+                self?.checkHooksAndShowSetupGuideIfNeeded()
+            }
         } else {
             isResolvingInitialLiveSessions = false
         }
@@ -525,6 +546,29 @@ final class AppModel {
         }
 
         window.orderOut(nil)
+    }
+
+    // MARK: - Setup Guide
+
+    func showSetupGuide() {
+        isSetupGuidePresented = true
+        openSetupGuideWindow?()
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func dismissSetupGuide() {
+        isSetupGuidePresented = false
+    }
+
+    /// Called after hook status is first loaded. Shows the setup guide if
+    /// any hooks are missing. Only fires once per launch.
+    func checkHooksAndShowSetupGuideIfNeeded() {
+        guard !hasCheckedHooksOnStartup else { return }
+        hasCheckedHooksOnStartup = true
+
+        if !hooks.claudeHooksInstalled || !hooks.codexHooksInstalled {
+            showSetupGuide()
+        }
     }
 
     func toggleSoundMuted() {

--- a/Sources/OpenIslandApp/OpenIslandApp.swift
+++ b/Sources/OpenIslandApp/OpenIslandApp.swift
@@ -117,6 +117,12 @@ struct OpenIslandApp: App {
             }
         }
 
+        Window("Setup Guide", id: "setup-guide") {
+            SetupGuideWindowContent(model: appDelegate.model)
+        }
+        .windowResizability(.contentSize)
+        .windowStyle(.hiddenTitleBar)
+
         #if DEBUG
         WindowGroup("Open Island Debug") {
             ControlCenterView(model: appDelegate.model)
@@ -145,6 +151,21 @@ private struct SettingsWindowContent: View {
             .onAppear {
                 model.openSettingsWindow = { [openWindow] in
                     openWindow(id: "settings")
+                }
+            }
+    }
+}
+
+/// Injects `openWindow` for the setup guide window.
+private struct SetupGuideWindowContent: View {
+    var model: AppModel
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        SetupGuideView(model: model)
+            .onAppear {
+                model.openSetupGuideWindow = { [openWindow] in
+                    openWindow(id: "setup-guide")
                 }
             }
     }

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -120,6 +120,16 @@
 "debug.sessionList" = "Session List";
 "debug.sessionListActionable" = "Session List (Actionable)";
 
+/* Setup Guide */
+"setup.title" = "Welcome to Open Island";
+"setup.subtitle" = "Open Island needs CLI hooks installed to monitor your AI coding agents.";
+"setup.hookReady" = "Installed and ready";
+"setup.hookMissing" = "Not installed";
+"setup.binaryMissing" = "Hook binary not found. Build the project first.";
+"setup.installAll" = "Install All";
+"setup.skip" = "Skip";
+"setup.done" = "Done";
+
 /* Window Titles */
 "window.settings" = "Open Island Settings";
 "window.debug" = "Open Island Debug";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -120,6 +120,16 @@
 "debug.sessionList" = "会话列表";
 "debug.sessionListActionable" = "会话列表 (可操作)";
 
+/* Setup Guide */
+"setup.title" = "欢迎使用 Open Island";
+"setup.subtitle" = "Open Island 需要安装 CLI Hooks 来监控你的 AI 编程代理。";
+"setup.hookReady" = "已安装就绪";
+"setup.hookMissing" = "未安装";
+"setup.binaryMissing" = "未找到 Hook 二进制文件，请先构建项目。";
+"setup.installAll" = "全部安装";
+"setup.skip" = "跳过";
+"setup.done" = "完成";
+
 /* Window Titles */
 "window.settings" = "Open Island 设置";
 "window.debug" = "Open Island 调试";

--- a/Sources/OpenIslandApp/Views/SetupGuideView.swift
+++ b/Sources/OpenIslandApp/Views/SetupGuideView.swift
@@ -1,0 +1,159 @@
+import SwiftUI
+
+struct SetupGuideView: View {
+    var model: AppModel
+    @Environment(\.dismiss) private var dismiss
+
+    private var lang: LanguageManager { model.lang }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            VStack(spacing: 12) {
+                OpenIslandBrandMark(size: 64, style: .duotone)
+                Text(lang.t("setup.title"))
+                    .font(.title2.bold())
+                Text(lang.t("setup.subtitle"))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(.top, 32)
+            .padding(.bottom, 24)
+
+            Divider()
+
+            // Hook rows
+            VStack(spacing: 0) {
+                hookRow(
+                    name: "Claude Code",
+                    installed: model.claudeHooksInstalled,
+                    busy: model.isClaudeHookSetupBusy,
+                    binaryMissing: model.hooksBinaryURL == nil,
+                    installAction: { model.installClaudeHooks() }
+                )
+
+                Divider().padding(.horizontal, 20)
+
+                hookRow(
+                    name: "Codex",
+                    installed: model.codexHooksInstalled,
+                    busy: model.isCodexSetupBusy,
+                    binaryMissing: model.hooksBinaryURL == nil,
+                    installAction: { model.installCodexHooks() }
+                )
+            }
+            .padding(.vertical, 16)
+
+            if model.hooksBinaryURL == nil {
+                binaryMissingHint
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 8)
+            }
+
+            Spacer()
+
+            Divider()
+
+            // Footer buttons
+            HStack {
+                Button(lang.t("setup.skip")) {
+                    model.dismissSetupGuide()
+                    dismiss()
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+
+                Spacer()
+
+                if allHooksInstalled {
+                    Button(lang.t("setup.done")) {
+                        model.dismissSetupGuide()
+                        dismiss()
+                    }
+                    .buttonStyle(.borderedProminent)
+                } else {
+                    Button(lang.t("setup.installAll")) {
+                        installAllMissing()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(model.hooksBinaryURL == nil || anyBusy)
+                }
+            }
+            .padding(20)
+        }
+        .frame(width: 420, height: 400)
+        .preferredColorScheme(.dark)
+    }
+
+    // MARK: - Subviews
+
+    private func hookRow(
+        name: String,
+        installed: Bool,
+        busy: Bool,
+        binaryMissing: Bool,
+        installAction: @escaping () -> Void
+    ) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(name)
+                    .font(.body.weight(.medium))
+                Text(installed
+                     ? lang.t("setup.hookReady")
+                     : lang.t("setup.hookMissing"))
+                    .font(.caption)
+                    .foregroundStyle(installed ? .green : .secondary)
+            }
+
+            Spacer()
+
+            if installed {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                    .font(.title3)
+            } else if busy {
+                ProgressView()
+                    .controlSize(.small)
+            } else {
+                Button(lang.t("settings.general.install")) {
+                    installAction()
+                }
+                .disabled(binaryMissing)
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+    }
+
+    @ViewBuilder
+    private var binaryMissingHint: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.yellow)
+                .font(.caption)
+            Text(lang.t("setup.binaryMissing"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var allHooksInstalled: Bool {
+        model.claudeHooksInstalled && model.codexHooksInstalled
+    }
+
+    private var anyBusy: Bool {
+        model.isClaudeHookSetupBusy || model.isCodexSetupBusy
+    }
+
+    private func installAllMissing() {
+        if !model.claudeHooksInstalled {
+            model.installClaudeHooks()
+        }
+        if !model.codexHooksInstalled {
+            model.installCodexHooks()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- App 启动时检测 Claude Code / Codex hooks 安装状态，若任一缺失则弹出独立引导窗口
- 支持一键安装全部缺失 hooks，也支持逐个安装
- 支持跳过，不会阻塞 app 正常使用
- 中英文双语本地化

## 实现细节
- `SetupGuideView.swift` — 独立引导窗口，展示每个 agent 的 hook 状态和安装按钮
- `AppModel` 新增 `checkHooksAndShowSetupGuideIfNeeded()` — 在 hook 状态加载后触发检测
- `OpenIslandApp.swift` 新增 `Window("Setup Guide")` scene
- 复用已有 `HookInstallationCoordinator` 的安装逻辑

## Test plan
- [ ] 卸载 Claude/Codex hooks 后启动 app，验证引导窗口自动弹出
- [ ] 点击 "Install All" 验证两个 hooks 同时安装成功
- [ ] 点击 "Skip" 验证窗口关闭，app 正常运行
- [ ] 所有 hooks 已安装时启动 app，验证引导窗口不弹出
- [ ] 切换语言验证中英文显示正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)