### PR TITLE
fix: copy SPM resource bundle to .app root to prevent launch crash

### DIFF
--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -47,10 +47,11 @@ cp "$setup_binary" "$bundle_dir/Contents/Helpers/OpenIslandSetup"
 cp "$brand_icon" "$bundle_dir/Contents/Resources/OpenIsland.icns"
 
 # Copy SPM resource bundle — required by Bundle.module at runtime (localization etc.).
-# SPM places it next to the executable in the build dir; we mirror that in the app bundle.
+# SPM's generated accessor looks for it at Bundle.main.bundleURL (the .app root),
+# so it must be copied there — NOT into Contents/MacOS/.
 spm_resource_bundle="$build_bin_dir/OpenIsland_OpenIslandApp.bundle"
 if [[ -d "$spm_resource_bundle" ]]; then
-    cp -R "$spm_resource_bundle" "$bundle_dir/Contents/MacOS/"
+    cp -R "$spm_resource_bundle" "$bundle_dir/"
 else
     echo "WARNING: SPM resource bundle not found at $spm_resource_bundle — app may crash on launch." >&2
 fi


### PR DESCRIPTION
## Summary
- `package-app.sh` 将 SPM 资源 bundle 复制到了 `Contents/MacOS/`，但 SPM 生成的 `Bundle.module` accessor 在 `Bundle.main.bundleURL`（即 `.app` 根目录）搜索资源
- 在分发的 app 中，两个搜索路径都找不到资源 bundle，导致 `fatalError` 崩溃
- Mac Mini M4 用户报告打开即崩溃（`EXC_BREAKPOINT` in `NSBundle.module` static init）
- 修复：将复制目标改为 `.app` 根目录，与 `launch-dev-app.sh` 的正确做法保持一致

## Test plan
- [ ] 运行 `scripts/package-app.sh` 打包
- [ ] 确认 `Open Island.app/OpenIsland_OpenIslandApp.bundle` 存在（而非 `Contents/MacOS/` 下）
- [ ] 在无 notch 的 Mac（如 Mac Mini）上启动验证不再崩溃

🤖 Generated with [Claude Code](https://claude.com/claude-code)