### PR TITLE
Add theme customization and intelligent hook installation detection

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -100,6 +100,7 @@ final class AppModel {
     var isQwenCodeDetected: Bool { hooks.isQwenCodeDetected }
     var isFactoryDetected: Bool { hooks.isFactoryDetected }
     var isCodebuddyDetected: Bool { hooks.isCodebuddyDetected }
+    var isGeminiDetected: Bool { hooks.isGeminiDetected }
     var claudeHookStatusTitle: String { hooks.claudeHookStatusTitle }
     var claudeHookStatusSummary: String { hooks.claudeHookStatusSummary }
     var claudeUsageStatusTitle: String { hooks.claudeUsageStatusTitle }
@@ -243,6 +244,8 @@ final class AppModel {
 
     // MARK: - Appearance
 
+    /// User-selectable color scheme for the app's UI.
+    /// Persisted to UserDefaults and applied to all views.
     enum AppColorScheme: String, CaseIterable, Codable, Identifiable {
         case system
         case light
@@ -250,6 +253,7 @@ final class AppModel {
 
         var id: String { rawValue }
 
+        /// Converts this color scheme to a SwiftUI ColorScheme for use with .preferredColorScheme().
         var swiftUIScheme: SwiftUI.ColorScheme? {
             switch self {
             case .system: nil
@@ -259,6 +263,8 @@ final class AppModel {
         }
     }
 
+    /// The user's preferred color scheme. Defaults to `.system` (follows macOS appearance).
+    /// Changes are persisted to UserDefaults and applied immediately to all views.
     var preferredColorScheme: AppColorScheme = .system {
         didSet {
             guard preferredColorScheme != oldValue else { return }

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -10,6 +10,7 @@ final class AppModel {
     private static let soundMutedDefaultsKey = "overlay.sound.muted"
     private static let showDockIconDefaultsKey = "app.showDockIcon"
     private static let hapticFeedbackEnabledDefaultsKey = "app.hapticFeedbackEnabled"
+    private static let preferredColorSchemeDefaultsKey = "app.preferredColorScheme"
     private static let islandAppearanceModeDefaultsKey = "appearance.island.mode"
     private static let islandClosedDisplayStyleDefaultsKey = "appearance.island.closedDisplayStyle"
     private static let islandHideIdleToEdgeDefaultsKey = "appearance.island.hideIdleToEdge"
@@ -242,6 +243,29 @@ final class AppModel {
 
     // MARK: - Appearance
 
+    enum AppColorScheme: String, CaseIterable, Codable, Identifiable {
+        case system
+        case light
+        case dark
+
+        var id: String { rawValue }
+
+        var swiftUIScheme: SwiftUI.ColorScheme? {
+            switch self {
+            case .system: nil
+            case .light: .light
+            case .dark: .dark
+            }
+        }
+    }
+
+    var preferredColorScheme: AppColorScheme = .system {
+        didSet {
+            guard preferredColorScheme != oldValue else { return }
+            UserDefaults.standard.set(preferredColorScheme.rawValue, forKey: Self.preferredColorSchemeDefaultsKey)
+        }
+    }
+
     var islandAppearanceMode: IslandAppearanceMode = .default {
         didSet {
             guard islandAppearanceMode != oldValue else { return }
@@ -454,6 +478,9 @@ final class AppModel {
             )
         }
         completionReplyEnabled = UserDefaults.standard.bool(forKey: Self.completionReplyEnabledDefaultsKey)
+        preferredColorScheme = AppColorScheme(
+            rawValue: UserDefaults.standard.string(forKey: Self.preferredColorSchemeDefaultsKey) ?? ""
+        ) ?? .system
         islandAppearanceMode = IslandAppearanceMode(
             rawValue: UserDefaults.standard.string(forKey: Self.islandAppearanceModeDefaultsKey) ?? ""
         ) ?? .default

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -91,6 +91,14 @@ final class AppModel {
     var isCodebuddyHookSetupBusy: Bool { hooks.isCodebuddyHookSetupBusy }
     var openCodePluginInstalled: Bool { hooks.openCodePluginInstalled }
     var claudeUsageInstalled: Bool { hooks.claudeUsageInstalled }
+    var isClaudeCodeDetected: Bool { hooks.isClaudeCodeDetected }
+    var isCodexDetected: Bool { hooks.isCodexDetected }
+    var isCursorDetected: Bool { hooks.isCursorDetected }
+    var isOpenCodeDetected: Bool { hooks.isOpenCodeDetected }
+    var isQoderDetected: Bool { hooks.isQoderDetected }
+    var isQwenCodeDetected: Bool { hooks.isQwenCodeDetected }
+    var isFactoryDetected: Bool { hooks.isFactoryDetected }
+    var isCodebuddyDetected: Bool { hooks.isCodebuddyDetected }
     var claudeHookStatusTitle: String { hooks.claudeHookStatusTitle }
     var claudeHookStatusSummary: String { hooks.claudeHookStatusSummary }
     var claudeUsageStatusTitle: String { hooks.claudeUsageStatusTitle }
@@ -1184,6 +1192,9 @@ final class AppModel {
         hooks.hooksBinaryURL = payload.hooksBinaryURL
         hooks.updateHooksBinaryIfNeeded()
 
+        // Detect which agent tools are present before attempting any installs.
+        self.hooks.detectInstalledTools()
+
         // Auto-install missing hooks and usage bridge, then run health checks.
         if payload.hooksBinaryURL != nil {
             Task { @MainActor [weak self] in
@@ -1192,16 +1203,16 @@ final class AppModel {
                 // Wait for all status reads to complete before checking install state.
                 await self.hooks.refreshAllHookStatusAndWait()
 
-                if !self.claudeHooksInstalled { self.installClaudeHooks() }
-                if !self.codexHooksInstalled { self.installCodexHooks() }
-                if !self.qoderHooksInstalled { self.installQoderHooks() }
-                if !self.qwenCodeHooksInstalled { self.installQwenCodeHooks() }
-                if !self.factoryHooksInstalled { self.installFactoryHooks() }
-                if !self.codebuddyHooksInstalled { self.installCodebuddyHooks() }
-                if !self.openCodePluginInstalled { self.installOpenCodePlugin() }
-                if !self.cursorHooksInstalled { self.installCursorHooks() }
+                if !self.claudeHooksInstalled && self.isClaudeCodeDetected { self.installClaudeHooks() }
+                if !self.codexHooksInstalled && self.isCodexDetected { self.installCodexHooks() }
+                if !self.qoderHooksInstalled && self.isQoderDetected { self.installQoderHooks() }
+                if !self.qwenCodeHooksInstalled && self.isQwenCodeDetected { self.installQwenCodeHooks() }
+                if !self.factoryHooksInstalled && self.isFactoryDetected { self.installFactoryHooks() }
+                if !self.codebuddyHooksInstalled && self.isCodebuddyDetected { self.installCodebuddyHooks() }
+                if !self.openCodePluginInstalled && self.isOpenCodeDetected { self.installOpenCodePlugin() }
+                if !self.cursorHooksInstalled && self.isCursorDetected { self.installCursorHooks() }
                 if !self.geminiHooksInstalled { self.installGeminiHooks() }
-                if !self.claudeUsageInstalled { self.installClaudeUsageBridge() }
+                if !self.claudeUsageInstalled && self.isClaudeCodeDetected { self.installClaudeUsageBridge() }
 
                 // Run health checks after install to detect stale paths, conflicts, etc.
                 try? await Task.sleep(for: .milliseconds(500))

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -21,14 +21,24 @@ final class HookInstallationCoordinator {
 
     // MARK: - Tool detection (set once at init, never changes during session)
 
+    /// Whether Claude Code is installed on this machine (detected by the presence of its config directory).
     var isClaudeCodeDetected: Bool = false
+    /// Whether Codex is installed on this machine.
     var isCodexDetected: Bool = false
+    /// Whether Cursor is installed on this machine.
     var isCursorDetected: Bool = false
+    /// Whether OpenCode is installed on this machine.
     var isOpenCodeDetected: Bool = false
+    /// Whether Qoder is installed on this machine.
     var isQoderDetected: Bool = false
+    /// Whether Qwen Code is installed on this machine.
     var isQwenCodeDetected: Bool = false
+    /// Whether Factory is installed on this machine.
     var isFactoryDetected: Bool = false
+    /// Whether CodeBuddy is installed on this machine.
     var isCodebuddyDetected: Bool = false
+    //// Whether Gemini CLI is installed on this machine.
+    var isGeminiDetected: Bool = false
 
     @ObservationIgnored
     private let fileManager = FileManager.default
@@ -127,6 +137,8 @@ final class HookInstallationCoordinator {
         isFactoryDetected = fileManager.fileExists(atPath: home.appendingPathComponent(".factory", isDirectory: true).path)
 
         isCodebuddyDetected = fileManager.fileExists(atPath: home.appendingPathComponent(".codebuddy", isDirectory: true).path)
+
+        isGeminiDetected = fileManager.fileExists(atPath: home.appendingPathComponent(".gemini", isDirectory: true).path)
     }
 
     // MARK: - Computed display properties
@@ -534,6 +546,7 @@ final class HookInstallationCoordinator {
 
     // MARK: - Refresh
 
+    /// Refreshes the Codex hook installation status.
     func refreshCodexHookStatus() {
         Task { [weak self] in
             guard let self else { return }
@@ -547,6 +560,7 @@ final class HookInstallationCoordinator {
         }
     }
 
+    /// Refreshes the Claude hook installation status.
     func refreshClaudeHookStatus() {
         Task { [weak self] in
             guard let self else { return }
@@ -560,6 +574,7 @@ final class HookInstallationCoordinator {
         }
     }
 
+    /// Refreshes hook installation status for all Claude Code fork agents (Qoder, Qwen Code, Factory, CodeBuddy).
     func refreshCCForkHookStatuses() {
         refreshCCForkHookStatus(manager: qoderHookInstallationManager, name: "Qoder") { [weak self] in self?.qoderHookStatus = $0 }
         refreshCCForkHookStatus(manager: qwenCodeHookInstallationManager, name: "Qwen Code") { [weak self] in self?.qwenCodeHookStatus = $0 }
@@ -658,6 +673,7 @@ final class HookInstallationCoordinator {
         }
     }
 
+    /// Refreshes the OpenCode plugin installation status.
     func refreshOpenCodePluginStatus() {
         Task { [weak self] in
             guard let self else { return }
@@ -671,6 +687,7 @@ final class HookInstallationCoordinator {
         }
     }
 
+    /// Refreshes the Cursor hook installation status.
     func refreshCursorHookStatus() {
         Task { [weak self] in
             guard let self else { return }
@@ -684,6 +701,7 @@ final class HookInstallationCoordinator {
         }
     }
 
+    /// Refreshes the Gemini CLI hook installation status.
     func refreshGeminiHookStatus() {
         Task { [weak self] in
             guard let self else { return }
@@ -697,6 +715,8 @@ final class HookInstallationCoordinator {
         }
     }
 
+    /// Refreshes the Claude usage bridge status and snapshot.
+    /// Automatically repairs the bridge if it needs restoration.
     func refreshClaudeUsageState() {
         let manager = claudeStatusLineInstallationManager
         Task { [weak self] in
@@ -724,6 +744,7 @@ final class HookInstallationCoordinator {
         }
     }
 
+    /// Refreshes the Codex usage snapshot from local rollout JSONL files.
     func refreshCodexUsageState() {
         Task { [weak self] in
             guard let self else { return }
@@ -843,6 +864,7 @@ final class HookInstallationCoordinator {
         }
     }
 
+    /// Installs the OpenCode plugin into the user's OpenCode configuration.
     func installOpenCodePlugin() {
         guard let pluginData = loadBundledOpenCodePlugin() else {
             onStatusMessage?("Could not find the bundled OpenCode plugin resource.")
@@ -871,6 +893,7 @@ final class HookInstallationCoordinator {
         }
     }
 
+    /// Removes the OpenCode plugin from the user's OpenCode configuration.
     func uninstallOpenCodePlugin() {
         isOpenCodeSetupBusy = true
         onStatusMessage?("Removing OpenCode plugin.")
@@ -907,6 +930,7 @@ final class HookInstallationCoordinator {
         }
     }
 
+    /// Installs the Gemini CLI hooks into ~/.gemini/settings.json.
     func installGeminiHooks() {
         guard let hooksBinaryURL else {
             onStatusMessage?("Could not find a local OpenIslandHooks binary. Build the package first.")
@@ -918,18 +942,21 @@ final class HookInstallationCoordinator {
         }
     }
 
+    /// Removes the Gemini CLI hooks from ~/.gemini/settings.json.
     func uninstallGeminiHooks() {
         updateGeminiHooks(userMessage: "Removing Gemini hooks.") { manager in
             try manager.uninstall()
         }
     }
 
+    /// Installs the Claude usage bridge (managed Claude status line) to cache rate limits locally.
     func installClaudeUsageBridge() {
         updateClaudeUsageBridge(userMessage: "Installing Claude usage bridge.") { manager in
             try manager.install()
         }
     }
 
+    /// Removes the Claude usage bridge (managed Claude status line).
     func uninstallClaudeUsageBridge() {
         updateClaudeUsageBridge(userMessage: "Removing Claude usage bridge.") { manager in
             try manager.uninstall()

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -18,6 +18,20 @@ final class HookInstallationCoordinator {
     var claudeUsageSnapshot: ClaudeUsageSnapshot?
     var codexUsageSnapshot: CodexUsageSnapshot?
     var hooksBinaryURL: URL?
+
+    // MARK: - Tool detection (set once at init, never changes during session)
+
+    var isClaudeCodeDetected: Bool = false
+    var isCodexDetected: Bool = false
+    var isCursorDetected: Bool = false
+    var isOpenCodeDetected: Bool = false
+    var isQoderDetected: Bool = false
+    var isQwenCodeDetected: Bool = false
+    var isFactoryDetected: Bool = false
+    var isCodebuddyDetected: Bool = false
+
+    @ObservationIgnored
+    private let fileManager = FileManager.default
     var isCodexSetupBusy = false
     var isClaudeHookSetupBusy = false
     var isQoderHookSetupBusy = false
@@ -89,6 +103,30 @@ final class HookInstallationCoordinator {
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .short
         return formatter
+    }
+
+    // MARK: - Tool detection
+
+    /// Detects which agent tools are present on this machine and sets the isXxxDetected properties.
+    /// Safe to call multiple times; subsequent calls overwrite with current state.
+    func detectInstalledTools() {
+        let home = fileManager.homeDirectoryForCurrentUser
+
+        isClaudeCodeDetected = fileManager.fileExists(atPath: ClaudeConfigDirectory.resolved().path)
+
+        isCodexDetected = fileManager.fileExists(atPath: home.appendingPathComponent(".codex", isDirectory: true).path)
+
+        isCursorDetected = fileManager.fileExists(atPath: home.appendingPathComponent(".cursor", isDirectory: true).path)
+
+        isOpenCodeDetected = fileManager.fileExists(atPath: home.appendingPathComponent(".config/opencode", isDirectory: true).path)
+
+        isQoderDetected = fileManager.fileExists(atPath: home.appendingPathComponent(".qoder", isDirectory: true).path)
+
+        isQwenCodeDetected = fileManager.fileExists(atPath: home.appendingPathComponent(".qwen", isDirectory: true).path)
+
+        isFactoryDetected = fileManager.fileExists(atPath: home.appendingPathComponent(".factory", isDirectory: true).path)
+
+        isCodebuddyDetected = fileManager.fileExists(atPath: home.appendingPathComponent(".codebuddy", isDirectory: true).path)
     }
 
     // MARK: - Computed display properties

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -45,6 +45,10 @@
 
 /* Settings - Appearance */
 "settings.tab.appearance" = "Appearance";
+"settings.appearance.colorScheme" = "Theme";
+"settings.appearance.colorScheme.system" = "Follow System";
+"settings.appearance.colorScheme.light" = "Light";
+"settings.appearance.colorScheme.dark" = "Dark";
 "settings.appearance.mode" = "Mode";
 "settings.appearance.mode.default" = "Default";
 "settings.appearance.mode.custom" = "Custom";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -45,6 +45,10 @@
 
 /* Settings - Appearance */
 "settings.tab.appearance" = "个性化";
+"settings.appearance.colorScheme" = "外观主题";
+"settings.appearance.colorScheme.system" = "跟随系统";
+"settings.appearance.colorScheme.light" = "浅色";
+"settings.appearance.colorScheme.dark" = "深色";
 "settings.appearance.mode" = "模式";
 "settings.appearance.mode.default" = "默认";
 "settings.appearance.mode.custom" = "自定义";

--- a/Sources/OpenIslandApp/Views/AppearanceSettingsPane.swift
+++ b/Sources/OpenIslandApp/Views/AppearanceSettingsPane.swift
@@ -10,6 +10,18 @@ struct AppearanceSettingsPane: View {
 
     var body: some View {
         Form {
+            Section(lang.t("settings.appearance.colorScheme")) {
+                Picker(lang.t("settings.appearance.colorScheme"), selection: Binding(
+                    get: { model.preferredColorScheme },
+                    set: { model.preferredColorScheme = $0 }
+                )) {
+                    Text(lang.t("settings.appearance.colorScheme.system")).tag(AppModel.AppColorScheme.system)
+                    Text(lang.t("settings.appearance.colorScheme.light")).tag(AppModel.AppColorScheme.light)
+                    Text(lang.t("settings.appearance.colorScheme.dark")).tag(AppModel.AppColorScheme.dark)
+                }
+                .pickerStyle(.segmented)
+            }
+
             Section(lang.t("settings.appearance.mode")) {
                 Picker(lang.t("settings.appearance.mode"), selection: Binding(
                     get: { model.islandAppearanceMode },

--- a/Sources/OpenIslandApp/Views/ControlCenterView.swift
+++ b/Sources/OpenIslandApp/Views/ControlCenterView.swift
@@ -18,7 +18,7 @@ struct ControlCenterView: View {
         .padding(28)
         .frame(width: 1280, height: 820)
         .background(debugBackground)
-        .preferredColorScheme(.dark)
+        .preferredColorScheme(model.preferredColorScheme.swiftUIScheme)
         .onAppear {
             refreshPreview(for: selectedScenario)
         }

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -224,7 +224,7 @@ struct IslandPanelView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .ignoresSafeArea()
-        .preferredColorScheme(.dark)
+        .preferredColorScheme(model.preferredColorScheme.swiftUIScheme)
     }
 
     @ViewBuilder

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -568,6 +568,7 @@ struct SetupSettingsPane: View {
                 hookRow(
                     name: "Gemini CLI",
                     installed: model.geminiHooksInstalled,
+                    detected: model.isGeminiDetected,
                     busy: model.isGeminiHookSetupBusy,
                     configLocationURL: geminiHookConfigURL,
                     installAction: { model.installGeminiHooks() },

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -101,8 +101,9 @@ struct SettingsView: View {
         } detail: {
             detailView
         }
-        .frame(minWidth: 680, idealWidth: 780, minHeight: 480, idealHeight: 560)
-        .preferredColorScheme(.dark)
+        .frame(minWidth: 680, minHeight: 480)
+        .frame(width: 780, height: 560)
+        .preferredColorScheme(model.preferredColorScheme.swiftUIScheme)
     }
 
     // MARK: Sidebar

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -421,6 +421,7 @@ struct SetupSettingsPane: View {
                 hookRow(
                     name: "Claude Code",
                     installed: model.claudeHooksInstalled,
+                    detected: model.isClaudeCodeDetected,
                     busy: model.isClaudeHookSetupBusy,
                     configLocationURL: model.claudeHookStatus?.settingsURL,
                     installAction: { model.installClaudeHooks() },
@@ -438,6 +439,7 @@ struct SetupSettingsPane: View {
                 hookRow(
                     name: "Codex",
                     installed: model.codexHooksInstalled,
+                    detected: model.isCodexDetected,
                     busy: model.isCodexSetupBusy,
                     configLocationURL: codexHookConfigURL,
                     installAction: { model.installCodexHooks() },
@@ -455,6 +457,7 @@ struct SetupSettingsPane: View {
                 hookRow(
                     name: "OpenCode",
                     installed: model.openCodePluginInstalled,
+                    detected: model.isOpenCodeDetected,
                     busy: model.isOpenCodeSetupBusy,
                     requiresBinary: false,
                     configLocationURL: model.openCodePluginStatus?.configURL,
@@ -473,6 +476,7 @@ struct SetupSettingsPane: View {
                 hookRow(
                     name: "Qoder",
                     installed: model.qoderHooksInstalled,
+                    detected: model.isQoderDetected,
                     busy: model.isQoderHookSetupBusy,
                     configLocationURL: model.qoderHookStatus?.settingsURL,
                     installAction: { model.installQoderHooks() },
@@ -490,6 +494,7 @@ struct SetupSettingsPane: View {
                 hookRow(
                     name: "Qwen Code",
                     installed: model.qwenCodeHooksInstalled,
+                    detected: model.isQwenCodeDetected,
                     busy: model.isQwenCodeHookSetupBusy,
                     configLocationURL: model.qwenCodeHookStatus?.settingsURL,
                     installAction: { model.installQwenCodeHooks() },
@@ -507,6 +512,7 @@ struct SetupSettingsPane: View {
                 hookRow(
                     name: "Factory",
                     installed: model.factoryHooksInstalled,
+                    detected: model.isFactoryDetected,
                     busy: model.isFactoryHookSetupBusy,
                     configLocationURL: model.factoryHookStatus?.settingsURL,
                     installAction: { model.installFactoryHooks() },
@@ -524,6 +530,7 @@ struct SetupSettingsPane: View {
                 hookRow(
                     name: "CodeBuddy",
                     installed: model.codebuddyHooksInstalled,
+                    detected: model.isCodebuddyDetected,
                     busy: model.isCodebuddyHookSetupBusy,
                     configLocationURL: model.codebuddyHookStatus?.settingsURL,
                     installAction: { model.installCodebuddyHooks() },
@@ -541,6 +548,7 @@ struct SetupSettingsPane: View {
                 hookRow(
                     name: "Cursor",
                     installed: model.cursorHooksInstalled,
+                    detected: model.isCursorDetected,
                     busy: model.isCursorHookSetupBusy,
                     requiresBinary: true,
                     configLocationURL: model.cursorHookStatus?.hooksURL,
@@ -639,16 +647,15 @@ struct SetupSettingsPane: View {
 
             Section {
                 Button(lang.t("setup.installAll")) {
-                    if !model.claudeHooksInstalled { model.installClaudeHooks() }
-                    if !model.codexHooksInstalled { model.installCodexHooks() }
-                    if !model.openCodePluginInstalled { model.installOpenCodePlugin() }
-                    if !model.qoderHooksInstalled { model.installQoderHooks() }
-                    if !model.qwenCodeHooksInstalled { model.installQwenCodeHooks() }
-                    if !model.factoryHooksInstalled { model.installFactoryHooks() }
-                    if !model.codebuddyHooksInstalled { model.installCodebuddyHooks() }
-                    if !model.cursorHooksInstalled { model.installCursorHooks() }
-                    if !model.geminiHooksInstalled { model.installGeminiHooks() }
-                    if !model.claudeUsageInstalled { model.installClaudeUsageBridge() }
+                    if !model.claudeHooksInstalled && model.isClaudeCodeDetected { model.installClaudeHooks() }
+                    if !model.codexHooksInstalled && model.isCodexDetected { model.installCodexHooks() }
+                    if !model.openCodePluginInstalled && model.isOpenCodeDetected { model.installOpenCodePlugin() }
+                    if !model.qoderHooksInstalled && model.isQoderDetected { model.installQoderHooks() }
+                    if !model.qwenCodeHooksInstalled && model.isQwenCodeDetected { model.installQwenCodeHooks() }
+                    if !model.factoryHooksInstalled && model.isFactoryDetected { model.installFactoryHooks() }
+                    if !model.codebuddyHooksInstalled && model.isCodebuddyDetected { model.installCodebuddyHooks() }
+                    if !model.cursorHooksInstalled && model.isCursorDetected { model.installCursorHooks() }
+                    if !model.claudeUsageInstalled && model.isClaudeCodeDetected { model.installClaudeUsageBridge() }
                 }
                 .disabled(model.hooksBinaryURL == nil || allReady)
                 .frame(maxWidth: .infinity, alignment: .center)
@@ -706,9 +713,16 @@ struct SetupSettingsPane: View {
     }
 
     private var allReady: Bool {
-        model.claudeHooksInstalled && model.codexHooksInstalled && model.openCodePluginInstalled
-            && model.qoderHooksInstalled && model.qwenCodeHooksInstalled && model.factoryHooksInstalled && model.codebuddyHooksInstalled
-            && model.cursorHooksInstalled && model.geminiHooksInstalled && model.claudeUsageInstalled
+        // All tools that are detected have their hooks installed.
+        (!model.isClaudeCodeDetected || model.claudeHooksInstalled)
+            && (!model.isCodexDetected || model.codexHooksInstalled)
+            && (!model.isOpenCodeDetected || model.openCodePluginInstalled)
+            && (!model.isQoderDetected || model.qoderHooksInstalled)
+            && (!model.isQwenCodeDetected || model.qwenCodeHooksInstalled)
+            && (!model.isFactoryDetected || model.factoryHooksInstalled)
+            && (!model.isCodebuddyDetected || model.codebuddyHooksInstalled)
+            && (!model.isCursorDetected || model.cursorHooksInstalled)
+            && (!model.isClaudeCodeDetected || model.claudeUsageInstalled)
     }
 
     private var codexHookConfigURL: URL? {
@@ -845,6 +859,7 @@ struct SetupSettingsPane: View {
     private func hookRow(
         name: String,
         installed: Bool,
+        detected: Bool,
         busy: Bool,
         requiresBinary: Bool = true,
         configLocationURL: URL? = nil,
@@ -880,6 +895,10 @@ struct SetupSettingsPane: View {
                 }
             } else if busy {
                 ProgressView().controlSize(.small)
+            } else if !detected {
+                Text("Not detected")
+                    .foregroundStyle(.tertiary)
+                    .font(.caption)
             } else {
                 Button(lang.t("settings.general.install")) {
                     installAction()


### PR DESCRIPTION
## Summary

Contribute two previously-merged PRs with proper merge commit history (instead of squash merge):

- **PR #1**: `fix(hooks): only install hooks for detected agent tools`
- **PR #2**: `feat(settings): add theme option — Follow System / Light / Dark`

## Changes

- `HookInstallationCoordinator.swift` — detect installed tools before installing hooks
- `AppModel.swift` — hook install guards + AppColorScheme enum + preferredColorScheme
- `SettingsView.swift` — detection-aware UI, theme picker, light theme font fixes
- `AppearanceSettingsPane.swift` — new theme picker section
- `IslandPanelView.swift` / `ControlCenterView.swift` — use preferredColorScheme
- Localizable strings (en/zh-Hans)

## Test plan

- [ ] Build and run, verify no spurious `.codex/.qoder/.factory/...` directories created on launch
- [ ] Settings → Appearance → Theme picker: System / Light / Dark all apply correctly
- [ ] Light theme: all text/icons visible and readable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent theme preference with selectable options (Follow System, Light, Dark) applied across control center, panels, and settings.
  * Improved tool detection for multiple AI coding assistants; install UI and “Install All” now only act on detected tools and show “Not detected” when absent.
  * Readiness logic updated so undetected tools no longer block overall setup.

* **Localization**
  * Added theme strings in English and Simplified Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->