### PR TITLE
feat(terminal): support alternate bundle identifiers for Trae CN app

### DIFF
--- a/Sources/OpenIslandApp/TerminalJumpService.swift
+++ b/Sources/OpenIslandApp/TerminalJumpService.swift
@@ -13,6 +13,23 @@ struct TerminalJumpService {
         let displayName: String
         let bundleIdentifier: String
         let aliases: [String]
+        let alternateBundleIdentifiers: [String]
+
+        init(
+            displayName: String,
+            bundleIdentifier: String,
+            aliases: [String],
+            alternateBundleIdentifiers: [String] = []
+        ) {
+            self.displayName = displayName
+            self.bundleIdentifier = bundleIdentifier
+            self.aliases = aliases
+            self.alternateBundleIdentifiers = alternateBundleIdentifiers
+        }
+
+        var allBundleIdentifiers: [String] {
+            [bundleIdentifier] + alternateBundleIdentifiers
+        }
     }
 
     private static let knownApps: [TerminalAppDescriptor] = [
@@ -74,7 +91,8 @@ struct TerminalJumpService {
         TerminalAppDescriptor(
             displayName: "Trae",
             bundleIdentifier: "com.trae.app",
-            aliases: ["trae"]
+            aliases: ["trae", "trae cn", "trae-cn", "traecn"],
+            alternateBundleIdentifiers: ["cn.trae.app"]
         ),
         TerminalAppDescriptor(
             displayName: "IntelliJ IDEA",
@@ -137,6 +155,7 @@ struct TerminalJumpService {
         "com.todesktop.230313mzl4w4u92",
         "com.exafunction.windsurf",
         "com.trae.app",
+        "cn.trae.app",
     ]
 
     /// Bundle identifiers of terminal emulators that commonly host Zellij,
@@ -219,7 +238,8 @@ struct TerminalJumpService {
             }
             return !value.isEmpty
         }
-        let appIsRunning = descriptor.map { appRunningChecker($0.bundleIdentifier) } ?? false
+        let resolvedBundleIdentifier = descriptor.map(resolvedBundleIdentifier(for:))
+        let appIsRunning = descriptor.map(isRunning(descriptor:)) ?? false
 
         // Zellij is a terminal multiplexer, not a macOS .app. Handle it
         // before the descriptor-based dispatch since it won't have one.
@@ -236,7 +256,7 @@ struct TerminalJumpService {
         }
 
         if let descriptor {
-            switch descriptor.bundleIdentifier {
+            switch resolvedBundleIdentifier ?? descriptor.bundleIdentifier {
             case "com.googlecode.iterm2":
                 if try jumpToITermSession(target) {
                     return "Focused the matching iTerm session."
@@ -266,7 +286,7 @@ struct TerminalJumpService {
                     }
                 }
                 if appIsRunning {
-                    try openAction(["-b", descriptor.bundleIdentifier])
+                    try openAction(["-b", id])
                     return "Activated \(descriptor.displayName)."
                 }
             case let id where Self.jetbrainsBundleIDs.contains(id):
@@ -277,7 +297,7 @@ struct TerminalJumpService {
                     }
                 }
                 if appIsRunning {
-                    try openAction(["-b", descriptor.bundleIdentifier])
+                    try openAction(["-b", id])
                     return "Activated \(descriptor.displayName)."
                 }
             default:
@@ -286,17 +306,17 @@ struct TerminalJumpService {
         }
 
         if let descriptor, hasPreciseLocator, appIsRunning {
-            try openAction(["-b", descriptor.bundleIdentifier])
+            try openAction(["-b", resolvedBundleIdentifier ?? descriptor.bundleIdentifier])
             return "Activated \(descriptor.displayName). Exact pane targeting could not find the live terminal."
         }
 
         if let descriptor, hasWorkingDirectory, let workingDirectory = target.workingDirectory {
-            try openAction(["-b", descriptor.bundleIdentifier, workingDirectory])
+            try openAction(["-b", resolvedBundleIdentifier ?? descriptor.bundleIdentifier, workingDirectory])
             return "Opened \(target.workspaceName) in \(descriptor.displayName). Exact pane targeting is still best-effort."
         }
 
         if let descriptor {
-            try openAction(["-b", descriptor.bundleIdentifier])
+            try openAction(["-b", resolvedBundleIdentifier ?? descriptor.bundleIdentifier])
             return "Activated \(descriptor.displayName). Exact pane targeting is still best-effort."
         }
 
@@ -348,6 +368,7 @@ struct TerminalJumpService {
         "com.todesktop.230313mzl4w4u92": "cursor",
         "com.exafunction.windsurf": "windsurf",
         "com.trae.app": "trae",
+        "cn.trae.app": "trae",
     ]
 
     private func jumpToVSCodeFamilyWorkspace(_ workspacePath: String, bundleIdentifier: String) -> Bool {
@@ -1018,11 +1039,25 @@ struct TerminalJumpService {
             return exact
         }
 
-        return Self.knownApps.first(where: { isInstalled(bundleIdentifier: $0.bundleIdentifier) })
+        return Self.knownApps.first(where: isInstalled(descriptor:))
     }
 
-    private func isInstalled(bundleIdentifier: String) -> Bool {
-        applicationResolver(bundleIdentifier) != nil
+    private func isInstalled(descriptor: TerminalAppDescriptor) -> Bool {
+        descriptor.allBundleIdentifiers.contains { applicationResolver($0) != nil }
+    }
+
+    private func isRunning(descriptor: TerminalAppDescriptor) -> Bool {
+        descriptor.allBundleIdentifiers.contains(where: appRunningChecker)
+    }
+
+    private func resolvedBundleIdentifier(for descriptor: TerminalAppDescriptor) -> String {
+        if let running = descriptor.allBundleIdentifiers.first(where: appRunningChecker) {
+            return running
+        }
+        if let installed = descriptor.allBundleIdentifiers.first(where: { applicationResolver($0) != nil }) {
+            return installed
+        }
+        return descriptor.bundleIdentifier
     }
 
     private func runAppleScript(_ script: String) throws -> String {

--- a/Sources/OpenIslandApp/TerminalJumpService.swift
+++ b/Sources/OpenIslandApp/TerminalJumpService.swift
@@ -14,17 +14,20 @@ struct TerminalJumpService {
         let bundleIdentifier: String
         let aliases: [String]
         let alternateBundleIdentifiers: [String]
+        let preferredBundleIdentifiersByAlias: [String: String]
 
         init(
             displayName: String,
             bundleIdentifier: String,
             aliases: [String],
-            alternateBundleIdentifiers: [String] = []
+            alternateBundleIdentifiers: [String] = [],
+            preferredBundleIdentifiersByAlias: [String: String] = [:]
         ) {
             self.displayName = displayName
             self.bundleIdentifier = bundleIdentifier
             self.aliases = aliases
             self.alternateBundleIdentifiers = alternateBundleIdentifiers
+            self.preferredBundleIdentifiersByAlias = preferredBundleIdentifiersByAlias
         }
 
         var allBundleIdentifiers: [String] {
@@ -92,7 +95,13 @@ struct TerminalJumpService {
             displayName: "Trae",
             bundleIdentifier: "com.trae.app",
             aliases: ["trae", "trae cn", "trae-cn", "traecn"],
-            alternateBundleIdentifiers: ["cn.trae.app"]
+            alternateBundleIdentifiers: ["cn.trae.app"],
+            preferredBundleIdentifiersByAlias: [
+                "trae": "com.trae.app",
+                "trae cn": "cn.trae.app",
+                "trae-cn": "cn.trae.app",
+                "traecn": "cn.trae.app",
+            ]
         ),
         TerminalAppDescriptor(
             displayName: "IntelliJ IDEA",
@@ -230,6 +239,7 @@ struct TerminalJumpService {
             }
         }
 
+        let normalizedPreferredName = normalizeTerminalAppName(target.terminalApp)
         let descriptor = resolveTerminalApp(preferredName: target.terminalApp)
         let hasWorkingDirectory = target.workingDirectory.map { FileManager.default.fileExists(atPath: $0) } ?? false
         let hasPreciseLocator = [target.terminalSessionID, target.terminalTTY].contains {
@@ -238,8 +248,26 @@ struct TerminalJumpService {
             }
             return !value.isEmpty
         }
-        let resolvedBundleIdentifier = descriptor.map(resolvedBundleIdentifier(for:))
-        let appIsRunning = descriptor.map(isRunning(descriptor:)) ?? false
+        let preferredBundleIdentifier: String?
+        if let descriptor {
+            preferredBundleIdentifier = preferredBundleIdentifierForAlias(
+                for: descriptor,
+                normalizedPreferredName: normalizedPreferredName
+            )
+        } else {
+            preferredBundleIdentifier = nil
+        }
+
+        let resolvedBundleIdentifier: String?
+        if let descriptor {
+            resolvedBundleIdentifier = resolveBundleIdentifier(
+                for: descriptor,
+                preferredBundleIdentifier: preferredBundleIdentifier
+            )
+        } else {
+            resolvedBundleIdentifier = nil
+        }
+        let appIsRunning = resolvedBundleIdentifier.map(appRunningChecker) ?? false
 
         // Zellij is a terminal multiplexer, not a macOS .app. Handle it
         // before the descriptor-based dispatch since it won't have one.
@@ -1020,9 +1048,7 @@ struct TerminalJumpService {
     }
 
     private func resolveTerminalApp(preferredName: String) -> TerminalAppDescriptor? {
-        let normalized = preferredName
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
+        let normalized = normalizeTerminalAppName(preferredName)
 
         // "Unknown" is the hook-side sentinel meaning "we could not classify this
         // terminal". Returning nil here lets jump() fall through to the Finder
@@ -1042,22 +1068,46 @@ struct TerminalJumpService {
         return Self.knownApps.first(where: isInstalled(descriptor:))
     }
 
+    private func normalizeTerminalAppName(_ preferredName: String) -> String {
+        preferredName
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+    }
+
     private func isInstalled(descriptor: TerminalAppDescriptor) -> Bool {
         descriptor.allBundleIdentifiers.contains { applicationResolver($0) != nil }
     }
 
-    private func isRunning(descriptor: TerminalAppDescriptor) -> Bool {
-        descriptor.allBundleIdentifiers.contains(where: appRunningChecker)
+    private func preferredBundleIdentifierForAlias(
+        for descriptor: TerminalAppDescriptor,
+        normalizedPreferredName: String
+    ) -> String? {
+        if let aliasSpecific = descriptor.preferredBundleIdentifiersByAlias[normalizedPreferredName] {
+            return aliasSpecific
+        }
+        if descriptor.displayName.lowercased() == normalizedPreferredName {
+            return descriptor.bundleIdentifier
+        }
+        return nil
     }
 
-    private func resolvedBundleIdentifier(for descriptor: TerminalAppDescriptor) -> String {
+    private func resolveBundleIdentifier(
+        for descriptor: TerminalAppDescriptor,
+        preferredBundleIdentifier: String?
+    ) -> String {
+        if let preferredBundleIdentifier, appRunningChecker(preferredBundleIdentifier) {
+            return preferredBundleIdentifier
+        }
+        if let preferredBundleIdentifier, applicationResolver(preferredBundleIdentifier) != nil {
+            return preferredBundleIdentifier
+        }
         if let running = descriptor.allBundleIdentifiers.first(where: appRunningChecker) {
             return running
         }
         if let installed = descriptor.allBundleIdentifiers.first(where: { applicationResolver($0) != nil }) {
             return installed
         }
-        return descriptor.bundleIdentifier
+        return preferredBundleIdentifier ?? descriptor.bundleIdentifier
     }
 
     private func runAppleScript(_ script: String) throws -> String {

--- a/Tests/OpenIslandAppTests/TerminalJumpServiceTests.swift
+++ b/Tests/OpenIslandAppTests/TerminalJumpServiceTests.swift
@@ -135,7 +135,8 @@ final class TerminalJumpServiceTests: XCTestCase {
             openAction: { arguments in
                 openedArguments.values.append(arguments)
             },
-            appleScriptRunner: { _ in "" }
+            appleScriptRunner: { _ in "" },
+            processRunner: { _, _ in false }
         )
 
         let result = try service.jump(

--- a/Tests/OpenIslandAppTests/TerminalJumpServiceTests.swift
+++ b/Tests/OpenIslandAppTests/TerminalJumpServiceTests.swift
@@ -8,6 +8,10 @@ final class TerminalJumpServiceTests: XCTestCase {
         var values: [[String]] = []
     }
 
+    private final class ProcessInvocationBox: @unchecked Sendable {
+        var values: [(String, [String])] = []
+    }
+
     func testGhosttyJumpScriptActivatesWindowAndRetriesFocusUntilItSticks() {
         let target = JumpTarget(
             terminalApp: "Ghostty",
@@ -205,6 +209,68 @@ final class TerminalJumpServiceTests: XCTestCase {
             result.contains("Finder"),
             "Expected Finder fallback, got: \(result)"
         )
+    }
+
+    func testTraeJumpActivatesRunningTraeCNApp() throws {
+        let openedArguments = OpenedArgumentsBox()
+        let service = TerminalJumpService(
+            applicationResolver: { bundleIdentifier in
+                bundleIdentifier == "cn.trae.app" ? URL(fileURLWithPath: "/Applications/Trae CN.app") : nil
+            },
+            appRunningChecker: { bundleIdentifier in
+                bundleIdentifier == "cn.trae.app"
+            },
+            openAction: { arguments in
+                openedArguments.values.append(arguments)
+            },
+            appleScriptRunner: { _ in "" }
+        )
+
+        let result = try service.jump(
+            to: JumpTarget(
+                terminalApp: "Trae",
+                workspaceName: "open-vibe-island",
+                paneTitle: "Trae abc123",
+                workingDirectory: "/Users/test/open-vibe-island"
+            )
+        )
+
+        XCTAssertEqual(result, "Activated Trae.")
+        XCTAssertEqual(openedArguments.values, [["-b", "cn.trae.app"]])
+    }
+
+    func testTraeCNJumpFallsBackToWorkspaceViaTraeCLI() throws {
+        let openedArguments = OpenedArgumentsBox()
+        let processInvocations = ProcessInvocationBox()
+        let service = TerminalJumpService(
+            applicationResolver: { bundleIdentifier in
+                bundleIdentifier == "cn.trae.app" ? URL(fileURLWithPath: "/Applications/Trae CN.app") : nil
+            },
+            appRunningChecker: { _ in false },
+            openAction: { arguments in
+                openedArguments.values.append(arguments)
+            },
+            appleScriptRunner: { _ in "" },
+            processRunner: { executable, arguments in
+                processInvocations.values.append((executable, arguments))
+                return true
+            }
+        )
+
+        let result = try service.jump(
+            to: JumpTarget(
+                terminalApp: "Trae CN",
+                workspaceName: "open-vibe-island",
+                paneTitle: "Trae abc123",
+                workingDirectory: "/Users/test/open-vibe-island"
+            )
+        )
+
+        XCTAssertEqual(result, "Focused the matching Trae workspace.")
+        XCTAssertTrue(openedArguments.values.isEmpty)
+        XCTAssertEqual(processInvocations.values.count, 1)
+        XCTAssertEqual(processInvocations.values.first?.0, "trae")
+        XCTAssertEqual(processInvocations.values.first?.1, ["-r", "/Users/test/open-vibe-island"])
     }
 }
 

--- a/Tests/OpenIslandAppTests/TerminalJumpServiceTests.swift
+++ b/Tests/OpenIslandAppTests/TerminalJumpServiceTests.swift
@@ -239,6 +239,40 @@ final class TerminalJumpServiceTests: XCTestCase {
         XCTAssertEqual(openedArguments.values, [["-b", "cn.trae.app"]])
     }
 
+    func testTraeCNJumpPrefersCNBundleWhenBothTraeVariantsExist() throws {
+        let openedArguments = OpenedArgumentsBox()
+        let service = TerminalJumpService(
+            applicationResolver: { bundleIdentifier in
+                switch bundleIdentifier {
+                case "com.trae.app":
+                    return URL(fileURLWithPath: "/Applications/Trae.app")
+                case "cn.trae.app":
+                    return URL(fileURLWithPath: "/Applications/Trae CN.app")
+                default:
+                    return nil
+                }
+            },
+            appRunningChecker: { bundleIdentifier in
+                bundleIdentifier == "com.trae.app"
+            },
+            openAction: { arguments in
+                openedArguments.values.append(arguments)
+            },
+            appleScriptRunner: { _ in "" }
+        )
+
+        let result = try service.jump(
+            to: JumpTarget(
+                terminalApp: "Trae CN",
+                workspaceName: "open-vibe-island",
+                paneTitle: "Trae abc123"
+            )
+        )
+
+        XCTAssertEqual(result, "Activated Trae. Exact pane targeting is still best-effort.")
+        XCTAssertEqual(openedArguments.values, [["-b", "cn.trae.app"]])
+    }
+
     func testTraeCNJumpFallsBackToWorkspaceViaTraeCLI() throws {
         let openedArguments = OpenedArgumentsBox()
         let processInvocations = ProcessInvocationBox()


### PR DESCRIPTION
Add support for handling alternate bundle identifiers in TerminalJumpService, specifically for Trae CN app. This allows the service to properly detect and activate both standard and CN variants of the Trae terminal app. Includes corresponding test cases to verify the new functionality.