### PR TITLE
feat(settings): allow settings window to be freely resized

### DIFF
--- a/Sources/OpenIslandApp/OpenIslandApp.swift
+++ b/Sources/OpenIslandApp/OpenIslandApp.swift
@@ -106,7 +106,7 @@ struct OpenIslandApp: App {
         Window("Open Island Settings", id: "settings") {
             SettingsWindowContent(model: appDelegate.model)
         }
-        .windowResizability(.contentSize)
+        .windowResizability(.contentMinSize)
         .commands {
             CommandGroup(replacing: .appSettings) {
                 Button("Settings…") {


### PR DESCRIPTION
## Summary
- Change `windowResizability` from `.contentSize` to `.contentMinSize` on the settings window, allowing users to freely drag-resize the panel while still respecting minimum content size.

## Test plan
- [ ] Open Settings window, verify it can be dragged to resize larger
- [ ] Verify the window cannot be shrunk smaller than its content minimum size
- [ ] Verify no regression in settings panel content layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)