### PR TITLE
fix: prevent Codex completion notification from flashing and disappearing

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -729,6 +729,17 @@ final class AppModel {
             return state.session(id: payload.sessionID)?.phase == .completed
         }()
 
+        // Guard: don't let rollout events downgrade a session from completed
+        // back to running. The bridge's sessionCompleted is authoritative; the
+        // rollout watcher may have read the JSONL before task_complete was
+        // flushed, producing a stale activityUpdated(phase: .running).
+        if ingress == .rollout,
+           case let .activityUpdated(payload) = event,
+           payload.phase == .running,
+           state.session(id: payload.sessionID)?.phase == .completed {
+            return
+        }
+
         state.apply(event)
         reconcileIslandSurfaceAfterStateChange()
         if ingress == .bridge {
@@ -747,6 +758,7 @@ final class AppModel {
 
         if let surface = IslandSurface.notificationSurface(for: event),
            !wasAlreadyCompleted,
+           surface.sessionID.flatMap({ state.session(id: $0) }) != nil,
            (ingress == .bridge || !isResolvingInitialLiveSessions),
            notchStatus == .closed || notchOpenReason == .notification {
             presentNotificationSurface(surface)

--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -260,8 +260,12 @@ final class OverlayUICoordinator {
     }
 
     var autoCollapseOnMouseLeaveRequiresPriorSurfaceEntry: Bool {
-        notchOpenReason == .notification
-            && islandSurface.autoDismissesWhenPresentedAsNotification(session: activeIslandCardSession)
+        guard notchOpenReason == .notification else { return false }
+        // If the session was removed from state (e.g. by process monitoring),
+        // default to requiring prior surface entry — prevents the notification
+        // from closing immediately on pointer exit before the user sees it.
+        guard let session = activeIslandCardSession else { return true }
+        return islandSurface.autoDismissesWhenPresentedAsNotification(session: session)
     }
 
     var showsNotificationCard: Bool {
@@ -346,7 +350,13 @@ final class OverlayUICoordinator {
         }
 
         notificationAutoCollapseTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .seconds(Self.notificationSurfaceAutoCollapseDelay))
+            do {
+                try await Task.sleep(for: .seconds(Self.notificationSurfaceAutoCollapseDelay))
+            } catch {
+                // Task was cancelled (e.g. a new event reset the timer).
+                // Do NOT proceed — the replacement task owns the new timer.
+                return
+            }
 
             guard let self,
                   self.notchStatus == .opened,

--- a/Sources/OpenIslandCore/CodexSessionTracking.swift
+++ b/Sources/OpenIslandCore/CodexSessionTracking.swift
@@ -655,6 +655,15 @@ public enum CodexRolloutReducer {
             return
         }
 
+        // After task_complete, trailing response_item entries (function_call
+        // results still being flushed) should not reset the completion state.
+        guard !snapshot.isCompleted else {
+            if let timestamp {
+                snapshot.updatedAt = timestamp
+            }
+            return
+        }
+
         snapshot.currentTool = toolName
         snapshot.currentCommandPreview = commandPreview(for: toolName, payload: payload)
         snapshot.phase = .running
@@ -692,12 +701,18 @@ public enum CodexRolloutReducer {
         to snapshot: inout CodexRolloutSnapshot
     ) {
         snapshot.lastAssistantMessage = message
-        snapshot.currentTool = nil
-        snapshot.currentCommandPreview = nil
         snapshot.summary = message
-        snapshot.phase = .running
-        snapshot.isCompleted = false
-        snapshot.isInterrupted = false
+
+        // After task_complete, the JSONL may still contain trailing
+        // response_item entries (the final assistant message). These should
+        // update content but NOT reset the completion state — only a new
+        // user prompt (applyUserMessage) starts a fresh turn.
+        if !snapshot.isCompleted {
+            snapshot.currentTool = nil
+            snapshot.currentCommandPreview = nil
+            snapshot.phase = .running
+            snapshot.isInterrupted = false
+        }
 
         if let timestamp {
             snapshot.updatedAt = timestamp


### PR DESCRIPTION
## Summary

- Codex 完成通知一闪即消，Claude Code 通知正常
- 根因：Codex JSONL 中 `task_complete` 之后可能还有 `response_item`（assistant message / function call result）被 flush 出来。rollout reducer 的 `applyAssistantMessage` 和 `applyResponseItem` 的 function_call 分支无条件重置 `isCompleted=false, phase=.running`，导致 rollout watcher 产生 `activityUpdated(phase: .running)` 事件，把 session phase 改回 running → `reconcileIslandSurfaceAfterStateChange` 发现 phase 与 completion notification 不匹配 → 立即关闭通知
- 修复：在 `applyAssistantMessage` 和 `applyResponseItem` 的 function_call 分支中增加 `!snapshot.isCompleted` 守卫，与已有的 `exec_command_end` / `patch_apply_end` 保持一致。只有 `applyUserMessage`（真正的新一轮对话）才重置完成状态

## Test plan

- [x] `swift build` 通过
- [x] `swift test` 全部 118 个测试通过
- [ ] Codex 完成一轮对话后，通知卡片稳定展示不再闪退
- [ ] Claude Code 完成通知不受影响
- [ ] Codex 完成后用户输入新 prompt 时，session 正常恢复为 running 状态

🤖 Generated with [Claude Code](https://claude.com/claude-code)