### PR TITLE
fix: remote session dismiss button + remote-setup.sh socket path

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -782,6 +782,12 @@ final class AppModel {
         )
     }
 
+    func dismissSession(_ sessionID: String) {
+        state.dismissSession(id: sessionID)
+        dismissNotificationSurfaceIfPresent(for: sessionID)
+        synchronizeSelection()
+    }
+
     func answerQuestion(for sessionID: String, answer: QuestionPromptResponse) {
         guard let session = state.session(id: sessionID) else {
             return

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1013,12 +1013,7 @@ private struct IslandSessionRow: View {
                             }
                             compactBadge(session.spotlightAgeBadge, presence: presence)
                             if let onDismiss {
-                                Button(action: onDismiss) {
-                                    Image(systemName: "xmark.circle.fill")
-                                        .font(.system(size: 12))
-                                        .foregroundStyle(.white.opacity(0.4))
-                                }
-                                .buttonStyle(.plain)
+                                DismissButton(action: onDismiss)
                             }
                         }
                     }
@@ -1923,4 +1918,19 @@ extension MarkdownUI.Theme {
                 .padding(.horizontal, 12)
                 .relativeLineSpacing(.em(0.25))
         }
+}
+
+private struct DismissButton: View {
+    let action: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "xmark.circle.fill")
+                .font(.system(size: 12))
+                .foregroundStyle(.white.opacity(isHovered ? 0.8 : 0.4))
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+    }
 }

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -553,7 +553,8 @@ struct IslandPanelView: View {
                         lang: model.lang,
                         onApprove: { model.approvePermission(for: session.id, action: $0) },
                         onAnswer: { model.answerQuestion(for: session.id, answer: $0) },
-                        onJump: { model.jumpToSession(session) }
+                        onJump: { model.jumpToSession(session) },
+                        onDismiss: session.isRemote ? { model.dismissSession(session.id) } : nil
                     )
                 }
             }
@@ -976,6 +977,7 @@ private struct IslandSessionRow: View {
     var onApprove: ((ApprovalAction) -> Void)?
     var onAnswer: ((QuestionPromptResponse) -> Void)?
     let onJump: () -> Void
+    var onDismiss: (() -> Void)?
 
     @State private var isHighlighted = false
     @State private var isManuallyExpanded = false
@@ -1010,6 +1012,14 @@ private struct IslandSessionRow: View {
                                 compactBadge(terminalBadge, presence: presence)
                             }
                             compactBadge(session.spotlightAgeBadge, presence: presence)
+                            if let onDismiss {
+                                Button(action: onDismiss) {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .font(.system(size: 12))
+                                        .foregroundStyle(.white.opacity(0.4))
+                                }
+                                .buttonStyle(.plain)
+                            }
                         }
                     }
 

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -371,6 +371,17 @@ public struct SessionState: Equatable, Sendable {
     /// Remove sessions that are no longer visible in the island.
     /// Returns `true` if any sessions were removed.
     @discardableResult
+    /// Manually mark a session as completed and ended.
+    /// Intended for remote sessions whose SSH tunnel dropped without a
+    /// SessionEnd hook.
+    public mutating func dismissSession(id: String) {
+        guard var session = sessionsByID[id] else { return }
+        session.isSessionEnded = true
+        session.phase = .completed
+        session.updatedAt = .now
+        upsert(session)
+    }
+
     public mutating func removeInvisibleSessions() -> Bool {
         let before = sessionsByID.count
         sessionsByID = sessionsByID.filter { _, session in

--- a/scripts/remote-setup.sh
+++ b/scripts/remote-setup.sh
@@ -37,70 +37,25 @@ ssh "$REMOTE" "chmod +x ~/$REMOTE_BIN_DIR/open-island-hooks.py"
 
 echo ""
 echo "==> Configuring Claude Code hooks on $REMOTE ..."
-# Build the hooks JSON fragment
-HOOKS_JSON=$(cat <<'ENDJSON'
+# Build the hooks JSON fragment.
+# Use the *local* UID in the socket path so the remote hook connects to the
+# forwarded socket created by the local Open Island app.  The heredoc is
+# unquoted so that $SOCKET_NAME is expanded.
+HOOK_CMD="OPEN_ISLAND_SOCKET_PATH=/tmp/$SOCKET_NAME python3 ~/.local/bin/open-island-hooks.py --source claude"
+HOOK_ENTRY="{\"matcher\": \"\", \"hooks\": [{\"type\": \"command\", \"command\": \"$HOOK_CMD\"}]}"
+HOOKS_JSON=$(cat <<ENDJSON
 {
   "hooks": {
-    "PreToolUse": [
-      {
-        "type": "command",
-        "command": "python3 ~/.local/bin/open-island-hooks.py --source claude"
-      }
-    ],
-    "PostToolUse": [
-      {
-        "type": "command",
-        "command": "python3 ~/.local/bin/open-island-hooks.py --source claude"
-      }
-    ],
-    "Notification": [
-      {
-        "type": "command",
-        "command": "python3 ~/.local/bin/open-island-hooks.py --source claude"
-      }
-    ],
-    "SessionStart": [
-      {
-        "type": "command",
-        "command": "python3 ~/.local/bin/open-island-hooks.py --source claude"
-      }
-    ],
-    "SessionEnd": [
-      {
-        "type": "command",
-        "command": "python3 ~/.local/bin/open-island-hooks.py --source claude"
-      }
-    ],
-    "Stop": [
-      {
-        "type": "command",
-        "command": "python3 ~/.local/bin/open-island-hooks.py --source claude"
-      }
-    ],
-    "UserPromptSubmit": [
-      {
-        "type": "command",
-        "command": "python3 ~/.local/bin/open-island-hooks.py --source claude"
-      }
-    ],
-    "PermissionRequest": [
-      {
-        "type": "command",
-        "command": "python3 ~/.local/bin/open-island-hooks.py --source claude"
-      }
-    ],
-    "SubagentStart": [
-      {
-        "type": "command",
-        "command": "python3 ~/.local/bin/open-island-hooks.py --source claude"
-      }
-    ],
-    "SubagentStop": [
-      {
-        "type": "command",
-        "command": "python3 ~/.local/bin/open-island-hooks.py --source claude"
-      }
-    ]
+    "PreToolUse": [$HOOK_ENTRY],
+    "PostToolUse": [$HOOK_ENTRY],
+    "Notification": [$HOOK_ENTRY],
+    "SessionStart": [$HOOK_ENTRY],
+    "SessionEnd": [$HOOK_ENTRY],
+    "Stop": [$HOOK_ENTRY],
+    "UserPromptSubmit": [$HOOK_ENTRY],
+    "PermissionRequest": [$HOOK_ENTRY],
+    "SubagentStart": [$HOOK_ENTRY],
+    "SubagentStop": [$HOOK_ENTRY]
   }
 }
 ENDJSON


### PR DESCRIPTION
## Summary
- Remote sessions linger in UI after SSH disconnect because `SessionEnd` hook never fires. Added a manual dismiss button (×) on remote session rows.
- `remote-setup.sh` had wrong hooks format (flat instead of `matcher+hooks` array) and did not pass the local UID socket path to the hook command, causing the remote hook to connect to a non-existent socket.

## Changes
- **SessionState**: add `dismissSession(id:)` to manually mark sessions completed
- **AppModel**: expose `dismissSession(_:)` for UI
- **IslandPanelView**: show × button on remote session rows with hover feedback
- **remote-setup.sh**: embed `OPEN_ISLAND_SOCKET_PATH` in hook commands, use correct `matcher+hooks` JSON structure

## Test plan
- [x] SSH to remote, start Claude Code, verify session appears in Open Island
- [x] Click × button, verify session is removed from UI
- [x] Hover over × button, verify opacity feedback (0.4 → 0.8)
- [x] Local sessions unaffected (no × button shown)
- [x] App does not crash after dismiss

🤖 Generated with [Claude Code](https://claude.com/claude-code)