### PR TITLE
fix: detect Cursor terminal via CURSOR_TRACE_ID

### DIFF
--- a/Sources/OpenIslandCore/ClaudeHooks.swift
+++ b/Sources/OpenIslandCore/ClaudeHooks.swift
@@ -1127,6 +1127,10 @@ public extension ClaudeHookPayload {
         case .some("wezterm"):
             return "WezTerm"
         case .some("vscode"):
+            // Cursor also sets TERM_PROGRAM=vscode; check its unique env var first
+            if environment["CURSOR_TRACE_ID"] != nil {
+                return "Cursor"
+            }
             return "VS Code"
         case .some("vscode-insiders"):
             return "VS Code Insiders"


### PR DESCRIPTION
## Problem

Cursor sets `TERM_PROGRAM=vscode` — identical to VS Code. The `inferTerminalApp` function maps `TERM_PROGRAM=vscode` → `"VS Code"`, so Claude Code sessions running inside Cursor's integrated terminal are misidentified. Jump-back opens VS Code instead of Cursor.

## Fix

Cursor injects a unique environment variable (`CURSOR_TRACE_ID`) that VS Code does not set. Check for it before evaluating `TERM_PROGRAM`:

```swift
case .some("vscode"):
    // Cursor also sets TERM_PROGRAM=vscode; check its unique env var first
    if environment["CURSOR_TRACE_ID"] != nil {
        return "Cursor"
    }
    return "VS Code"
```

## Verification

Confirmed `CURSOR_TRACE_ID` is present in Cursor's integrated terminal environment and absent in VS Code. Jump-back now correctly focuses Cursor.app instead of VS Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)