### PR TITLE
feat: add --skip-setup flag to launch-dev-app.sh

### DIFF
--- a/scripts/launch-dev-app.sh
+++ b/scripts/launch-dev-app.sh
@@ -2,6 +2,13 @@
 
 set -euo pipefail
 
+skip_setup=false
+for arg in "$@"; do
+  case "$arg" in
+    --skip-setup) skip_setup=true ;;
+  esac
+done
+
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 build_root="$repo_root/.build/arm64-apple-macosx/debug"
 app_binary="$build_root/OpenIslandApp"
@@ -20,7 +27,9 @@ swift build -c debug --product OpenIslandHooks
 swift build -c debug --product OpenIslandSetup
 
 python3 "$brand_script"
-"$setup_binary" install --hooks-binary "$hooks_binary"
+if [ "$skip_setup" = false ]; then
+  "$setup_binary" install --hooks-binary "$hooks_binary"
+fi
 
 mkdir -p "$bundle_dir/Contents/MacOS" "$bundle_dir/Contents/Resources"
 cp "$app_binary" "$bundle_binary"


### PR DESCRIPTION
## Summary
- 给 `launch-dev-app.sh` 添加 `--skip-setup` 参数，跳过自动安装 hooks 步骤
- 用于测试首次启动引导（Setup Guide）流程：`zsh scripts/launch-dev-app.sh --skip-setup`

## Test plan
- [ ] `zsh scripts/launch-dev-app.sh` 正常启动，hooks 自动安装
- [ ] `zsh scripts/launch-dev-app.sh --skip-setup` 启动时不安装 hooks，Setup Guide 弹出

🤖 Generated with [Claude Code](https://claude.com/claude-code)