### PR TITLE
fix: give dev app a separate socket path

### DIFF
--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -51,7 +51,7 @@ public final class BridgeServer: @unchecked Sendable {
     private var localState = SessionState()
 
     public init(
-        socketURL: URL = BridgeSocketLocation.defaultURL
+        socketURL: URL = BridgeSocketLocation.currentURL()
     ) {
         self.socketURL = socketURL
         queue.setSpecific(key: queueKey, value: ())

--- a/Sources/OpenIslandCore/LocalBridgeClient.swift
+++ b/Sources/OpenIslandCore/LocalBridgeClient.swift
@@ -11,7 +11,7 @@ public final class LocalBridgeClient: @unchecked Sendable {
     private var continuation: AsyncThrowingStream<AgentEvent, Error>.Continuation?
     private var buffer = Data()
 
-    public init(socketURL: URL = BridgeSocketLocation.defaultURL) {
+    public init(socketURL: URL = BridgeSocketLocation.currentURL()) {
         self.socketURL = socketURL
     }
 

--- a/scripts/launch-dev-app.sh
+++ b/scripts/launch-dev-app.sh
@@ -54,6 +54,8 @@ cat > "$plist_path" <<EOF
     <dict>
         <key>OPEN_ISLAND_HOOKS_BINARY</key>
         <string>$hooks_binary</string>
+        <key>OPEN_ISLAND_SOCKET_PATH</key>
+        <string>/tmp/open-island-dev-$(id -u).sock</string>
     </dict>
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>


### PR DESCRIPTION
## Summary
- `BridgeServer` 和 `LocalBridgeClient` 改用 `currentURL()` 替代 `defaultURL`，使其响应 `OPEN_ISLAND_SOCKET_PATH` 环境变量
- Dev app 的 `LSEnvironment` 新增 `OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-dev-{uid}.sock`
- Production app 继续使用默认 socket 路径 `/tmp/open-island-{uid}.sock`

两个 app 同时运行时不再争抢同一个 socket，解决 production app 收不到 hook 事件和 session 重复的问题。

## Test plan
- [ ] 同时运行 dev app 和 production app，确认各自使用不同 socket
- [ ] 验证 production app 能正常接收 hook 通知
- [ ] 验证 dev app 独立运行不影响 production app

🤖 Generated with [Claude Code](https://claude.com/claude-code)