### PR TITLE
fix: sign DMG and fix notarization order in package-app.sh

### DIFF
--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -21,6 +21,20 @@ security find-identity -v -p codesigning
 
 If that command reports `0 valid identities found`, packaging is limited to unsigned output until the certificate is created in the Apple Developer account and imported into the login keychain.
 
+### "Open Island is damaged and can't be opened"
+
+This Gatekeeper error appears when macOS quarantines an unsigned or un-notarized download. There are two workarounds:
+
+**Option 1 — remove quarantine (internal/dev use only):**
+
+```bash
+xattr -dr com.apple.quarantine "/Applications/Open Island.app"
+```
+
+Or right-click the app → **Open** → click **Open** to bypass the block once.
+
+**Option 2 — sign and notarize (required for external distribution):** follow the section below.
+
 ## Signing And Notarization
 
 When a signing identity is available, pass it in with environment variables:
@@ -30,9 +44,9 @@ OPEN_ISLAND_SIGN_IDENTITY="Developer ID Application: Your Name (TEAMID)" \
 zsh scripts/package-app.sh
 ```
 
-The script signs the helper binaries first, then signs the app bundle with the Apple Events entitlement declared in `config/packaging/OpenIslandApp.entitlements`.
+The script signs the helper binaries and app bundle, then also signs the DMG itself (required for notarization). Entitlements are declared in `config/packaging/OpenIslandApp.entitlements`.
 
-If a `notarytool` keychain profile is already stored, the same script can also notarize and staple:
+If a `notarytool` keychain profile is already stored, the same script notarizes and staples in the correct order (app bundle first so the stapled bundle is embedded in the DMG, then the DMG):
 
 ```bash
 OPEN_ISLAND_SIGN_IDENTITY="Developer ID Application: Your Name (TEAMID)" \

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -118,6 +118,14 @@ fi
 
 ditto -c -k --keepParent "$bundle_dir" "$zip_path"
 
+# --- Notarize app bundle (before DMG so the stapled bundle goes into the DMG) ---
+if [[ -n "$signing_identity" && -n "$notary_profile" ]]; then
+    xcrun notarytool submit "$zip_path" --keychain-profile "$notary_profile" --wait
+    xcrun stapler staple -v "$bundle_dir"
+    rm -f "$zip_path"
+    ditto -c -k --keepParent "$bundle_dir" "$zip_path"
+fi
+
 # --- Styled DMG creation ---
 dmg_bg="$repo_root/Assets/Brand/dmg-background@2x.png"
 
@@ -135,12 +143,17 @@ create-dmg \
     "$dmg_path" \
     "$bundle_dir"
 
-if [[ -n "$signing_identity" && -n "$notary_profile" ]]; then
-    xcrun notarytool submit "$zip_path" --keychain-profile "$notary_profile" --wait
-    xcrun stapler staple -v "$bundle_dir"
-    rm -f "$zip_path"
-    ditto -c -k --keepParent "$bundle_dir" "$zip_path"
+# Sign the DMG itself (required before notarization)
+if [[ -n "$signing_identity" ]]; then
+    codesign \
+        --force \
+        --sign "$signing_identity" \
+        --timestamp \
+        "$dmg_path"
+fi
 
+# Notarize and staple the DMG
+if [[ -n "$signing_identity" && -n "$notary_profile" ]]; then
     xcrun notarytool submit "$dmg_path" --keychain-profile "$notary_profile" --wait
     xcrun stapler staple -v "$dmg_path"
 fi


### PR DESCRIPTION
## Summary
- DMG was not being signed before notarization submission — Apple requires DMG to be codesigned with Developer ID before `notarytool submit`
- Fixed notarization order: app bundle is now notarized and stapled *before* the DMG is created, so the DMG contains the already-stapled bundle
- Added `xattr -dr com.apple.quarantine` workaround to `docs/packaging.md` for the \"Open Island is damaged\" Gatekeeper error on unsigned builds

## Test plan
- [ ] Run `zsh scripts/package-app.sh` without signing identity — produces unsigned bundle and DMG as before
- [ ] Run with `OPEN_ISLAND_SIGN_IDENTITY` only — verifies DMG is now also signed (`codesign -vvv output/package/Open\ Island.dmg`)
- [ ] Run with both `OPEN_ISLAND_SIGN_IDENTITY` and `OPEN_ISLAND_NOTARY_PROFILE` — verifies full notarize+staple flow completes without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)