### PR TITLE
fix: detect Cursor.app via bundle ID for session liveness

### DIFF
--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Observation
 import OpenIslandCore
@@ -296,6 +297,18 @@ final class ProcessMonitoringCoordinator {
         let hasOpenCodeProcess = activeProcesses.contains { $0.tool == .openCode }
         if hasOpenCodeProcess {
             for session in sessions where session.tool == .openCode && !session.isDemoSession {
+                aliveIDs.insert(session.id)
+            }
+        }
+
+        // Cursor sessions: Cursor is an Electron IDE — we cannot match
+        // individual session IDs from ps/lsof.  Keep all Cursor sessions
+        // alive as long as Cursor.app is running.
+        let isCursorRunning = !NSRunningApplication.runningApplications(
+            withBundleIdentifier: "com.todesktop.230313mzl4w4u92"
+        ).isEmpty
+        if isCursorRunning {
+            for session in sessions where session.tool == .cursor && !session.isDemoSession {
                 aliveIDs.insert(session.id)
             }
         }


### PR DESCRIPTION
## Problem

Cursor sessions in Open Island had two issues:

1. **Sessions disappearing mid-conversation**: The process liveness monitor (`markProcessLiveness`) could not match Cursor's Electron process to individual session IDs via `ps`/`lsof`. Since `sessionIDsWithAliveProcesses` never included Cursor session IDs, the hook-managed fallback marked sessions as ended after just 2 missed polls (~4 seconds), causing them to vanish from the island while the user was still actively working.

2. **Stale sessions lingering forever**: A previous attempt to fix #1 by blanket-skipping all Cursor sessions from process liveness polling (`session.tool == .cursor → continue`) solved the disappearance but introduced the opposite problem — old Cursor sessions could never be cleaned up, leaving ghost sessions in the island indefinitely.

## Solution

Use the same pattern as OpenCode: detect whether the IDE is running at the app level, not per-session.

- Use `NSRunningApplication.runningApplications(withBundleIdentifier:)` with Cursor's bundle identifier (`com.todesktop.230313mzl4w4u92`) to check if Cursor.app is alive.
- When Cursor.app is running → all Cursor sessions stay alive (no premature disappearance).
- When Cursor.app exits → sessions fall through to the normal hook-managed liveness countdown and get cleaned up within ~4 seconds.

## Changes

- **`ProcessMonitoringCoordinator.swift`**: Added Cursor liveness detection via `NSRunningApplication` in `sessionIDsWithAliveProcesses`, following the OpenCode pattern.
- **`SessionState.swift`**: Removed the blanket `session.tool == .cursor` skip from `markProcessLiveness`, letting Cursor sessions go through the normal hook-managed path.

## Test plan

- [x] `swift build` passes
- [x] `swift test` — all 138 tests pass
- [x] Manual: Verify Cursor sessions appear in island while Cursor is running
- [x] Manual: Quit Cursor → sessions disappear within ~4 seconds
- [x] Manual: Reopen Cursor and start a new agent conversation → session reappears