### PR TITLE
fix: correct GitHub repo URL in UpdateChecker

### DIFF
--- a/Sources/OpenIslandApp/UpdateChecker.swift
+++ b/Sources/OpenIslandApp/UpdateChecker.swift
@@ -4,10 +4,10 @@ import Foundation
 @MainActor
 @Observable
 final class UpdateChecker {
-    static let releasesURL = URL(string: "https://github.com/nicepkg/open-island/releases")!
+    static let releasesURL = URL(string: "https://github.com/Octane0411/open-vibe-island/releases")!
     private static let checkInterval: TimeInterval = 1 * 60 * 60 // 1 hour
 
-    private static let apiEndpoint = "https://api.github.com/repos/nicepkg/open-island/releases/latest"
+    private static let apiEndpoint = "https://api.github.com/repos/Octane0411/open-vibe-island/releases/latest"
 
     enum State: Equatable {
         case idle


### PR DESCRIPTION
## Summary
- `UpdateChecker` 里的 GitHub release API 地址和 releases 页面 URL 写的是不存在的 `nicepkg/open-island`，导致更新检查始终 404 失败
- 修正为实际仓库 `Octane0411/open-vibe-island`，更新提示功能恢复正常

## Test plan
- [ ] 启动 app，打开设置页，确认能看到更新提示（本地版本 0.1 < 远端 0.1.5）
- [ ] 点击更新链接，确认跳转到正确的 releases 页面

🤖 Generated with [Claude Code](https://claude.com/claude-code)