### PR TITLE
dx(scripts): stable self-signed identity so TCC grants survive dev rebuilds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ Open `Package.swift` in Xcode for the app target. Requires macOS 14+, Swift 6.2.
 - `OpenIslandApp` (via `swift run OpenIslandApp` or the Xcode target) is the canonical development runtime.
 - `~/Applications/Open Island Dev.app` is a local bundle wrapper around the repo-built binary, not a separate product.
 - When launching `Open Island Dev.app`, refresh the bundle first with `zsh scripts/launch-dev-app.sh` instead of only `open -na` (avoids stale binaries).
+- **One-time setup**: run `zsh scripts/setup-dev-signing.sh` once to create a local self-signed code signing identity. Without it the dev bundle is ad-hoc signed, which changes cdhash every rebuild and silently invalidates any macOS TCC grant (Accessibility, Automation) you gave the previous build. Required when iterating on features that touch AX API (precision jump, keystroke/menu injection, etc.).
 - Use `scripts/harness.sh smoke` or `scripts/smoke-dev-app.sh` only for deterministic harness runs.
 - `/Applications/Vibe Island.app` and `https://vibeisland.app/` are closed-source reference baselines only — behavior benchmarks, not the development runtime.
 

--- a/scripts/launch-dev-app.sh
+++ b/scripts/launch-dev-app.sh
@@ -119,6 +119,26 @@ fi
 # Remove stale symlinks from previous runs.
 [ -L "$root_bundle" ] && rm -f "$root_bundle"
 
-codesign --force --deep --sign - "$bundle_dir" 2>/dev/null || true
+# Detect a local stable signing identity so the dev bundle's cdhash
+# stays stable across rebuilds and macOS TCC grants (Accessibility,
+# Automation) persist. Without it we fall back to ad-hoc signing, which
+# changes the cdhash every build and silently invalidates any TCC
+# grants the developer had approved — extremely disruptive when
+# iterating on features that need AX permission. See
+# scripts/setup-dev-signing.sh for a one-time setup that creates this
+# identity locally with zero Apple Developer Program involvement.
+sign_identity="-"
+if security find-identity -p codesigning -v "$HOME/Library/Keychains/login.keychain-db" 2>/dev/null \
+       | grep -q '"Open Island Dev Local"'; then
+    sign_identity="Open Island Dev Local"
+else
+    echo
+    echo "⚠ Using ad-hoc signing. macOS TCC grants (Accessibility, Automation)"
+    echo "  will be invalidated on every rebuild. Run once to fix:"
+    echo "    zsh scripts/setup-dev-signing.sh"
+    echo
+fi
+
+codesign --force --deep --sign "$sign_identity" "$bundle_dir" 2>/dev/null || true
 
 open -na "$bundle_dir"

--- a/scripts/setup-dev-signing.sh
+++ b/scripts/setup-dev-signing.sh
@@ -1,0 +1,117 @@
+#!/bin/zsh
+#
+# Create a local self-signed code signing identity for Open Island dev
+# builds. One-time setup; idempotent on re-run.
+#
+# Why this exists
+# ---------------
+# Without a stable signing identity, `launch-dev-app.sh` ad-hoc signs
+# the dev bundle with `codesign --sign -`, which produces a new cdhash
+# every rebuild. macOS TCC tracks Accessibility (and other) permission
+# grants for ad-hoc binaries by cdhash, so every `swift build` silently
+# invalidates any grant the developer had previously approved. That
+# makes iterating on features that require Accessibility permission —
+# precision jump, keystroke injection, menu clicks — almost impossible
+# without re-dragging the .app into System Settings → Privacy &
+# Security → Accessibility every single iteration.
+#
+# With a real signing identity (even self-signed local), TCC tracks the
+# grant by the certificate's designated requirement instead of cdhash.
+# The cert doesn't change between rebuilds, so the permission persists.
+#
+# What this script does
+# ---------------------
+# 1. Generates an RSA 2048, 10-year, Code-Signing-EKU self-signed cert
+#    via openssl.
+# 2. Imports the cert + private key into the login keychain, with the
+#    key ACL set so /usr/bin/codesign can use it non-interactively.
+# 3. Adds a user-level Code Signing trust override so the identity
+#    shows up as valid in `security find-identity -p codesigning -v`.
+#
+# The cert is scoped to the developer's login keychain, never touches
+# the system keychain, and requires no sudo.
+#
+# What to do with it
+# ------------------
+# After running this once, `launch-dev-app.sh` auto-detects the
+# identity and uses it. On the first run after signing, you still have
+# to grant Accessibility once (System Settings → Privacy & Security
+# → Accessibility → drag the .app from ~/Applications/ into the
+# list). From that grant onwards, permission persists across rebuilds.
+#
+# To undo: `security delete-identity -Z <sha1> ~/Library/Keychains/login.keychain-db`
+# where <sha1> is from `security find-identity -p codesigning -v`. Also
+# `security remove-trusted-cert <cert.pem>` if you want the trust
+# override gone.
+
+set -euo pipefail
+
+IDENTITY_NAME="Open Island Dev Local"
+KEYCHAIN="$HOME/Library/Keychains/login.keychain-db"
+
+if security find-identity -p codesigning -v "$KEYCHAIN" 2>/dev/null | grep -q "\"$IDENTITY_NAME\""; then
+    echo "✓ Code signing identity \"$IDENTITY_NAME\" already exists and is trusted."
+    echo "  launch-dev-app.sh will use it automatically."
+    exit 0
+fi
+
+if ! command -v openssl >/dev/null 2>&1; then
+    echo "✗ openssl is required but not on PATH." >&2
+    exit 1
+fi
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+key_pem="$tmp_dir/key.pem"
+cert_pem="$tmp_dir/cert.pem"
+cert_p12="$tmp_dir/cert.p12"
+# The p12 password is ephemeral — it exists for the duration of this
+# script only, used to hand the cert + key from openssl to security and
+# then discarded. It is NOT a persistent secret.
+p12_password=$(openssl rand -hex 16)
+
+echo "• Generating 10-year self-signed code signing certificate…"
+openssl req -x509 -newkey rsa:2048 \
+    -keyout "$key_pem" -out "$cert_pem" \
+    -days 3650 -nodes \
+    -subj "/CN=$IDENTITY_NAME" \
+    -addext "keyUsage=critical,digitalSignature" \
+    -addext "extendedKeyUsage=critical,codeSigning" \
+    2>/dev/null
+
+# `-legacy` uses the older PKCS#12 encryption format that Apple's
+# `security` tool can read. Modern OpenSSL 3.x defaults to a format
+# Apple hasn't adopted; without this flag the import fails with
+# "MAC verification failed during PKCS12 import".
+echo "• Packaging into PKCS#12 (legacy format for Apple compatibility)…"
+openssl pkcs12 -export -legacy \
+    -out "$cert_p12" -inkey "$key_pem" -in "$cert_pem" \
+    -name "$IDENTITY_NAME" \
+    -password "pass:$p12_password" \
+    2>/dev/null
+
+# `-T /usr/bin/codesign` adds codesign to the key ACL so codesign can
+# use the private key non-interactively (no "allow?" prompt per build).
+echo "• Importing into login keychain…"
+security import "$cert_p12" \
+    -k "$KEYCHAIN" \
+    -P "$p12_password" \
+    -T /usr/bin/codesign \
+    >/dev/null
+
+# Without this trust override the cert imports but
+# `security find-identity -p codesigning -v` filters it out as
+# CSSMERR_TP_NOT_TRUSTED, and codesign will refuse to use it by name.
+# `-p codeSign` is a user-level trust for Code Signing only — does not
+# touch system trust stores and does not require sudo.
+echo "• Adding Code Signing trust override…"
+security add-trusted-cert -p codeSign -k "$KEYCHAIN" "$cert_pem" >/dev/null
+
+echo
+echo "✓ Identity \"$IDENTITY_NAME\" created and trusted."
+security find-identity -p codesigning -v "$KEYCHAIN" | grep "\"$IDENTITY_NAME\""
+echo
+echo "Next: run \`zsh scripts/launch-dev-app.sh\`. The bundle will now be"
+echo "signed with this identity, and any Accessibility/Automation grant"
+echo "you give Open Island Dev will persist across rebuilds."


### PR DESCRIPTION
## Summary

Currently `scripts/launch-dev-app.sh` ad-hoc signs the dev bundle with `codesign --force --deep --sign -`, which produces a new cdhash every rebuild. macOS TCC tracks Accessibility (and Automation) permission grants for ad-hoc binaries by cdhash, so every `swift build` silently invalidates any grant the developer had previously approved. This is sharply disruptive when iterating on any feature that touches AX API — precision jump, keystroke/menu injection, Automation-driven window management. The recent debugging round for #261 hit this hard: re-drag the .app into System Settings → Privacy & Security → Accessibility on every rebuild, for dozens of iterations.

This PR introduces a one-time setup that generates a local self-signed code signing certificate scoped to the developer's login keychain, with zero Apple Developer Program involvement. A bundle signed with a real certificate has a designated requirement pinned to `(bundle id, certificate leaf hash)` rather than cdhash — both stable across rebuilds — so TCC grants persist until the developer actively revokes them.

Independent of #261 and #262 — this is pure DX tooling, no Swift code touched.

## Changes

### `scripts/setup-dev-signing.sh` (new, idempotent)

- Generates an RSA 2048 Code-Signing-EKU cert via `openssl req -x509 ... -addext "extendedKeyUsage=critical,codeSigning"`.
- Packages via `openssl pkcs12 -export -legacy` — the `-legacy` flag is load-bearing because OpenSSL 3.x's default PKCS#12 format is incompatible with Apple's `security` tool (import fails with `MAC verification failed`).
- Imports into login keychain with `-T /usr/bin/codesign` so codesign can use the key non-interactively (no "allow?" prompt per build).
- Adds a user-level `codeSign` trust override via `security add-trusted-cert -p codeSign`. Without it the cert imports but `find-identity -p codesigning -v` filters it out as `CSSMERR_TP_NOT_TRUSTED`, and codesign refuses to use it by name. `-p codeSign` is a user-level override scoped to the Code Signing policy only; does not touch system keychains and does not require sudo.
- Re-runs are no-ops (`security find-identity | grep ...` short-circuit).

### `scripts/launch-dev-app.sh`

Replaces `codesign --force --deep --sign - "$bundle_dir"` with a conditional:

```sh
sign_identity="-"
if security find-identity -p codesigning -v "$HOME/Library/Keychains/login.keychain-db" 2>/dev/null \
       | grep -q '"Open Island Dev Local"'; then
    sign_identity="Open Island Dev Local"
else
    # one-line hint pointing at setup-dev-signing.sh
fi
codesign --force --deep --sign "$sign_identity" "$bundle_dir" 2>/dev/null || true
```

Existing contributors who haven't run setup continue to work with ad-hoc signing (the old behavior) — they just see a one-time hint telling them how to fix the TCC churn.

### `CLAUDE.md`

One-line addition under "App Targets And Naming" pointing at the setup script.

## Verification

Before (ad-hoc):
```
Format=app bundle with Mach-O thin (arm64)
CodeDirectory v=20400 flags=0x2(adhoc)
Signature=adhoc
```

After (real signature):
```
Format=app bundle with Mach-O thin (arm64)
CodeDirectory v=20400 flags=0x0(none)
Signature size=1738
Authority=Open Island Dev Local
TeamIdentifier=not set
```

Designated requirement:
```
designated => identifier "app.openisland.dev"
              and certificate leaf = H"6eef19419e38fe10df19ff4a1a5bba7a59654df5"
```

Both components of the DR (`identifier` + `certificate leaf`) are stable across rebuilds, which is exactly what TCC needs to persist grants.

Sanity-checked by running `launch-dev-app.sh` twice back-to-back and confirming:
- Bundle format switched from `adhoc` to real signature.
- Authority string is `Open Island Dev Local` both times.
- Identifier is `app.openisland.dev` both times.
- Ran `swift build` and `swift test` — 141/141 pass (unchanged, since this PR touches no Swift code).

## Test plan

- [x] Fresh run of `zsh scripts/setup-dev-signing.sh` creates the identity and it shows up in `security find-identity -p codesigning -v`.
- [x] Re-run of `setup-dev-signing.sh` is a no-op.
- [x] `zsh scripts/launch-dev-app.sh` signs the bundle with the new identity (not ad-hoc) and the Designated Requirement is stable across rebuilds.
- [x] Without the identity, `launch-dev-app.sh` falls back to ad-hoc and prints the hint.
- [x] Full `swift test` — 141/141 pass.
- [ ] **Post-merge verification (cannot automate)**: grant Accessibility to Open Island Dev once, run `launch-dev-app.sh` again with a code change, verify Accessibility permission still holds without re-dragging. This is the actual user-facing win but requires manual interaction with System Settings.

## Revocation

To undo the cert:
```sh
# find the SHA-1
security find-identity -p codesigning -v
# delete identity (cert + key)
security delete-identity -Z <sha1> ~/Library/Keychains/login.keychain-db
# optionally drop the trust override
# (extract the cert to cert.pem first via security find-certificate -c "Open Island Dev Local" -p > cert.pem)
security remove-trusted-cert cert.pem
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)