### PR TITLE
feat: add Gemini CLI hook integration

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -106,6 +106,11 @@ final class AppModel {
     var isCursorHookSetupBusy: Bool { hooks.isCursorHookSetupBusy }
     var cursorHookStatusTitle: String { hooks.cursorHookStatusTitle }
     var cursorHookStatusSummary: String { hooks.cursorHookStatusSummary }
+    var geminiHooksInstalled: Bool { hooks.geminiHooksInstalled }
+    var isGeminiHookSetupBusy: Bool { hooks.isGeminiHookSetupBusy }
+    var geminiHookStatus: GeminiHookInstallationStatus? { hooks.geminiHookStatus }
+    var geminiHookStatusTitle: String { hooks.geminiHookStatusTitle }
+    var geminiHookStatusSummary: String { hooks.geminiHookStatusSummary }
     var codexHookStatusTitle: String { hooks.codexHookStatusTitle }
     var codexHookStatusSummary: String { hooks.codexHookStatusSummary }
     func refreshCodexHookStatus() { hooks.refreshCodexHookStatus() }
@@ -131,6 +136,9 @@ final class AppModel {
     func uninstallOpenCodePlugin() { hooks.uninstallOpenCodePlugin() }
     func installCursorHooks() { hooks.installCursorHooks() }
     func uninstallCursorHooks() { hooks.uninstallCursorHooks() }
+    func refreshGeminiHookStatus() { hooks.refreshGeminiHookStatus() }
+    func installGeminiHooks() { hooks.installGeminiHooks() }
+    func uninstallGeminiHooks() { hooks.uninstallGeminiHooks() }
     func installClaudeUsageBridge() { hooks.installClaudeUsageBridge() }
     func uninstallClaudeUsageBridge() { hooks.uninstallClaudeUsageBridge() }
     func updateClaudeConfigDirectory(to newDirectory: URL?) { hooks.updateClaudeConfigDirectory(to: newDirectory) }

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -13,6 +13,7 @@ final class HookInstallationCoordinator {
     var codebuddyHookStatus: ClaudeHookInstallationStatus?
     var openCodePluginStatus: OpenCodePluginInstallationStatus?
     var cursorHookStatus: CursorHookInstallationStatus?
+    var geminiHookStatus: GeminiHookInstallationStatus?
     var claudeStatusLineStatus: ClaudeStatusLineInstallationStatus?
     var claudeUsageSnapshot: ClaudeUsageSnapshot?
     var codexUsageSnapshot: CodexUsageSnapshot?
@@ -25,6 +26,7 @@ final class HookInstallationCoordinator {
     var isCodebuddyHookSetupBusy = false
     var isOpenCodeSetupBusy = false
     var isCursorHookSetupBusy = false
+    var isGeminiHookSetupBusy = false
     var isClaudeUsageSetupBusy = false
 
     @ObservationIgnored
@@ -67,6 +69,9 @@ final class HookInstallationCoordinator {
 
     @ObservationIgnored
     private let cursorHookInstallationManager = CursorHookInstallationManager()
+
+    @ObservationIgnored
+    private let geminiHookInstallationManager = GeminiHookInstallationManager()
 
     /// Computed so it always reflects the latest `ClaudeConfigDirectory` setting.
     private var claudeStatusLineInstallationManager: ClaudeStatusLineInstallationManager {
@@ -118,6 +123,11 @@ final class HookInstallationCoordinator {
 
     var cursorHooksInstalled: Bool {
         cursorHookStatus?.managedHooksPresent == true
+    }
+
+    var geminiHooksInstalled: Bool {
+        if case .installed = geminiHookStatus { return true }
+        return false
     }
 
     var claudeUsageInstalled: Bool {
@@ -306,6 +316,35 @@ final class HookInstallationCoordinator {
         }
 
         return "no managed Cursor hooks"
+    }
+
+    var geminiHookStatusTitle: String {
+        switch geminiHookStatus {
+        case nil:
+            return "Gemini hooks loading"
+        case .geminiNotFound:
+            return "Gemini CLI not found"
+        case .notInstalled:
+            return "Gemini hooks not installed"
+        case .installed:
+            return "Gemini hooks installed"
+        }
+    }
+
+    var geminiHookStatusSummary: String {
+        switch geminiHookStatus {
+        case nil:
+            return "Reading ~/.gemini/settings.json."
+        case .geminiNotFound:
+            return "Install Gemini CLI to enable hooks."
+        case .notInstalled:
+            if hooksBinaryURL == nil {
+                return "Build OpenIslandHooks before installing."
+            }
+            return "no managed Gemini hooks"
+        case .installed:
+            return "managed hooks present"
+        }
     }
 
     var codexHookStatusTitle: String {
@@ -581,6 +620,16 @@ final class HookInstallationCoordinator {
                     }
                 }
             }
+
+            group.addTask { @MainActor [weak self] in
+                guard let self else { return }
+                do {
+                    let status = try self.geminiHookInstallationManager.status(hooksBinaryURL: self.hooksBinaryURL)
+                    self.geminiHookStatus = status
+                } catch {
+                    self.onStatusMessage?("Failed to read Gemini hook status: \(error.localizedDescription)")
+                }
+            }
         }
     }
 
@@ -606,6 +655,19 @@ final class HookInstallationCoordinator {
                 self.cursorHookStatus = status
             } catch {
                 self.onStatusMessage?("Failed to read Cursor hook status: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    func refreshGeminiHookStatus() {
+        Task { [weak self] in
+            guard let self else { return }
+
+            do {
+                let status = try self.geminiHookInstallationManager.status(hooksBinaryURL: self.hooksBinaryURL)
+                self.geminiHookStatus = status
+            } catch {
+                self.onStatusMessage?("Failed to read Gemini hook status: \(error.localizedDescription)")
             }
         }
     }
@@ -820,6 +882,28 @@ final class HookInstallationCoordinator {
         }
     }
 
+    func installGeminiHooks() {
+        guard let hooksBinaryURL else {
+            onStatusMessage?("Could not find a local OpenIslandHooks binary. Build the package first.")
+            return
+        }
+
+        updateGeminiHooks(userMessage: "Installing Gemini hooks.") { manager in
+            try manager.install(hooksBinaryURL: hooksBinaryURL)
+        }
+    }
+
+    func uninstallGeminiHooks() {
+        guard let hooksBinaryURL else {
+            onStatusMessage?("Could not find a local OpenIslandHooks binary. Build the package first.")
+            return
+        }
+
+        updateGeminiHooks(userMessage: "Removing Gemini hooks.") { manager in
+            try manager.uninstall(hooksBinaryURL: hooksBinaryURL)
+        }
+    }
+
     func installClaudeUsageBridge() {
         updateClaudeUsageBridge(userMessage: "Installing Claude usage bridge.") { manager in
             try manager.install()
@@ -960,6 +1044,32 @@ final class HookInstallationCoordinator {
                 }
             } catch {
                 self.onStatusMessage?("Cursor hook update failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func updateGeminiHooks(
+        userMessage: String,
+        operation: @escaping (GeminiHookInstallationManager) throws -> GeminiHookInstallationStatus
+    ) {
+        isGeminiHookSetupBusy = true
+        onStatusMessage?(userMessage)
+
+        Task { [weak self] in
+            guard let self else { return }
+
+            defer { self.isGeminiHookSetupBusy = false }
+
+            do {
+                let status = try operation(self.geminiHookInstallationManager)
+                self.geminiHookStatus = status
+                if case .installed = status {
+                    self.onStatusMessage?("Gemini hooks are installed and ready.")
+                } else {
+                    self.onStatusMessage?("Gemini hooks are not installed.")
+                }
+            } catch {
+                self.onStatusMessage?("Gemini hook update failed: \(error.localizedDescription)")
             }
         }
     }

--- a/Sources/OpenIslandApp/Views/ControlCenterView.swift
+++ b/Sources/OpenIslandApp/Views/ControlCenterView.swift
@@ -115,6 +115,8 @@ struct ControlCenterView: View {
 
                 ccForkHookCard(title: "CodeBuddy Hooks", installed: model.codebuddyHooksInstalled, status: model.codebuddyHookStatus, isBusy: model.isCodebuddyHookSetupBusy, install: model.installCodebuddyHooks, uninstall: model.uninstallCodebuddyHooks)
 
+                geminiHookCard
+
                 usageDebugCard(
                     title: "Claude Usage",
                     statusTitle: model.claudeUsageStatusTitle,
@@ -247,6 +249,35 @@ struct ControlCenterView: View {
             RoundedRectangle(cornerRadius: 18, style: .continuous)
                 .strokeBorder(selectedScenario == scenario ? .white.opacity(0.18) : .white.opacity(0.05))
         )
+    }
+
+    private var geminiHookCard: some View {
+        usageDebugCard(
+            title: "Gemini Hooks",
+            statusTitle: model.geminiHookStatusTitle,
+            statusSummary: model.geminiHookStatusSummary,
+            isActive: model.geminiHooksInstalled,
+            accentColor: model.geminiHooksInstalled ? .mint : .blue
+        ) {
+            EmptyView()
+        } actions: {
+            HStack(spacing: 10) {
+                Button(lang.t("debug.refresh")) {
+                    model.refreshGeminiHookStatus()
+                }
+                .buttonStyle(DebugActionButtonStyle(kind: .secondary))
+
+                Button(model.geminiHooksInstalled ? lang.t("debug.removeHooks") : lang.t("debug.installHooks")) {
+                    if model.geminiHooksInstalled {
+                        model.uninstallGeminiHooks()
+                    } else {
+                        model.installGeminiHooks()
+                    }
+                }
+                .buttonStyle(DebugActionButtonStyle(kind: .primary))
+                .disabled(model.isGeminiHookSetupBusy || model.hooksBinaryURL == nil || model.geminiHookStatus == .geminiNotFound)
+            }
+        }
     }
 
     private var actionCard: some View {

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -431,6 +431,9 @@ public final class BridgeServer: @unchecked Sendable {
 
         case let .processCursorHook(payload):
             handleCursorHook(payload, from: clientID)
+
+        case let .processGeminiHook(payload):
+            handleGeminiHook(payload, from: clientID)
         }
     }
 
@@ -1207,6 +1210,103 @@ public final class BridgeServer: @unchecked Sendable {
             )
             send(.response(.acknowledged), to: clientID)
         }
+    }
+
+    private func handleGeminiHook(_ payload: GeminiHookPayload, from clientID: UUID) {
+        switch payload.hookEventName {
+        case .sessionStart:
+            emit(
+                .sessionStarted(
+                    SessionStarted(
+                        sessionID: payload.sessionID,
+                        title: payload.sessionTitle,
+                        tool: .geminiCLI,
+                        origin: .live,
+                        initialPhase: .running,
+                        summary: payload.implicitStartSummary,
+                        timestamp: .now
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .userPromptSubmit:
+            ensureGeminiSessionExists(for: payload)
+            emit(
+                .activityUpdated(
+                    SessionActivityUpdated(
+                        sessionID: payload.sessionID,
+                        summary: payload.implicitStartSummary,
+                        phase: .running,
+                        timestamp: .now
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .preToolUse:
+            ensureGeminiSessionExists(for: payload)
+            emit(
+                .activityUpdated(
+                    SessionActivityUpdated(
+                        sessionID: payload.sessionID,
+                        summary: payload.implicitStartSummary,
+                        phase: .running,
+                        timestamp: .now
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .postToolUse:
+            ensureGeminiSessionExists(for: payload)
+            emit(
+                .activityUpdated(
+                    SessionActivityUpdated(
+                        sessionID: payload.sessionID,
+                        summary: payload.implicitStartSummary,
+                        phase: .running,
+                        timestamp: .now
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .stop:
+            ensureGeminiSessionExists(for: payload)
+            let summary = payload.lastAssistantMessage.flatMap { $0.isEmpty ? nil : String($0.prefix(120)) }
+                ?? payload.implicitStartSummary
+            emit(
+                .sessionCompleted(
+                    SessionCompleted(
+                        sessionID: payload.sessionID,
+                        summary: summary,
+                        timestamp: .now
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+        }
+    }
+
+    private func ensureGeminiSessionExists(for payload: GeminiHookPayload) {
+        guard !hasSession(id: payload.sessionID) else {
+            return
+        }
+
+        emit(
+            .sessionStarted(
+                SessionStarted(
+                    sessionID: payload.sessionID,
+                    title: payload.sessionTitle,
+                    tool: .geminiCLI,
+                    origin: .live,
+                    initialPhase: .running,
+                    summary: payload.implicitStartSummary,
+                    timestamp: .now
+                )
+            )
+        )
     }
 
     private func clearStaleCursorInteractionIfNeeded(for sessionID: String) {

--- a/Sources/OpenIslandCore/BridgeTransport.swift
+++ b/Sources/OpenIslandCore/BridgeTransport.swift
@@ -88,6 +88,7 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
     case processClaudeHook(ClaudeHookPayload)
     case processOpenCodeHook(OpenCodeHookPayload)
     case processCursorHook(CursorHookPayload)
+    case processGeminiHook(GeminiHookPayload)
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -100,6 +101,7 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
         case claudeHook
         case openCodeHook
         case cursorHook
+        case geminiHook
     }
 
     private enum CommandType: String, Codable {
@@ -111,6 +113,7 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
         case processClaudeHook
         case processOpenCodeHook
         case processCursorHook
+        case processGeminiHook
     }
 
     public init(from decoder: any Decoder) throws {
@@ -143,6 +146,8 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
             self = .processOpenCodeHook(try container.decode(OpenCodeHookPayload.self, forKey: .openCodeHook))
         case .processCursorHook:
             self = .processCursorHook(try container.decode(CursorHookPayload.self, forKey: .cursorHook))
+        case .processGeminiHook:
+            self = .processGeminiHook(try container.decode(GeminiHookPayload.self, forKey: .geminiHook))
         }
     }
 
@@ -177,6 +182,9 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
         case let .processCursorHook(payload):
             try container.encode(CommandType.processCursorHook, forKey: .type)
             try container.encode(payload, forKey: .cursorHook)
+        case let .processGeminiHook(payload):
+            try container.encode(CommandType.processGeminiHook, forKey: .type)
+            try container.encode(payload, forKey: .geminiHook)
         }
     }
 }

--- a/Sources/OpenIslandCore/GeminiHookInstallationManager.swift
+++ b/Sources/OpenIslandCore/GeminiHookInstallationManager.swift
@@ -6,7 +6,7 @@ public enum GeminiHookInstallationStatus: Equatable, Sendable {
     case geminiNotFound
 }
 
-public final class GeminiHookInstallationManager: Sendable {
+public final class GeminiHookInstallationManager: @unchecked Sendable {
     private let geminiDirectory: URL
 
     public init(
@@ -20,14 +20,17 @@ public final class GeminiHookInstallationManager: Sendable {
         geminiDirectory.appendingPathComponent("settings.json")
     }
 
-    public func checkStatus(hooksBinaryURL: URL) async -> GeminiHookInstallationStatus {
+    public func status(hooksBinaryURL: URL? = nil) throws -> GeminiHookInstallationStatus {
         guard FileManager.default.fileExists(atPath: geminiDirectory.path) else {
             return .geminiNotFound
         }
         guard let data = try? Data(contentsOf: settingsURL) else {
             return .notInstalled
         }
-        let hookCommand = GeminiHookInstaller.hookCommand(for: hooksBinaryURL.path)
+        guard let binaryURL = hooksBinaryURL else {
+            return .notInstalled
+        }
+        let hookCommand = GeminiHookInstaller.hookCommand(for: binaryURL.path)
         guard let mutation = try? GeminiHookInstaller.uninstallSettingsJSON(
             existingData: data,
             hookCommand: hookCommand
@@ -39,7 +42,8 @@ public final class GeminiHookInstallationManager: Sendable {
             : .notInstalled
     }
 
-    public func install(hooksBinaryURL: URL) async throws -> GeminiHookInstallationStatus {
+    @discardableResult
+    public func install(hooksBinaryURL: URL) throws -> GeminiHookInstallationStatus {
         try FileManager.default.createDirectory(at: geminiDirectory, withIntermediateDirectories: true)
         let existingData = try? Data(contentsOf: settingsURL)
         let hookCommand = GeminiHookInstaller.hookCommand(for: hooksBinaryURL.path)
@@ -53,7 +57,8 @@ public final class GeminiHookInstallationManager: Sendable {
         return .installed(hookCommand: hookCommand)
     }
 
-    public func uninstall(hooksBinaryURL: URL) async throws -> GeminiHookInstallationStatus {
+    @discardableResult
+    public func uninstall(hooksBinaryURL: URL) throws -> GeminiHookInstallationStatus {
         let existingData = try? Data(contentsOf: settingsURL)
         let hookCommand = GeminiHookInstaller.hookCommand(for: hooksBinaryURL.path)
         let mutation = try GeminiHookInstaller.uninstallSettingsJSON(

--- a/Sources/OpenIslandCore/GeminiHookInstallationManager.swift
+++ b/Sources/OpenIslandCore/GeminiHookInstallationManager.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+public enum GeminiHookInstallationStatus: Equatable, Sendable {
+    case notInstalled
+    case installed(hookCommand: String)
+    case geminiNotFound
+}
+
+public final class GeminiHookInstallationManager: Sendable {
+    private let geminiDirectory: URL
+
+    public init(
+        geminiDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".gemini", isDirectory: true)
+    ) {
+        self.geminiDirectory = geminiDirectory
+    }
+
+    private var settingsURL: URL {
+        geminiDirectory.appendingPathComponent("settings.json")
+    }
+
+    public func checkStatus(hooksBinaryURL: URL) async -> GeminiHookInstallationStatus {
+        guard FileManager.default.fileExists(atPath: geminiDirectory.path) else {
+            return .geminiNotFound
+        }
+        guard let data = try? Data(contentsOf: settingsURL) else {
+            return .notInstalled
+        }
+        let hookCommand = GeminiHookInstaller.hookCommand(for: hooksBinaryURL.path)
+        guard let mutation = try? GeminiHookInstaller.uninstallSettingsJSON(
+            existingData: data,
+            hookCommand: hookCommand
+        ) else {
+            return .notInstalled
+        }
+        return mutation.managedHooksPresent
+            ? .installed(hookCommand: hookCommand)
+            : .notInstalled
+    }
+
+    public func install(hooksBinaryURL: URL) async throws -> GeminiHookInstallationStatus {
+        try FileManager.default.createDirectory(at: geminiDirectory, withIntermediateDirectories: true)
+        let existingData = try? Data(contentsOf: settingsURL)
+        let hookCommand = GeminiHookInstaller.hookCommand(for: hooksBinaryURL.path)
+        let mutation = try GeminiHookInstaller.installSettingsJSON(
+            existingData: existingData,
+            hookCommand: hookCommand
+        )
+        if let contents = mutation.contents {
+            try contents.write(to: settingsURL, options: .atomic)
+        }
+        return .installed(hookCommand: hookCommand)
+    }
+
+    public func uninstall(hooksBinaryURL: URL) async throws -> GeminiHookInstallationStatus {
+        let existingData = try? Data(contentsOf: settingsURL)
+        let hookCommand = GeminiHookInstaller.hookCommand(for: hooksBinaryURL.path)
+        let mutation = try GeminiHookInstaller.uninstallSettingsJSON(
+            existingData: existingData,
+            hookCommand: hookCommand
+        )
+        if let contents = mutation.contents {
+            try contents.write(to: settingsURL, options: .atomic)
+        }
+        return .notInstalled
+    }
+}

--- a/Sources/OpenIslandCore/GeminiHookInstaller.swift
+++ b/Sources/OpenIslandCore/GeminiHookInstaller.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+public struct GeminiHookFileMutation: Equatable, Sendable {
+    public var contents: Data?
+    public var changed: Bool
+    public var managedHooksPresent: Bool
+
+    public init(contents: Data?, changed: Bool, managedHooksPresent: Bool) {
+        self.contents = contents
+        self.changed = changed
+        self.managedHooksPresent = managedHooksPresent
+    }
+}
+
+public enum GeminiHookInstallerError: Error, LocalizedError {
+    case invalidSettingsJSON
+
+    public var errorDescription: String? {
+        "The existing Gemini settings.json is not valid JSON."
+    }
+}
+
+public enum GeminiHookInstaller {
+    private static let hookEvents: [String] = ["SessionStart", "PreToolUse", "PostToolUse", "Stop", "UserPromptSubmit"]
+
+    public static func hookCommand(for binaryPath: String) -> String {
+        "'\(binaryPath.replacingOccurrences(of: "'", with: "'\\''"))' --source gemini"
+    }
+
+    public static func installSettingsJSON(
+        existingData: Data?,
+        hookCommand: String
+    ) throws -> GeminiHookFileMutation {
+        var root = try loadRoot(from: existingData)
+        var hooks = root["hooks"] as? [String: Any] ?? [:]
+        var changed = false
+
+        for event in hookEvents {
+            var entries = hooks[event] as? [[String: Any]] ?? []
+            let alreadyPresent = entries.contains { ($0["command"] as? String)?.contains("--source gemini") == true }
+            if !alreadyPresent {
+                entries.append(["command": hookCommand])
+                hooks[event] = entries
+                changed = true
+            }
+        }
+
+        root["hooks"] = hooks
+        let data = try JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+        return GeminiHookFileMutation(contents: data, changed: changed, managedHooksPresent: true)
+    }
+
+    public static func uninstallSettingsJSON(
+        existingData: Data?,
+        hookCommand: String
+    ) throws -> GeminiHookFileMutation {
+        guard let existingData else {
+            return GeminiHookFileMutation(contents: nil, changed: false, managedHooksPresent: false)
+        }
+        var root = try loadRoot(from: existingData)
+        guard var hooks = root["hooks"] as? [String: Any] else {
+            return GeminiHookFileMutation(contents: existingData, changed: false, managedHooksPresent: false)
+        }
+
+        var changed = false
+        for event in hookEvents {
+            if var entries = hooks[event] as? [[String: Any]] {
+                let before = entries.count
+                entries.removeAll { ($0["command"] as? String)?.contains("--source gemini") == true }
+                if entries.count != before {
+                    hooks[event] = entries.isEmpty ? nil : entries
+                    changed = true
+                }
+            }
+        }
+
+        root["hooks"] = hooks
+        let data = try JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+        let stillPresent = hookEvents.contains { event in
+            (hooks[event] as? [[String: Any]])?.contains {
+                ($0["command"] as? String)?.contains("--source gemini") == true
+            } == true
+        }
+        return GeminiHookFileMutation(contents: data, changed: changed, managedHooksPresent: stillPresent)
+    }
+
+    private static func loadRoot(from data: Data?) throws -> [String: Any] {
+        guard let data, !data.isEmpty else { return [:] }
+        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw GeminiHookInstallerError.invalidSettingsJSON
+        }
+        return root
+    }
+}

--- a/Sources/OpenIslandCore/GeminiHooks.swift
+++ b/Sources/OpenIslandCore/GeminiHooks.swift
@@ -6,6 +6,15 @@ public enum GeminiHookEventName: String, Codable, Sendable {
     case preToolUse = "PreToolUse"
     case postToolUse = "PostToolUse"
     case stop = "Stop"
+    case userPromptSubmit = "UserPromptSubmit"
+}
+
+public struct GeminiHookToolInput: Equatable, Codable, Sendable {
+    public var command: String
+
+    public init(command: String) {
+        self.command = command
+    }
 }
 
 public struct GeminiHookPayload: Equatable, Codable, Sendable {
@@ -14,7 +23,7 @@ public struct GeminiHookPayload: Equatable, Codable, Sendable {
     public var cwd: String
     public var model: String
     public var toolName: String?
-    public var toolInput: [String: String]?
+    public var toolInput: GeminiHookToolInput?
     public var lastAssistantMessage: String?
 
     private enum CodingKeys: String, CodingKey {
@@ -33,7 +42,7 @@ public struct GeminiHookPayload: Equatable, Codable, Sendable {
         cwd: String,
         model: String,
         toolName: String? = nil,
-        toolInput: [String: String]? = nil,
+        toolInput: GeminiHookToolInput? = nil,
         lastAssistantMessage: String? = nil
     ) {
         self.sessionID = sessionID
@@ -66,6 +75,8 @@ public extension GeminiHookPayload {
             return "Gemini CLI finished a tool call in \(workspaceName)."
         case .stop:
             return "Gemini CLI completed a turn in \(workspaceName)."
+        case .userPromptSubmit:
+            return "Gemini CLI received a new prompt in \(workspaceName)."
         }
     }
 }

--- a/Sources/OpenIslandCore/GeminiHooks.swift
+++ b/Sources/OpenIslandCore/GeminiHooks.swift
@@ -71,7 +71,7 @@ public extension GeminiHookPayload {
 }
 
 public enum GeminiHookOutputEncoder {
-    public static func standardOutput(for response: BridgeResponse) throws -> Data? {
+    public static func standardOutput(for response: BridgeResponse) -> Data? {
         // Gemini CLI hooks are fire-and-forget — no block/deny directive needed yet.
         return nil
     }

--- a/Sources/OpenIslandCore/GeminiHooks.swift
+++ b/Sources/OpenIslandCore/GeminiHooks.swift
@@ -1,0 +1,78 @@
+// Sources/OpenIslandCore/GeminiHooks.swift
+import Foundation
+
+public enum GeminiHookEventName: String, Codable, Sendable {
+    case sessionStart = "SessionStart"
+    case preToolUse = "PreToolUse"
+    case postToolUse = "PostToolUse"
+    case stop = "Stop"
+}
+
+public struct GeminiHookPayload: Equatable, Codable, Sendable {
+    public var sessionID: String
+    public var hookEventName: GeminiHookEventName
+    public var cwd: String
+    public var model: String
+    public var toolName: String?
+    public var toolInput: [String: String]?
+    public var lastAssistantMessage: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionID = "session_id"
+        case hookEventName = "hook_event_name"
+        case cwd
+        case model
+        case toolName = "tool_name"
+        case toolInput = "tool_input"
+        case lastAssistantMessage = "last_assistant_message"
+    }
+
+    public init(
+        sessionID: String,
+        hookEventName: GeminiHookEventName,
+        cwd: String,
+        model: String,
+        toolName: String? = nil,
+        toolInput: [String: String]? = nil,
+        lastAssistantMessage: String? = nil
+    ) {
+        self.sessionID = sessionID
+        self.hookEventName = hookEventName
+        self.cwd = cwd
+        self.model = model
+        self.toolName = toolName
+        self.toolInput = toolInput
+        self.lastAssistantMessage = lastAssistantMessage
+    }
+}
+
+public extension GeminiHookPayload {
+    var workspaceName: String {
+        WorkspaceNameResolver.workspaceName(for: cwd)
+    }
+
+    var sessionTitle: String {
+        "Gemini CLI · \(workspaceName)"
+    }
+
+    var implicitStartSummary: String {
+        switch hookEventName {
+        case .sessionStart:
+            return "Started Gemini CLI session in \(workspaceName)."
+        case .preToolUse:
+            let tool = toolName ?? "tool"
+            return "Gemini CLI is running \(tool) in \(workspaceName)."
+        case .postToolUse:
+            return "Gemini CLI finished a tool call in \(workspaceName)."
+        case .stop:
+            return "Gemini CLI completed a turn in \(workspaceName)."
+        }
+    }
+}
+
+public enum GeminiHookOutputEncoder {
+    public static func standardOutput(for response: BridgeResponse) throws -> Data? {
+        // Gemini CLI hooks are fire-and-forget — no block/deny directive needed yet.
+        return nil
+    }
+}

--- a/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
+++ b/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
@@ -14,12 +14,13 @@ struct OpenIslandHooksCLI {
         case droid
         case codebuddy
         case cursor
+        case gemini
 
         var isClaudeFormat: Bool {
             switch self {
             case .claude, .qoder, .qwen, .factory, .droid, .codebuddy:
                 return true
-            case .codex, .cursor:
+            case .codex, .cursor, .gemini:
                 return false
             }
         }
@@ -86,6 +87,15 @@ struct OpenIslandHooksCLI {
                     let output = try encoder.encode(directive)
                     FileHandle.standardOutput.write(output)
                     FileHandle.standardOutput.write(Data("\n".utf8))
+                }
+            case .gemini:
+                let payload = try decoder.decode(GeminiHookPayload.self, from: input)
+                guard let response = try? client.send(.processGeminiHook(payload)) else {
+                    logStderr("bridge unavailable for gemini hook (\(payload.hookEventName.rawValue))")
+                    return
+                }
+                if let output = GeminiHookOutputEncoder.standardOutput(for: response) {
+                    FileHandle.standardOutput.write(output)
                 }
             }
         } catch {

--- a/Tests/OpenIslandCoreTests/GeminiHookTests.swift
+++ b/Tests/OpenIslandCoreTests/GeminiHookTests.swift
@@ -113,10 +113,10 @@ struct GeminiHookTests {
         #expect(entries.count == 2)
     }
 
-    @Test func installationManagerReturnsGeminiNotFoundForMissingDirectory() async {
+    @Test func installationManagerReturnsGeminiNotFoundForMissingDirectory() throws {
         let tempURL = URL(fileURLWithPath: "/tmp/gemini-test-nonexistent-\(UUID().uuidString)")
         let manager = GeminiHookInstallationManager(geminiDirectory: tempURL)
-        let status = await manager.checkStatus(
+        let status = try manager.status(
             hooksBinaryURL: URL(fileURLWithPath: "/usr/local/bin/open-island-hooks")
         )
         #expect(status == .geminiNotFound)

--- a/Tests/OpenIslandCoreTests/GeminiHookTests.swift
+++ b/Tests/OpenIslandCoreTests/GeminiHookTests.swift
@@ -121,4 +121,18 @@ struct GeminiHookTests {
         )
         #expect(status == .geminiNotFound)
     }
+
+    @Test func bridgeCommandRoundTripsGeminiHook() throws {
+        let payload = GeminiHookPayload(
+            sessionID: "s1",
+            hookEventName: .preToolUse,
+            cwd: "/tmp",
+            model: "gemini-2.0-flash",
+            toolName: "bash"
+        )
+        let command = BridgeCommand.processGeminiHook(payload)
+        let data = try JSONEncoder().encode(command)
+        let decoded = try JSONDecoder().decode(BridgeCommand.self, from: data)
+        #expect(decoded == command)
+    }
 }

--- a/Tests/OpenIslandCoreTests/GeminiHookTests.swift
+++ b/Tests/OpenIslandCoreTests/GeminiHookTests.swift
@@ -35,11 +35,41 @@ struct GeminiHookTests {
         let payload = try JSONDecoder().decode(GeminiHookPayload.self, from: json)
         #expect(payload.hookEventName == .preToolUse)
         #expect(payload.toolName == "bash")
-        #expect(payload.toolInput?["command"] == "ls -la")
+        #expect(payload.toolInput?.command == "ls -la")
     }
 
     @Test func encoderReturnsNilForAcknowledged() {
         let result = GeminiHookOutputEncoder.standardOutput(for: .acknowledged)
         #expect(result == nil)
+    }
+
+    @Test func optionalFieldsDecodeAsNilWhenAbsent() throws {
+        let json = """
+        {
+          "session_id": "s1",
+          "hook_event_name": "Stop",
+          "cwd": "/tmp",
+          "model": "gemini-2.0-flash"
+        }
+        """.data(using: .utf8)!
+        let payload = try JSONDecoder().decode(GeminiHookPayload.self, from: json)
+        #expect(payload.toolName == nil)
+        #expect(payload.toolInput == nil)
+        #expect(payload.lastAssistantMessage == nil)
+    }
+
+    @Test func implicitStartSummaryForAllEvents() {
+        let base = GeminiHookPayload(sessionID: "s", hookEventName: .sessionStart, cwd: "/Users/user/myapp", model: "g")
+        var p = base
+        p = GeminiHookPayload(sessionID: "s", hookEventName: .sessionStart, cwd: "/Users/user/myapp", model: "g")
+        #expect(p.implicitStartSummary.contains("Started"))
+        p = GeminiHookPayload(sessionID: "s", hookEventName: .preToolUse, cwd: "/Users/user/myapp", model: "g", toolName: "bash")
+        #expect(p.implicitStartSummary.contains("bash"))
+        p = GeminiHookPayload(sessionID: "s", hookEventName: .postToolUse, cwd: "/Users/user/myapp", model: "g")
+        #expect(p.implicitStartSummary.contains("finished"))
+        p = GeminiHookPayload(sessionID: "s", hookEventName: .stop, cwd: "/Users/user/myapp", model: "g")
+        #expect(p.implicitStartSummary.contains("completed"))
+        p = GeminiHookPayload(sessionID: "s", hookEventName: .userPromptSubmit, cwd: "/Users/user/myapp", model: "g")
+        #expect(p.implicitStartSummary.contains("prompt"))
     }
 }

--- a/Tests/OpenIslandCoreTests/GeminiHookTests.swift
+++ b/Tests/OpenIslandCoreTests/GeminiHookTests.swift
@@ -72,4 +72,44 @@ struct GeminiHookTests {
         p = GeminiHookPayload(sessionID: "s", hookEventName: .userPromptSubmit, cwd: "/Users/user/myapp", model: "g")
         #expect(p.implicitStartSummary.contains("prompt"))
     }
+
+    @Test func installerAddsManagedHooksToEmptyFile() throws {
+        let mutation = try GeminiHookInstaller.installSettingsJSON(
+            existingData: nil,
+            hookCommand: "/usr/local/bin/open-island-hooks --source gemini"
+        )
+        #expect(mutation.changed == true)
+        #expect(mutation.managedHooksPresent == true)
+        let obj = try JSONSerialization.jsonObject(with: mutation.contents!) as! [String: Any]
+        let hooks = obj["hooks"] as! [String: Any]
+        let entries = hooks["PreToolUse"] as! [[String: String]]
+        #expect(entries.first?["command"]?.contains("--source gemini") == true)
+    }
+
+    @Test func installerUninstallRemovesManagedHooks() throws {
+        let installed = try GeminiHookInstaller.installSettingsJSON(
+            existingData: nil,
+            hookCommand: "/usr/local/bin/open-island-hooks --source gemini"
+        )
+        let uninstalled = try GeminiHookInstaller.uninstallSettingsJSON(
+            existingData: installed.contents,
+            hookCommand: "/usr/local/bin/open-island-hooks --source gemini"
+        )
+        #expect(uninstalled.changed == true)
+        #expect(uninstalled.managedHooksPresent == false)
+    }
+
+    @Test func installerPreservesExistingUserHooks() throws {
+        let existing = """
+        {"hooks":{"PreToolUse":[{"command":"echo user-hook"}]}}
+        """.data(using: .utf8)!
+        let mutation = try GeminiHookInstaller.installSettingsJSON(
+            existingData: existing,
+            hookCommand: "/usr/local/bin/open-island-hooks --source gemini"
+        )
+        let obj = try JSONSerialization.jsonObject(with: mutation.contents!) as! [String: Any]
+        let hooks = obj["hooks"] as! [String: Any]
+        let entries = hooks["PreToolUse"] as! [[String: String]]
+        #expect(entries.count == 2)
+    }
 }

--- a/Tests/OpenIslandCoreTests/GeminiHookTests.swift
+++ b/Tests/OpenIslandCoreTests/GeminiHookTests.swift
@@ -112,4 +112,13 @@ struct GeminiHookTests {
         let entries = hooks["PreToolUse"] as! [[String: String]]
         #expect(entries.count == 2)
     }
+
+    @Test func installationManagerReturnsGeminiNotFoundForMissingDirectory() async {
+        let tempURL = URL(fileURLWithPath: "/tmp/gemini-test-nonexistent-\(UUID().uuidString)")
+        let manager = GeminiHookInstallationManager(geminiDirectory: tempURL)
+        let status = await manager.checkStatus(
+            hooksBinaryURL: URL(fileURLWithPath: "/usr/local/bin/open-island-hooks")
+        )
+        #expect(status == .geminiNotFound)
+    }
 }

--- a/Tests/OpenIslandCoreTests/GeminiHookTests.swift
+++ b/Tests/OpenIslandCoreTests/GeminiHookTests.swift
@@ -1,0 +1,45 @@
+// Tests/OpenIslandCoreTests/GeminiHookTests.swift
+import Testing
+import Foundation
+@testable import OpenIslandCore
+
+@Suite("GeminiHooks")
+struct GeminiHookTests {
+    @Test func decodesSessionStartPayload() throws {
+        let json = """
+        {
+          "session_id": "abc-123",
+          "hook_event_name": "SessionStart",
+          "cwd": "/Users/user/project",
+          "model": "gemini-2.0-flash"
+        }
+        """.data(using: .utf8)!
+        let payload = try JSONDecoder().decode(GeminiHookPayload.self, from: json)
+        #expect(payload.sessionID == "abc-123")
+        #expect(payload.hookEventName == .sessionStart)
+        #expect(payload.model == "gemini-2.0-flash")
+        #expect(payload.cwd == "/Users/user/project")
+    }
+
+    @Test func decodesPreToolUsePayload() throws {
+        let json = """
+        {
+          "session_id": "xyz",
+          "hook_event_name": "PreToolUse",
+          "cwd": "/tmp",
+          "model": "gemini-2.0-flash",
+          "tool_name": "bash",
+          "tool_input": {"command": "ls -la"}
+        }
+        """.data(using: .utf8)!
+        let payload = try JSONDecoder().decode(GeminiHookPayload.self, from: json)
+        #expect(payload.hookEventName == .preToolUse)
+        #expect(payload.toolName == "bash")
+        #expect(payload.toolInput?["command"] == "ls -la")
+    }
+
+    @Test func encoderReturnsNilForAcknowledged() throws {
+        let result = try GeminiHookOutputEncoder.standardOutput(for: .acknowledged)
+        #expect(result == nil)
+    }
+}

--- a/Tests/OpenIslandCoreTests/GeminiHookTests.swift
+++ b/Tests/OpenIslandCoreTests/GeminiHookTests.swift
@@ -38,8 +38,8 @@ struct GeminiHookTests {
         #expect(payload.toolInput?["command"] == "ls -la")
     }
 
-    @Test func encoderReturnsNilForAcknowledged() throws {
-        let result = try GeminiHookOutputEncoder.standardOutput(for: .acknowledged)
+    @Test func encoderReturnsNilForAcknowledged() {
+        let result = GeminiHookOutputEncoder.standardOutput(for: .acknowledged)
         #expect(result == nil)
     }
 }


### PR DESCRIPTION
## Summary

- Adds full Gemini CLI hook pipeline — from `~/.gemini/settings.json` installation to session tracking in Open Island
- `GeminiHookPayload` model with 5 hook events: `sessionStart`, `preToolUse`, `postToolUse`, `stop`, `userPromptSubmit`
- `GeminiHookInstaller` manages hook entries in `~/.gemini/settings.json`, preserving existing user hooks
- `GeminiHookInstallationManager` for install/uninstall/status lifecycle (aligned to `CodexHookInstallationManager` peer pattern)
- `BridgeTransport` + `BridgeServer` wired to handle `processGeminiHook` command
- `OpenIslandHooksCLI` routes `--source gemini` to the new pipeline
- Control Center UI card for Gemini hook install/remove/refresh

## Test Plan

- [ ] `swift test` — 10 new `GeminiHookTests` pass alongside existing suite
- [ ] Install hook via Control Center → verify `~/.gemini/settings.json` updated
- [ ] Run `gemini` in a project → session appears in Open Island island
- [ ] Remove hook via Control Center → settings.json cleaned up