### PR TITLE
chore: add v0.1.6 to Sparkle appcast

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -6,5 +6,18 @@
         <description>Most recent changes with links to updates.</description>
         <language>en</language>
         <!-- Items are added by the release workflow. See docs/releasing.md. -->
+        <item>
+            <title>Version 0.1.6</title>
+            <sparkle:version>1</sparkle:version>
+            <sparkle:shortVersionString>0.1.6</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+            <pubDate>Sun, 06 Apr 2026 00:00:00 +0000</pubDate>
+            <enclosure
+                url="https://github.com/Octane0411/open-vibe-island/releases/download/v0.1.6/Open.Island.zip"
+                type="application/octet-stream"
+                sparkle:edSignature="OgNgltzkr4q3xCDicJmh6rarVW7hQ34zjaxy7mARciKMvOiHl4vS9q2YCXuz/MVthrbh8nFM/LR4hlI03qLgDQ=="
+                length="5218435"
+            />
+        </item>
     </channel>
 </rss>


### PR DESCRIPTION
## Summary
- 添加 v0.1.6 的 Sparkle appcast 条目（含 EdDSA 签名）
- **必须在创建 GitHub Release 之前合并**，否则 Sparkle 客户端找不到更新

## Test plan
- [x] release 包本地验收通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)