### PR TITLE
fix: prevent phantom notification sound when panel open races with mouse click

### DIFF
--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -300,8 +300,29 @@ final class OverlayUICoordinator {
             return
         }
 
-        NotificationSoundService.playNotification(isMuted: isSoundMuted)
+        // Skip sound when a notification is already showing for the same session
+        // (e.g. permission denied → sessionCompleted while the card is still open).
+        let shouldPlaySound = !(notchStatus == .opened
+            && notchOpenReason == .notification
+            && islandSurface.sessionID == surface.sessionID)
+
         notchOpen(reason: .notification, surface: surface)
+
+        // Defer sound to after the panel transition is confirmed. Playing it
+        // synchronously before `notchOpen` causes phantom sounds when a mouse
+        // click races with the async Phase 2 panel show — the click triggers
+        // `notchClose` (because the panel frame hasn't expanded yet), the
+        // generation guard cancels the open, and the user hears a sound with
+        // no visible notification. By gating on the same generation, the sound
+        // only plays when the panel actually appears.
+        if shouldPlaySound {
+            let capturedGeneration = overlayTransitionGeneration
+            DispatchQueue.main.async { [weak self] in
+                guard let self,
+                      self.overlayTransitionGeneration == capturedGeneration else { return }
+                NotificationSoundService.playNotification(isMuted: self.isSoundMuted)
+            }
+        }
     }
 
     func reconcileIslandSurfaceAfterStateChange() {


### PR DESCRIPTION
## Summary

修复偶发的"通知音效响了但看不到通知卡片"的 bug。

**根因**：`presentNotificationSurface` 中音效是同步播放的，但面板展开是异步的（`transitionOverlay` 的 Phase 2 通过 `DispatchQueue.main.async` 执行）。在 Phase 1（设置 `notchStatus = .opened`）和 Phase 2（实际展开面板 frame）之间存在一个短暂窗口：
1. 事件监视器的 `handleMouseDown` 检测到 `notchStatus == .opened`
2. 但面板 frame 还是 closed 大小，所以点击位置在面板外
3. 触发 `notchClose()`，generation 增加
4. Phase 2 的 generation 检查失败，面板不展开
5. 音效已经播放 → 用户听到音效但看不到通知

**修复**：将音效播放延迟到与面板展开相同的异步 dispatch 中，并使用相同的 generation 检查保护。如果面板展开被取消，音效也同步被取消。同时也修复了同一个 session 的通知卡片已展示时重复播放音效的问题。

## Test plan

- [x] `swift build` 通过
- [x] 全部 118 个测试通过
- [ ] 手动测试：在终端中快速点击时触发通知 → 不应再出现"只有音效没有弹窗"的情况
- [ ] 手动测试：正常通知仍应有音效伴随弹窗

🤖 Generated with [Claude Code](https://claude.com/claude-code)