### PR TITLE
feat: port approval UX features from pixel-office

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -744,12 +744,12 @@ final class AppModel {
         }
     }
 
-    func approvePermission(for sessionID: String, approved: Bool) {
+    func approvePermission(for sessionID: String, approved: Bool, additionalContext: String? = nil) {
         guard let session = state.session(id: sessionID) else {
             return
         }
 
-        let resolution = permissionResolution(for: approved)
+        let resolution = permissionResolution(for: approved, additionalContext: additionalContext)
         dismissNotificationSurfaceIfPresent(for: sessionID)
         state.resolvePermission(sessionID: session.id, resolution: resolution)
         synchronizeSelection()
@@ -763,7 +763,7 @@ final class AppModel {
         )
     }
 
-    func approvePermission(for sessionID: String, action: ApprovalAction) {
+    func approvePermission(for sessionID: String, action: ApprovalAction, additionalContext: String? = nil) {
         guard let session = state.session(id: sessionID) else {
             return
         }
@@ -773,13 +773,13 @@ final class AppModel {
 
         switch action {
         case .deny:
-            resolution = .deny(message: "Permission denied in Open Island.", interrupt: false)
+            resolution = .deny(message: "Permission denied in Open Island.", interrupt: false, additionalContext: additionalContext)
             message = "Denying permission for \(session.title)."
         case .allowOnce:
-            resolution = .allowOnce()
+            resolution = .allowOnce(additionalContext: additionalContext)
             message = "Approving permission for \(session.title)."
         case let .allowWithUpdates(updates):
-            resolution = .allowOnce(updatedPermissions: updates)
+            resolution = .allowOnce(updatedPermissions: updates, additionalContext: additionalContext)
             message = "Always allowing for \(session.title)."
         }
 
@@ -833,12 +833,26 @@ final class AppModel {
         }
     }
 
-    private func permissionResolution(for approved: Bool) -> PermissionResolution {
+    private func permissionResolution(for approved: Bool, additionalContext: String? = nil) -> PermissionResolution {
         if approved {
-            return .allowOnce()
+            return .allowOnce(additionalContext: additionalContext)
         }
 
-        return .deny(message: "Permission denied in Open Island.", interrupt: false)
+        return .deny(message: "Permission denied in Open Island.", interrupt: false, additionalContext: additionalContext)
+    }
+
+    // MARK: - Approval Rules
+
+    var approvalRules: [ApprovalRule] {
+        ApprovalRuleEngine.shared.getRules()
+    }
+
+    func addApprovalRule(pattern: String, action: ApprovalRule.RuleAction, label: String? = nil) {
+        ApprovalRuleEngine.shared.addRule(pattern: pattern, action: action, label: label)
+    }
+
+    func removeApprovalRule(id: UUID) {
+        ApprovalRuleEngine.shared.removeRule(id: id)
     }
 
     func applyTrackedEvent(

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -524,7 +524,8 @@ struct IslandPanelView: View {
                     useDrawingGroup: model.notchStatus == .opened,
                     isInteractive: model.notchStatus == .opened,
                     lang: model.lang,
-                    onApprove: { model.approvePermission(for: session.id, action: $0) },
+                    onApprove: { action, context in model.approvePermission(for: session.id, action: action, additionalContext: context) },
+                    onCreateRule: { pattern, action in model.addApprovalRule(pattern: pattern, action: action) },
                     onAnswer: { model.answerQuestion(for: session.id, answer: $0) },
                     onJump: { model.jumpToSession(session) }
                 )
@@ -551,7 +552,8 @@ struct IslandPanelView: View {
                         useDrawingGroup: model.notchStatus == .opened,
                         isInteractive: model.notchStatus == .opened,
                         lang: model.lang,
-                        onApprove: { model.approvePermission(for: session.id, action: $0) },
+                        onApprove: { action, context in model.approvePermission(for: session.id, action: action, additionalContext: context) },
+                        onCreateRule: { pattern, action in model.addApprovalRule(pattern: pattern, action: action) },
                         onAnswer: { model.answerQuestion(for: session.id, answer: $0) },
                         onJump: { model.jumpToSession(session) },
                         onDismiss: session.isRemote ? { model.dismissSession(session.id) } : nil
@@ -974,13 +976,17 @@ private struct IslandSessionRow: View {
     var useDrawingGroup: Bool = true
     var isInteractive: Bool = true
     var lang: LanguageManager = .shared
-    var onApprove: ((ApprovalAction) -> Void)?
+    var onApprove: ((ApprovalAction, String?) -> Void)?
+    var onCreateRule: ((String, ApprovalRule.RuleAction) -> Void)?
     var onAnswer: ((QuestionPromptResponse) -> Void)?
     let onJump: () -> Void
     var onDismiss: (() -> Void)?
 
     @State private var isHighlighted = false
     @State private var isManuallyExpanded = false
+    @State private var approvalNote = ""
+    @State private var isNoteExpanded = false
+    @FocusState private var isNoteFocused: Bool
 
     var body: some View {
         rowBody(referenceDate: referenceDate)
@@ -1220,11 +1226,69 @@ private struct IslandSessionRow: View {
                     .strokeBorder(.orange.opacity(0.18))
             )
 
+            // Permission suggestion buttons from Claude
+            if let suggestions = session.permissionRequest?.suggestedUpdates, !suggestions.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(Array(suggestions.enumerated()), id: \.offset) { _, update in
+                        Button(update.displayLabel) {
+                            onApprove?(.allowWithUpdates([update]), nil)
+                        }
+                        .buttonStyle(IslandWideButtonStyle(kind: .primary))
+                    }
+                }
+            }
+
+            // Note input
+            if isNoteExpanded {
+                TextField("Instructions for Claude...", text: $approvalNote, axis: .vertical)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 12, design: .default))
+                    .foregroundStyle(.white.opacity(0.9))
+                    .padding(10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .frame(minHeight: 36)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .fill(.white.opacity(0.06))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .strokeBorder(.white.opacity(0.12))
+                    )
+                    .focused($isNoteFocused)
+                    .lineLimit(1 ... 4)
+                    .onSubmit {
+                        isNoteFocused = false
+                    }
+            } else {
+                Button {
+                    isNoteExpanded = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                        isNoteFocused = true
+                    }
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "plus.circle")
+                            .font(.system(size: 11))
+                        Text("add note")
+                            .font(.system(size: 11))
+                    }
+                    .foregroundStyle(.white.opacity(0.4))
+                }
+                .buttonStyle(.plain)
+            }
+
             HStack(spacing: 8) {
-                Button("No") { onApprove?(.deny) }
-                    .buttonStyle(IslandWideButtonStyle(kind: .secondary))
-                Button("Yes") { onApprove?(.allowOnce) }
-                    .buttonStyle(IslandWideButtonStyle(kind: .warning))
+                Button("No") {
+                    onApprove?(.deny, approvalNote.isEmpty ? nil : "[Boss says] \(approvalNote)")
+                }
+                .buttonStyle(IslandWideButtonStyle(kind: .secondary))
+                .keyboardShortcut("n", modifiers: .command)
+                Button("Yes") {
+                    onApprove?(.allowOnce, approvalNote.isEmpty ? nil : "[Boss says] \(approvalNote)")
+                }
+                .buttonStyle(IslandWideButtonStyle(kind: .warning))
+                .keyboardShortcut("y", modifiers: .command)
                 if let toolName = session.permissionRequest?.toolName {
                     Button("Always Allow (\(toolName))") {
                         let rule = ClaudePermissionRuleValue(toolName: toolName)
@@ -1233,9 +1297,22 @@ private struct IslandSessionRow: View {
                             rules: [rule],
                             behavior: .allow
                         )
-                        onApprove?(.allowWithUpdates([update]))
+                        onApprove?(.allowWithUpdates([update]), approvalNote.isEmpty ? nil : "[Boss says] \(approvalNote)")
                     }
                     .buttonStyle(IslandWideButtonStyle(kind: .danger))
+
+                    Button("Save Rule") {
+                        let pattern: String
+                        if toolName == "Bash", let summary = session.permissionRequest?.summary {
+                            // Extract base command from summary (e.g. "rm -rf /tmp/foo" -> "rm")
+                            let base = summary.split(separator: " ").first.map(String.init) ?? summary
+                            pattern = base
+                        } else {
+                            pattern = toolName
+                        }
+                        onCreateRule?(pattern, .allow)
+                    }
+                    .buttonStyle(IslandWideButtonStyle(kind: .primary))
                 }
             }
         }

--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -292,8 +292,8 @@ public enum ApprovalAction: Sendable {
 }
 
 public enum PermissionResolution: Equatable, Codable, Sendable {
-    case allowOnce(updatedInput: ClaudeHookJSONValue? = nil, updatedPermissions: [ClaudePermissionUpdate] = [])
-    case deny(message: String? = nil, interrupt: Bool = false)
+    case allowOnce(updatedInput: ClaudeHookJSONValue? = nil, updatedPermissions: [ClaudePermissionUpdate] = [], additionalContext: String? = nil)
+    case deny(message: String? = nil, interrupt: Bool = false, additionalContext: String? = nil)
 
     public var isApproved: Bool {
         switch self {
@@ -301,6 +301,13 @@ public enum PermissionResolution: Equatable, Codable, Sendable {
             true
         case .deny:
             false
+        }
+    }
+
+    public var additionalContext: String? {
+        switch self {
+        case let .allowOnce(_, _, ctx): ctx
+        case let .deny(_, _, ctx): ctx
         }
     }
 }

--- a/Sources/OpenIslandCore/ApprovalRuleEngine.swift
+++ b/Sources/OpenIslandCore/ApprovalRuleEngine.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+/// A persistent allow/deny rule for tool calls.
+public struct ApprovalRule: Codable, Sendable, Identifiable, Equatable {
+    public var id: UUID
+    public var pattern: String
+    public var action: RuleAction
+    public var label: String
+    public var addedAt: Date
+
+    public enum RuleAction: String, Codable, Sendable {
+        case allow
+        case deny
+    }
+
+    public init(
+        id: UUID = UUID(),
+        pattern: String,
+        action: RuleAction,
+        label: String? = nil,
+        addedAt: Date = Date()
+    ) {
+        self.id = id
+        self.pattern = pattern.lowercased()
+        self.action = action
+        self.label = label ?? pattern
+        self.addedAt = addedAt
+    }
+}
+
+/// Persistent rule engine for auto-approving or auto-denying tool calls.
+/// Rules are checked before the built-in classifier. Deny wins over allow.
+public final class ApprovalRuleEngine: Sendable {
+    private let rulesURL: URL
+    private let lock = NSLock()
+
+    private struct RulesData: Codable {
+        var rules: [ApprovalRule]
+    }
+
+    public static let shared = ApprovalRuleEngine()
+
+    private init() {
+        let supportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            .first!
+            .appendingPathComponent("OpenIsland", isDirectory: true)
+        try? FileManager.default.createDirectory(at: supportDir, withIntermediateDirectories: true)
+        rulesURL = supportDir.appendingPathComponent("rules.json")
+    }
+
+    // MARK: - Public API
+
+    public func getRules() -> [ApprovalRule] {
+        lock.withLock { load().rules }
+    }
+
+    public func addRule(pattern: String, action: ApprovalRule.RuleAction, label: String? = nil) -> Bool {
+        lock.withLock {
+            var data = load()
+            let normalized = pattern.lowercased()
+            // Prevent duplicates
+            if data.rules.contains(where: { $0.pattern == normalized && $0.action == action }) {
+                return false
+            }
+            data.rules.append(ApprovalRule(pattern: pattern, action: action, label: label))
+            save(data)
+            return true
+        }
+    }
+
+    public func removeRule(id: UUID) -> Bool {
+        lock.withLock {
+            var data = load()
+            let before = data.rules.count
+            data.rules.removeAll { $0.id == id }
+            if data.rules.count < before {
+                save(data)
+                return true
+            }
+            return false
+        }
+    }
+
+    /// Check a Bash command against rules. Returns 'allow', 'deny', or nil (no match).
+    public func matchBashCommand(_ command: String) -> ApprovalRule.RuleAction? {
+        let rules = lock.withLock { load().rules }
+        let normalized = command.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+
+        var bestDeny: ApprovalRule? = nil
+        var bestAllow: ApprovalRule? = nil
+
+        for rule in rules {
+            let pat = rule.pattern
+            // Full command prefix match
+            if matchPrefix(normalized, pattern: pat) {
+                if rule.action == .deny {
+                    if bestDeny == nil || pat.count > bestDeny!.pattern.count { bestDeny = rule }
+                } else {
+                    if bestAllow == nil || pat.count > bestAllow!.pattern.count { bestAllow = rule }
+                }
+                continue
+            }
+            // Check individual segments of compound commands
+            let segments = normalized.split(whereSeparator: { "&&||;|".contains($0) })
+            for seg in segments {
+                let trimmed = seg.trimmingCharacters(in: .whitespaces)
+                if matchPrefix(trimmed, pattern: pat) {
+                    if rule.action == .deny {
+                        if bestDeny == nil || pat.count > bestDeny!.pattern.count { bestDeny = rule }
+                    } else {
+                        if bestAllow == nil || pat.count > bestAllow!.pattern.count { bestAllow = rule }
+                    }
+                    break
+                }
+            }
+        }
+
+        // Deny wins over allow
+        if let bestDeny { return .deny }
+        if let bestAllow { return .allow }
+        return nil
+    }
+
+    /// Check a non-Bash tool name against rules. Returns 'allow', 'deny', or nil.
+    public func matchToolName(_ toolName: String) -> ApprovalRule.RuleAction? {
+        let rules = lock.withLock { load().rules }
+        // Check deny first
+        if rules.contains(where: { $0.action == .deny && $0.pattern == toolName }) { return .deny }
+        if rules.contains(where: { $0.action == .allow && $0.pattern == toolName }) { return .allow }
+        return nil
+    }
+
+    // MARK: - Private
+
+    private func load() -> RulesData {
+        guard let data = try? Data(contentsOf: rulesURL),
+              let decoded = try? JSONDecoder().decode(RulesData.self, from: data) else {
+            return RulesData(rules: [])
+        }
+        return decoded
+    }
+
+    private func save(_ data: RulesData) {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        if let encoded = try? encoder.encode(data) {
+            try? encoded.write(to: rulesURL, options: .atomic)
+        }
+    }
+
+    private func matchPrefix(_ command: String, pattern: String) -> Bool {
+        command == pattern
+            || command.hasPrefix(pattern + " ")
+            || command.hasPrefix(pattern + "\t")
+    }
+}

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -29,6 +29,13 @@ public final class BridgeServer: @unchecked Sendable {
 
         let clientID: UUID
         let kind: Kind
+        let createdAt: ContinuousClock.Instant
+
+        init(clientID: UUID, kind: Kind) {
+            self.clientID = clientID
+            self.kind = kind
+            self.createdAt = ContinuousClock.now
+        }
     }
 
     private struct PendingOpenCodeInteraction {
@@ -68,6 +75,9 @@ public final class BridgeServer: @unchecked Sendable {
     /// Maps toolUseID → temporary task ID for TaskCreate, so postToolUse can update with real ID.
     private var pendingTaskCreations: [String: String] = [:]
     private var stateSnapshot = SessionState()
+    /// Timer that auto-denies stale pending interactions after 10 minutes.
+    private var pendingInteractionTimer: DispatchSourceTimer?
+    private static let pendingInteractionTimeout: Duration = .seconds(600) // 10 minutes
     /// Local working state: tracks sessions emitted by this server between
     /// snapshot pushes from AppModel. This is NOT a duplicate of AppModel's
     /// state — it only contains sessions created via bridge hooks and is
@@ -101,6 +111,37 @@ public final class BridgeServer: @unchecked Sendable {
             if let legacyListener = try? bindListener(at: legacyURL) {
                 listeners.append(legacyListener)
             }
+        }
+
+        startPendingInteractionTimer()
+    }
+
+    private func startPendingInteractionTimer() {
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + 60, repeating: .seconds(60))
+        timer.setEventHandler { [weak self] in
+            self?.expireStalePendingInteractions()
+        }
+        timer.resume()
+        pendingInteractionTimer = timer
+    }
+
+    private func expireStalePendingInteractions() {
+        let now = ContinuousClock.now
+        let threshold = now - Self.pendingInteractionTimeout
+
+        let staleSessions = pendingClaudeInteractions.filter { $0.value.createdAt < threshold }
+        for (sessionID, _) in staleSessions {
+            pendingClaudeInteractions.removeValue(forKey: sessionID)
+            emit(
+                .actionableStateResolved(
+                    ActionableStateResolved(
+                        sessionID: sessionID,
+                        summary: "Approval timed out after 10 minutes.",
+                        timestamp: .now
+                    )
+                )
+            )
         }
     }
 
@@ -172,6 +213,9 @@ public final class BridgeServer: @unchecked Sendable {
     }
 
     private func stopLocked() {
+        pendingInteractionTimer?.cancel()
+        pendingInteractionTimer = nil
+
         pendingApprovals.removeAll()
         pendingClaudeInteractions.removeAll()
         pendingClaudeToolContexts.removeAll()
@@ -340,7 +384,7 @@ public final class BridgeServer: @unchecked Sendable {
                     directive = CursorHookDirective(continue: true, permission: .allow)
                     summary = "Permission approved."
                     phase = .running
-                case let .deny(message, _):
+                case let .deny(message, _, _):
                     directive = CursorHookDirective(continue: true, permission: .deny, agentMessage: message)
                     summary = message ?? "Permission denied in Open Island."
                     phase = .completed
@@ -654,31 +698,54 @@ public final class BridgeServer: @unchecked Sendable {
                     kind: .question(payload, prompt)
                 )
             } else {
-                let suggestions = payload.permissionSuggestions ?? []
+                // Auto-approve safe tools via classifier
+                let risk = ToolRiskClassifier.classify(
+                    toolName: payload.toolName ?? "",
+                    toolInput: payload.toolInput
+                )
 
-                emit(
-                    .permissionRequested(
-                        PermissionRequested(
-                            sessionID: payload.sessionID,
-                            request: PermissionRequest(
-                                title: payload.permissionRequestTitle,
-                                summary: payload.permissionRequestSummary,
-                                affectedPath: payload.permissionAffectedPath,
-                                primaryActionTitle: "Allow Once",
-                                secondaryActionTitle: "Deny",
-                                toolName: payload.toolName,
-                                toolUseID: claudeToolUseID(for: payload),
-                                suggestedUpdates: suggestions
-                            ),
-                            timestamp: .now
+                if risk == .safe {
+                    let directive: ClaudeHookDirective = .permissionRequest(
+                        .allow(updatedInput: payload.toolInput)
+                    )
+                    send(.response(.claudeHookDirective(directive)), to: clientID)
+                    emit(
+                        .activityUpdated(
+                            SessionActivityUpdated(
+                                sessionID: payload.sessionID,
+                                summary: "Auto-approved \(payload.toolName ?? "tool").",
+                                phase: .running,
+                                timestamp: .now
+                            )
                         )
                     )
-                )
+                } else {
+                    let suggestions = payload.permissionSuggestions ?? []
 
-                pendingClaudeInteractions[payload.sessionID] = PendingClaudeInteraction(
-                    clientID: clientID,
-                    kind: .permission(payload)
-                )
+                    emit(
+                        .permissionRequested(
+                            PermissionRequested(
+                                sessionID: payload.sessionID,
+                                request: PermissionRequest(
+                                    title: payload.permissionRequestTitle,
+                                    summary: payload.permissionRequestSummary,
+                                    affectedPath: payload.permissionAffectedPath,
+                                    primaryActionTitle: "Allow Once",
+                                    secondaryActionTitle: "Deny",
+                                    toolName: payload.toolName,
+                                    toolUseID: claudeToolUseID(for: payload),
+                                    suggestedUpdates: suggestions
+                                ),
+                                timestamp: .now
+                            )
+                        )
+                    )
+
+                    pendingClaudeInteractions[payload.sessionID] = PendingClaudeInteraction(
+                        clientID: clientID,
+                        kind: .permission(payload)
+                    )
+                }
             }
 
         case .postToolUse:
@@ -1474,7 +1541,7 @@ public final class BridgeServer: @unchecked Sendable {
             summary = payload.toolName.map { "Permission approved for \($0)." } ?? "Permission approved."
             phase = .running
 
-        case let (.permission(_), .deny(message, _)):
+        case let (.permission(_), .deny(message, _, _)):
             directive = .deny(reason: message ?? "Permission denied in Open Island.")
             summary = message ?? "Permission denied in Open Island."
             phase = .completed
@@ -1484,7 +1551,7 @@ public final class BridgeServer: @unchecked Sendable {
             summary = "OpenCode's question was answered."
             phase = .running
 
-        case let (.question(_), .deny(message, _)):
+        case let (.question(_), .deny(message, _, _)):
             directive = .deny(reason: message ?? "Declined to answer.")
             summary = message ?? "Declined to answer."
             phase = .completed
@@ -2060,32 +2127,32 @@ public final class BridgeServer: @unchecked Sendable {
         let phase: SessionPhase
 
         switch (pendingInteraction.kind, resolution) {
-        case let (.permission(payload), .allowOnce(updatedInput, updatedPermissions)):
+        case let (.permission(payload), .allowOnce(updatedInput, updatedPermissions, additionalContext)):
             let finalInput = updatedInput ?? payload.toolInput
             directive = .permissionRequest(
-                .allow(updatedInput: finalInput, updatedPermissions: updatedPermissions)
+                .allow(updatedInput: finalInput, updatedPermissions: updatedPermissions, additionalContext: additionalContext)
             )
             summary = payload.toolName.map { "Permission approved for \($0)." } ?? "Permission approved."
             phase = .running
 
-        case let (.permission(_), .deny(message, interrupt)):
+        case let (.permission(_), .deny(message, interrupt, additionalContext)):
             directive = .permissionRequest(
-                .deny(message: message ?? "Permission denied in Open Island.", interrupt: interrupt)
+                .deny(message: message ?? "Permission denied in Open Island.", interrupt: interrupt, additionalContext: additionalContext)
             )
             summary = message ?? "Permission denied in Open Island."
             phase = .completed
 
-        case let (.question(payload, _), .allowOnce(updatedInput, updatedPermissions)):
+        case let (.question(payload, _), .allowOnce(updatedInput, updatedPermissions, additionalContext)):
             let finalInput = updatedInput ?? payload.toolInput
             directive = .permissionRequest(
-                .allow(updatedInput: finalInput, updatedPermissions: updatedPermissions)
+                .allow(updatedInput: finalInput, updatedPermissions: updatedPermissions, additionalContext: additionalContext)
             )
             summary = "Claude's questions were answered."
             phase = .running
 
-        case let (.question(_, _), .deny(message, interrupt)):
+        case let (.question(_, _), .deny(message, interrupt, additionalContext)):
             directive = .permissionRequest(
-                .deny(message: message ?? "Declined to answer Claude's questions.", interrupt: interrupt)
+                .deny(message: message ?? "Declined to answer Claude's questions.", interrupt: interrupt, additionalContext: additionalContext)
             )
             summary = message ?? "Declined to answer Claude's questions."
             phase = .completed

--- a/Sources/OpenIslandCore/ClaudeHooks.swift
+++ b/Sources/OpenIslandCore/ClaudeHooks.swift
@@ -484,8 +484,8 @@ public struct ClaudePreToolUseDirective: Equatable, Codable, Sendable {
 }
 
 public enum ClaudePermissionRequestDecision: Equatable, Codable, Sendable {
-    case allow(updatedInput: ClaudeHookJSONValue? = nil, updatedPermissions: [ClaudePermissionUpdate] = [])
-    case deny(message: String? = nil, interrupt: Bool = false)
+    case allow(updatedInput: ClaudeHookJSONValue? = nil, updatedPermissions: [ClaudePermissionUpdate] = [], additionalContext: String? = nil)
+    case deny(message: String? = nil, interrupt: Bool = false, additionalContext: String? = nil)
 
     private enum CodingKeys: String, CodingKey {
         case behavior
@@ -493,6 +493,7 @@ public enum ClaudePermissionRequestDecision: Equatable, Codable, Sendable {
         case updatedPermissions
         case message
         case interrupt
+        case additionalContext
     }
 
     private enum Behavior: String, Codable {
@@ -503,17 +504,20 @@ public enum ClaudePermissionRequestDecision: Equatable, Codable, Sendable {
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let behavior = try container.decode(Behavior.self, forKey: .behavior)
+        let additionalContext = try container.decodeIfPresent(String.self, forKey: .additionalContext)
 
         switch behavior {
         case .allow:
             self = .allow(
                 updatedInput: try container.decodeIfPresent(ClaudeHookJSONValue.self, forKey: .updatedInput),
-                updatedPermissions: try container.decodeIfPresent([ClaudePermissionUpdate].self, forKey: .updatedPermissions) ?? []
+                updatedPermissions: try container.decodeIfPresent([ClaudePermissionUpdate].self, forKey: .updatedPermissions) ?? [],
+                additionalContext: additionalContext
             )
         case .deny:
             self = .deny(
                 message: try container.decodeIfPresent(String.self, forKey: .message),
-                interrupt: try container.decodeIfPresent(Bool.self, forKey: .interrupt) ?? false
+                interrupt: try container.decodeIfPresent(Bool.self, forKey: .interrupt) ?? false,
+                additionalContext: additionalContext
             )
         }
     }
@@ -522,18 +526,20 @@ public enum ClaudePermissionRequestDecision: Equatable, Codable, Sendable {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         switch self {
-        case let .allow(updatedInput, updatedPermissions):
+        case let .allow(updatedInput, updatedPermissions, additionalContext):
             try container.encode(Behavior.allow, forKey: .behavior)
             try container.encodeIfPresent(updatedInput, forKey: .updatedInput)
             if !updatedPermissions.isEmpty {
                 try container.encode(updatedPermissions, forKey: .updatedPermissions)
             }
-        case let .deny(message, interrupt):
+            try container.encodeIfPresent(additionalContext, forKey: .additionalContext)
+        case let .deny(message, interrupt, additionalContext):
             try container.encode(Behavior.deny, forKey: .behavior)
             try container.encodeIfPresent(message, forKey: .message)
             if interrupt {
                 try container.encode(true, forKey: .interrupt)
             }
+            try container.encodeIfPresent(additionalContext, forKey: .additionalContext)
         }
     }
 }

--- a/Sources/OpenIslandCore/ToolRiskClassifier.swift
+++ b/Sources/OpenIslandCore/ToolRiskClassifier.swift
@@ -1,0 +1,479 @@
+import Foundation
+
+/// Result of classifying a tool call.
+public enum ToolRisk: Sendable, Equatable {
+    case safe
+    case risky
+    case unknown
+
+    public var needsApproval: Bool {
+        self != .safe
+    }
+}
+
+/// Classifies Claude Code tool calls by risk level to auto-approve safe operations.
+public enum ToolRiskClassifier: Sendable {
+    // MARK: - Tool name sets
+
+    private static let readingTools: Set<String> = [
+        "Read", "Grep", "Glob", "LS", "WebFetch", "WebSearch",
+        "ListMcpResourcesTool", "ReadMcpResourceTool", "ToolSearch",
+    ]
+
+    private static let typingTools: Set<String> = [
+        "Edit", "Write", "MultiEdit", "NotebookEdit",
+    ]
+
+    private static let agentTools: Set<String> = [
+        "Agent", "TodoWrite", "AskUserQuestion", "Skill",
+        "EnterPlanMode", "ExitPlanMode",
+        "TaskCreate", "TaskUpdate", "TaskGet", "TaskList", "TaskOutput", "TaskStop",
+    ]
+
+    // MARK: - Safe commands
+
+    private static let safeCommands: Set<String> = [
+        "ls", "pwd", "echo", "cat", "head", "tail", "wc", "sort", "uniq",
+        "date", "whoami", "which", "type", "file", "stat", "du", "df",
+        "grep", "rg", "find", "sed", "awk", "tr", "cut", "paste",
+        "node", "deno",
+        "tsc", "eslint", "prettier", "jest", "vitest", "mocha", "playwright",
+        "python", "python3", "cargo", "go", "rustc", "gcc", "g++", "make", "cmake",
+        "mkdir", "touch", "ln",
+        "tar", "zip", "unzip", "gzip", "gunzip",
+        "jq", "yq", "xargs", "diff", "patch",
+        "curl", "wget", "http",
+        "sleep", "true", "false", "test", "[",
+        "printf", "read", "set", "export", "source", ".",
+        "cd", "pushd", "popd", "dirs",
+        "shfmt", "shellcheck",
+        "xcodebuild", "xcrun", "xcode-select", "xcresulttool",
+        "simctl", "swift", "swiftc", "swift-format", "swift-demangle",
+        "instruments", "lipo", "otool", "nm", "dsymutil", "dwarfdump",
+        "plutil", "defaults", "codesign", "security",
+        "xctrace", "actool", "ibtool",
+        "maestro", "fastlane", "pod", "appium",
+        "tree", "env", "open", "pbcopy", "pbpaste", "uname", "arch", "sysctl", "sw_vers",
+        "nvm", "fnm", "asdf", "rbenv", "pyenv",
+        "bundle", "gem", "ruby",
+        "biome", "oxlint", "dprint",
+    ]
+
+    private static let safeGitSubcommands: Set<String> = [
+        "status", "log", "diff", "add", "show", "fetch",
+        "blame", "bisect", "format-patch",
+        "rev-parse", "ls-files", "ls-tree", "remote",
+        "describe", "shortlog", "reflog", "worktree",
+    ]
+
+    private static let safeNpmSubcommands: Set<String> = [
+        "run", "test", "start", "build", "init", "info", "ls", "list",
+        "outdated", "audit", "pack", "version", "why",
+    ]
+
+    private static let safeNpxPackages: Set<String> = [
+        "tsc", "typescript", "ts-node", "tsx",
+        "prettier", "eslint", "biome",
+        "jest", "vitest", "mocha", "playwright",
+        "next", "vite", "nuxi", "astro",
+        "tailwindcss", "postcss",
+        "prisma", "drizzle-kit",
+        "turbo", "lerna", "nx",
+        "create-react-app", "create-next-app", "create-vite",
+        "rimraf", "shx", "cross-env",
+        "concurrently", "wait-on",
+        "depcheck", "madge", "license-checker",
+        "changeset", "semantic-release",
+    ]
+
+    private static let safeDockerSubcommands: Set<String> = [
+        "ps", "images", "inspect", "logs", "stats", "version", "info",
+        "pull", "network", "volume", "context", "buildx", "compose",
+        "top", "port", "diff", "history",
+    ]
+
+    private static let safeBrewSubcommands: Set<String> = [
+        "list", "ls", "info", "search", "home", "deps", "uses",
+        "leaves", "outdated", "doctor", "config", "desc", "cat",
+        "log", "pin", "unpin", "tap", "untap",
+    ]
+
+    private static let riskyCommands: Set<String> = [
+        "rm", "rmdir", "sudo", "su",
+        "chmod", "chown", "chgrp",
+        "dd", "mkfs", "fdisk",
+        "reboot", "shutdown", "halt", "poweroff",
+        "iptables", "ufw", "systemctl",
+    ]
+
+    private static let codeInterpreters: Set<String> = [
+        "node", "python", "python3", "perl", "ruby", "deno", "bun",
+    ]
+
+    private static let evalFlags: Set<String> = [
+        "-e", "-c", "--eval", "--print", "-p",
+    ]
+
+    private static let gitValueFlags: Set<String> = [
+        "-C", "-c", "--git-dir", "--work-tree", "--namespace",
+    ]
+
+    // MARK: - MCP patterns
+
+    private static let safeMCPActionWords: Set<String> = [
+        "get", "list", "read", "find", "search", "describe", "show", "view",
+        "count", "check", "fetch", "browse", "tabs_context",
+    ]
+
+    private static let riskyMCPActionWords: Set<String> = [
+        "delete", "remove", "drop", "destroy", "execute", "javascript", "computer",
+        "send", "create", "update", "modify", "edit", "write", "upload", "publish",
+        "run", "invoke", "apply", "trigger", "call", "patch", "deploy", "post", "put",
+    ]
+
+    private static let safeMCPServers: Set<String> = [
+        "claude-in-chrome", "stitch", "n8n-mcp",
+    ]
+
+    // MARK: - Compound command detection
+
+    private static let compoundChars: Set<Character> = ["|", "&", ";", "$", "`", "(", ")", "{", "}", "<", ">", "\n"]
+
+    // MARK: - Public API
+
+    /// Classify a tool call by name and input.
+    /// User rules (deny > allow) are checked before the built-in classifier.
+    public static func classify(toolName: String, toolInput: ClaudeHookJSONValue?) -> ToolRisk {
+        // Check user rules first
+        if toolName == "Bash" || toolName == "BashOutput" {
+            let command = extractCommand(from: toolInput)
+            if let ruleAction = ApprovalRuleEngine.shared.matchBashCommand(command) {
+                return ruleAction == .deny ? .risky : .safe
+            }
+        } else {
+            if let ruleAction = ApprovalRuleEngine.shared.matchToolName(toolName) {
+                return ruleAction == .deny ? .risky : .safe
+            }
+        }
+
+        // Reading tools — always safe
+        if readingTools.contains(toolName) { return .safe }
+
+        // Typing tools — always safe
+        if typingTools.contains(toolName) { return .safe }
+
+        // Agent/internal tools — always safe
+        if agentTools.contains(toolName) { return .safe }
+
+        // MCP tools — classify by action pattern
+        if toolName.hasPrefix("mcp__") {
+            return classifyMCP(toolName: toolName)
+        }
+
+        // Bash tools — classify by command content
+        if toolName == "Bash" || toolName == "BashOutput" {
+            let command = extractCommand(from: toolInput)
+            return classifyBashCommand(command)
+        }
+
+        // Unknown tool
+        return .unknown
+    }
+
+    // MARK: - MCP classification
+
+    private static func classifyMCP(toolName: String) -> ToolRisk {
+        let parts = toolName.split(separator: "_")
+        guard parts.count >= 3 else { return .unknown }
+        // mcp__server__action or mcp__server_group__action
+        let server = parts.count > 2 ? String(parts[2]) : ""
+        if safeMCPServers.contains(server) { return .safe }
+
+        // Extract action words (everything after the last __)
+        guard let lastUnderscoreRange = toolName.range(of: "__", options: .backwards) else {
+            return .unknown
+        }
+        let action = String(toolName[lastUnderscoreRange.upperBound...])
+        let actionWords = action.split(separator: "_").map(String.init)
+
+        // Risky first (e.g. "get_and_delete" should be risky)
+        for word in actionWords {
+            if riskyMCPActionWords.contains(word) { return .risky }
+        }
+        for word in actionWords {
+            if safeMCPActionWords.contains(word) { return .safe }
+        }
+        return .unknown
+    }
+
+    // MARK: - Bash classification
+
+    private static func classifyBashCommand(_ command: String) -> ToolRisk {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .safe }
+
+        // Strip quoted strings before compound detection
+        let unquoted = trimmed
+            .replacingOccurrences(of: "'[^']*'", with: "\"\"")
+            .replacingOccurrences(of: "\"[^\"]*\"", with: "\"\"")
+
+        if unquoted.unicodeScalars.contains(where: { compoundChars.contains(Character($0)) }) {
+            return classifyCompoundCommand(trimmed)
+        }
+
+        let args = trimmed.split(separator: " ", omittingEmptySubsequences: true).map(String.init)
+        return classifySingleCommand(args)
+    }
+
+    private static func classifyCompoundCommand(_ command: String) -> ToolRisk {
+        guard let commands = extractCommandsViaAST(command) else {
+            // AST parsing failed on a compound command — can't trust it
+            return .unknown
+        }
+
+        var worst: ToolRisk = .safe
+        for args in commands {
+            let result = classifySingleCommand(args)
+            if result == .risky { return .risky }
+            if result == .unknown { worst = .unknown }
+        }
+        return worst
+    }
+
+    // MARK: - AST parsing via shfmt
+
+    private static func extractCommandsViaAST(_ command: String) -> [[String]]? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["shfmt", "--tojson"]
+
+        let stdinPipe = Pipe()
+        let stdoutPipe = Pipe()
+        process.standardInput = stdinPipe
+        process.standardOutput = stdoutPipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            stdinPipe.fileHandleForWriting.write(command.data(using: .utf8)!)
+            stdinPipe.fileHandleForWriting.closeFile()
+            process.waitUntilExit()
+
+            guard process.terminationStatus == 0,
+                  let data = try? stdoutPipe.fileHandleForReading.readToEnd(),
+                  let json = try? JSONSerialization.jsonObject(with: data) else { return nil }
+            var commands: [[String]] = []
+            walkAST(json, into: &commands)
+            return commands.isEmpty ? nil : commands
+        } catch {
+            return nil
+        }
+    }
+
+    private static func walkAST(_ node: Any, into commands: inout [[String]]) {
+        guard let dict = node as? [String: Any] else { return }
+
+        if dict["Type"] as? String == "CallExpr", let args = dict["Args"] as? [[String: Any]] {
+            var argStrings: [String] = []
+            for arg in args {
+                if let parts = arg["Parts"] as? [[String: Any]] {
+                    for part in parts {
+                        if part["Type"] as? String == "ParamExp" {
+                            argStrings.append("$__VAR_EXPANSION__")
+                        } else if let value = part["Value"] as? String {
+                            argStrings.append(value)
+                        }
+                    }
+                }
+            }
+            if !argStrings.isEmpty { commands.append(argStrings) }
+        }
+
+        for value in dict.values {
+            if let arr = value as? [Any] {
+                for item in arr { walkAST(item, into: &commands) }
+            } else if let nested = value as? [String: Any] {
+                walkAST(nested, into: &commands)
+            }
+        }
+    }
+
+    // MARK: - Single command classification
+
+    private static func classifySingleCommand(_ args: [String]) -> ToolRisk {
+        guard let cmd = args.first else { return .unknown }
+
+        // Strip path prefix
+        let base = (cmd as NSString).lastPathComponent
+
+        // Variable expansion
+        if base.hasPrefix("$") || base == "__VAR_EXPANSION__" { return .unknown }
+
+        // Code interpreter eval
+        if codeInterpreters.contains(base), args.contains(where: { evalFlags.contains($0) }) {
+            return .unknown
+        }
+
+        // sed -i
+        if base == "sed", args.contains(where: { $0 == "-i" || $0.hasPrefix("-i") }) {
+            return .risky
+        }
+
+        // find with destructive flags
+        if base == "find" {
+            if args.contains("-delete") { return .risky }
+            if let execIdx = args.firstIndex(of: "-exec"), execIdx + 1 < args.count {
+                let execCmd = (args[execIdx + 1] as NSString).lastPathComponent
+                if !safeCommands.contains(execCmd) { return .risky }
+            }
+            if let execIdx = args.firstIndex(of: "-execdir"), execIdx + 1 < args.count {
+                let execCmd = (args[execIdx + 1] as NSString).lastPathComponent
+                if !safeCommands.contains(execCmd) { return .risky }
+            }
+        }
+
+        // curl data upload
+        if base == "curl" {
+            if args.contains(where: { $0 == "-d" || $0 == "--data" || $0 == "--data-binary"
+                || $0 == "--data-raw" || $0 == "--data-urlencode"
+                || $0 == "-F" || $0 == "--form" || $0 == "-T" || $0 == "--upload-file"
+            }) { return .risky }
+            if let xIdx = args.firstIndex(of: "-X"), xIdx + 1 < args.count {
+                let method = args[xIdx + 1].uppercased()
+                if method != "GET" && method != "HEAD" && method != "OPTIONS" { return .risky }
+            }
+            if let xIdx = args.firstIndex(of: "--request"), xIdx + 1 < args.count {
+                let method = args[xIdx + 1].uppercased()
+                if method != "GET" && method != "HEAD" && method != "OPTIONS" { return .risky }
+            }
+        }
+
+        // wget upload
+        if base == "wget", args.contains(where: { $0 == "--post-data" || $0 == "--post-file" }) {
+            return .risky
+        }
+
+        // tee can overwrite files
+        if base == "tee" { return .unknown }
+
+        // Check deny list first
+        if riskyCommands.contains(base) { return .risky }
+
+        // Git subcommands
+        if base == "git" {
+            return classifyGit(args: args)
+        }
+
+        // npm/pip
+        if base == "npm" || base == "pip" || base == "pip3" {
+            return classifyNpmPip(args: args, base: base)
+        }
+
+        // npx
+        if base == "npx" {
+            return classifyNpx(args: args)
+        }
+
+        // pnpm/yarn/bun
+        if base == "pnpm" || base == "yarn" || base == "bun" {
+            return classifyPnpmYarn(args: args)
+        }
+
+        // Docker
+        if base == "docker" {
+            let sub = args.dropFirst().first
+            if safeDockerSubcommands.contains(sub ?? "") { return .safe }
+            return .unknown
+        }
+
+        // Brew
+        if base == "brew" {
+            let sub = args.dropFirst().first
+            if sub == "install" || sub == "uninstall" || sub == "remove" || sub == "upgrade" { return .risky }
+            if safeBrewSubcommands.contains(sub ?? "") { return .safe }
+            return .unknown
+        }
+
+        // apt/apk
+        if base == "apt" || base == "apt-get" || base == "apk" {
+            let sub = args.dropFirst().first
+            if ["list", "show", "search", "info", "depends"].contains(sub) { return .safe }
+            return .risky
+        }
+
+        // Force flags
+        if args.contains("--force") || args.contains("--no-verify") { return .risky }
+
+        // Shell -c
+        if ["bash", "sh", "zsh"].contains(base), args.contains("-c") { return .unknown }
+
+        // cp/mv with force
+        if base == "cp" || base == "mv" {
+            if args.contains(where: { $0 == "-f" || $0 == "--force" || $0 == "-rf" || $0 == "-Rf" }) {
+                return .risky
+            }
+            return .safe
+        }
+
+        // Safe list
+        if safeCommands.contains(base) { return .safe }
+
+        return .unknown
+    }
+
+    // MARK: - Subcommand classifiers
+
+    private static func classifyGit(args: [String]) -> ToolRisk {
+        var sub: String?
+        var i = 1
+        while i < args.count {
+            let a = args[i]
+            if gitValueFlags.contains(a) { i += 2; continue }
+            if a.hasPrefix("-") { i += 1; continue }
+            sub = a
+            break
+        }
+        guard let sub else { return .safe }
+
+        if sub == "push" { return .risky }
+        if sub == "reset", args.contains("--hard") { return .risky }
+        if sub == "clean", args.contains(where: { $0.hasPrefix("-") && !$0.hasPrefix("--") && $0.contains("f") }) {
+            return .risky
+        }
+        if safeGitSubcommands.contains(sub) { return .safe }
+        return .unknown
+    }
+
+    private static func classifyNpmPip(args: [String], base: String) -> ToolRisk {
+        let sub = args.dropFirst().first
+        if ["install", "i", "uninstall", "remove", "exec", "x", "publish"].contains(sub) { return .risky }
+        if base == "npm", safeNpmSubcommands.contains(sub ?? "") { return .safe }
+        return .unknown
+    }
+
+    private static func classifyNpx(args: [String]) -> ToolRisk {
+        let pkg = args.dropFirst().first(where: { !$0.hasPrefix("-") })
+        guard let pkg else { return .safe }
+        if safeNpxPackages.contains(pkg) { return .safe }
+        return .unknown
+    }
+
+    private static func classifyPnpmYarn(args: [String]) -> ToolRisk {
+        let sub = args.dropFirst().first
+        if ["add", "install", "i", "remove", "uninstall", "dlx", "exec", "x", "publish"].contains(sub) {
+            return .risky
+        }
+        if ["run", "test", "build", "start", "info", "list", "ls", "why", "outdated", "audit"].contains(sub) {
+            return .safe
+        }
+        return .unknown
+    }
+
+    // MARK: - Helpers
+
+    private static func extractCommand(from toolInput: ClaudeHookJSONValue?) -> String {
+        guard case let .object(dict) = toolInput,
+              case let .string(cmd) = dict["command"] else { return "" }
+        return cmd
+    }
+}


### PR DESCRIPTION
## Summary
- **Note/context input**: Collapsible text field on approval cards to send instructions to Claude via `additionalContext` (`[Boss says]` prefix)
- **Permission suggestions**: Claude's `permissionSuggestions` now rendered as actionable always-allow buttons (data was already flowing but never shown in UI)
- **Tool risk classifier**: New `ToolRiskClassifier` auto-approves safe tools (Read, Grep, Glob, Edit, common bash commands) without user interaction. Uses AST-based bash parsing via `shfmt --tojson` for compound commands.
- **Persistent rule engine**: New `ApprovalRuleEngine` with prefix-based pattern matching, deny-wins semantics, JSON persistence to `~/Library/Application Support/OpenIsland/rules.json`. "Save Rule" button on approval cards.
- **Safety improvements**: 10-minute timeout on pending approvals, keyboard shortcuts (Cmd+Y allow, Cmd+N deny)

## New files
- `Sources/OpenIslandCore/ToolRiskClassifier.swift` — tool risk classification
- `Sources/OpenIslandCore/ApprovalRuleEngine.swift` — persistent allow/deny rules

## Modified files
- `Sources/OpenIslandCore/AgentSession.swift` — `PermissionResolution` now carries `additionalContext`
- `Sources/OpenIslandCore/ClaudeHooks.swift` — `ClaudePermissionRequestDecision` passes `additionalContext` on wire
- `Sources/OpenIslandCore/BridgeServer.swift` — auto-approve safe tools, timeout timer, context passthrough
- `Sources/OpenIslandApp/AppModel.swift` — `approvePermission` accepts `additionalContext`, rule management methods
- `Sources/OpenIslandApp/Views/IslandPanelView.swift` — note input, suggestion buttons, save rule button, keyboard shortcuts

## Test plan
- [ ] Run `swift build` — passes
- [ ] Trigger a Claude Code session, verify safe tools (Read, Grep) auto-approve without island popup
- [ ] Trigger a risky tool, verify approval card shows with note input
- [ ] Type a note and approve — verify Claude receives the `[Boss says] ...` context
- [ ] Verify `permissionSuggestions` buttons appear when Claude provides them
- [ ] Click "Save Rule" on an approval, restart app, verify the rule persists and auto-approves
- [ ] Verify pending approvals auto-deny after 10 minutes
- [ ] Verify Cmd+Y / Cmd+N keyboard shortcuts work on approval cards