### PR TITLE
Add custom avatar upload in display settings

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -170,6 +170,7 @@ final class AppModel {
             NotificationSoundService.selectedSoundName = selectedSoundName
         }
     }
+    var customAvatarImage: NSImage? = nil
     var overlayDisplaySelectionID: String {
         get { overlay.overlayDisplaySelectionID }
         set { overlay.overlayDisplaySelectionID = newValue }
@@ -219,6 +220,7 @@ final class AppModel {
         isSoundMuted = UserDefaults.standard.bool(forKey: Self.soundMutedDefaultsKey)
         selectedSoundName = NotificationSoundService.selectedSoundName
         showDockIcon = UserDefaults.standard.bool(forKey: Self.showDockIconDefaultsKey)
+        customAvatarImage = AvatarImageStore.currentImage()
 
         overlay.appModel = self
         overlay.restoreDisplayPreference()
@@ -711,6 +713,36 @@ final class AppModel {
 
                 self?.lastActionMessage = "Jump failed: \(error.localizedDescription)"
             }
+        }
+    }
+
+    func importCustomAvatar() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = [.png, .jpeg, .heic, .tiff]
+        panel.message = "Choose a static image for the island avatar."
+
+        guard panel.runModal() == .OK, let url = panel.url else {
+            return
+        }
+
+        do {
+            customAvatarImage = try AvatarImageStore.importImage(from: url)
+            lastActionMessage = "Custom avatar updated."
+        } catch {
+            lastActionMessage = error.localizedDescription
+        }
+    }
+
+    func removeCustomAvatar() {
+        do {
+            try AvatarImageStore.removeCurrentImage()
+            customAvatarImage = nil
+            lastActionMessage = "Custom avatar removed."
+        } catch {
+            lastActionMessage = error.localizedDescription
         }
     }
 

--- a/Sources/OpenIslandApp/AvatarImageStore.swift
+++ b/Sources/OpenIslandApp/AvatarImageStore.swift
@@ -1,0 +1,125 @@
+import AppKit
+import Foundation
+import UniformTypeIdentifiers
+
+enum AvatarImageStore {
+    static let maxImportBytes = 10 * 1024 * 1024
+    static let maxPixelDimension: CGFloat = 256
+
+    private static let directoryName = "OpenIsland"
+    private static let fileName = "custom-avatar.png"
+
+    enum ImportError: LocalizedError {
+        case unsupportedImage
+        case fileTooLarge(limitBytes: Int)
+        case encodeFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .unsupportedImage:
+                return "The selected file is not a supported static image."
+            case .fileTooLarge(let limitBytes):
+                let limitMB = limitBytes / (1024 * 1024)
+                return "The selected file is too large. Choose an image under \(limitMB) MB."
+            case .encodeFailed:
+                return "Open Island could not process that image."
+            }
+        }
+    }
+
+    static func currentImage(fileManager: FileManager = .default) -> NSImage? {
+        let url = avatarURL(fileManager: fileManager)
+        guard fileManager.fileExists(atPath: url.path) else {
+            return nil
+        }
+        return NSImage(contentsOf: url)
+    }
+
+    static func removeCurrentImage(fileManager: FileManager = .default) throws {
+        let url = avatarURL(fileManager: fileManager)
+        guard fileManager.fileExists(atPath: url.path) else {
+            return
+        }
+        try fileManager.removeItem(at: url)
+    }
+
+    @discardableResult
+    static func importImage(from sourceURL: URL, fileManager: FileManager = .default) throws -> NSImage {
+        let values = try sourceURL.resourceValues(forKeys: [.fileSizeKey, .contentTypeKey])
+        if let fileSize = values.fileSize, fileSize > maxImportBytes {
+            throw ImportError.fileTooLarge(limitBytes: maxImportBytes)
+        }
+
+        if let contentType = values.contentType {
+            let supportedTypes: [UTType] = [.png, .jpeg, .heic, .tiff]
+            guard supportedTypes.contains(where: { contentType.conforms(to: $0) }) else {
+                throw ImportError.unsupportedImage
+            }
+        }
+
+        guard let sourceImage = NSImage(contentsOf: sourceURL) else {
+            throw ImportError.unsupportedImage
+        }
+
+        let normalizedImage = normalizedAvatarImage(from: sourceImage)
+        let targetURL = avatarURL(fileManager: fileManager)
+        try fileManager.createDirectory(
+            at: targetURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        guard
+            let tiffData = normalizedImage.tiffRepresentation,
+            let bitmap = NSBitmapImageRep(data: tiffData),
+            let pngData = bitmap.representation(using: .png, properties: [:])
+        else {
+            throw ImportError.encodeFailed
+        }
+
+        try pngData.write(to: targetURL, options: .atomic)
+        return normalizedImage
+    }
+
+    private static func avatarURL(fileManager: FileManager) -> URL {
+        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+
+        return appSupport
+            .appendingPathComponent(directoryName, isDirectory: true)
+            .appendingPathComponent(fileName)
+    }
+
+    private static func normalizedAvatarImage(from sourceImage: NSImage) -> NSImage {
+        let cgImage = sourceImage.cgImage(forProposedRect: nil, context: nil, hints: nil)
+            ?? NSImage(size: sourceImage.size).cgImage(forProposedRect: nil, context: nil, hints: nil)
+
+        guard let cgImage else {
+            return sourceImage
+        }
+
+        let width = CGFloat(cgImage.width)
+        let height = CGFloat(cgImage.height)
+        let squareSide = min(width, height)
+        let cropRect = CGRect(
+            x: (width - squareSide) / 2,
+            y: (height - squareSide) / 2,
+            width: squareSide,
+            height: squareSide
+        ).integral
+
+        guard let croppedCGImage = cgImage.cropping(to: cropRect) else {
+            return sourceImage
+        }
+
+        let targetSize = CGSize(width: maxPixelDimension, height: maxPixelDimension)
+        let image = NSImage(size: targetSize)
+        image.lockFocus()
+        NSGraphicsContext.current?.imageInterpolation = .high
+        NSImage(cgImage: croppedCGImage, size: targetSize)
+            .draw(in: CGRect(origin: .zero, size: targetSize))
+        image.unlockFocus()
+        return image
+    }
+}

--- a/Sources/OpenIslandApp/OpenIslandBrandMark.swift
+++ b/Sources/OpenIslandApp/OpenIslandBrandMark.swift
@@ -36,13 +36,14 @@ struct OpenIslandBrandMark: View {
         } else {
             spriteBody(pattern: Self.scoutPattern)
                 .frame(width: size, height: size)
+                .drawingGroup(opaque: false, colorMode: .extendedLinear)
         }
     }
 
     private func spriteBody(pattern: [String]) -> some View {
         GeometryReader { proxy in
             let gridSize = CGFloat(pattern.count)
-            let cell = floor(min(proxy.size.width / gridSize, proxy.size.height / gridSize))
+            let cell = min(proxy.size.width / gridSize, proxy.size.height / gridSize)
             let markWidth = cell * gridSize
             let markHeight = cell * gridSize
             let originX = (proxy.size.width - markWidth) / 2

--- a/Sources/OpenIslandApp/OpenIslandBrandMark.swift
+++ b/Sources/OpenIslandApp/OpenIslandBrandMark.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct OpenIslandBrandMark: View {
     enum Style {
@@ -10,6 +11,7 @@ struct OpenIslandBrandMark: View {
     var tint: Color = .mint
     var isAnimating: Bool = false
     var style: Style = .duotone
+    var customAvatarImage: NSImage? = nil
 
     private static let scoutPattern = [
         "..B..B..",
@@ -22,22 +24,33 @@ struct OpenIslandBrandMark: View {
         "........",
     ]
 
-    private static let pixels: [(x: Int, y: Int, role: Character)] = scoutPattern.enumerated().flatMap { rowIndex, row in
-        row.enumerated().compactMap { columnIndex, character in
-            character == "." ? nil : (columnIndex, rowIndex, character)
+    var body: some View {
+        if style == .duotone, let customAvatarImage {
+            Image(nsImage: customAvatarImage)
+                .resizable()
+                .interpolation(.high)
+                .antialiased(true)
+                .scaledToFill()
+                .frame(width: size, height: size)
+                .clipShape(Circle())
+        } else {
+            spriteBody(pattern: Self.scoutPattern)
+                .frame(width: size, height: size)
         }
     }
 
-    var body: some View {
+    private func spriteBody(pattern: [String]) -> some View {
         GeometryReader { proxy in
-            let cell = min(proxy.size.width / 8, proxy.size.height / 8)
-            let markWidth = cell * 8
-            let markHeight = cell * 8
+            let gridSize = CGFloat(pattern.count)
+            let cell = floor(min(proxy.size.width / gridSize, proxy.size.height / gridSize))
+            let markWidth = cell * gridSize
+            let markHeight = cell * gridSize
             let originX = (proxy.size.width - markWidth) / 2
             let originY = (proxy.size.height - markHeight) / 2
+            let pixels = Self.pixels(for: pattern)
 
             ZStack(alignment: .topLeading) {
-                ForEach(Array(Self.pixels.enumerated()), id: \.offset) { _, pixel in
+                ForEach(Array(pixels.enumerated()), id: \.offset) { _, pixel in
                     Rectangle()
                         .fill(fillColor(for: pixel.role))
                         .frame(width: cell, height: cell)
@@ -48,8 +61,14 @@ struct OpenIslandBrandMark: View {
                 }
             }
         }
-        .frame(width: size, height: size)
-        .drawingGroup(opaque: false, colorMode: .extendedLinear)
+    }
+
+    private static func pixels(for pattern: [String]) -> [(x: Int, y: Int, role: Character)] {
+        pattern.enumerated().flatMap { rowIndex, row in
+            row.enumerated().compactMap { columnIndex, character in
+                character == "." ? nil : (columnIndex, rowIndex, character)
+            }
+        }
     }
 
     private func fillColor(for role: Character) -> Color {

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -41,6 +41,10 @@
 /* Settings - Display */
 "settings.display.monitor" = "Monitor";
 "settings.display.position" = "Display Position";
+"settings.display.avatar" = "Avatar";
+"settings.display.uploadAvatar" = "Upload Avatar";
+"settings.display.removeAvatar" = "Remove Avatar";
+"settings.display.avatarHelp" = "Currently only static images are supported.";
 "settings.display.diagnostics" = "Diagnostics";
 "settings.display.currentScreen" = "Current Screen";
 "settings.display.layoutMode" = "Layout Mode";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -41,6 +41,10 @@
 /* Settings - Display */
 "settings.display.monitor" = "显示器";
 "settings.display.position" = "显示位置";
+"settings.display.avatar" = "头像";
+"settings.display.uploadAvatar" = "上传头像";
+"settings.display.removeAvatar" = "移除头像";
+"settings.display.avatarHelp" = "目前只支持静态图片展示";
 "settings.display.diagnostics" = "诊断";
 "settings.display.currentScreen" = "当前屏幕";
 "settings.display.layoutMode" = "布局模式";

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -304,7 +304,7 @@ struct IslandPanelView: View {
                 if hasClosedPresence {
                     HStack(spacing: 4) {
                         OpenIslandIcon(
-                            size: 18,
+                            size: model.customAvatarImage != nil ? 18 : 14,
                             isAnimating: hasClosedActivity,
                             tint: scoutTint,
                             customAvatarImage: model.customAvatarImage

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -133,10 +133,9 @@ struct IslandPanelView: View {
 
     /// Whether any session has activity worth showing in the closed notch
     private var hasClosedActivity: Bool {
-        guard let session = closedSpotlightSession else {
-            return false
+        model.surfacedSessions.contains { session in
+            session.phase == .running || session.phase.requiresAttention
         }
-        return session.phase == .running || session.phase.requiresAttention
     }
 
     /// Scout icon tint: blue if any running, green if any live, else gray.
@@ -304,7 +303,12 @@ struct IslandPanelView: View {
             HStack(spacing: 0) {
                 if hasClosedPresence {
                     HStack(spacing: 4) {
-                        OpenIslandIcon(size: 14, isAnimating: hasClosedActivity, tint: scoutTint)
+                        OpenIslandIcon(
+                            size: 18,
+                            isAnimating: hasClosedActivity,
+                            tint: scoutTint,
+                            customAvatarImage: model.customAvatarImage
+                        )
                             .matchedGeometryEffect(id: "island-icon", in: notchNamespace, isSource: true)
 
                         if closedSpotlightSession?.phase.requiresAttention == true {
@@ -1646,13 +1650,15 @@ private struct OpenIslandIcon: View {
     let size: CGFloat
     var isAnimating: Bool = false
     var tint: Color = .mint
+    var customAvatarImage: NSImage? = nil
 
     var body: some View {
         OpenIslandBrandMark(
             size: size,
             tint: tint,
             isAnimating: isAnimating,
-            style: .duotone
+            style: .duotone,
+            customAvatarImage: customAvatarImage
         )
     }
 }

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -223,6 +223,34 @@ struct DisplaySettingsPane: View {
                 }
             }
 
+            Section(lang.t("settings.display.avatar")) {
+                HStack(spacing: 16) {
+                    OpenIslandBrandMark(
+                        size: 56,
+                        style: .duotone,
+                        customAvatarImage: model.customAvatarImage
+                    )
+                    .frame(width: 56, height: 56)
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(lang.t("settings.display.avatarHelp"))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(.vertical, 4)
+
+                HStack {
+                    Button(lang.t("settings.display.uploadAvatar")) {
+                        model.importCustomAvatar()
+                    }
+
+                    Button(lang.t("settings.display.removeAvatar")) {
+                        model.removeCustomAvatar()
+                    }
+                    .disabled(model.customAvatarImage == nil)
+                }
+            }
+
             if let diag = model.overlayPlacementDiagnostics {
                 Section(lang.t("settings.display.diagnostics")) {
                     LabeledContent(lang.t("settings.display.currentScreen"), value: diag.targetScreenName)

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -223,6 +223,13 @@ struct DisplaySettingsPane: View {
                 }
             }
 
+            if let diag = model.overlayPlacementDiagnostics {
+                Section(lang.t("settings.display.diagnostics")) {
+                    LabeledContent(lang.t("settings.display.currentScreen"), value: diag.targetScreenName)
+                    LabeledContent(lang.t("settings.display.layoutMode"), value: diag.modeDescription)
+                }
+            }
+
             Section(lang.t("settings.display.avatar")) {
                 HStack(spacing: 16) {
                     OpenIslandBrandMark(
@@ -248,13 +255,6 @@ struct DisplaySettingsPane: View {
                         model.removeCustomAvatar()
                     }
                     .disabled(model.customAvatarImage == nil)
-                }
-            }
-
-            if let diag = model.overlayPlacementDiagnostics {
-                Section(lang.t("settings.display.diagnostics")) {
-                    LabeledContent(lang.t("settings.display.currentScreen"), value: diag.targetScreenName)
-                    LabeledContent(lang.t("settings.display.layoutMode"), value: diag.modeDescription)
                 }
             }
         }


### PR DESCRIPTION
Summary
  - add avatar upload controls in Display settings
  - support importing a local static image as the island avatar
  - crop imported images to a square, render them as a circle, and store a normalized local PNG
  - allow removing the custom avatar and restoring the default pixel avatar

 Details
  - static images only in this version
  - supported import types: PNG, JPEG, HEIC, TIFF
  - imported files are limited to 10 MB
  - imported avatars are normalized to 256x256 to keep runtime cost low

Testing
  - swift build --product OpenIslandApp
  - verified the Display settings show upload/remove controls
  - verified removing the custom avatar restores the default pixel avatar