### PR TITLE
fix: clean script bugs and update install docs for unsigned app

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -71,24 +71,15 @@ All release notes **must be bilingual** (English + Simplified Chinese). Use the 
 1. Download **Open Island.dmg**, open it, and drag **Open Island** to **Applications**.
    下载 **Open Island.dmg**，打开后将 **Open Island** 拖入 **Applications**。
 
-2. On first launch, macOS Gatekeeper will block the unsigned app. Follow these steps:
-   首次启动时，macOS Gatekeeper 会阻止未签名应用。请按以下步骤操作：
+2. Since this is an unsigned app, macOS will show **"Open Island is damaged"** when you try to open it. Run this command in Terminal to fix it:
+   由于应用未签名，macOS 会提示**「"Open Island"已损坏」**。请在终端中执行以下命令：
 
-   **Method 1 (Recommended) | 方法一（推荐）：**
-   - Double-click to open the app → a warning dialog appears → click **Done**.
-     双击打开应用 → 弹出安全提示 → 点击**完成**。
-   - Go to **System Settings → Privacy & Security**, scroll down to find the blocked app message, click **Open Anyway**.
-     前往**系统设置 → 隐私与安全性**，向下滚动找到被阻止的应用提示，点击**仍要打开**。
-   - A confirmation dialog appears → click **Open Anyway** again, then enter your password.
-     再次弹出确认对话框 → 点击**仍要打开**，然后输入密码。
-
-   **Method 2 (Terminal) | 方法二（终端）：**
    ```bash
    xattr -dr com.apple.quarantine "/Applications/Open Island.app"
    ```
 
 3. Requirements: **macOS 14+**, **Apple Silicon** (M1/M2/M3/M4/M5).
-   系统要求：**macOS 14+**，**Apple Silicon**（M1/M2/M3/M4）。
+   系统要求：**macOS 14+**，**Apple Silicon**（M1/M2/M3/M4/M5）。
 
 > ⚠️ **Note**: This is an unsigned early-access build. Code signing and notarization will be added once our Apple Developer account is approved.
 > **注意**：这是未签名的早期测试版。代码签名和 Apple 公证将在 Developer 账号审核通过后添加。

--- a/scripts/clean-user-env.sh
+++ b/scripts/clean-user-env.sh
@@ -14,22 +14,22 @@ red()    { printf '\033[31m%s\033[0m\n' "$1"; }
 green()  { printf '\033[32m%s\033[0m\n' "$1"; }
 yellow() { printf '\033[33m%s\033[0m\n' "$1"; }
 
-remove() {
+clean_path() {
     local path="$1"
     if [[ -e "$path" || -L "$path" ]]; then
         if $DRY_RUN; then
             yellow "[dry-run] would remove: $path"
         else
-            rm -rf "$path"
+            /bin/rm -rf "$path"
             green "removed: $path"
         fi
     fi
 }
 
-remove_glob() {
+clean_glob() {
     local pattern="$1"
     for f in $~pattern(N); do
-        remove "$f"
+        clean_path "$f"
     done
 }
 
@@ -78,9 +78,9 @@ if changed:
 " "$claude_settings" 2>/dev/null && green "cleaned hooks in $claude_settings" || true
     fi
 fi
-remove ~/.claude/open-island-claude-hooks-install.json
-remove ~/.claude/vibe-island-claude-hooks-install.json
-remove_glob ~/.claude/'settings.json.backup.*'
+clean_path ~/.claude/open-island-claude-hooks-install.json
+clean_path ~/.claude/vibe-island-claude-hooks-install.json
+clean_glob ~/.claude/'settings.json.backup.*'
 
 # Codex: remove Open Island entries from hooks.json
 codex_hooks=~/.codex/hooks.json
@@ -92,9 +92,11 @@ if [[ -f "$codex_hooks" ]]; then
 import json, sys, pathlib
 p = pathlib.Path(sys.argv[1])
 d = json.loads(p.read_text())
+# Codex hooks.json nests events under a 'hooks' key
+hooks = d.get('hooks', d)
 changed = False
-for event in list(d.keys()):
-    original = d[event]
+for event in list(hooks.keys()):
+    original = hooks[event]
     if not isinstance(original, list): continue
     filtered = [h for h in original
                 if not any('OpenIslandHooks' in c.get('command','')
@@ -102,44 +104,44 @@ for event in list(d.keys()):
     if len(filtered) != len(original):
         changed = True
         if filtered:
-            d[event] = filtered
+            hooks[event] = filtered
         else:
-            del d[event]
+            del hooks[event]
 if changed:
     p.write_text(json.dumps(d, indent=2, ensure_ascii=False) + '\n')
     print('stripped OpenIsland hooks from', sys.argv[1])
 " "$codex_hooks" 2>/dev/null && green "cleaned hooks in $codex_hooks" || true
     fi
 fi
-remove ~/.codex/open-island-codex-hooks-install.json
-remove_glob ~/.codex/'config.toml.backup.*'
-remove_glob ~/.codex/'hooks.json.backup.*'
+clean_path ~/.codex/open-island-codex-hooks-install.json
+clean_glob ~/.codex/'config.toml.backup.*'
+clean_glob ~/.codex/'hooks.json.backup.*'
 
 # --- Installed hooks binary ---
 echo "--- Hooks binary ---"
-remove ~/Library/Application\ Support/OpenIsland
-remove ~/Library/Application\ Support/VibeIsland
+clean_path ~/Library/Application\ Support/OpenIsland
+clean_path ~/Library/Application\ Support/VibeIsland
 
 # --- Status line scripts ---
 echo "--- Status line ---"
-remove ~/.open-island
-remove ~/.vibe-island
+clean_path ~/.open-island
+clean_path ~/.vibe-island
 
 # --- Session registry & app data ---
 echo "--- App data ---"
-remove ~/Library/Application\ Support/open-island
+clean_path ~/Library/Application\ Support/open-island
 
 # --- Temp / socket files ---
 echo "--- Temp files ---"
-remove "/tmp/open-island-${uid}.sock"
-remove /tmp/open-island-rl.json
-remove /tmp/vibe-island-rl.json
+clean_path "/tmp/open-island-${uid}.sock"
+clean_path /tmp/open-island-rl.json
+clean_path /tmp/vibe-island-rl.json
 
 # --- Installed app ---
 echo "--- App bundle ---"
-remove /Applications/Open\ Island.app
-remove ~/Applications/Open\ Island.app
-remove ~/Applications/Open\ Island\ Dev.app
+clean_path /Applications/Open\ Island.app
+clean_path ~/Applications/Open\ Island.app
+clean_path ~/Applications/Open\ Island\ Dev.app
 
 # --- UserDefaults ---
 echo "--- UserDefaults ---"


### PR DESCRIPTION
## Summary
- 修复 `clean-user-env.sh` 三个 bug：`remove` 与 zsh 内置命令冲突、`rm` alias 导致失败、codex hooks.json 嵌套结构未正确解析
- 更新 `releasing.md` 安装说明：未签名 app 实际表现是"已损坏"而非 Gatekeeper 拦截，改为直接引导用户执行 `xattr` 命令

## Test plan
- [ ] `zsh scripts/clean-user-env.sh --dry-run` 正常列出所有清理项
- [ ] `zsh scripts/clean-user-env.sh` 能正确清理 codex hooks.json 中的 OpenIsland 条目

🤖 Generated with [Claude Code](https://claude.com/claude-code)