### PR TITLE
fix: suppress duplicate/stale Codex completion notifications

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -719,6 +719,15 @@ final class AppModel {
         updateLastActionMessage: Bool = true,
         ingress: TrackedEventIngress = .bridge
     ) {
+        // Snapshot whether this session was already completed before applying
+        // the event. Used to suppress duplicate/stale completion notifications
+        // (e.g. rollout watcher re-discovering an old completion on startup,
+        // or producing a duplicate sessionCompleted that races with the bridge).
+        let wasAlreadyCompleted: Bool = {
+            guard case let .sessionCompleted(payload) = event else { return false }
+            return state.session(id: payload.sessionID)?.phase == .completed
+        }()
+
         state.apply(event)
         reconcileIslandSurfaceAfterStateChange()
         if ingress == .bridge {
@@ -736,6 +745,7 @@ final class AppModel {
         }
 
         if let surface = IslandSurface.notificationSurface(for: event),
+           !wasAlreadyCompleted,
            (ingress == .bridge || !isResolvingInitialLiveSessions),
            notchStatus == .closed || notchOpenReason == .notification {
             presentNotificationSurface(surface)


### PR DESCRIPTION
## Summary

- Codex 完成通知存在两个关联问题：每次启动 app 都会弹出一个早已完成的旧通知；实时完成时通知卡片不展示（只有音效和颜色变化）
- 根因：rollout watcher 每次初始化 observation 时从头读 JSONL，对已完成的 session 产生重复的 `sessionCompleted` 事件。实时场景下 bridge 和 rollout 同时产生完成事件，rollout 事件的 `presentNotificationSurface` bump 了 overlay transition generation，导致 bridge 的 Phase 2（实际显示面板）被 generation guard 跳过
- 修复：在 `applyTrackedEvent` 中，apply 事件前快照 session 是否已处于 `.completed` 状态，若是则抑制通知展示

## Test plan

- [x] `swift build` 通过
- [x] `swift test` 全部 118 个测试通过
- [ ] 启动 app 后不再弹出旧的 Codex 完成通知
- [ ] Codex 完成一轮对话后，通知卡片正常展示（音效 + 面板展开 + 完成内容）
- [ ] Claude Code 完成通知不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)