### PR TITLE
fix: make settings panel content adaptive when resized

### DIFF
--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -101,8 +101,7 @@ struct SettingsView: View {
         } detail: {
             detailView
         }
-        .frame(minWidth: 680, minHeight: 480)
-        .frame(width: 780, height: 560)
+        .frame(minWidth: 680, idealWidth: 780, minHeight: 480, idealHeight: 560)
         .preferredColorScheme(.dark)
     }
 


### PR DESCRIPTION
## Summary
- Replace the fixed `.frame(width: 780, height: 560)` with flexible `.frame(minWidth: 680, idealWidth: 780, minHeight: 480, idealHeight: 560)` so that settings pane content fills available space when the window is resized.

## Test plan
- [ ] Open Settings window, verify it opens at the default 780×560 size
- [ ] Drag to resize the window — content (sidebar + detail pane) should expand/shrink to fill the space
- [ ] Verify all tabs (General, Setup, Display, Sound, Appearance, Watch, About) render correctly at various sizes
- [ ] Verify the window cannot be shrunk below 680×480

🤖 Generated with [Claude Code](https://claude.com/claude-code)