### PR TITLE
feat: support custom Claude config directory (CLAUDE_CONFIG_DIR)

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -121,6 +121,7 @@ final class AppModel {
     func uninstallCursorHooks() { hooks.uninstallCursorHooks() }
     func installClaudeUsageBridge() { hooks.installClaudeUsageBridge() }
     func uninstallClaudeUsageBridge() { hooks.uninstallClaudeUsageBridge() }
+    func updateClaudeConfigDirectory(to newDirectory: URL?) { hooks.updateClaudeConfigDirectory(to: newDirectory) }
     func runHealthChecks() { hooks.runHealthChecks() }
     func repairHooks() {
         Task { @MainActor in

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -337,6 +337,30 @@ final class HookInstallationCoordinator {
         return status.featureFlagEnabled ? "feature on · no managed hooks" : "feature off · no managed hooks"
     }
 
+    // MARK: - Claude config directory
+
+    /// Updates the custom Claude config directory, cleans up old hooks if present, and refreshes status.
+    func updateClaudeConfigDirectory(to newDirectory: URL?) {
+        let oldDirectory = ClaudeConfigDirectory.resolved()
+        let oldHadHooks = claudeHookStatus?.managedHooksPresent == true
+
+        ClaudeConfigDirectory.customDirectory = newDirectory
+
+        // Refresh status from the new directory
+        refreshClaudeHookStatus()
+        refreshClaudeUsageState()
+
+        let newPath = ClaudeConfigDirectory.resolved().path
+        if oldHadHooks {
+            let oldPath = oldDirectory.path
+            if oldPath != newPath {
+                onStatusMessage?("Claude config directory changed to \(newPath). Hooks in \(oldPath) were not removed — uninstall them manually if no longer needed.")
+            }
+        } else {
+            onStatusMessage?("Claude config directory set to \(newPath).")
+        }
+    }
+
     // MARK: - Auto-update hooks binary
 
     /// Overwrites the installed hooks binary if the app bundle ships a newer version.

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -33,8 +33,10 @@ final class HookInstallationCoordinator {
     @ObservationIgnored
     private let codexHookInstallationManager = CodexHookInstallationManager()
 
-    @ObservationIgnored
-    private let claudeHookInstallationManager = ClaudeHookInstallationManager()
+    /// Computed so it always reflects the latest `ClaudeConfigDirectory` setting.
+    private var claudeHookInstallationManager: ClaudeHookInstallationManager {
+        ClaudeHookInstallationManager()
+    }
 
     @ObservationIgnored
     private let qoderHookInstallationManager = ClaudeHookInstallationManager(
@@ -66,8 +68,10 @@ final class HookInstallationCoordinator {
     @ObservationIgnored
     private let cursorHookInstallationManager = CursorHookInstallationManager()
 
-    @ObservationIgnored
-    private let claudeStatusLineInstallationManager = ClaudeStatusLineInstallationManager()
+    /// Computed so it always reflects the latest `ClaudeConfigDirectory` setting.
+    private var claudeStatusLineInstallationManager: ClaudeStatusLineInstallationManager {
+        ClaudeStatusLineInstallationManager()
+    }
 
     @ObservationIgnored
     private var claudeUsageMonitorTask: Task<Void, Never>?
@@ -134,7 +138,7 @@ final class HookInstallationCoordinator {
 
     var claudeHookStatusSummary: String {
         guard let status = claudeHookStatus else {
-            return "Reading ~/.claude/settings.json."
+            return "Reading \(ClaudeConfigDirectory.resolved().appendingPathComponent("settings.json").path)."
         }
 
         if claudeHooksInstalled {
@@ -177,7 +181,7 @@ final class HookInstallationCoordinator {
 
     var claudeUsageStatusSummary: String {
         guard let status = claudeStatusLineStatus else {
-            return "Reading ~/.claude/settings.json."
+            return "Reading \(ClaudeConfigDirectory.resolved().appendingPathComponent("settings.json").path)."
         }
 
         if status.managedStatusLineInstalled {
@@ -841,11 +845,12 @@ final class HookInstallationCoordinator {
         snapshot: ClaudeUsageSnapshot?,
         repairedManagedBridge: Bool
     ) {
-        var status = try claudeStatusLineInstallationManager.status()
+        let manager = ClaudeStatusLineInstallationManager()
+        var status = try manager.status()
         var repairedManagedBridge = false
 
         if repairManagedBridgeIfNeeded && status.managedStatusLineNeedsRepair {
-            status = try claudeStatusLineInstallationManager.install()
+            status = try manager.install()
             repairedManagedBridge = true
         }
 

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -53,6 +53,11 @@
 /* Settings - Setup */
 "settings.tab.setup" = "Setup";
 "setup.section.binary" = "Hook Binary";
+"setup.claudeConfigDir.section" = "Claude Config Directory";
+"setup.claudeConfigDir.title" = "Config Directory";
+"setup.claudeConfigDir.choose" = "Choose…";
+"setup.claudeConfigDir.reset" = "Reset";
+"setup.claudeConfigDir.footer" = "For users who run Claude Code with CLAUDE_CONFIG_DIR. Leave default unless you use a custom config path.";
 "setup.section.hooks" = "CLI Hooks";
 "setup.section.usage" = "Usage Bridge";
 "setup.section.permissions" = "Permissions";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -53,6 +53,11 @@
 /* Settings - Setup */
 "settings.tab.setup" = "安装引导";
 "setup.section.binary" = "Hook 二进制";
+"setup.claudeConfigDir.section" = "Claude 配置目录";
+"setup.claudeConfigDir.title" = "配置目录";
+"setup.claudeConfigDir.choose" = "选择…";
+"setup.claudeConfigDir.reset" = "重置";
+"setup.claudeConfigDir.footer" = "适用于通过 CLAUDE_CONFIG_DIR 使用自定义配置路径启动 Claude Code 的用户。如无需要请保持默认。";
 "setup.section.hooks" = "CLI Hooks";
 "setup.section.usage" = "用量桥接";
 "setup.section.permissions" = "权限";

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -553,7 +553,7 @@ struct SetupSettingsPane: View {
                 Spacer()
                 if ClaudeConfigDirectory.customDirectory != nil {
                     Button(lang.t("setup.claudeConfigDir.reset")) {
-                        ClaudeConfigDirectory.customDirectory = nil
+                        model.updateClaudeConfigDirectory(to: nil)
                     }
                     .font(.caption)
                 }
@@ -564,7 +564,7 @@ struct SetupSettingsPane: View {
                     panel.canCreateDirectories = true
                     panel.prompt = lang.t("setup.claudeConfigDir.choose")
                     if panel.runModal() == .OK, let url = panel.url {
-                        ClaudeConfigDirectory.customDirectory = url
+                        model.updateClaudeConfigDirectory(to: url)
                     }
                 }
             }

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -333,6 +333,8 @@ struct SetupSettingsPane: View {
 
     var body: some View {
         Form {
+            claudeConfigDirectorySection
+
             Section(lang.t("setup.section.hooks")) {
                 hookRow(
                     name: "Claude Code",
@@ -530,6 +532,53 @@ struct SetupSettingsPane: View {
         }
         .formStyle(.grouped)
         .navigationTitle(lang.t("settings.tab.setup"))
+    }
+
+    @ViewBuilder
+    private var claudeConfigDirectorySection: some View {
+        Section {
+            HStack {
+                Label {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(lang.t("setup.claudeConfigDir.title"))
+                        Text(ClaudeConfigDirectory.resolved().path)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                } icon: {
+                    Image(systemName: "folder")
+                }
+                Spacer()
+                if ClaudeConfigDirectory.customDirectory != nil {
+                    Button(lang.t("setup.claudeConfigDir.reset")) {
+                        ClaudeConfigDirectory.customDirectory = nil
+                    }
+                    .font(.caption)
+                }
+                Button(lang.t("setup.claudeConfigDir.choose")) {
+                    let panel = NSOpenPanel()
+                    panel.canChooseDirectories = true
+                    panel.canChooseFiles = false
+                    panel.canCreateDirectories = true
+                    panel.prompt = lang.t("setup.claudeConfigDir.choose")
+                    if panel.runModal() == .OK, let url = panel.url {
+                        ClaudeConfigDirectory.customDirectory = url
+                    }
+                }
+            }
+        } header: {
+            HStack(spacing: 4) {
+                Text(lang.t("setup.claudeConfigDir.section"))
+                Text(lang.t("setup.optional"))
+                    .foregroundStyle(.tertiary)
+            }
+        } footer: {
+            Text(lang.t("setup.claudeConfigDir.footer"))
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
     }
 
     private var allReady: Bool {

--- a/Sources/OpenIslandCore/ClaudeConfigDirectory.swift
+++ b/Sources/OpenIslandCore/ClaudeConfigDirectory.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Resolves the Claude Code configuration directory.
+///
+/// Checks the `CLAUDE_CONFIG_DIR` environment variable first, falling back to `~/.claude`.
+/// This allows users who run Claude Code with a custom config directory to have their
+/// hooks and settings managed correctly.
+public enum ClaudeConfigDirectory {
+    public static func resolved(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL {
+        if let customPath = environment["CLAUDE_CONFIG_DIR"], !customPath.isEmpty {
+            return URL(fileURLWithPath: (customPath as NSString).expandingTildeInPath, isDirectory: true)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude", isDirectory: true)
+    }
+}

--- a/Sources/OpenIslandCore/ClaudeConfigDirectory.swift
+++ b/Sources/OpenIslandCore/ClaudeConfigDirectory.swift
@@ -2,15 +2,36 @@ import Foundation
 
 /// Resolves the Claude Code configuration directory.
 ///
-/// Checks the `CLAUDE_CONFIG_DIR` environment variable first, falling back to `~/.claude`.
-/// This allows users who run Claude Code with a custom config directory to have their
-/// hooks and settings managed correctly.
+/// Priority: user setting (UserDefaults) > `CLAUDE_CONFIG_DIR` env var > `~/.claude`.
 public enum ClaudeConfigDirectory {
+    public static let defaultsKey = "claude.configDirectory"
+
+    /// The user-configured custom directory, or `nil` if not set.
+    public static var customDirectory: URL? {
+        get {
+            guard let path = UserDefaults.standard.string(forKey: defaultsKey), !path.isEmpty else {
+                return nil
+            }
+            return URL(fileURLWithPath: path, isDirectory: true)
+        }
+        set {
+            if let path = newValue?.path {
+                UserDefaults.standard.set(path, forKey: defaultsKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: defaultsKey)
+            }
+        }
+    }
+
+    /// Resolves the effective Claude config directory.
     public static func resolved(
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> URL {
-        if let customPath = environment["CLAUDE_CONFIG_DIR"], !customPath.isEmpty {
-            return URL(fileURLWithPath: (customPath as NSString).expandingTildeInPath, isDirectory: true)
+        if let custom = customDirectory {
+            return custom
+        }
+        if let envPath = environment["CLAUDE_CONFIG_DIR"], !envPath.isEmpty {
+            return URL(fileURLWithPath: (envPath as NSString).expandingTildeInPath, isDirectory: true)
         }
         return FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".claude", isDirectory: true)

--- a/Sources/OpenIslandCore/ClaudeHookInstallationManager.swift
+++ b/Sources/OpenIslandCore/ClaudeHookInstallationManager.swift
@@ -36,7 +36,7 @@ public final class ClaudeHookInstallationManager: @unchecked Sendable {
     private let fileManager: FileManager
 
     public init(
-        claudeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".claude", isDirectory: true),
+        claudeDirectory: URL = ClaudeConfigDirectory.resolved(),
         managedHooksBinaryURL: URL = ManagedHooksBinary.defaultURL(),
         hookSource: String = "claude",
         fileManager: FileManager = .default

--- a/Sources/OpenIslandCore/ClaudeStatusLineInstallationManager.swift
+++ b/Sources/OpenIslandCore/ClaudeStatusLineInstallationManager.swift
@@ -68,7 +68,7 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
     private let fileManager: FileManager
 
     public init(
-        claudeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".claude", isDirectory: true),
+        claudeDirectory: URL = ClaudeConfigDirectory.resolved(),
         scriptDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".open-island", isDirectory: true)
             .appendingPathComponent("bin", isDirectory: true),

--- a/Sources/OpenIslandCore/HookHealthCheck.swift
+++ b/Sources/OpenIslandCore/HookHealthCheck.swift
@@ -94,7 +94,7 @@ public struct HookHealthReport: Equatable, Sendable {
 public enum HookHealthCheck {
     /// Check Claude Code hook health.
     public static func checkClaude(
-        claudeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".claude", isDirectory: true),
+        claudeDirectory: URL = ClaudeConfigDirectory.resolved(),
         hooksBinaryURL: URL? = nil,
         managedHooksBinaryURL: URL = ManagedHooksBinary.defaultURL(),
         fileManager: FileManager = .default

--- a/Sources/OpenIslandSetup/OpenIslandSetupCLI.swift
+++ b/Sources/OpenIslandSetup/OpenIslandSetupCLI.swift
@@ -42,7 +42,7 @@ private struct SetupCommand {
 
         var hooksBinary: URL?
         var codexDirectory = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".codex", isDirectory: true)
-        var claudeDirectory = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".claude", isDirectory: true)
+        var claudeDirectory = ClaudeConfigDirectory.resolved()
 
         var index = 1
         while index < arguments.count {


### PR DESCRIPTION
## Summary
- Add `ClaudeConfigDirectory` helper — resolves config dir with priority: **user setting > `CLAUDE_CONFIG_DIR` env var > `~/.claude`**
- Add "Claude Config Directory" section in Settings → Setup with folder picker and reset button
- Auto-refresh hook & usage bridge status when directory changes
- If old directory had hooks installed, show a reminder to clean them up manually
- Bilingual UI (English + 简体中文)

Closes #237

## User flow
1. Open Settings → Setup
2. Click "Choose…" to select the custom Claude config directory
3. Hook status refreshes automatically to reflect the new directory
4. Click "Install" to install hooks into the new directory
5. If the old directory had hooks, a status message reminds the user to uninstall them

## Test plan
- [x] `swift build` passes
- [x] All 138 tests pass
- [ ] Manual: open Settings → Setup, verify "Claude Config Directory" section
- [ ] Manual: choose custom dir → verify status refreshes immediately
- [ ] Manual: click "Reset" → verify fallback to `~/.claude` and status refreshes
- [ ] Manual: with hooks in old dir, change dir → verify reminder message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)