### PR TITLE
feat: support CLAUDE_CONFIG_DIR environment variable

### DIFF
--- a/Sources/OpenIslandCore/ClaudeConfigDirectory.swift
+++ b/Sources/OpenIslandCore/ClaudeConfigDirectory.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Resolves the Claude Code configuration directory.
+///
+/// Checks the `CLAUDE_CONFIG_DIR` environment variable first, falling back to `~/.claude`.
+/// This allows users who run Claude Code with a custom config directory to have their
+/// hooks and settings managed correctly.
+public enum ClaudeConfigDirectory {
+    public static func resolved(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL {
+        if let customPath = environment["CLAUDE_CONFIG_DIR"], !customPath.isEmpty {
+            return URL(fileURLWithPath: (customPath as NSString).expandingTildeInPath, isDirectory: true)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude", isDirectory: true)
+    }
+}

--- a/Sources/OpenIslandCore/ClaudeHookInstallationManager.swift
+++ b/Sources/OpenIslandCore/ClaudeHookInstallationManager.swift
@@ -36,7 +36,7 @@ public final class ClaudeHookInstallationManager: @unchecked Sendable {
     private let fileManager: FileManager
 
     public init(
-        claudeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".claude", isDirectory: true),
+        claudeDirectory: URL = ClaudeConfigDirectory.resolved(),
         managedHooksBinaryURL: URL = ManagedHooksBinary.defaultURL(),
         hookSource: String = "claude",
         fileManager: FileManager = .default

--- a/Sources/OpenIslandCore/ClaudeStatusLineInstallationManager.swift
+++ b/Sources/OpenIslandCore/ClaudeStatusLineInstallationManager.swift
@@ -68,7 +68,7 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
     private let fileManager: FileManager
 
     public init(
-        claudeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".claude", isDirectory: true),
+        claudeDirectory: URL = ClaudeConfigDirectory.resolved(),
         scriptDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".open-island", isDirectory: true)
             .appendingPathComponent("bin", isDirectory: true),

--- a/Sources/OpenIslandCore/HookHealthCheck.swift
+++ b/Sources/OpenIslandCore/HookHealthCheck.swift
@@ -94,7 +94,7 @@ public struct HookHealthReport: Equatable, Sendable {
 public enum HookHealthCheck {
     /// Check Claude Code hook health.
     public static func checkClaude(
-        claudeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".claude", isDirectory: true),
+        claudeDirectory: URL = ClaudeConfigDirectory.resolved(),
         hooksBinaryURL: URL? = nil,
         managedHooksBinaryURL: URL = ManagedHooksBinary.defaultURL(),
         fileManager: FileManager = .default

--- a/Sources/OpenIslandSetup/OpenIslandSetupCLI.swift
+++ b/Sources/OpenIslandSetup/OpenIslandSetupCLI.swift
@@ -42,7 +42,7 @@ private struct SetupCommand {
 
         var hooksBinary: URL?
         var codexDirectory = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".codex", isDirectory: true)
-        var claudeDirectory = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".claude", isDirectory: true)
+        var claudeDirectory = ClaudeConfigDirectory.resolved()
 
         var index = 1
         while index < arguments.count {


### PR DESCRIPTION
## Summary
- Add `ClaudeConfigDirectory.resolved()` helper that reads the `CLAUDE_CONFIG_DIR` environment variable, falling back to `~/.claude`
- Replace all 4 hardcoded `~/.claude` default values (`ClaudeHookInstallationManager`, `HookHealthCheck`, `ClaudeStatusLineInstallationManager`, `OpenIslandSetupCLI`)
- Users who run Claude Code with a custom config directory now get hooks installed to the correct location automatically

Closes #237

## Test plan
- [x] `swift build` passes
- [x] All 138 tests pass
- [ ] Manual: set `CLAUDE_CONFIG_DIR=/tmp/test-claude` and verify hooks install to that directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)