### PR TITLE
fix: add quit button to About settings pane

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1068,4 +1068,8 @@ final class AppModel {
         }
     }
 
+    func quitApplication() {
+        NSApplication.shared.terminate(nil)
+    }
+
 }

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -81,6 +81,7 @@
 /* Settings - About */
 "settings.about.version" = "Version %@";
 "settings.about.checkForUpdates" = "Check for Updates…";
+"settings.about.quitApp" = "Quit Open Island";
 
 /* Settings - Update */
 "settings.update.available" = "v%@ Available — Update";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -81,6 +81,7 @@
 /* Settings - About */
 "settings.about.version" = "版本 %@";
 "settings.about.checkForUpdates" = "检查更新…";
+"settings.about.quitApp" = "退出 Open Island";
 
 /* Settings - Update */
 "settings.update.available" = "v%@ 可更新 — 点击更新";

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 import OpenIslandCore
 
 // MARK: - Settings tabs
@@ -288,30 +289,89 @@ struct AboutSettingsPane: View {
     var model: AppModel
 
     private var lang: LanguageManager { model.lang }
+    private let primaryInk = Color.white.opacity(0.94)
 
     var body: some View {
-        VStack(spacing: 16) {
-            Spacer()
-            Image(systemName: "island")
-                .font(.system(size: 48))
-                .foregroundStyle(.secondary)
-            Text(lang.t("app.name"))
-                .font(.title.bold())
-            Text(lang.t("app.description"))
-                .foregroundStyle(.secondary)
-            if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
-                Text(lang.t("settings.about.version", version))
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
+        VStack(spacing: 0) {
+            VStack(spacing: 8) {
+                Image(nsImage: NSApplication.shared.applicationIconImage)
+                    .resizable()
+                    .frame(width: 56, height: 56)
+
+                Text(lang.t("app.name"))
+                    .font(.title.bold())
+
+                Text(lang.t("app.description"))
+                    .foregroundStyle(.secondary)
+
+                if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+                    Text(lang.t("settings.about.version", version))
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
             }
-            Button(lang.t("settings.about.checkForUpdates")) {
-                model.updateChecker.checkForUpdates()
+            .padding(.top, 24)
+            .padding(.bottom, 20)
+
+            Divider()
+
+            Form {
+                Section {
+                    aboutActionRow(
+                        title: lang.t("settings.about.checkForUpdates"),
+                        systemImage: "arrow.triangle.2.circlepath",
+                        tint: primaryInk,
+                        action: {
+                            model.updateChecker.checkForUpdates()
+                        }
+                    )
+                    .disabled(!model.updateChecker.canCheckForUpdates)
+                    .opacity(model.updateChecker.canCheckForUpdates ? 1 : 0.55)
+                    .accessibilityIdentifier("settings.about.checkForUpdates")
+                }
+
+                Section {
+                    aboutActionRow(
+                        title: lang.t("settings.about.quitApp"),
+                        systemImage: "rectangle.portrait.and.arrow.right",
+                        tint: Color(red: 1.0, green: 0.29, blue: 0.29),
+                        action: {
+                            model.quitApplication()
+                        }
+                    )
+                    .accessibilityIdentifier("settings.about.quitApp")
+                }
             }
-            .disabled(!model.updateChecker.canCheckForUpdates)
+            .formStyle(.grouped)
+
             Spacer()
         }
         .frame(maxWidth: .infinity)
         .navigationTitle(lang.t("settings.tab.about"))
+    }
+
+    private func aboutActionRow(
+        title: String,
+        systemImage: String,
+        tint: Color,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 10) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 13, weight: .medium))
+                    .frame(width: 18, alignment: .leading)
+
+                Text(title)
+                    .font(.system(size: 11.5, weight: .semibold))
+
+                Spacer()
+            }
+            .foregroundStyle(tint)
+            .padding(.vertical, 2)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
 }
 


### PR DESCRIPTION
  ## Summary
  - Add `quitApplication()` method to `AppModel` for quitting the app
  - Redesign `AboutSettingsPane` with app icon, name, description, and version header
  - Add bilingual translation keys for `settings.about.quitApp`
  - Restore original button style (with system icons) for check updates and quit actions

  ## Changes
  - `AppModel.swift`: add `quitApplication()` method
  - `SettingsView.swift`: redesign AboutSettingsPane with app icon header + action buttons
  - `Localizable.strings` (en/zh-Hans): add `settings.about.quitApp` translations

  ## Test plan
  - [ ] Open About tab in Settings, verify app icon, name, description, and version
  display correctly
  - [ ] Tap "Check for Updates" button — should trigger update check
  - [ ] Tap "Quit" button — should exit the app
  - [ ] Verify UI in both English and Chinese locales

  🤖 Generated with [Claude Code](https://claude.com/claude-code)