### PR TITLE
ci: add plutil lint for .strings files

### DIFF
--- a/scripts/harness.sh
+++ b/scripts/harness.sh
@@ -23,6 +23,10 @@ run_step() {
             echo "==> test"
             swift test
             ;;
+        lint)
+            echo "==> lint"
+            zsh "$repo_root/scripts/lint-strings.sh"
+            ;;
         build)
             echo "==> build"
             swift build
@@ -36,6 +40,7 @@ run_step() {
             zsh "$repo_root/scripts/smoke-all-scenarios.sh"
             ;;
         ci)
+            run_step lint
             run_step docs
             run_step test
             run_step build

--- a/scripts/lint-strings.sh
+++ b/scripts/lint-strings.sh
@@ -1,0 +1,27 @@
+#!/bin/zsh
+# Validates all .strings files with plutil to catch syntax errors
+# (unescaped quotes, bad Unicode, missing semicolons, etc.) early.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+failed=0
+
+while IFS= read -r file; do
+    if ! plutil -lint "$file" >/dev/null 2>&1; then
+        echo "FAIL: $file"
+        plutil -lint "$file" 2>&1 | sed 's/^/  /'
+        failed=1
+    fi
+done < <(find "$repo_root/Sources" -name '*.strings' -type f)
+
+if (( failed )); then
+    echo ""
+    echo "Localizable.strings validation failed. Common causes:"
+    echo "  - Chinese quotes "" inside values (use「」or \\\" instead)"
+    echo "  - Missing semicolons at end of lines"
+    echo "  - Unescaped backslashes or special characters"
+    exit 1
+fi
+
+echo "All .strings files passed validation."


### PR DESCRIPTION
## Summary
- 新增 `scripts/lint-strings.sh`，用 `plutil -lint` 校验所有 `.strings` 文件语法
- 集成到 `harness.sh ci` 流程中，作为第一步运行（lint → docs → test → build）
- 能在 CI 阶段提前发现中文引号、缺少分号等导致整个 locale 加载失败的问题

## 背景
#71 中 zh-Hans 的 `setup.permissionsDesc` 使用了中文引号 `""`，被 `.strings` 解析器误判为字符串分隔符，导致整个中文本地化失效。这个 lint 步骤可以在 CI 阶段拦截此类问题。

## Test plan
- [x] 所有现有 `.strings` 文件通过 `plutil -lint`
- [ ] 故意破坏一个 `.strings` 文件，验证 `harness.sh ci` 失败并给出清晰提示

🤖 Generated with [Claude Code](https://claude.com/claude-code)