### PR TITLE
feat: add tmux session/window/pane jump support

### DIFF
--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -16,6 +16,8 @@ struct ActiveAgentProcessDiscovery {
         var terminalTTY: String?
         var terminalApp: String?
         var transcriptPath: String?
+        var tmuxTarget: String?
+        var tmuxSocketPath: String?
 
         init(
             tool: AgentTool,
@@ -23,7 +25,9 @@ struct ActiveAgentProcessDiscovery {
             workingDirectory: String?,
             terminalTTY: String?,
             terminalApp: String? = nil,
-            transcriptPath: String? = nil
+            transcriptPath: String? = nil,
+            tmuxTarget: String? = nil,
+            tmuxSocketPath: String? = nil
         ) {
             self.tool = tool
             self.sessionID = sessionID
@@ -31,6 +35,8 @@ struct ActiveAgentProcessDiscovery {
             self.terminalTTY = terminalTTY
             self.terminalApp = terminalApp
             self.transcriptPath = transcriptPath
+            self.tmuxTarget = tmuxTarget
+            self.tmuxSocketPath = tmuxSocketPath
         }
     }
 
@@ -151,13 +157,28 @@ struct ActiveAgentProcessDiscovery {
             return nil
         }
 
-        return ProcessSnapshot(
+        var snapshot = ProcessSnapshot(
             tool: .codex,
             sessionID: sessionID,
             workingDirectory: workingDirectory(from: lsofOutput),
             terminalTTY: process.terminalTTY,
             terminalApp: terminalApp(for: process, processesByPID: processesByPID)
         )
+
+        // If terminalApp is nil and we have a TTY, try to resolve tmux info
+        if snapshot.terminalApp == nil, let agentTTY = process.terminalTTY {
+            if let (tmuxTarget, hostTerminalApp, socketPath) = resolveTmuxInfo(
+                agentTTY: agentTTY,
+                processes: processesByPID.values.map { $0 },
+                processesByPID: processesByPID
+            ) {
+                snapshot.terminalApp = hostTerminalApp
+                snapshot.tmuxTarget = tmuxTarget
+                snapshot.tmuxSocketPath = socketPath
+            }
+        }
+
+        return snapshot
     }
 
     private func isClaudeSubagentWorktree(_ path: String) -> Bool {
@@ -187,7 +208,7 @@ struct ActiveAgentProcessDiscovery {
             return nil
         }
 
-        return ProcessSnapshot(
+        var snapshot = ProcessSnapshot(
             tool: .claudeCode,
             sessionID: sessionID,
             workingDirectory: workingDirectory,
@@ -195,6 +216,21 @@ struct ActiveAgentProcessDiscovery {
             terminalApp: terminalApp(for: process, processesByPID: processesByPID),
             transcriptPath: transcriptPath
         )
+
+        // If terminalApp is nil and we have a TTY, try to resolve tmux info
+        if snapshot.terminalApp == nil, let agentTTY = process.terminalTTY {
+            if let (tmuxTarget, hostTerminalApp, socketPath) = resolveTmuxInfo(
+                agentTTY: agentTTY,
+                processes: processesByPID.values.map { $0 },
+                processesByPID: processesByPID
+            ) {
+                snapshot.terminalApp = hostTerminalApp
+                snapshot.tmuxTarget = tmuxTarget
+                snapshot.tmuxSocketPath = socketPath
+            }
+        }
+
+        return snapshot
     }
 
     private func bestClaudeTranscriptPath(in lsofOutput: String, workingDirectory: String?) -> String? {
@@ -526,5 +562,134 @@ struct ActiveAgentProcessDiscovery {
         }
 
         return output
+    }
+
+    // MARK: - Tmux support
+
+    private func resolveTmuxPath() -> String? {
+        let candidates = [
+            "/opt/homebrew/bin/tmux",
+            "/usr/local/bin/tmux",
+            "/usr/bin/tmux",
+        ]
+
+        if let found = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) {
+            return found
+        }
+
+        // Fallback to 'which'
+        guard let output = commandRunner("/usr/bin/which", ["tmux"]) else {
+            return nil
+        }
+
+        let path = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        return path.isEmpty ? nil : path
+    }
+
+    private func resolveTmuxInfo(
+        agentTTY: String,
+        processes: [RunningProcess],
+        processesByPID: [String: RunningProcess]
+    ) -> (target: String, hostTerminalApp: String?, socketPath: String?)? {
+        guard let tmuxPath = resolveTmuxPath() else {
+            return nil
+        }
+
+        // Find tmux-server process to extract socket path if custom
+        var socketPath: String? = nil
+        for process in processes {
+            if isTmuxServerProcess(command: process.command) {
+                // Extract socket path from tmux-server command line
+                let parts = process.command.split(separator: " ").map(String.init)
+                for (index, part) in parts.enumerated() {
+                    if (part == "-S" || part == "-L"), parts.indices.contains(index + 1) {
+                        socketPath = String(parts[index + 1])
+                        break
+                    }
+                }
+                break
+            }
+        }
+
+        // Query tmux list-panes to find the pane matching our TTY
+        guard let tmuxTarget = queryTmuxTarget(agentTTY: agentTTY, tmuxPath: tmuxPath, socketPath: socketPath) else {
+            return nil
+        }
+
+        // Find the terminal app hosting the tmux client connected to this pane
+        guard let hostTerminalApp = findTmuxClientTerminal(tmuxPath: tmuxPath, socketPath: socketPath, processesByPID: processesByPID) else {
+            return nil
+        }
+
+        return (tmuxTarget, hostTerminalApp, socketPath)
+    }
+
+    private func queryTmuxTarget(agentTTY: String, tmuxPath: String, socketPath: String?) -> String? {
+        var args: [String] = ["list-panes", "-a", "-F", "#{pane_tty}\t#{session_name}:#{window_index}.#{pane_index}"]
+
+        if let socketPath = socketPath {
+            args = ["-S", socketPath] + args
+        }
+
+        guard let output = commandRunner(tmuxPath, args) else {
+            return nil
+        }
+
+        for line in output.split(separator: "\n") {
+            let parts = line.split(separator: "\t", maxSplits: 1).map(String.init)
+            guard parts.count == 2 else {
+                continue
+            }
+
+            let ptrTTY = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
+            let target = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
+
+            if ptrTTY == agentTTY {
+                return target
+            }
+        }
+
+        return nil
+    }
+
+    private func findTmuxClientTerminal(
+        tmuxPath: String,
+        socketPath: String?,
+        processesByPID: [String: RunningProcess]
+    ) -> String? {
+        var args: [String] = ["list-clients", "-F", "#{client_tty}"]
+
+        if let socketPath = socketPath {
+            args = ["-S", socketPath] + args
+        }
+
+        guard let output = commandRunner(tmuxPath, args) else {
+            return nil
+        }
+
+        for clientTTYLine in output.split(separator: "\n") {
+            let clientTTY = clientTTYLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !clientTTY.isEmpty else {
+                continue
+            }
+
+            // Find the process whose TTY matches this client TTY, then walk its parents
+            for process in processesByPID.values {
+                if process.terminalTTY == clientTTY {
+                    if let terminalApp = terminalApp(for: process, processesByPID: processesByPID) {
+                        return terminalApp
+                    }
+                }
+            }
+        }
+
+        return nil
+    }
+
+    private func isTmuxServerProcess(command: String) -> Bool {
+        let lowered = command.lowercased()
+        return lowered.contains("tmux") && lowered.contains("new-session")
+            || lowered.hasSuffix("tmux-server")
+            || lowered.contains("tmux") && lowered.contains("server")
     }
 }

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -385,7 +385,9 @@ final class ProcessMonitoringCoordinator {
                 workspaceName: workspaceName,
                 paneTitle: "Claude \(workspaceName)",
                 workingDirectory: workingDirectory,
-                terminalTTY: process.terminalTTY
+                terminalTTY: process.terminalTTY,
+                tmuxTarget: process.tmuxTarget,
+                tmuxSocketPath: process.tmuxSocketPath
             )
         )
         session.isProcessAlive = true

--- a/Sources/OpenIslandApp/TerminalJumpService.swift
+++ b/Sources/OpenIslandApp/TerminalJumpService.swift
@@ -172,6 +172,45 @@ struct TerminalJumpService {
     }
 
     func jump(to target: JumpTarget) throws -> String {
+        // tmux sessions: switch pane first, then use the terminal-specific
+        // jump to focus the correct window/tab (not just activate the app).
+        if let tmuxTarget = target.tmuxTarget, !tmuxTarget.isEmpty {
+            let paneSelected = jumpToTmuxPane(target)
+
+            let descriptor = resolveTerminalApp(preferredName: target.terminalApp)
+
+            // Use the full terminal-specific jump (AppleScript for Ghostty/iTerm,
+            // CLI for WezTerm, etc.) to focus the correct window/tab.
+            if let descriptor {
+                switch descriptor.bundleIdentifier {
+                case "com.mitchellh.ghostty":
+                    if try jumpToGhosttyTerminal(target) {
+                        return "Focused the matching tmux pane in Ghostty."
+                    }
+                case "com.googlecode.iterm2":
+                    if try jumpToITermSession(target) {
+                        return "Focused the matching tmux pane in iTerm."
+                    }
+                case "com.apple.Terminal":
+                    if try jumpToTerminalTab(target) {
+                        return "Focused the matching tmux pane in Terminal."
+                    }
+                default:
+                    break
+                }
+
+                // Fallback: at least activate the app
+                try openAction(["-b", descriptor.bundleIdentifier])
+                return paneSelected
+                    ? "Focused the matching tmux pane and activated \(descriptor.displayName)."
+                    : "Activated \(descriptor.displayName). tmux pane targeting failed."
+            }
+
+            if paneSelected {
+                return "Focused the matching tmux pane."
+            }
+        }
+
         let descriptor = resolveTerminalApp(preferredName: target.terminalApp)
         let hasWorkingDirectory = target.workingDirectory.map { FileManager.default.fileExists(atPath: $0) } ?? false
         let hasPreciseLocator = [target.terminalSessionID, target.terminalTTY].contains {
@@ -411,6 +450,116 @@ struct TerminalJumpService {
         }
 
         return nil
+    }
+
+    // MARK: - Tmux CLI-based jump
+
+    private func jumpToTmuxPane(_ target: JumpTarget) -> Bool {
+        guard let tmuxTarget = target.tmuxTarget, !tmuxTarget.isEmpty else {
+            return false
+        }
+
+        guard let tmuxPath = resolveTmuxPath() else {
+            return false
+        }
+
+        // tmuxTarget is "session:window.pane" (e.g. "oss-contributions:3.0")
+        // When running from a macOS GUI app (outside tmux), there is no
+        // "current client" — $TMUX is not set. We must explicitly find the
+        // client TTY and pass it via -c to switch-client.
+
+        func socketArgs() -> [String] {
+            if let socketPath = target.tmuxSocketPath, !socketPath.isEmpty {
+                return ["-S", socketPath]
+            }
+            return []
+        }
+
+        // Extract "session:window" and "session" from "session:window.pane"
+        let sessionWindow: String
+        if let dotIndex = tmuxTarget.lastIndex(of: ".") {
+            sessionWindow = String(tmuxTarget[tmuxTarget.startIndex..<dotIndex])
+        } else {
+            sessionWindow = tmuxTarget
+        }
+
+        let sessionName: String
+        if let colonIndex = tmuxTarget.firstIndex(of: ":") {
+            sessionName = String(tmuxTarget[tmuxTarget.startIndex..<colonIndex])
+        } else {
+            sessionName = tmuxTarget
+        }
+
+        // Find the client TTY so we can explicitly target it with switch-client.
+        let clientTTY = runTmuxCommand(tmuxPath: tmuxPath, socketArgs: socketArgs(),
+                                       args: ["list-clients", "-F", "#{client_tty}"])?
+            .components(separatedBy: "\n").first { !$0.isEmpty }
+
+        // Step 1: switch-client — point the client at the target session.
+        if let clientTTY = clientTTY {
+            _ = runTmuxCommand(tmuxPath: tmuxPath, socketArgs: socketArgs(),
+                               args: ["switch-client", "-c", clientTTY, "-t", sessionName])
+        }
+
+        // Step 2: select-window — switch to the correct window.
+        _ = runTmuxCommand(tmuxPath: tmuxPath, socketArgs: socketArgs(),
+                           args: ["select-window", "-t", sessionWindow])
+
+        // Step 3: select-pane — focus the exact pane.
+        let spResult = runTmuxCommand(tmuxPath: tmuxPath, socketArgs: socketArgs(),
+                                      args: ["select-pane", "-t", tmuxTarget])
+
+        return spResult != nil
+    }
+
+    /// Run a tmux command and return its stdout (nil on failure).
+    /// Uses the same direct-exec pattern as ActiveAgentProcessDiscovery.commandOutput.
+    private func runTmuxCommand(tmuxPath: String, socketArgs: [String], args: [String]) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: tmuxPath)
+        process.arguments = socketArgs + args
+
+        let outPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+
+            guard process.terminationStatus == 0 else { return nil }
+
+            return String(data: outPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        } catch {
+            return nil
+        }
+    }
+
+    private func resolveTmuxPath() -> String? {
+        let candidates = [
+            "/opt/homebrew/bin/tmux",
+            "/usr/local/bin/tmux",
+            "/usr/bin/tmux",
+        ]
+
+        if let found = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) {
+            return found
+        }
+
+        // Fallback to 'which'
+        let whichTask = Process()
+        whichTask.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        whichTask.arguments = ["tmux"]
+        let pipe = Pipe()
+        whichTask.standardOutput = pipe
+        whichTask.standardError = FileHandle.nullDevice
+        guard (try? whichTask.run()) != nil else { return nil }
+        whichTask.waitUntilExit()
+        guard whichTask.terminationStatus == 0 else { return nil }
+        let path = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return path.isEmpty ? nil : path
     }
 
     // MARK: - Zellij CLI-based jump

--- a/Sources/OpenIslandApp/TerminalJumpTargetResolver.swift
+++ b/Sources/OpenIslandApp/TerminalJumpTargetResolver.swift
@@ -29,6 +29,12 @@ struct TerminalJumpTargetResolver {
         var ttyName: String?
     }
 
+    struct TmuxPaneSnapshot: Sendable {
+        var paneID: String
+        var tty: String
+        var title: String
+    }
+
     private static let appleScriptTimeout: TimeInterval = 3
     private static let fieldSeparator = "\u{1F}"
     private static let recordSeparator = "\u{1E}"
@@ -49,8 +55,29 @@ struct TerminalJumpTargetResolver {
             let name = normalizedTerminalName(for: $0.jumpTarget?.terminalApp)
             return name == "kaku" || name == "wezterm"
         }
+        // Tmux candidates: sessions that already have a tmuxTarget, OR sessions
+        // whose terminalTTY maps to a tmux pane (e.g. OpenCode sessions created
+        // by BridgeServer without tmux info). We discover the mapping below.
+        let tmuxSessions = sessions.filter {
+            $0.jumpTarget?.tmuxTarget != nil || $0.jumpTarget?.terminalTTY != nil
+        }
 
         var jumpTargetUpdates: [String: JumpTarget] = [:]
+
+        // Tmux: match sessions and resolve their tmux pane info.
+        // Also discovers tmux targets for sessions that only have a TTY.
+        if !tmuxSessions.isEmpty {
+            let tmuxSnapshots = fetchTmuxSnapshots()
+            if let snapshots = tmuxSnapshots {
+                let matched = matchTmuxSnapshots(snapshots, to: tmuxSessions)
+                for (sessionID, snapshot) in matched {
+                    if let session = sessions.first(where: { $0.id == sessionID }),
+                       let corrected = correctedTmuxJumpTarget(for: session, snapshot: snapshot) {
+                        jumpTargetUpdates[sessionID] = corrected
+                    }
+                }
+            }
+        }
 
         // Ghostty: match sessions to AppleScript snapshots.
         if !ghosttySessions.isEmpty || sessions.contains(where: { needsGhosttyProbe($0) }) {
@@ -200,6 +227,184 @@ struct TerminalJumpTargetResolver {
         }
 
         return changed ? jumpTarget : nil
+    }
+
+    // MARK: - Tmux matching
+
+    private func matchTmuxSnapshots(
+        _ snapshots: [TmuxPaneSnapshot],
+        to sessions: [AgentSession]
+    ) -> [String: TmuxPaneSnapshot] {
+        var assignments: [String: TmuxPaneSnapshot] = [:]
+
+        for snapshot in snapshots {
+            // TTY match
+            if let session = sessions.first(where: {
+                assignments[$0.id] == nil
+                    && nonEmptyValue($0.jumpTarget?.terminalTTY) == snapshot.tty
+            }) {
+                assignments[session.id] = snapshot
+                continue
+            }
+
+            // Pane ID match (tmuxTarget)
+            if let session = sessions.first(where: {
+                assignments[$0.id] == nil
+                    && nonEmptyValue($0.jumpTarget?.tmuxTarget) == snapshot.paneID
+            }) {
+                assignments[session.id] = snapshot
+                continue
+            }
+
+            // Title match
+            if let session = sessions.first(where: {
+                assignments[$0.id] == nil
+                    && nonEmptyValue($0.jumpTarget?.paneTitle).map { snapshot.title.contains($0) } == true
+            }) {
+                assignments[session.id] = snapshot
+            }
+        }
+
+        return assignments
+    }
+
+    private func correctedTmuxJumpTarget(
+        for session: AgentSession,
+        snapshot: TmuxPaneSnapshot
+    ) -> JumpTarget? {
+        guard var jumpTarget = session.jumpTarget else {
+            return nil
+        }
+
+        var changed = false
+
+        if nonEmptyValue(jumpTarget.terminalTTY) != snapshot.tty {
+            jumpTarget.terminalTTY = snapshot.tty
+            changed = true
+        }
+
+        if nonEmptyValue(jumpTarget.tmuxTarget) != snapshot.paneID {
+            jumpTarget.tmuxTarget = snapshot.paneID
+            changed = true
+        }
+
+        if let title = nonEmptyValue(snapshot.title),
+           title != jumpTarget.paneTitle {
+            jumpTarget.paneTitle = title
+            changed = true
+        }
+
+        return changed ? jumpTarget : nil
+    }
+
+    // MARK: - Tmux fetching
+
+    private func fetchTmuxSnapshots() -> [TmuxPaneSnapshot]? {
+        guard let tmuxPath = resolveTmuxPath() else {
+            return nil
+        }
+
+        // Use a printable multi-char separator — tmux converts control
+        // characters (0x09, 0x1F, etc.) to printable equivalents.
+        // Use session:window.pane target format so the jump service can
+        // extract session name for switch-client and session:window for
+        // select-window. Also fetch pane_tty for TTY matching.
+        let tmuxSep = "<|>"
+        guard let output = runTmuxCommand(
+            tmuxPath: tmuxPath,
+            arguments: [
+                "list-panes", "-a", "-F",
+                "#{session_name}:#{window_index}.#{pane_index}\(tmuxSep)#{pane_tty}\(tmuxSep)#{pane_title}",
+            ]
+        ) else {
+            return nil
+        }
+
+        let lines = output.split(separator: "\n")
+
+        return lines
+            .compactMap { line in
+                let parts = line.components(separatedBy: tmuxSep)
+                guard parts.count == 3 else {
+                    return nil
+                }
+
+                return TmuxPaneSnapshot(
+                    paneID: parts[0],  // e.g. "rust-projects:5.3"
+                    tty: parts[1],
+                    title: parts[2]
+                )
+            }
+    }
+
+    private func resolveTmuxPath() -> String? {
+        let candidates = [
+            "/opt/homebrew/bin/tmux",
+            "/usr/local/bin/tmux",
+            "/usr/bin/tmux",
+        ]
+
+        if let found = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) {
+            return found
+        }
+
+        // Fallback to 'which'
+        let whichTask = Process()
+        whichTask.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        whichTask.arguments = ["tmux"]
+        let pipe = Pipe()
+        whichTask.standardOutput = pipe
+        whichTask.standardError = FileHandle.nullDevice
+        if let _ = try? whichTask.run() {
+            whichTask.waitUntilExit()
+            if whichTask.terminationStatus == 0 {
+                let path = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                if !path.isEmpty { return path }
+            }
+        }
+
+        return nil
+    }
+
+    private func runTmuxCommand(tmuxPath: String, arguments: [String]) -> String? {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: tmuxPath)
+        task.arguments = arguments
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = FileHandle.nullDevice
+
+        let completionGroup = DispatchGroup()
+        completionGroup.enter()
+        task.terminationHandler = { _ in
+            completionGroup.leave()
+        }
+
+        do {
+            try task.run()
+        } catch {
+            return nil
+        }
+
+        let waitResult = completionGroup.wait(timeout: .now() + Self.appleScriptTimeout)
+        if waitResult == .timedOut {
+            task.terminate()
+            _ = completionGroup.wait(timeout: .now() + 0.2)
+            return nil
+        }
+
+        guard task.terminationStatus == 0 else { return nil }
+
+        let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        guard let output = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !output.isEmpty else {
+            return nil
+        }
+
+        return output
     }
 
     // MARK: - Terminal.app matching

--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -118,6 +118,8 @@ public struct JumpTarget: Equatable, Codable, Sendable {
     public var workingDirectory: String?
     public var terminalSessionID: String?
     public var terminalTTY: String?
+    public var tmuxTarget: String?
+    public var tmuxSocketPath: String?
 
     public init(
         terminalApp: String,
@@ -125,7 +127,9 @@ public struct JumpTarget: Equatable, Codable, Sendable {
         paneTitle: String,
         workingDirectory: String? = nil,
         terminalSessionID: String? = nil,
-        terminalTTY: String? = nil
+        terminalTTY: String? = nil,
+        tmuxTarget: String? = nil,
+        tmuxSocketPath: String? = nil
     ) {
         self.terminalApp = terminalApp
         self.workspaceName = workspaceName
@@ -133,6 +137,8 @@ public struct JumpTarget: Equatable, Codable, Sendable {
         self.workingDirectory = workingDirectory
         self.terminalSessionID = terminalSessionID
         self.terminalTTY = terminalTTY
+        self.tmuxTarget = tmuxTarget
+        self.tmuxSocketPath = tmuxSocketPath
     }
 }
 


### PR DESCRIPTION
Hi, thanks for this project! Super happy to see this open source alternative ❤️ 

I did see the CLAUDE.md file mention that tmux was out of scope, but I took
it as an instruction for agents, not a project-level restriction. As I exclusively use 
tmux, I went ahead. I was further motivated by the author of issue #235.

I hope this is the right time.

## Summary

When an agent (Claude Code, OpenCode, etc.) runs inside a tmux pane, clicking
its card in the Island UI now navigates to the exact tmux session, window, and
pane where the agent is running. Previously, clicking only activated the
terminal app (e.g. Ghostty) without switching the tmux context.

This required plumbing tmux pane information through the full discovery →
session → jump pipeline, and handling the constraint that GUI apps have no
`$TMUX` environment — so all tmux commands must explicitly target a client.

## Changes

- Add `tmuxTarget` and `tmuxSocketPath` fields to `JumpTarget` and
  `ProcessSnapshot` so tmux pane info flows end-to-end through the pipeline.
- Wire tmux fields from `ProcessSnapshot` into `JumpTarget` in
  `ProcessMonitoringCoordinator.syntheticClaudeSession()` for Claude Code
  sessions discovered via process monitoring.
- Broaden the `TerminalJumpTargetResolver` tmux candidate filter to include
  sessions with only a `terminalTTY` (no existing `tmuxTarget`), enabling
  tmux pane discovery for OpenCode/BridgeServer sessions via TTY matching.
- Add tmux pane fetching to `TerminalJumpTargetResolver` using `list-panes -a`
  with `session:window.pane` target format and a printable multi-char
  separator (`<|>`) — tmux converts control characters like `\t` and `\x1f`
  to printable equivalents when passed as raw bytes via Process arguments.
- Add `jumpToTmuxPane()` to `TerminalJumpService` executing the sequence
  `switch-client` → `select-window` → `select-pane`, with explicit client
  targeting via `list-clients` (required from GUI apps without `$TMUX`).
- Add `resolveTmuxInfo()` in `ActiveAgentProcessDiscovery` to discover tmux
  target, socket path, and host terminal app from the agent's TTY.

## Tested workflows

- Jump from a different window within the same tmux session → switches to
  the correct window and pane.
- Jump from a different tmux session entirely → switches session, window,
  and pane.
- Jump when Ghostty is on another macOS desktop space → brings Ghostty to
  focus and switches to the correct tmux context.
- Multiple agent panes in the same window (e.g. two OpenCode instances) →
  selects the correct pane matching the clicked agent card.

## Additional note

I'm not a huge fan of the mutating `ProcessSnapshot`, but preparing all the fields
upfront was not very nice either. Given the pace of the project, I expect all of this
will be refactored soon anyway. In my view, having a fully working tmux jump feature
is both a differentiation factor and a guard against drifting away from being able to 
support it in the future.

Closes #235