### PR TITLE
fix: jump to correct VSCode/JetBrains window when multiple are open

### DIFF
--- a/Sources/OpenIslandApp/TerminalJumpService.swift
+++ b/Sources/OpenIslandApp/TerminalJumpService.swift
@@ -259,26 +259,26 @@ struct TerminalJumpService {
                     return "Focused the matching \(descriptor.displayName) pane."
                 }
             case let id where Self.vscodeFamilyBundleIDs.contains(id):
-                if appIsRunning {
-                    try openAction(["-b", descriptor.bundleIdentifier])
-                    return "Activated \(descriptor.displayName)."
-                }
                 if let workingDirectory = target.workingDirectory {
                     let opened = jumpToVSCodeFamilyWorkspace(workingDirectory, bundleIdentifier: id)
-                    return opened
-                        ? "Focused the matching \(descriptor.displayName) workspace."
-                        : "Focused the matching \(descriptor.displayName) workspace. The CLI may not be available."
+                    if opened {
+                        return "Focused the matching \(descriptor.displayName) workspace."
+                    }
                 }
-            case let id where Self.jetbrainsBundleIDs.contains(id):
                 if appIsRunning {
                     try openAction(["-b", descriptor.bundleIdentifier])
                     return "Activated \(descriptor.displayName)."
                 }
+            case let id where Self.jetbrainsBundleIDs.contains(id):
                 if let workingDirectory = target.workingDirectory {
                     let opened = jumpToJetBrainsProject(workingDirectory, bundleIdentifier: id)
-                    return opened
-                        ? "Focused the matching \(descriptor.displayName) project."
-                        : "Focused the matching \(descriptor.displayName) project. The CLI may not be available."
+                    if opened {
+                        return "Focused the matching \(descriptor.displayName) project."
+                    }
+                }
+                if appIsRunning {
+                    try openAction(["-b", descriptor.bundleIdentifier])
+                    return "Activated \(descriptor.displayName)."
                 }
             default:
                 break


### PR DESCRIPTION
## Summary
- Fix incorrect terminal identification and window jump when using VSCode's built-in terminal (#257)
- **Root cause 1 — terminal misidentification**: When VSCode is launched from Ghostty, its built-in terminal inherits `GHOSTTY_RESOURCES_DIR`. Since that env var was checked before `TERM_PROGRAM`, all sessions inside VSCode's terminal were misidentified as Ghostty.
- **Root cause 2 — wrong jump target**: Even when the terminal was correctly identified, the jump logic used `open -b` (generic app activation) instead of workspace-specific CLI commands when the IDE was already running.
- **Root cause 3 — `code -r` replaces window**: The `-r` flag tells VSCode to reuse/replace the current window, not focus an existing one. Removed it so `code <path>` focuses the already-open workspace window.

## Changes
1. `ClaudeHooks.swift`: Move `TERM_PROGRAM`-based detection ahead of single-env-var checks (`GHOSTTY_RESOURCES_DIR`, `WARP_IS_LOCAL_SHELL_SESSION`). `TERM_PROGRAM` is set by the innermost terminal and is the most specific signal.
2. `TerminalJumpService.swift`: Try workspace-specific CLI jump (`code <path>`) before falling back to generic app activation. Remove `-r` flag from VSCode CLI invocation.

## Test plan
- [x] `swift build` passes
- [x] All 141 tests pass
- [x] Manual: run agent in VSCode built-in terminal launched from Ghostty → session shows "VS Code" (not "Ghostty")
- [x] Manual: click session in island → focuses the correct VSCode window

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)