### PR TITLE
fix: correct release template and add clean-user-env script

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -84,10 +84,10 @@ All release notes **must be bilingual** (English + Simplified Chinese). Use the 
 
    **Method 2 (Terminal) | 方法二（终端）：**
    ```bash
-   xattr -cr /Applications/Open\ Island.app
+   xattr -dr com.apple.quarantine "/Applications/Open Island.app"
    ```
 
-3. Requirements: **macOS 14+**, **Apple Silicon** (M1/M2/M3/M4).
+3. Requirements: **macOS 14+**, **Apple Silicon** (M1/M2/M3/M4/M5).
    系统要求：**macOS 14+**，**Apple Silicon**（M1/M2/M3/M4）。
 
 > ⚠️ **Note**: This is an unsigned early-access build. Code signing and notarization will be added once our Apple Developer account is approved.

--- a/scripts/clean-user-env.sh
+++ b/scripts/clean-user-env.sh
@@ -1,0 +1,168 @@
+#!/bin/zsh
+# clean-user-env.sh — Reset to a clean "new user" state for testing.
+# Usage: zsh scripts/clean-user-env.sh [--dry-run]
+#
+# This removes all Open Island (and legacy Vibe Island) artifacts from the
+# current user's environment, simulating a fresh install.
+
+set -euo pipefail
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+red()    { printf '\033[31m%s\033[0m\n' "$1"; }
+green()  { printf '\033[32m%s\033[0m\n' "$1"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$1"; }
+
+remove() {
+    local path="$1"
+    if [[ -e "$path" || -L "$path" ]]; then
+        if $DRY_RUN; then
+            yellow "[dry-run] would remove: $path"
+        else
+            rm -rf "$path"
+            green "removed: $path"
+        fi
+    fi
+}
+
+remove_glob() {
+    local pattern="$1"
+    for f in $~pattern(N); do
+        remove "$f"
+    done
+}
+
+echo "==> Quit Open Island if running"
+if ! $DRY_RUN; then
+    pkill -x OpenIslandApp 2>/dev/null || true
+    sleep 0.5
+fi
+
+uid="$(id -u)"
+
+echo ""
+echo "==> Cleaning Open Island artifacts"
+
+# --- Hook configurations ---
+echo "--- Hook configs ---"
+
+# Claude: remove Open Island hook entries from settings.json
+claude_settings=~/.claude/settings.json
+if [[ -f "$claude_settings" ]]; then
+    if $DRY_RUN; then
+        yellow "[dry-run] would strip OpenIsland hooks from: $claude_settings"
+    else
+        python3 -c "
+import json, sys, pathlib
+p = pathlib.Path(sys.argv[1])
+d = json.loads(p.read_text())
+hooks = d.get('hooks', {})
+changed = False
+for event in list(hooks.keys()):
+    original = hooks[event]
+    filtered = [h for h in original
+                if not any('OpenIslandHooks' in (c.get('command',''))
+                           for c in h.get('hooks',[]))]
+    if len(filtered) != len(original):
+        changed = True
+        if filtered:
+            hooks[event] = filtered
+        else:
+            del hooks[event]
+if changed:
+    if not hooks:
+        del d['hooks']
+    p.write_text(json.dumps(d, indent=2, ensure_ascii=False) + '\n')
+    print('stripped OpenIsland hooks from', sys.argv[1])
+" "$claude_settings" 2>/dev/null && green "cleaned hooks in $claude_settings" || true
+    fi
+fi
+remove ~/.claude/open-island-claude-hooks-install.json
+remove ~/.claude/vibe-island-claude-hooks-install.json
+remove_glob ~/.claude/'settings.json.backup.*'
+
+# Codex: remove Open Island entries from hooks.json
+codex_hooks=~/.codex/hooks.json
+if [[ -f "$codex_hooks" ]]; then
+    if $DRY_RUN; then
+        yellow "[dry-run] would strip OpenIsland hooks from: $codex_hooks"
+    else
+        python3 -c "
+import json, sys, pathlib
+p = pathlib.Path(sys.argv[1])
+d = json.loads(p.read_text())
+changed = False
+for event in list(d.keys()):
+    original = d[event]
+    if not isinstance(original, list): continue
+    filtered = [h for h in original
+                if not any('OpenIslandHooks' in c.get('command','')
+                           for c in h.get('hooks',[]))]
+    if len(filtered) != len(original):
+        changed = True
+        if filtered:
+            d[event] = filtered
+        else:
+            del d[event]
+if changed:
+    p.write_text(json.dumps(d, indent=2, ensure_ascii=False) + '\n')
+    print('stripped OpenIsland hooks from', sys.argv[1])
+" "$codex_hooks" 2>/dev/null && green "cleaned hooks in $codex_hooks" || true
+    fi
+fi
+remove ~/.codex/open-island-codex-hooks-install.json
+remove_glob ~/.codex/'config.toml.backup.*'
+remove_glob ~/.codex/'hooks.json.backup.*'
+
+# --- Installed hooks binary ---
+echo "--- Hooks binary ---"
+remove ~/Library/Application\ Support/OpenIsland
+remove ~/Library/Application\ Support/VibeIsland
+
+# --- Status line scripts ---
+echo "--- Status line ---"
+remove ~/.open-island
+remove ~/.vibe-island
+
+# --- Session registry & app data ---
+echo "--- App data ---"
+remove ~/Library/Application\ Support/open-island
+
+# --- Temp / socket files ---
+echo "--- Temp files ---"
+remove "/tmp/open-island-${uid}.sock"
+remove /tmp/open-island-rl.json
+remove /tmp/vibe-island-rl.json
+
+# --- Installed app ---
+echo "--- App bundle ---"
+remove /Applications/Open\ Island.app
+remove ~/Applications/Open\ Island.app
+remove ~/Applications/Open\ Island\ Dev.app
+
+# --- UserDefaults ---
+echo "--- UserDefaults ---"
+# Find the bundle ID used by the app
+for bid in app.openisland.dev app.vibeisland.dev; do
+    plist=~/Library/Preferences/${bid}.plist
+    if [[ -e "$plist" ]]; then
+        if $DRY_RUN; then
+            yellow "[dry-run] would remove defaults for: $bid"
+        else
+            defaults delete "$bid" 2>/dev/null || true
+            green "removed defaults: $bid"
+        fi
+    fi
+done
+
+echo ""
+if $DRY_RUN; then
+    yellow "Dry run complete. Re-run without --dry-run to actually clean."
+else
+    green "Done! Environment is clean."
+    echo ""
+    echo "Next steps:"
+    echo "  1. Install Open Island.dmg from the latest release"
+    echo "  2. Launch the app — you are now a fresh user"
+fi


### PR DESCRIPTION
## Summary
- 修正 releasing.md 模板中的 xattr 命令：`xattr -cr` → `xattr -dr com.apple.quarantine`
- Apple Silicon 芯片列表添加 M5
- 新增 `scripts/clean-user-env.sh` 一键清理脚本，重置为新用户状态便于测试

## Context
v0.1.0~v0.1.2 的 release notes 已同步修正。模板更新确保后续发版使用正确内容。

## Test plan
- [ ] `zsh scripts/clean-user-env.sh --dry-run` 正常列出所有清理项
- [ ] `zsh scripts/clean-user-env.sh` 执行后环境干净，重装 DMG 体验与新用户一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)