### PR TITLE
revert: remove dev app separate socket path

### DIFF
--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -51,7 +51,7 @@ public final class BridgeServer: @unchecked Sendable {
     private var localState = SessionState()
 
     public init(
-        socketURL: URL = BridgeSocketLocation.currentURL()
+        socketURL: URL = BridgeSocketLocation.defaultURL
     ) {
         self.socketURL = socketURL
         queue.setSpecific(key: queueKey, value: ())

--- a/Sources/OpenIslandCore/LocalBridgeClient.swift
+++ b/Sources/OpenIslandCore/LocalBridgeClient.swift
@@ -11,7 +11,7 @@ public final class LocalBridgeClient: @unchecked Sendable {
     private var continuation: AsyncThrowingStream<AgentEvent, Error>.Continuation?
     private var buffer = Data()
 
-    public init(socketURL: URL = BridgeSocketLocation.currentURL()) {
+    public init(socketURL: URL = BridgeSocketLocation.defaultURL) {
         self.socketURL = socketURL
     }
 

--- a/scripts/launch-dev-app.sh
+++ b/scripts/launch-dev-app.sh
@@ -54,8 +54,6 @@ cat > "$plist_path" <<EOF
     <dict>
         <key>OPEN_ISLAND_HOOKS_BINARY</key>
         <string>$hooks_binary</string>
-        <key>OPEN_ISLAND_SOCKET_PATH</key>
-        <string>/tmp/open-island-dev-$(id -u).sock</string>
     </dict>
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>


### PR DESCRIPTION
## Summary
- 回滚 #72 的改动
- `BridgeServer` 和 `LocalBridgeClient` 改回 `defaultURL`
- `launch-dev-app.sh` 删除 `OPEN_ISLAND_SOCKET_PATH` 环境变量

#72 的方案有缺陷：hook 二进制被 Claude Code 调用时环境里没有 `OPEN_ISLAND_SOCKET_PATH`，始终连默认 socket，导致 dev app 永远收不到 hook 通知。

## Test plan
- [ ] 只运行 dev app，确认能收到 hook 通知
- [ ] 只运行 production app，确认能收到 hook 通知

🤖 Generated with [Claude Code](https://claude.com/claude-code)