### PR TITLE
fix: pass executableDirectory to HooksBinaryLocator so release DMG can find hooks binary

### DIFF
--- a/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
+++ b/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
@@ -83,7 +83,9 @@ final class SessionDiscoveryCoordinator {
             claudeRecordsNeedPrune: claudeRecords != allClaude,
             discoveredCodexRecords: discoveredCodex,
             discoveredClaudeSessions: discoveredClaude,
-            hooksBinaryURL: HooksBinaryLocator.locate()
+            hooksBinaryURL: HooksBinaryLocator.locate(
+                executableDirectory: Bundle.main.executableURL?.deletingLastPathComponent()
+            )
         )
     }
 


### PR DESCRIPTION
## Summary
- In `SessionDiscoveryCoordinator.loadStartupDiscoveryPayload()`, pass `executableDirectory: Bundle.main.executableURL?.deletingLastPathComponent()` to `HooksBinaryLocator.locate()`
- This allows the release DMG (where `OpenIslandHooks` lives at `Contents/Helpers/OpenIslandHooks`) to be found relative to the app executable at `Contents/MacOS/OpenIslandApp`
- Without this, fresh DMG installs had `hooksBinaryURL = nil`, which permanently disabled the Install buttons in Settings

## Root cause
`HooksBinaryLocator.locate()` already checks `executableDirectory?.deletingLastPathComponent().appendingPathComponent("Helpers/OpenIslandHooks")`, but `executableDirectory` defaulted to `nil` when called from the startup discovery task. The dev build worked because `launch-dev-app.sh` injects `OPEN_ISLAND_HOOKS_BINARY` via `LSEnvironment`, but the release Info.plist has no such entry.

## Test plan
- [ ] Build release bundle with `scripts/package-app.sh`, install from DMG, open Settings → General → CLI Hooks: both Install buttons should be enabled
- [ ] Dev build via `launch-dev-app.sh` still works (env var path takes priority)
- [ ] After first Install, managed binary at `~/Library/Application Support/OpenIsland/bin/OpenIslandHooks` is found on subsequent launches even without the bundled path

🤖 Generated with [Claude Code](https://claude.com/claude-code)