### PR TITLE
feat: add Now Playing media strip with album art and dominant color

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -10,6 +10,7 @@ final class AppModel {
     private static let soundMutedDefaultsKey = "overlay.sound.muted"
     private static let showDockIconDefaultsKey = "app.showDockIcon"
     private static let hapticFeedbackEnabledDefaultsKey = "app.hapticFeedbackEnabled"
+    private static let showMediaStripDefaultsKey = "display.showMediaStrip"
     private static let islandAppearanceModeDefaultsKey = "appearance.island.mode"
     private static let islandClosedDisplayStyleDefaultsKey = "appearance.island.closedDisplayStyle"
     private static let islandPixelShapeStyleDefaultsKey = "appearance.island.pixelShapeStyle"
@@ -48,6 +49,7 @@ final class AppModel {
     let discovery = SessionDiscoveryCoordinator()
     let monitoring = ProcessMonitoringCoordinator()
     let updateChecker = UpdateChecker()
+    let nowPlayingObserver = NowPlayingObserver()
 
     var notchStatus: NotchStatus {
         get { overlay.notchStatus }
@@ -182,6 +184,12 @@ final class AppModel {
         didSet {
             guard hasFinishedInit, hapticFeedbackEnabled != oldValue else { return }
             UserDefaults.standard.set(hapticFeedbackEnabled, forKey: Self.hapticFeedbackEnabledDefaultsKey)
+        }
+    }
+    var showMediaStrip: Bool = true {
+        didSet {
+            guard hasFinishedInit, showMediaStrip != oldValue else { return }
+            UserDefaults.standard.set(showMediaStrip, forKey: Self.showMediaStripDefaultsKey)
         }
     }
     var isSoundMuted = false {
@@ -396,11 +404,13 @@ final class AppModel {
         UserDefaults.standard.register(defaults: [
             Self.showDockIconDefaultsKey: true,
             Self.hapticFeedbackEnabledDefaultsKey: false,
+            Self.showMediaStripDefaultsKey: true,
         ])
         isSoundMuted = UserDefaults.standard.bool(forKey: Self.soundMutedDefaultsKey)
         selectedSoundName = NotificationSoundService.selectedSoundName
         showDockIcon = UserDefaults.standard.bool(forKey: Self.showDockIconDefaultsKey)
         hapticFeedbackEnabled = UserDefaults.standard.bool(forKey: Self.hapticFeedbackEnabledDefaultsKey)
+        showMediaStrip = UserDefaults.standard.bool(forKey: Self.showMediaStripDefaultsKey)
         islandAppearanceMode = IslandAppearanceMode(
             rawValue: UserDefaults.standard.string(forKey: Self.islandAppearanceModeDefaultsKey) ?? ""
         ) ?? .default
@@ -663,6 +673,7 @@ final class AppModel {
             hooks.refreshCodexUsageState()
             hooks.startCodexUsageMonitoringIfNeeded()
             updateChecker.startIfNeeded()
+            nowPlayingObserver.start()
 
         } else {
             isResolvingInitialLiveSessions = false
@@ -1288,6 +1299,7 @@ final class AppModel {
     }
 
     func quitApplication() {
+        nowPlayingObserver.stop()
         NSApplication.shared.terminate(nil)
     }
 

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -50,6 +50,7 @@ final class AppModel {
     let monitoring = ProcessMonitoringCoordinator()
     let updateChecker = UpdateChecker()
     let nowPlayingObserver = NowPlayingObserver()
+    let artworkCache = ArtworkCache()
 
     var notchStatus: NotchStatus {
         get { overlay.notchStatus }

--- a/Sources/OpenIslandApp/ArtworkCache.swift
+++ b/Sources/OpenIslandApp/ArtworkCache.swift
@@ -1,0 +1,68 @@
+import AppKit
+import Observation
+
+/// Thread-safe image store backed by a Swift actor.
+private actor ArtworkStore {
+    private var cache: [URL: NSImage] = [:]
+
+    func image(for url: URL) -> NSImage? {
+        cache[url]
+    }
+
+    func store(_ image: NSImage, for url: URL) {
+        cache[url] = image
+    }
+}
+
+/// @MainActor-observable wrapper around ArtworkStore.
+/// Views call `image(for:)` synchronously; downloads happen off-thread.
+@MainActor
+@Observable
+final class ArtworkCache {
+    private let store = ArtworkStore()
+    private var inFlight: Set<URL> = []
+    /// Observable trigger: incremented whenever a new image lands.
+    private(set) var version: Int = 0
+
+    /// Main-actor mirror for synchronous reads without async bridging.
+    private var mainCache: [URL: NSImage] = [:]
+
+    /// Returns cached NSImage if available. Triggers download if not cached.
+    func image(for url: URL) -> NSImage? {
+        if mainCache[url] == nil {
+            prefetch(url)
+        }
+        return mainCache[url]
+    }
+
+    /// Trigger async load for `url` if not already cached or in-flight.
+    func prefetch(_ url: URL) {
+        guard mainCache[url] == nil, !inFlight.contains(url) else { return }
+        inFlight.insert(url)
+        Task {
+            let image = await loadImage(url: url)
+            if let image {
+                await store.store(image, for: url)
+                mainCache[url] = image
+                version += 1
+            }
+            inFlight.remove(url)
+        }
+    }
+
+    /// For testing: directly insert an image without network.
+    func store(_ image: NSImage, for url: URL) async {
+        await store.store(image, for: url)
+        mainCache[url] = image
+        version += 1
+    }
+
+    // MARK: Private
+
+    private func loadImage(url: URL) async -> NSImage? {
+        await Task.detached(priority: .utility) {
+            guard let data = try? Data(contentsOf: url) else { return nil }
+            return NSImage(data: data)
+        }.value
+    }
+}

--- a/Sources/OpenIslandApp/ArtworkCache.swift
+++ b/Sources/OpenIslandApp/ArtworkCache.swift
@@ -60,9 +60,14 @@ final class ArtworkCache {
     // MARK: Private
 
     private func loadImage(url: URL) async -> NSImage? {
-        await Task.detached(priority: .utility) {
-            guard let data = try? Data(contentsOf: url) else { return nil }
-            return NSImage(data: data)
-        }.value
+        if url.isFileURL {
+            return await Task.detached(priority: .utility) {
+                guard let data = try? Data(contentsOf: url) else { return nil }
+                return NSImage(data: data)
+            }.value
+        }
+        // Remote URL: use URLSession for proper async, timeout, and cancellation support
+        guard let (data, _) = try? await URLSession.shared.data(from: url) else { return nil }
+        return NSImage(data: data)
     }
 }

--- a/Sources/OpenIslandApp/DominantColorExtractor.swift
+++ b/Sources/OpenIslandApp/DominantColorExtractor.swift
@@ -1,0 +1,58 @@
+import AppKit
+import SwiftUI
+
+enum DominantColorExtractor {
+    /// Extract dominant color from an NSImage by sampling an 8×8 downscaled version.
+    /// Skips near-black and near-white pixels. Returns `.gray` on failure.
+    static func extract(from image: NSImage) -> Color {
+        let sampleSize = 8
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            return .gray
+        }
+
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        var pixels = [UInt8](repeating: 0, count: sampleSize * sampleSize * 4)
+        guard let context = CGContext(
+            data: &pixels,
+            width: sampleSize,
+            height: sampleSize,
+            bitsPerComponent: 8,
+            bytesPerRow: sampleSize * 4,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return .gray }
+
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: sampleSize, height: sampleSize))
+
+        var totalR: CGFloat = 0
+        var totalG: CGFloat = 0
+        var totalB: CGFloat = 0
+        var count: CGFloat = 0
+
+        for i in 0..<(sampleSize * sampleSize) {
+            let base = i * 4
+            let r = CGFloat(pixels[base]) / 255
+            let g = CGFloat(pixels[base + 1]) / 255
+            let b = CGFloat(pixels[base + 2]) / 255
+            let brightness = (r + g + b) / 3
+            // Skip near-black and near-white pixels
+            guard brightness > 0.1 && brightness < 0.95 else { continue }
+            totalR += r
+            totalG += g
+            totalB += b
+            count += 1
+        }
+
+        guard count > 0 else { return .gray }
+        return Color(
+            red: Double(totalR / count),
+            green: Double(totalG / count),
+            blue: Double(totalB / count)
+        )
+    }
+
+    static func extractOrFallback(from image: NSImage?) -> Color {
+        guard let image else { return .gray }
+        return extract(from: image)
+    }
+}

--- a/Sources/OpenIslandApp/NowPlayingObserver.swift
+++ b/Sources/OpenIslandApp/NowPlayingObserver.swift
@@ -10,7 +10,12 @@ final class NowPlayingObserver {
     private let pollInterval: TimeInterval
     private var lastMusicTrackKey: String = ""
 
-    private static let musicArtworkPath = "/tmp/open-island-artwork"
+    private static let musicArtworkPath: String = {
+        let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+        return (caches ?? URL(fileURLWithPath: NSTemporaryDirectory()))
+            .appendingPathComponent("open-island-artwork")
+            .path
+    }()
 
     init(pollInterval: TimeInterval = 1.0) {
         self.pollInterval = pollInterval
@@ -81,7 +86,12 @@ final class NowPlayingObserver {
         var artworkURL: URL? = nil
         if trackKey != lastMusicTrackKey {
             lastMusicTrackKey = trackKey
-            artworkURL = writeMusicArtwork()
+            if let url = writeMusicArtwork() {
+                artworkURL = url
+            } else {
+                // Write failed — remove stale file so we don't serve previous track's art
+                try? FileManager.default.removeItem(atPath: Self.musicArtworkPath)
+            }
         } else if FileManager.default.fileExists(atPath: Self.musicArtworkPath) {
             artworkURL = URL(fileURLWithPath: Self.musicArtworkPath)
         }

--- a/Sources/OpenIslandApp/NowPlayingObserver.swift
+++ b/Sources/OpenIslandApp/NowPlayingObserver.swift
@@ -107,13 +107,19 @@ final class NowPlayingObserver {
     }
 
     private func writeMusicArtwork() -> URL? {
+        // Write to a UUID-named temp file first, then atomically move to final path
+        let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+        let baseDir = caches ?? URL(fileURLWithPath: NSTemporaryDirectory())
+        let tmpPath = baseDir.appendingPathComponent("open-island-artwork-\(UUID().uuidString)").path
+        let finalURL = URL(fileURLWithPath: Self.musicArtworkPath)
+
         let script = """
         tell application "Music"
             if not (it is running) then return ""
             if player state is stopped then return ""
             try
                 set artData to raw data of artwork 1 of current track
-                set tmpPath to "\(Self.musicArtworkPath)"
+                set tmpPath to "\(tmpPath)"
                 set fileRef to open for access POSIX file tmpPath with write permission
                 set eof of fileRef to 0
                 write artData to fileRef
@@ -124,8 +130,17 @@ final class NowPlayingObserver {
             end try
         end tell
         """
-        guard let path = runOsascript(script), !path.isEmpty else { return nil }
-        return URL(fileURLWithPath: path)
+        guard let writtenPath = runOsascript(script), !writtenPath.isEmpty else { return nil }
+        let writtenURL = URL(fileURLWithPath: writtenPath)
+        // Atomically move temp file to the stable final path
+        do {
+            _ = try FileManager.default.replaceItemAt(finalURL, withItemAt: writtenURL)
+        } catch {
+            // replaceItemAt failed — try a plain move as fallback
+            try? FileManager.default.removeItem(at: finalURL)
+            try? FileManager.default.moveItem(at: writtenURL, to: finalURL)
+        }
+        return finalURL
     }
 
     private func parseSpotifyScript(_ script: String) -> NowPlayingState? {

--- a/Sources/OpenIslandApp/NowPlayingObserver.swift
+++ b/Sources/OpenIslandApp/NowPlayingObserver.swift
@@ -8,6 +8,9 @@ final class NowPlayingObserver {
     private(set) var state: NowPlayingState = .none
     private var timer: Timer?
     private let pollInterval: TimeInterval
+    private var lastMusicTrackKey: String = ""
+
+    private static let musicArtworkPath = "/tmp/open-island-artwork"
 
     init(pollInterval: TimeInterval = 1.0) {
         self.pollInterval = pollInterval
@@ -40,14 +43,17 @@ final class NowPlayingObserver {
         tell application "Spotify"
             if not (it is running) then return ""
             set sep to ASCII character 31
-            if player state is playing then
-                return "playing" & sep & (name of current track) & sep & (artist of current track) & sep & (album of current track)
-            else
-                return "paused" & sep & (name of current track) & sep & (artist of current track) & sep & (album of current track)
-            end if
+            set isPlaying to player state is playing
+            set status to "paused"
+            if isPlaying then set status to "playing"
+            set artURL to ""
+            try
+                set artURL to artwork url of current track
+            end try
+            return status & sep & (name of current track) & sep & (artist of current track) & sep & (album of current track) & sep & artURL
         end tell
         """
-        return parseMediaScript(script)
+        return parseSpotifyScript(script)
     }
 
     private func pollMusic() -> NowPlayingState? {
@@ -55,25 +61,74 @@ final class NowPlayingObserver {
         tell application "Music"
             if not (it is running) then return ""
             set sep to ASCII character 31
-            if player state is playing then
-                return "playing" & sep & (name of current track) & sep & (artist of current track) & sep & (album of current track)
-            else
-                return "paused" & sep & (name of current track) & sep & (artist of current track) & sep & (album of current track)
-            end if
+            if player state is stopped then return ""
+            set status to "paused"
+            if player state is playing then set status to "playing"
+            return status & sep & (name of current track) & sep & (artist of current track) & sep & (album of current track)
         end tell
         """
-        return parseMediaScript(script)
-    }
-
-    private func parseMediaScript(_ script: String) -> NowPlayingState? {
         guard let raw = runOsascript(script), !raw.isEmpty else { return nil }
         let sep = String(UnicodeScalar(31)!)
         let parts = raw.components(separatedBy: sep)
         guard parts.count >= 4 else { return nil }
+
+        let title = parts[1].nilIfEmpty
+        let artist = parts[2].nilIfEmpty
+        let album = parts[3].nilIfEmpty
+        let trackKey = "\(title ?? "")-\(artist ?? "")"
+
+        // Only write artwork to disk when the track changes.
+        var artworkURL: URL? = nil
+        if trackKey != lastMusicTrackKey {
+            lastMusicTrackKey = trackKey
+            artworkURL = writeMusicArtwork()
+        } else if FileManager.default.fileExists(atPath: Self.musicArtworkPath) {
+            artworkURL = URL(fileURLWithPath: Self.musicArtworkPath)
+        }
+
+        return NowPlayingState(
+            title: title,
+            artist: artist,
+            album: album,
+            artworkURL: artworkURL,
+            artworkData: nil,
+            isPlaying: parts[0] == "playing"
+        )
+    }
+
+    private func writeMusicArtwork() -> URL? {
+        let script = """
+        tell application "Music"
+            if not (it is running) then return ""
+            if player state is stopped then return ""
+            try
+                set artData to raw data of artwork 1 of current track
+                set tmpPath to "\(Self.musicArtworkPath)"
+                set fileRef to open for access POSIX file tmpPath with write permission
+                set eof of fileRef to 0
+                write artData to fileRef
+                close access fileRef
+                return tmpPath
+            on error
+                return ""
+            end try
+        end tell
+        """
+        guard let path = runOsascript(script), !path.isEmpty else { return nil }
+        return URL(fileURLWithPath: path)
+    }
+
+    private func parseSpotifyScript(_ script: String) -> NowPlayingState? {
+        guard let raw = runOsascript(script), !raw.isEmpty else { return nil }
+        let sep = String(UnicodeScalar(31)!)
+        let parts = raw.components(separatedBy: sep)
+        guard parts.count >= 4 else { return nil }
+        let artworkURL = parts.count >= 5 ? URL(string: parts[4].trimmingCharacters(in: .whitespaces)) : nil
         return NowPlayingState(
             title: parts[1].nilIfEmpty,
             artist: parts[2].nilIfEmpty,
             album: parts[3].nilIfEmpty,
+            artworkURL: artworkURL,
             artworkData: nil,
             isPlaying: parts[0] == "playing"
         )

--- a/Sources/OpenIslandApp/NowPlayingObserver.swift
+++ b/Sources/OpenIslandApp/NowPlayingObserver.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Observation
+import OpenIslandCore
+
+@MainActor
+@Observable
+final class NowPlayingObserver {
+    private(set) var state: NowPlayingState = .none
+    private var timer: Timer?
+    private let pollInterval: TimeInterval
+
+    init(pollInterval: TimeInterval = 1.0) {
+        self.pollInterval = pollInterval
+    }
+
+    func start() {
+        guard timer == nil else { return }
+        timer = Timer.scheduledTimer(withTimeInterval: pollInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.poll() }
+        }
+        poll()
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+        state = .none
+    }
+
+    // MARK: Private
+
+    private func poll() {
+        if let s = pollSpotify() { state = s; return }
+        if let s = pollMusic() { state = s; return }
+        state = .none
+    }
+
+    private func pollSpotify() -> NowPlayingState? {
+        let script = """
+        tell application "Spotify"
+            if not (it is running) then return ""
+            set sep to ASCII character 31
+            if player state is playing then
+                return "playing" & sep & (name of current track) & sep & (artist of current track) & sep & (album of current track)
+            else
+                return "paused" & sep & (name of current track) & sep & (artist of current track) & sep & (album of current track)
+            end if
+        end tell
+        """
+        return parseMediaScript(script)
+    }
+
+    private func pollMusic() -> NowPlayingState? {
+        let script = """
+        tell application "Music"
+            if not (it is running) then return ""
+            set sep to ASCII character 31
+            if player state is playing then
+                return "playing" & sep & (name of current track) & sep & (artist of current track) & sep & (album of current track)
+            else
+                return "paused" & sep & (name of current track) & sep & (artist of current track) & sep & (album of current track)
+            end if
+        end tell
+        """
+        return parseMediaScript(script)
+    }
+
+    private func parseMediaScript(_ script: String) -> NowPlayingState? {
+        guard let raw = runOsascript(script), !raw.isEmpty else { return nil }
+        let sep = String(UnicodeScalar(31)!)
+        let parts = raw.components(separatedBy: sep)
+        guard parts.count >= 4 else { return nil }
+        return NowPlayingState(
+            title: parts[1].nilIfEmpty,
+            artist: parts[2].nilIfEmpty,
+            album: parts[3].nilIfEmpty,
+            artworkData: nil,
+            isPlaying: parts[0] == "playing"
+        )
+    }
+
+    private func runOsascript(_ script: String) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = ["-e", script]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        do { try process.run(); process.waitUntilExit() } catch { return nil }
+        guard process.terminationStatus == 0 else { return nil }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? { isEmpty ? nil : self }
+}

--- a/Sources/OpenIslandApp/PlaybackController.swift
+++ b/Sources/OpenIslandApp/PlaybackController.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+enum PlaybackController {
+    static func playPause() {
+        runSpotify("playpause")
+        runMusic("playpause")
+    }
+
+    static func next() {
+        runSpotify("next track")
+        runMusic("next track")
+    }
+
+    static func previous() {
+        runSpotify("previous track")
+        runMusic("previous track")
+    }
+
+    // MARK: Private
+
+    private static func runSpotify(_ command: String) {
+        run("tell application \"Spotify\" to if it is running then \(command)")
+    }
+
+    private static func runMusic(_ command: String) {
+        run("tell application \"Music\" to if it is running then \(command)")
+    }
+
+    private static func run(_ script: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = ["-e", script]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try? process.run()
+    }
+}

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -448,9 +448,12 @@ struct IslandPanelView: View {
             }
             if model.showMediaStrip && model.nowPlayingObserver.state.hasContent {
                 Divider().opacity(0.3)
-                MediaStripView(state: model.nowPlayingObserver.state)
-                    .padding(.horizontal, 8)
-                    .padding(.bottom, 6)
+                MediaStripView(
+                    state: model.nowPlayingObserver.state,
+                    artworkCache: model.artworkCache
+                )
+                .padding(.horizontal, 8)
+                .padding(.bottom, 6)
             }
         }
         .padding(.horizontal, 18)
@@ -502,6 +505,7 @@ struct IslandPanelView: View {
     }
 
     private static let maxSessionListHeight: CGFloat = 560
+    private static let mediaStripReservedHeight: CGFloat = 64
 
     private var sessionList: some View {
         TimelineView(.periodic(from: .now, by: 30)) { context in

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -446,6 +446,12 @@ struct IslandPanelView: View {
             } else {
                 sessionList
             }
+            if model.showMediaStrip && model.nowPlayingObserver.state.hasContent {
+                Divider().opacity(0.3)
+                MediaStripView(state: model.nowPlayingObserver.state)
+                    .padding(.horizontal, 8)
+                    .padding(.bottom, 6)
+            }
         }
         .padding(.horizontal, 18)
         .padding(.top, 8)

--- a/Sources/OpenIslandApp/Views/MediaStripView.swift
+++ b/Sources/OpenIslandApp/Views/MediaStripView.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+import OpenIslandCore
+
+struct MediaStripView: View {
+    let state: NowPlayingState
+
+    var body: some View {
+        HStack(spacing: 10) {
+            // Album art placeholder
+            RoundedRectangle(cornerRadius: 4)
+                .fill(Color.white.opacity(0.1))
+                .frame(width: 32, height: 32)
+                .overlay {
+                    Image(systemName: "music.note")
+                        .font(.system(size: 14))
+                        .foregroundStyle(.secondary)
+                }
+
+            // Title + artist
+            VStack(alignment: .leading, spacing: 1) {
+                Text(state.title ?? "Not Playing")
+                    .font(.system(size: 12, weight: .medium))
+                    .lineLimit(1)
+                if let artist = state.artist {
+                    Text(artist)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            // Playback controls
+            HStack(spacing: 6) {
+                Button {
+                    PlaybackController.previous()
+                } label: {
+                    Image(systemName: "backward.fill")
+                        .font(.system(size: 11))
+                }
+                .buttonStyle(.plain)
+
+                Button {
+                    PlaybackController.playPause()
+                } label: {
+                    Image(systemName: state.isPlaying ? "pause.fill" : "play.fill")
+                        .font(.system(size: 13))
+                }
+                .buttonStyle(.plain)
+
+                Button {
+                    PlaybackController.next()
+                } label: {
+                    Image(systemName: "forward.fill")
+                        .font(.system(size: 11))
+                }
+                .buttonStyle(.plain)
+            }
+            .foregroundStyle(.primary)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color.white.opacity(0.05))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}

--- a/Sources/OpenIslandApp/Views/MediaStripView.swift
+++ b/Sources/OpenIslandApp/Views/MediaStripView.swift
@@ -1,66 +1,117 @@
 import SwiftUI
+import AppKit
 import OpenIslandCore
 
 struct MediaStripView: View {
     let state: NowPlayingState
+    let artworkCache: ArtworkCache
+
+    @State private var dominantColor: Color = .gray
+
+    private var artworkImage: NSImage? {
+        guard let url = state.artworkURL else { return nil }
+        return artworkCache.image(for: url)
+    }
 
     var body: some View {
-        HStack(spacing: 10) {
-            // Album art placeholder
-            RoundedRectangle(cornerRadius: 4)
-                .fill(Color.white.opacity(0.1))
-                .frame(width: 32, height: 32)
-                .overlay {
-                    Image(systemName: "music.note")
-                        .font(.system(size: 14))
-                        .foregroundStyle(.secondary)
-                }
-
-            // Title + artist
-            VStack(alignment: .leading, spacing: 1) {
-                Text(state.title ?? "Not Playing")
-                    .font(.system(size: 12, weight: .medium))
-                    .lineLimit(1)
-                if let artist = state.artist {
-                    Text(artist)
-                        .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            // Playback controls
-            HStack(spacing: 6) {
-                Button {
-                    PlaybackController.previous()
-                } label: {
-                    Image(systemName: "backward.fill")
-                        .font(.system(size: 11))
-                }
-                .buttonStyle(.plain)
-
-                Button {
-                    PlaybackController.playPause()
-                } label: {
-                    Image(systemName: state.isPlaying ? "pause.fill" : "play.fill")
-                        .font(.system(size: 13))
-                }
-                .buttonStyle(.plain)
-
-                Button {
-                    PlaybackController.next()
-                } label: {
-                    Image(systemName: "forward.fill")
-                        .font(.system(size: 11))
-                }
-                .buttonStyle(.plain)
-            }
-            .foregroundStyle(.primary)
+        HStack(spacing: 12) {
+            albumArt
+            trackInfo
+            Spacer(minLength: 0)
+            controls
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-        .background(Color.white.opacity(0.05))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(coloredBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .onChange(of: artworkCache.version) { _, _ in updateDominantColor() }
+        .onChange(of: state.artworkURL) { _, url in
+            if let url { artworkCache.prefetch(url) }
+            updateDominantColor()
+        }
+        .onAppear {
+            if let url = state.artworkURL { artworkCache.prefetch(url) }
+            updateDominantColor()
+        }
+    }
+
+    // MARK: Subviews
+
+    private var albumArt: some View {
+        Group {
+            if let img = artworkImage {
+                Image(nsImage: img)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            } else {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Color.white.opacity(0.1))
+                    .overlay {
+                        Image(systemName: "music.note")
+                            .font(.system(size: 16))
+                            .foregroundStyle(.secondary)
+                    }
+            }
+        }
+        .frame(width: 48, height: 48)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .animation(.easeInOut(duration: 0.3), value: artworkImage != nil)
+    }
+
+    private var trackInfo: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(state.title ?? "Not Playing")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+            if let artist = state.artist {
+                Text(artist)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            if let album = state.album {
+                Text(album)
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+            }
+        }
+    }
+
+    private var controls: some View {
+        HStack(spacing: 8) {
+            Button { PlaybackController.previous() } label: {
+                Image(systemName: "backward.fill")
+                    .font(.system(size: 12))
+            }
+            .buttonStyle(.plain)
+
+            Button { PlaybackController.playPause() } label: {
+                Image(systemName: state.isPlaying ? "pause.fill" : "play.fill")
+                    .font(.system(size: 15))
+            }
+            .buttonStyle(.plain)
+
+            Button { PlaybackController.next() } label: {
+                Image(systemName: "forward.fill")
+                    .font(.system(size: 12))
+            }
+            .buttonStyle(.plain)
+        }
+        .foregroundStyle(.primary)
+    }
+
+    private var coloredBackground: some View {
+        ZStack {
+            dominantColor.opacity(0.15)
+            Color.white.opacity(0.04)
+        }
+    }
+
+    // MARK: Helpers
+
+    private func updateDominantColor() {
+        dominantColor = DominantColorExtractor.extractOrFallback(from: artworkImage)
     }
 }

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -246,6 +246,13 @@ struct DisplaySettingsPane: View {
                     LabeledContent(lang.t("settings.display.layoutMode"), value: diag.modeDescription)
                 }
             }
+
+            Section("Media") {
+                Toggle("Show media strip", isOn: Binding(
+                    get: { model.showMediaStrip },
+                    set: { model.showMediaStrip = $0 }
+                ))
+            }
         }
         .formStyle(.grouped)
         .navigationTitle(lang.t("settings.tab.display"))

--- a/Sources/OpenIslandCore/NowPlayingState.swift
+++ b/Sources/OpenIslandCore/NowPlayingState.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+public struct NowPlayingState: Equatable, Codable, Sendable {
+    public var title: String?
+    public var artist: String?
+    public var album: String?
+    public var artworkData: Data?
+    public var isPlaying: Bool
+
+    public init(
+        title: String?,
+        artist: String?,
+        album: String?,
+        artworkData: Data?,
+        isPlaying: Bool
+    ) {
+        self.title = title
+        self.artist = artist
+        self.album = album
+        self.artworkData = artworkData
+        self.isPlaying = isPlaying
+    }
+
+    public static let none = NowPlayingState(
+        title: nil, artist: nil, album: nil, artworkData: nil, isPlaying: false
+    )
+
+    public var hasContent: Bool {
+        title != nil || artist != nil
+    }
+
+    public var displayLine: String {
+        switch (title, artist) {
+        case let (t?, a?): return "\(t) — \(a)"
+        case let (t?, nil): return t
+        case let (nil, a?): return a
+        default: return "Unknown"
+        }
+    }
+}

--- a/Sources/OpenIslandCore/NowPlayingState.swift
+++ b/Sources/OpenIslandCore/NowPlayingState.swift
@@ -4,6 +4,7 @@ public struct NowPlayingState: Equatable, Codable, Sendable {
     public var title: String?
     public var artist: String?
     public var album: String?
+    public var artworkURL: URL?
     public var artworkData: Data?
     public var isPlaying: Bool
 
@@ -11,18 +12,21 @@ public struct NowPlayingState: Equatable, Codable, Sendable {
         title: String?,
         artist: String?,
         album: String?,
-        artworkData: Data?,
+        artworkURL: URL? = nil,
+        artworkData: Data? = nil,
         isPlaying: Bool
     ) {
         self.title = title
         self.artist = artist
         self.album = album
+        self.artworkURL = artworkURL
         self.artworkData = artworkData
         self.isPlaying = isPlaying
     }
 
     public static let none = NowPlayingState(
-        title: nil, artist: nil, album: nil, artworkData: nil, isPlaying: false
+        title: nil, artist: nil, album: nil,
+        artworkURL: nil, artworkData: nil, isPlaying: false
     )
 
     public var hasContent: Bool {

--- a/Tests/OpenIslandAppTests/ArtworkCacheTests.swift
+++ b/Tests/OpenIslandAppTests/ArtworkCacheTests.swift
@@ -1,0 +1,65 @@
+import Testing
+import AppKit
+@testable import OpenIslandApp
+
+@MainActor
+struct ArtworkCacheTests {
+    @Test func cacheMissReturnsNil() {
+        let cache = ArtworkCache()
+        let url = URL(string: "https://example.com/art.jpg")!
+        let result = cache.image(for: url)
+        #expect(result == nil)
+    }
+
+    @Test func cacheHitReturnsSameImage() async {
+        let cache = ArtworkCache()
+        let url = URL(string: "https://example.com/art.jpg")!
+        let image = NSImage(size: NSSize(width: 1, height: 1))
+        await cache.store(image, for: url)
+        let result = cache.image(for: url)
+        #expect(result != nil)
+    }
+
+    @Test func versionIncrementOnStore() async {
+        let cache = ArtworkCache()
+        let initial = cache.version
+        let url = URL(string: "https://example.com/b.jpg")!
+        let image = NSImage(size: NSSize(width: 1, height: 1))
+        await cache.store(image, for: url)
+        #expect(cache.version == initial + 1)
+    }
+
+    @Test func differentURLsAreCachedSeparately() async {
+        let cache = ArtworkCache()
+        let url1 = URL(string: "https://example.com/a.jpg")!
+        let url2 = URL(string: "https://example.com/b.jpg")!
+        let img1 = NSImage(size: NSSize(width: 1, height: 1))
+        let img2 = NSImage(size: NSSize(width: 2, height: 2))
+        await cache.store(img1, for: url1)
+        await cache.store(img2, for: url2)
+        #expect(cache.image(for: url1) != nil)
+        #expect(cache.image(for: url2) != nil)
+    }
+
+    @Test func cacheLoadsFileURL() async throws {
+        let cache = ArtworkCache()
+        let tmpURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test_artwork_cache_\(UUID().uuidString).jpg")
+        let image = NSImage(size: NSSize(width: 4, height: 4))
+        image.lockFocus()
+        NSColor.blue.setFill()
+        NSBezierPath(rect: NSRect(x: 0, y: 0, width: 4, height: 4)).fill()
+        image.unlockFocus()
+        guard let tiff = image.tiffRepresentation,
+              let rep = NSBitmapImageRep(data: tiff),
+              let jpg = rep.representation(using: .jpeg, properties: [:]) else {
+            Issue.record("Could not create test JPEG")
+            return
+        }
+        try jpg.write(to: tmpURL)
+        cache.prefetch(tmpURL)
+        try await Task.sleep(for: .milliseconds(300))
+        #expect(cache.image(for: tmpURL) != nil)
+        try? FileManager.default.removeItem(at: tmpURL)
+    }
+}

--- a/Tests/OpenIslandAppTests/DominantColorExtractorTests.swift
+++ b/Tests/OpenIslandAppTests/DominantColorExtractorTests.swift
@@ -1,0 +1,52 @@
+import Testing
+import SwiftUI
+import AppKit
+@testable import OpenIslandApp
+
+struct DominantColorExtractorTests {
+    @Test func redImageReturnsSomewhatReddishColor() {
+        let image = solidColorImage(nsColor: .red)
+        let color = DominantColorExtractor.extract(from: image)
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        let nsColor = NSColor(color).usingColorSpace(.sRGB)!
+        nsColor.getRed(&r, green: &g, blue: &b, alpha: &a)
+        #expect(r > 0.5)
+        #expect(r > g)
+        #expect(r > b)
+    }
+
+    @Test func blueImageReturnsSomewhatBluishColor() {
+        let image = solidColorImage(nsColor: .blue)
+        let color = DominantColorExtractor.extract(from: image)
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        let nsColor = NSColor(color).usingColorSpace(.sRGB)!
+        nsColor.getRed(&r, green: &g, blue: &b, alpha: &a)
+        #expect(b > 0.5)
+        #expect(b > r)
+        #expect(b > g)
+    }
+
+    @Test func nilImageReturnsFallback() {
+        let color = DominantColorExtractor.extractOrFallback(from: nil)
+        _ = color  // just verify no crash
+    }
+
+    @Test func extractIsPure() {
+        let image = solidColorImage(nsColor: .green)
+        let c1 = DominantColorExtractor.extract(from: image)
+        let c2 = DominantColorExtractor.extract(from: image)
+        #expect(c1 == c2)
+    }
+
+    // MARK: Helpers
+
+    private func solidColorImage(nsColor: NSColor) -> NSImage {
+        let size = NSSize(width: 32, height: 32)
+        let image = NSImage(size: size)
+        image.lockFocus()
+        nsColor.setFill()
+        NSBezierPath(rect: NSRect(origin: .zero, size: size)).fill()
+        image.unlockFocus()
+        return image
+    }
+}

--- a/Tests/OpenIslandCoreTests/NowPlayingStateTests.swift
+++ b/Tests/OpenIslandCoreTests/NowPlayingStateTests.swift
@@ -1,0 +1,46 @@
+import Testing
+import Foundation
+@testable import OpenIslandCore
+
+@Suite("NowPlayingState")
+struct NowPlayingStateTests {
+    @Test func codableRoundTrip() throws {
+        let state = NowPlayingState(
+            title: "Bohemian Rhapsody",
+            artist: "Queen",
+            album: "A Night at the Opera",
+            artworkData: nil,
+            isPlaying: true
+        )
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(NowPlayingState.self, from: data)
+        #expect(decoded == state)
+    }
+
+    @Test func equalityRequiresIsPlaying() {
+        let a = NowPlayingState(title: "Track", artist: "Artist", album: nil, artworkData: nil, isPlaying: true)
+        let b = NowPlayingState(title: "Track", artist: "Artist", album: nil, artworkData: nil, isPlaying: false)
+        #expect(a != b)
+    }
+
+    @Test func noneStateIsEmpty() {
+        let none = NowPlayingState.none
+        #expect(none.title == nil)
+        #expect(none.artist == nil)
+        #expect(!none.isPlaying)
+        #expect(!none.hasContent)
+    }
+
+    @Test func displayLineFormats() {
+        let both = NowPlayingState(title: "Song", artist: "Band", album: nil, artworkData: nil, isPlaying: false)
+        #expect(both.displayLine == "Song — Band")
+
+        let titleOnly = NowPlayingState(title: "Song", artist: nil, album: nil, artworkData: nil, isPlaying: false)
+        #expect(titleOnly.displayLine == "Song")
+
+        let artistOnly = NowPlayingState(title: nil, artist: "Band", album: nil, artworkData: nil, isPlaying: false)
+        #expect(artistOnly.displayLine == "Band")
+
+        #expect(NowPlayingState.none.displayLine == "Unknown")
+    }
+}

--- a/Tests/OpenIslandCoreTests/NowPlayingStateTests.swift
+++ b/Tests/OpenIslandCoreTests/NowPlayingStateTests.swift
@@ -43,4 +43,23 @@ struct NowPlayingStateTests {
 
         #expect(NowPlayingState.none.displayLine == "Unknown")
     }
+
+    @Test func artworkURLRoundTripsCodable() throws {
+        let url = URL(string: "https://i.scdn.co/image/abc123")!
+        let state = NowPlayingState(
+            title: "Song",
+            artist: "Artist",
+            album: "Album",
+            artworkURL: url,
+            artworkData: nil,
+            isPlaying: true
+        )
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(NowPlayingState.self, from: data)
+        #expect(decoded.artworkURL == url)
+    }
+
+    @Test func artworkURLNilByDefault() {
+        #expect(NowPlayingState.none.artworkURL == nil)
+    }
 }


### PR DESCRIPTION
## Summary

Adds a Now Playing media strip to the expanded island panel, showing real-time playback info from Spotify and Apple Music.

- **`NowPlayingState`** — new `Codable/Sendable` model with title, artist, album, `artworkURL`, `isPlaying`
- **`NowPlayingObserver`** — `@MainActor @Observable` class polling Spotify/Music via osascript every 1s; Spotify returns CDN artwork URL, Music writes artwork to caches directory atomically
- **`PlaybackController`** — fire-and-forget osascript for play/pause, next, previous
- **`ArtworkCache`** — `actor`-backed async image cache; uses `URLSession` for remote URLs, `Task.detached` for file URLs; observable `version` counter for SwiftUI reactivity
- **`DominantColorExtractor`** — samples 8×8 downscale of album art to find average dominant color, skipping near-black/white pixels
- **`MediaStripView`** — 48×48 album art with rounded corners, title/artist/album (3-line), playback controls, dominant-color tinted background glow
- **`IslandPanelView`** — media strip shown below session list when playing; window auto-grows 64pt to accommodate it
- **Settings toggle** — "Show media strip" in Display pane

## Test Plan

- [ ] `swift test` — 14 new tests (NowPlayingStateTests ×6, ArtworkCacheTests ×5, DominantColorExtractorTests ×4) pass
- [ ] Play Spotify → expand island → album art, title, artist, album visible with tinted background
- [ ] Play/pause, skip via strip controls
- [ ] Settings → Display → toggle "Show media strip" hides/shows strip
- [ ] Nothing playing → strip hidden