### PR TITLE
fix: copy SPM resource bundle into app bundle to fix startup crash

### DIFF
--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -46,6 +46,15 @@ cp "$hooks_binary" "$bundle_dir/Contents/Helpers/OpenIslandHooks"
 cp "$setup_binary" "$bundle_dir/Contents/Helpers/OpenIslandSetup"
 cp "$brand_icon" "$bundle_dir/Contents/Resources/OpenIsland.icns"
 
+# Copy SPM resource bundle — required by Bundle.module at runtime (localization etc.).
+# SPM places it next to the executable in the build dir; we mirror that in the app bundle.
+spm_resource_bundle="$build_bin_dir/OpenIsland_OpenIslandApp.bundle"
+if [[ -d "$spm_resource_bundle" ]]; then
+    cp -R "$spm_resource_bundle" "$bundle_dir/Contents/MacOS/"
+else
+    echo "WARNING: SPM resource bundle not found at $spm_resource_bundle — app may crash on launch." >&2
+fi
+
 chmod +x \
     "$bundle_dir/Contents/MacOS/OpenIslandApp" \
     "$bundle_dir/Contents/Helpers/OpenIslandHooks" \


### PR DESCRIPTION
## Summary
- App crashed immediately on launch with `EXC_BREAKPOINT` in `Bundle.module` / `LanguageManager.init()`
- Root cause: `OpenIsland_OpenIslandApp.bundle` (SPM-generated resource bundle containing `.lproj` localization files) was not being copied into the packaged app bundle
- `Bundle.module` calls `_assertionFailure` when the bundle is missing — before any UI renders
- Fix: copy the bundle from `$build_bin_dir/OpenIsland_OpenIslandApp.bundle` into `Contents/MacOS/` (same location SPM uses during normal builds)

## Test plan
- [ ] Run `zsh scripts/package-app.sh`
- [ ] Verify `output/package/Open Island.app/Contents/MacOS/OpenIsland_OpenIslandApp.bundle` exists and contains `en.lproj` / `zh-hans.lproj`
- [ ] Install and launch the app — should open without crashing
- [ ] Test language switching in Settings to confirm localization works

🤖 Generated with [Claude Code](https://claude.com/claude-code)