### PR TITLE
feat: add Setup tab in settings with auto-install on first launch

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -393,6 +393,7 @@ final class AppModel {
             hooks.refreshCodexUsageState()
             hooks.startCodexUsageMonitoringIfNeeded()
             updateChecker.checkIfNeeded()
+
         } else {
             isResolvingInitialLiveSessions = false
         }
@@ -764,6 +765,17 @@ final class AppModel {
 
         // Apply hooks binary URL.
         hooks.hooksBinaryURL = payload.hooksBinaryURL
+
+        // Auto-install missing hooks and usage bridge on first launch.
+        if payload.hooksBinaryURL != nil {
+            Task { @MainActor [weak self] in
+                try? await Task.sleep(for: .milliseconds(800))
+                guard let self else { return }
+                if !self.claudeHooksInstalled { self.installClaudeHooks() }
+                if !self.codexHooksInstalled { self.installCodexHooks() }
+                if !self.claudeUsageInstalled { self.installClaudeUsageBridge() }
+            }
+        }
 
         // Reconcile attachments and start monitoring (requires sessions to be loaded).
         monitoring.reconcileSessionAttachments()

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -49,6 +49,24 @@
 "settings.sound.mute" = "Mute";
 "settings.sound.selectSound" = "Select Sound";
 
+/* Settings - Setup */
+"settings.tab.setup" = "Setup";
+"setup.section.binary" = "Hook Binary";
+"setup.section.hooks" = "CLI Hooks";
+"setup.section.usage" = "Usage Bridge";
+"setup.section.permissions" = "Permissions";
+"setup.binaryReady" = "Ready";
+"setup.binaryMissing" = "Not found — build OpenIslandHooks first";
+"setup.hookReady" = "Hooks installed";
+"setup.hookMissing" = "Hooks not installed";
+"setup.usageBridge" = "Claude Usage Bridge";
+"setup.usageBridgeReady" = "Installed";
+"setup.usageBridgeDesc" = "Tracks Claude API usage locally";
+"setup.optional" = "Optional";
+"setup.permissionsTitle" = "Accessibility";
+"setup.permissionsDesc" = "Open Island may need Accessibility permission to detect terminal windows. Grant it in System Settings → Privacy & Security → Accessibility.";
+"setup.installAll" = "Install All";
+
 /* Settings - Placeholder */
 "settings.shortcuts.comingSoon" = "Keyboard shortcuts coming soon.";
 "settings.lab.comingSoon" = "Experimental features coming soon.";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -49,6 +49,24 @@
 "settings.sound.mute" = "静音";
 "settings.sound.selectSound" = "选择音效";
 
+/* Settings - Setup */
+"settings.tab.setup" = "安装引导";
+"setup.section.binary" = "Hook 二进制";
+"setup.section.hooks" = "CLI Hooks";
+"setup.section.usage" = "用量桥接";
+"setup.section.permissions" = "权限";
+"setup.binaryReady" = "就绪";
+"setup.binaryMissing" = "未找到 — 请先构建 OpenIslandHooks";
+"setup.hookReady" = "Hooks 已安装";
+"setup.hookMissing" = "Hooks 未安装";
+"setup.usageBridge" = "Claude 用量桥接";
+"setup.usageBridgeReady" = "已安装";
+"setup.usageBridgeDesc" = "在本地追踪 Claude API 用量";
+"setup.optional" = "可选";
+"setup.permissionsTitle" = "辅助功能";
+"setup.permissionsDesc" = "Open Island 可能需要辅助功能权限来检测终端窗口。请在「系统设置 → 隐私与安全性 → 辅助功能」中授权。";
+"setup.installAll" = "全部安装";
+
 /* Settings - Placeholder */
 "settings.shortcuts.comingSoon" = "快捷键设置即将推出。";
 "settings.lab.comingSoon" = "实验性功能即将推出。";

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -5,6 +5,7 @@ import OpenIslandCore
 
 enum SettingsTab: String, CaseIterable, Identifiable {
     case general
+    case setup
     case display
     case sound
     case shortcuts
@@ -16,6 +17,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     func label(_ lang: LanguageManager) -> String {
         switch self {
         case .general:   lang.t("settings.tab.general")
+        case .setup:     lang.t("settings.tab.setup")
         case .display:   lang.t("settings.tab.display")
         case .sound:     lang.t("settings.tab.sound")
         case .shortcuts: lang.t("settings.tab.shortcuts")
@@ -27,6 +29,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     var icon: String {
         switch self {
         case .general:   "gearshape.fill"
+        case .setup:     "arrow.down.circle.fill"
         case .display:   "textformat.size"
         case .sound:     "speaker.wave.2.fill"
         case .shortcuts: "keyboard.fill"
@@ -38,6 +41,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     var iconColor: Color {
         switch self {
         case .general:   .gray
+        case .setup:     .orange
         case .display:   .blue
         case .sound:     .green
         case .shortcuts: .gray
@@ -48,9 +52,9 @@ enum SettingsTab: String, CaseIterable, Identifiable {
 
     var section: SettingsSection {
         switch self {
-        case .general, .display, .sound: .system
-        case .shortcuts, .lab:           .advanced
-        case .about:                     .app
+        case .general, .setup, .display, .sound: .system
+        case .shortcuts, .lab:                   .advanced
+        case .about:                             .app
         }
     }
 }
@@ -123,6 +127,8 @@ struct SettingsView: View {
             switch selectedTab {
             case .general:
                 GeneralSettingsPane(model: model)
+            case .setup:
+                SetupSettingsPane(model: model)
             case .display:
                 DisplaySettingsPane(model: model)
             case .sound:
@@ -150,8 +156,6 @@ struct GeneralSettingsPane: View {
     var model: AppModel
 
     @State private var launchAtLogin = false
-    @State private var confirmingUninstallClaude = false
-    @State private var confirmingUninstallCodex = false
 
     private var lang: LanguageManager { model.lang }
 
@@ -188,73 +192,6 @@ struct GeneralSettingsPane: View {
                 Toggle(lang.t("settings.general.autoCollapse"), isOn: .constant(true))
             }
 
-            Section(lang.t("settings.general.cliHooks")) {
-                HStack {
-                    Text("Claude Code")
-                    Spacer()
-                    if model.claudeHooksInstalled {
-                        HStack(spacing: 8) {
-                            HStack(spacing: 4) {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .foregroundStyle(.green)
-                                Text(lang.t("settings.general.activated"))
-                                    .foregroundStyle(.secondary)
-                            }
-                            Button(lang.t("settings.general.uninstall")) {
-                                confirmingUninstallClaude = true
-                            }
-                            .foregroundStyle(.red)
-                            .font(.caption)
-                        }
-                    } else {
-                        Button(lang.t("settings.general.install")) {
-                            model.installClaudeHooks()
-                        }
-                        .disabled(model.hooksBinaryURL == nil)
-                    }
-                }
-                .alert(lang.t("settings.general.uninstallConfirmTitle"), isPresented: $confirmingUninstallClaude) {
-                    Button(lang.t("settings.general.uninstallConfirmAction"), role: .destructive) {
-                        model.uninstallClaudeHooks()
-                    }
-                    Button(lang.t("settings.general.cancel"), role: .cancel) {}
-                } message: {
-                    Text(lang.t("settings.general.uninstallConfirmMessage.claude"))
-                }
-
-                HStack {
-                    Text("Codex")
-                    Spacer()
-                    if model.codexHooksInstalled {
-                        HStack(spacing: 8) {
-                            HStack(spacing: 4) {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .foregroundStyle(.green)
-                                Text(lang.t("settings.general.activated"))
-                                    .foregroundStyle(.secondary)
-                            }
-                            Button(lang.t("settings.general.uninstall")) {
-                                confirmingUninstallCodex = true
-                            }
-                            .foregroundStyle(.red)
-                            .font(.caption)
-                        }
-                    } else {
-                        Button(lang.t("settings.general.install")) {
-                            model.installCodexHooks()
-                        }
-                        .disabled(model.hooksBinaryURL == nil)
-                    }
-                }
-                .alert(lang.t("settings.general.uninstallConfirmTitle"), isPresented: $confirmingUninstallCodex) {
-                    Button(lang.t("settings.general.uninstallConfirmAction"), role: .destructive) {
-                        model.uninstallCodexHooks()
-                    }
-                    Button(lang.t("settings.general.cancel"), role: .cancel) {}
-                } message: {
-                    Text(lang.t("settings.general.uninstallConfirmMessage.codex"))
-                }
-            }
         }
         .formStyle(.grouped)
         .navigationTitle(lang.t("settings.tab.general"))
@@ -367,6 +304,150 @@ struct AboutSettingsPane: View {
         }
         .frame(maxWidth: .infinity)
         .navigationTitle(lang.t("settings.tab.about"))
+    }
+}
+
+// MARK: - Setup
+
+struct SetupSettingsPane: View {
+    var model: AppModel
+
+    @State private var confirmingUninstallClaude = false
+    @State private var confirmingUninstallCodex = false
+
+    private var lang: LanguageManager { model.lang }
+
+    var body: some View {
+        Form {
+            Section(lang.t("setup.section.hooks")) {
+                hookRow(
+                    name: "Claude Code",
+                    installed: model.claudeHooksInstalled,
+                    busy: model.isClaudeHookSetupBusy,
+                    installAction: { model.installClaudeHooks() },
+                    uninstallAction: { confirmingUninstallClaude = true }
+                )
+                .alert(lang.t("settings.general.uninstallConfirmTitle"), isPresented: $confirmingUninstallClaude) {
+                    Button(lang.t("settings.general.uninstallConfirmAction"), role: .destructive) {
+                        model.uninstallClaudeHooks()
+                    }
+                    Button(lang.t("settings.general.cancel"), role: .cancel) {}
+                } message: {
+                    Text(lang.t("settings.general.uninstallConfirmMessage.claude"))
+                }
+
+                hookRow(
+                    name: "Codex",
+                    installed: model.codexHooksInstalled,
+                    busy: model.isCodexSetupBusy,
+                    installAction: { model.installCodexHooks() },
+                    uninstallAction: { confirmingUninstallCodex = true }
+                )
+                .alert(lang.t("settings.general.uninstallConfirmTitle"), isPresented: $confirmingUninstallCodex) {
+                    Button(lang.t("settings.general.uninstallConfirmAction"), role: .destructive) {
+                        model.uninstallCodexHooks()
+                    }
+                    Button(lang.t("settings.general.cancel"), role: .cancel) {}
+                } message: {
+                    Text(lang.t("settings.general.uninstallConfirmMessage.codex"))
+                }
+            }
+
+            Section {
+                HStack {
+                    Label(lang.t("setup.usageBridge"), systemImage: "chart.bar")
+                    Spacer()
+                    if model.claudeUsageInstalled {
+                        HStack(spacing: 4) {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(.green)
+                            Text(lang.t("setup.usageBridgeReady"))
+                                .foregroundStyle(.secondary)
+                        }
+                    } else if model.isClaudeUsageSetupBusy {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Button(lang.t("settings.general.install")) {
+                            model.installClaudeUsageBridge()
+                        }
+                    }
+                }
+            } header: {
+                HStack(spacing: 4) {
+                    Text(lang.t("setup.section.usage"))
+                    Text(lang.t("setup.optional"))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+
+            Section(lang.t("setup.section.permissions")) {
+                HStack(alignment: .top) {
+                    Label {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(lang.t("setup.permissionsTitle"))
+                            Text(lang.t("setup.permissionsDesc"))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    } icon: {
+                        Image(systemName: "lock.shield")
+                    }
+                    Spacer()
+                }
+            }
+
+            Section {
+                Button(lang.t("setup.installAll")) {
+                    if !model.claudeHooksInstalled { model.installClaudeHooks() }
+                    if !model.codexHooksInstalled { model.installCodexHooks() }
+                    if !model.claudeUsageInstalled { model.installClaudeUsageBridge() }
+                }
+                .disabled(model.hooksBinaryURL == nil || allReady)
+                .frame(maxWidth: .infinity, alignment: .center)
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle(lang.t("settings.tab.setup"))
+    }
+
+    private var allReady: Bool {
+        model.claudeHooksInstalled && model.codexHooksInstalled && model.claudeUsageInstalled
+    }
+
+    @ViewBuilder
+    private func hookRow(
+        name: String,
+        installed: Bool,
+        busy: Bool,
+        installAction: @escaping () -> Void,
+        uninstallAction: @escaping () -> Void
+    ) -> some View {
+        HStack {
+            Label(name, systemImage: "terminal")
+            Spacer()
+            if installed {
+                HStack(spacing: 8) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                        Text(lang.t("settings.general.activated"))
+                            .foregroundStyle(.secondary)
+                    }
+                    Button(lang.t("settings.general.uninstall")) {
+                        uninstallAction()
+                    }
+                    .foregroundStyle(.red)
+                    .font(.caption)
+                }
+            } else if busy {
+                ProgressView().controlSize(.small)
+            } else {
+                Button(lang.t("settings.general.install")) {
+                    installAction()
+                }
+                .disabled(model.hooksBinaryURL == nil)
+            }
+        }
     }
 }
 

--- a/scripts/clean-user-env.sh
+++ b/scripts/clean-user-env.sh
@@ -70,11 +70,15 @@ for event in list(hooks.keys()):
             hooks[event] = filtered
         else:
             del hooks[event]
+sl = d.get('statusLine', {})
+if 'open-island' in sl.get('command', '') or 'vibe-island' in sl.get('command', ''):
+    del d['statusLine']
+    changed = True
 if changed:
-    if not hooks:
+    if not hooks and 'hooks' in d:
         del d['hooks']
     p.write_text(json.dumps(d, indent=2, ensure_ascii=False) + '\n')
-    print('stripped OpenIsland hooks from', sys.argv[1])
+    print('stripped OpenIsland hooks/statusLine from', sys.argv[1])
 " "$claude_settings" 2>/dev/null && green "cleaned hooks in $claude_settings" || true
     fi
 fi

--- a/scripts/launch-dev-app.sh
+++ b/scripts/launch-dev-app.sh
@@ -2,6 +2,13 @@
 
 set -euo pipefail
 
+skip_setup=false
+for arg in "$@"; do
+  case "$arg" in
+    --skip-setup) skip_setup=true ;;
+  esac
+done
+
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 build_root="$repo_root/.build/arm64-apple-macosx/debug"
 app_binary="$build_root/OpenIslandApp"
@@ -20,12 +27,21 @@ swift build -c debug --product OpenIslandHooks
 swift build -c debug --product OpenIslandSetup
 
 python3 "$brand_script"
-"$setup_binary" install --hooks-binary "$hooks_binary"
+if [ "$skip_setup" = false ]; then
+  "$setup_binary" install --hooks-binary "$hooks_binary"
+fi
 
 mkdir -p "$bundle_dir/Contents/MacOS" "$bundle_dir/Contents/Resources"
 cp "$app_binary" "$bundle_binary"
 cp "$brand_icon" "$bundle_dir/Contents/Resources/OpenIsland.icns"
 chmod +x "$bundle_binary"
+
+# Copy SPM resource bundle so Bundle.module can find localized strings.
+resource_bundle="$build_root/OpenIsland_OpenIslandApp.bundle"
+if [ -d "$resource_bundle" ]; then
+    rm -rf "$bundle_dir/OpenIsland_OpenIslandApp.bundle"
+    cp -R "$resource_bundle" "$bundle_dir/"
+fi
 
 cat > "$plist_path" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary
- 在设置页新增 **安装引导（Setup）** tab，集中展示 hooks、用量桥接、权限状态，提供安装/卸载操作
- 将 CLI Hooks 从通用页移至 Setup tab
- App 启动时自动安装缺失的 hooks 和 usage bridge（新用户首次启动即可用）
- `launch-dev-app.sh` 新增 `--skip-setup` 参数用于测试新用户流程
- 修复 `clean-user-env.sh` 未清理 statusLine 配置的问题
- 修复 `launch-dev-app.sh` resource bundle 未更新的问题

## Test plan
- [ ] `zsh scripts/clean-user-env.sh && zsh scripts/launch-dev-app.sh --skip-setup` 模拟新用户，确认 hooks 自动安装
- [ ] 设置页 Setup tab 显示正确状态，安装/卸载按钮可用
- [ ] 通用页不再显示 CLI Hooks section

🤖 Generated with [Claude Code](https://claude.com/claude-code)