### PR TITLE
fix: completion card content area intermittently blank

### DIFF
--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1109,7 +1109,7 @@ private struct IslandSessionRow: View {
             },
             alignment: .bottom
         )
-        .modifier(ConditionalDrawingGroup(enabled: useDrawingGroup))
+        .modifier(ConditionalDrawingGroup(enabled: useDrawingGroup && !isActionable))
         .contentShape(RoundedRectangle(cornerRadius: isActionable ? 24 : 22, style: .continuous))
         .onTapGesture(perform: handlePrimaryTap)
         .onHover { hovering in
@@ -1270,7 +1270,10 @@ private struct IslandSessionRow: View {
     }
 
     private var completionMessageText: String {
-        session.lastAssistantMessageText?.trimmedForNotificationCard ?? session.summary
+        if let text = session.lastAssistantMessageText?.trimmedForNotificationCard, !text.isEmpty {
+            return text
+        }
+        return session.summary
     }
 
     private var commandLabel: String {


### PR DESCRIPTION
## Summary
- 禁用 actionable 行卡片的 `drawingGroup()`，避免 MarkdownUI 在 Metal 纹理中偶现渲染失败
- 修复 `completionMessageText` 在 `lastAssistantMessageText` 为空字符串（非 nil）时不回退到 `session.summary` 的问题

## Root cause
1. **`drawingGroup()` + MarkdownUI 冲突**：`drawingGroup()` 将整个 `IslandSessionRow` 渲染为 Metal 纹理，已知会导致 MarkdownUI 的复杂视图层级偶现渲染空白。Actionable 行在通知模式下只有 1 张卡片，无性能顾虑，可安全禁用。
2. **空字符串未回退**：`completionMessageText` 使用 `?.trimmedForNotificationCard ?? session.summary`，当 `lastAssistantMessageText` 是 `""` 而非 `nil` 时，Optional 不为空，`??` 不触发回退。现在与 `spotlightActivityLineText` 保持一致的空值检查模式。

## Test plan
- [ ] 完成一个 Claude Code 会话，观察完成卡片是否正确显示助手回复
- [ ] 多次触发完成通知，确认不再偶现空白
- [ ] 确认非 actionable 行列表滚动性能无退化

🤖 Generated with [Claude Code](https://claude.com/claude-code)