### PR TITLE
docs: add bilingual privacy policy for App Store

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,0 +1,53 @@
+# Privacy Policy / 隐私政策
+
+**Last updated: 2026-04-11**
+
+## English
+
+Open Island ("the App") is a companion app for AI coding agents. We are committed to protecting your privacy.
+
+### Data Collection
+
+The App does **not** collect, store, or transmit any personal data to external servers.
+
+### How It Works
+
+- The App communicates exclusively over your **local network** (LAN) between your Mac, iPhone, and Apple Watch.
+- All data (agent session events, permission requests, notifications) stays on your devices and never leaves your local network.
+- No analytics, telemetry, or crash reporting services are used.
+- No third-party SDKs or tracking frameworks are included.
+
+### Local Storage
+
+The App stores minimal preferences (e.g., notification settings, pairing token) in on-device UserDefaults. This data is never transmitted externally.
+
+### Contact
+
+If you have any questions about this privacy policy, please open an issue at:
+https://github.com/Octane0411/open-vibe-island/issues
+
+---
+
+## 中文
+
+Open Island（"本应用"）是一款 AI 编程助手的配套应用。我们致力于保护您的隐私。
+
+### 数据收集
+
+本应用**不会**收集、存储或向外部服务器传输任何个人数据。
+
+### 工作原理
+
+- 本应用仅通过**本地局域网**（LAN）在您的 Mac、iPhone 和 Apple Watch 之间通信。
+- 所有数据（代理会话事件、权限请求、通知）均保留在您的设备上，不会离开本地网络。
+- 不使用任何分析、遥测或崩溃报告服务。
+- 不包含任何第三方 SDK 或追踪框架。
+
+### 本地存储
+
+本应用在设备的 UserDefaults 中存储少量偏好设置（如通知设置、配对令牌）。这些数据不会被传输到外部。
+
+### 联系方式
+
+如果您对本隐私政策有任何疑问，请在以下地址提交 issue：
+https://github.com/Octane0411/open-vibe-island/issues


### PR DESCRIPTION
## Summary
- Add `PRIVACY_POLICY.md` with bilingual (English + Chinese) privacy policy
- URL for App Store Connect: `https://github.com/Octane0411/open-vibe-island/blob/main/PRIVACY_POLICY.md`
- No data collection, local network only, no third-party SDKs

## Test plan
- [ ] Verify URL resolves after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)