### PR TITLE
fix(core): improve notification sizing and add freeform input

### DIFF
--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -28,7 +28,10 @@ final class OverlayPanelController {
     private static let completionCardChromeHeight: CGFloat = 187
     private static let completionCardMinHeight: CGFloat = 210
     private static let completionCardMaxHeight: CGFloat = 400
-    private static let hiddenIdleEdgeHoverHitHeight: CGFloat = 8
+    private static let firstPassNotificationSafetyPadding: CGFloat = 64
+    private static let firstPassApprovalBodyMinHeight: CGFloat = 210
+    private static let firstPassQuestionBodyMinHeight: CGFloat = 150
+    private static let firstPassCompletionBodyMinHeight: CGFloat = 230
 
     private var panel: NotchPanel?
     private var eventMonitors = NotchEventMonitors()
@@ -276,36 +279,24 @@ final class OverlayPanelController {
         hoverCancelGrace?.cancel()
         hoverCancelGrace = nil
 
-        guard let model else { return }
-
-        if model.showsIdleEdgeWhenCollapsed {
-            performHoverOpen(model)
-            return
-        }
-
         guard hoverTimer == nil else { return }
 
         let item = DispatchWorkItem { [weak self] in
             guard let self, let model = self.model else { return }
-            self.performHoverOpen(model)
+            if model.notchStatus == .closed {
+                if model.hapticFeedbackEnabled {
+                    NSHapticFeedbackManager.defaultPerformer.perform(
+                        NSHapticFeedbackManager.FeedbackPattern.alignment,
+                        performanceTime: .now
+                    )
+                }
+                model.notchOpen(reason: .hover)
+            }
             self.hoverTimer = nil
         }
 
         hoverTimer = item
         DispatchQueue.main.asyncAfter(deadline: .now() + AppModel.hoverOpenDelay, execute: item)
-    }
-
-    private func performHoverOpen(_ model: AppModel) {
-        guard model.notchStatus == .closed else { return }
-
-        if model.hapticFeedbackEnabled {
-            NSHapticFeedbackManager.defaultPerformer.perform(
-                NSHapticFeedbackManager.FeedbackPattern.alignment,
-                performanceTime: .now
-            )
-        }
-
-        model.notchOpen(reason: .hover)
     }
 
     private func cancelHoverOpen() {
@@ -407,62 +398,12 @@ final class OverlayPanelController {
         )
     }
 
-    nonisolated static func hiddenIdleEdgeHoverRect(
-        notchRect: NSRect,
-        closedWidth: CGFloat,
-        hoverHitHeight: CGFloat
-    ) -> NSRect {
-        let cx = notchRect.midX
-        let effectiveHeight = min(notchRect.height, max(1, hoverHitHeight))
-        return NSRect(
-            x: cx - closedWidth / 2,
-            y: notchRect.maxY - effectiveHeight,
-            width: closedWidth,
-            height: effectiveHeight
-        )
-    }
-
-    nonisolated static func closedPanelWidth(
-        notchWidth: CGFloat,
-        notchHeight: CGFloat,
-        liveSessionCount: Int,
-        hasAttention: Bool,
-        notchStatus: NotchStatus,
-        showsIdleEdgeWhenCollapsed: Bool
-    ) -> CGFloat {
-        let popWidth = notchStatus == .popping ? 18 : 0
-
-        guard !showsIdleEdgeWhenCollapsed else {
-            return notchWidth + CGFloat(popWidth)
-        }
-
-        guard liveSessionCount > 0 else {
-            return notchWidth
-        }
-
-        let sideWidth = max(0, notchHeight - 12) + 10
-        let digits = max(1, "\(liveSessionCount)".count)
-        let countBadgeWidth = CGFloat(26 + max(0, digits - 1) * 8)
-        let leftWidth = sideWidth + 8 + (hasAttention ? 18 : 0)
-        let rightWidth = max(sideWidth, countBadgeWidth)
-        let expansionWidth = leftWidth + rightWidth + 16 + (hasAttention ? 6 : 0)
-        return notchWidth + expansionWidth + CGFloat(popWidth)
-    }
-
     private func closedSurfaceRect(for model: AppModel) -> NSRect? {
         guard let screen = resolveTargetScreen() else {
             return nil
         }
 
         let closedWidth = closedPanelWidth(for: model, on: screen)
-        if model.showsIdleEdgeWhenCollapsed {
-            return Self.hiddenIdleEdgeHoverRect(
-                notchRect: notchRect,
-                closedWidth: closedWidth,
-                hoverHitHeight: Self.hiddenIdleEdgeHoverHitHeight
-            )
-        }
-
         return Self.closedSurfaceRect(
             notchRect: notchRect,
             closedWidth: closedWidth
@@ -518,15 +459,21 @@ final class OverlayPanelController {
         let spotlightSession = model.surfacedSessions.first(where: { $0.phase.requiresAttention })
             ?? model.surfacedSessions.first(where: { $0.phase == .running })
             ?? model.surfacedSessions.first
+        let hasClosedPresence = model.liveSessionCount > 0
 
-        return Self.closedPanelWidth(
-            notchWidth: notchWidth,
-            notchHeight: notchHeight,
-            liveSessionCount: model.liveSessionCount,
-            hasAttention: spotlightSession?.phase.requiresAttention == true,
-            notchStatus: model.notchStatus,
-            showsIdleEdgeWhenCollapsed: model.showsIdleEdgeWhenCollapsed
-        )
+        guard hasClosedPresence else {
+            return notchWidth
+        }
+
+        let sideWidth = max(0, notchHeight - 12) + 10
+        let digits = max(1, "\(model.liveSessionCount)".count)
+        let countBadgeWidth = CGFloat(26 + max(0, digits - 1) * 8)
+        let hasAttention = spotlightSession?.phase.requiresAttention == true
+        let leftWidth = sideWidth + 8 + (hasAttention ? 18 : 0)
+        let rightWidth = max(sideWidth, countBadgeWidth)
+        let expansionWidth = leftWidth + rightWidth + 16 + (hasAttention ? 6 : 0)
+        let popWidth = model.notchStatus == .popping ? 18 : 0
+        return notchWidth + expansionWidth + CGFloat(popWidth)
     }
 
     private func openedContentHeight(for model: AppModel) -> CGFloat {
@@ -554,10 +501,13 @@ final class OverlayPanelController {
             if let actionableID,
                let session = model.state.session(id: actionableID) {
                 let rowHeight = session.estimatedIslandRowHeight(at: now)
-                let bodyHeight = actionableBodyHeight(for: session, model: model)
+                let bodyHeight = max(
+                    actionableBodyHeight(for: session, model: model) + Self.firstPassNotificationSafetyPadding,
+                    minimumFirstPassNotificationBodyHeight(for: session)
+                )
                 return rowHeight + bodyHeight + Self.openedContentVerticalInsets
             }
-            return 300
+            return 360
         }
 
         let rowHeights = visibleSessions.map { session -> CGFloat in
@@ -580,11 +530,62 @@ final class OverlayPanelController {
     private func actionableBodyHeight(for session: AgentSession, model: AppModel) -> CGFloat {
         switch session.phase {
         case .waitingForApproval:
-            return Self.approvalCardHeight - 44
+            return approvalBodyHeight(for: session)
         case .waitingForAnswer:
-            return questionCardHeight(for: session.questionPrompt) - 44
+            return questionBodyHeight(for: session.questionPrompt)
         case .completed:
             return completionBodyHeight(for: session)
+        case .running:
+            return 0
+        }
+    }
+
+    private func approvalBodyHeight(for session: AgentSession) -> CGFloat {
+        let preview = session.currentCommandPreviewText?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let text = preview?.isEmpty == false ? "$ \(preview!)" : (session.permissionRequest?.summary ?? session.summary)
+        
+        let availableWidth = Self.preferredNotificationPanelWidth - 96
+        let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .semibold)
+        let textSize = (text as NSString).boundingRect(
+            with: NSSize(width: availableWidth, height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: [.font: font]
+        )
+        
+        let baseHeight: CGFloat = 126 // 16(label) + 14(path) + 24(padding) + 36(buttons) + 36(spacing)
+        return baseHeight + ceil(textSize.height)
+    }
+
+    private func questionBodyHeight(for prompt: QuestionPrompt?) -> CGFloat {
+        guard let prompt else { return Self.questionCardHeight - 44 }
+        
+        let titleText = prompt.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let availableWidth = Self.preferredNotificationPanelWidth - 64
+        let font = NSFont.systemFont(ofSize: 13, weight: .semibold)
+        let titleSize = (titleText as NSString).boundingRect(
+            with: NSSize(width: availableWidth, height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: [.font: font]
+        )
+        let titleHeight = ceil(titleSize.height) + 12
+        
+        if !prompt.questions.isEmpty {
+            return min(320, titleHeight + CGFloat(prompt.questions.count * 60) + 40)
+        } else if prompt.options.isEmpty {
+            return titleHeight + 88 // TextField + Button
+        } else {
+            return titleHeight + 36 // Buttons
+        }
+    }
+
+    private func minimumFirstPassNotificationBodyHeight(for session: AgentSession) -> CGFloat {
+        switch session.phase {
+        case .waitingForApproval:
+            return Self.firstPassApprovalBodyMinHeight
+        case .waitingForAnswer:
+            return Self.firstPassQuestionBodyMinHeight
+        case .completed:
+            return Self.firstPassCompletionBodyMinHeight
         case .running:
             return 0
         }

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -107,7 +107,6 @@ struct IslandPanelView: View {
     private static let headerHorizontalPadding: CGFloat = 18
     private static let headerTopPadding: CGFloat = 2
     private static let notchLaneSafetyInset: CGFloat = 12
-    private static let closedIdleEdgeHeight: CGFloat = 4
 
     var model: AppModel
 
@@ -145,10 +144,6 @@ struct IslandPanelView: View {
         model.liveSessionCount > 0
     }
 
-    private var showsIdleEdgeWhenCollapsed: Bool {
-        model.showsIdleEdgeWhenCollapsed
-    }
-
     /// Whether any session has activity worth showing in the closed notch
     private var hasClosedActivity: Bool {
         guard let session = closedSpotlightSession else {
@@ -159,9 +154,6 @@ struct IslandPanelView: View {
 
     /// Scout icon tint: blue if any running, green if any live, else gray.
     private var scoutTint: Color {
-        if model.isCustomAppearance, let phase = closedSpotlightSession?.phase {
-            return model.statusColor(for: phase)
-        }
         let sessions = model.surfacedSessions
         if sessions.contains(where: { $0.phase == .running }) {
             return Color(red: 0.43, green: 0.62, blue: 1.0) // #6E9FFF working blue
@@ -178,7 +170,6 @@ struct IslandPanelView: View {
     }
 
     private var expansionWidth: CGFloat {
-        guard !showsIdleEdgeWhenCollapsed else { return 0 }
         guard hasClosedPresence else { return 0 }
         let leftWidth = sideWidth + 8 + (closedSpotlightSession?.phase.requiresAttention == true ? 18 : 0)
         let rightWidth = max(sideWidth, countBadgeWidth)
@@ -258,55 +249,39 @@ struct IslandPanelView: View {
             topCornerRadius: usesOpenedVisualState ? NotchShape.openedTopRadius : NotchShape.closedTopRadius,
             bottomCornerRadius: usesOpenedVisualState ? NotchShape.openedBottomRadius : NotchShape.closedBottomRadius
         )
-        let hidesClosedSurfaceChrome = showsIdleEdgeWhenCollapsed && !usesOpenedVisualState
-        let idleEdgeWidth = closedNotchWidth + (isPopping ? 18 : 0)
 
-        VStack(spacing: 0) {
-            ZStack(alignment: .top) {
-                surfaceShape
-                    .fill(Color.black.opacity(hidesClosedSurfaceChrome ? 0 : 1))
-                    .frame(width: surfaceWidth, height: surfaceHeight)
+        ZStack(alignment: .top) {
+            surfaceShape
+                .fill(Color.black)
+                .frame(width: surfaceWidth, height: surfaceHeight)
 
-                VStack(spacing: 0) {
-                    headerRow
-                        .frame(height: closedNotchHeight)
-                        .opacity(hidesClosedSurfaceChrome ? 0 : 1)
+            VStack(spacing: 0) {
+                headerRow
+                    .frame(height: closedNotchHeight)
 
-                    openedContent
-                        .frame(width: openedWidth - 24)
-                        .frame(maxHeight: usesOpenedVisualState ? currentHeight - closedNotchHeight - 12 : 0, alignment: .top)
-                        .opacity(usesOpenedVisualState ? 1 : 0)
-                        .clipped()
-                }
-                .frame(width: currentWidth, height: currentHeight, alignment: .top)
-                .padding(.horizontal, horizontalInset)
-                .padding(.bottom, bottomInset)
-                .clipShape(surfaceShape)
-                .overlay(alignment: .top) {
-                    // Black strip to blend with physical notch at the very top
-                    Rectangle()
-                        .fill(Color.black)
-                        .frame(height: 1)
-                        .padding(.horizontal, usesOpenedVisualState ? NotchShape.openedTopRadius : NotchShape.closedTopRadius)
-                        .opacity(hidesClosedSurfaceChrome ? 0 : 1)
-                }
-                .overlay {
-                    surfaceShape
-                        .stroke(Color.white.opacity(hidesClosedSurfaceChrome ? 0 : (usesOpenedVisualState ? 0.07 : 0.04)), lineWidth: 1)
-                }
-                .overlay(alignment: .top) {
-                    Capsule()
-                        .fill(Color.black)
-                        .frame(width: idleEdgeWidth, height: Self.closedIdleEdgeHeight)
-                        .overlay {
-                            Capsule()
-                                .stroke(Color.white.opacity(0.05), lineWidth: 1)
-                        }
-                        .opacity(showsIdleEdgeWhenCollapsed ? 1 : 0)
-                }
+                openedContent
+                    .frame(width: openedWidth - 24)
+                    .frame(maxHeight: usesOpenedVisualState ? currentHeight - closedNotchHeight - 12 : 0, alignment: .top)
+                    .opacity(usesOpenedVisualState ? 1 : 0)
+                    .clipped()
             }
-            .frame(width: surfaceWidth, height: surfaceHeight, alignment: .top)
+            .frame(width: currentWidth, height: currentHeight, alignment: .top)
+            .padding(.horizontal, horizontalInset)
+            .padding(.bottom, bottomInset)
+            .clipShape(surfaceShape)
+            .overlay(alignment: .top) {
+                // Black strip to blend with physical notch at the very top
+                Rectangle()
+                    .fill(Color.black)
+                    .frame(height: 1)
+                    .padding(.horizontal, usesOpenedVisualState ? NotchShape.openedTopRadius : NotchShape.closedTopRadius)
+            }
+            .overlay {
+                surfaceShape
+                    .stroke(Color.white.opacity(usesOpenedVisualState ? 0.07 : 0.04), lineWidth: 1)
+            }
         }
+        .frame(width: surfaceWidth, height: surfaceHeight, alignment: .top)
         .scaleEffect(usesOpenedVisualState ? 1 : (isHovering ? IslandChromeMetrics.closedHoverScale : 1), anchor: .top)
         .padding(.horizontal, panelShadowHorizontalInset)
         .padding(.bottom, panelShadowBottomInset)
@@ -346,18 +321,8 @@ struct IslandPanelView: View {
             HStack(spacing: 0) {
                 if hasClosedPresence {
                     HStack(spacing: 4) {
-                        if model.isCustomAppearance {
-                            IslandPixelGlyph(
-                                tint: scoutTint,
-                                style: model.islandPixelShapeStyle,
-                                isAnimating: hasClosedActivity,
-                                customAvatarImage: model.customAvatarImage
-                            )
+                        OpenIslandIcon(size: 14, isAnimating: hasClosedActivity, tint: scoutTint)
                             .matchedGeometryEffect(id: "island-icon", in: notchNamespace, isSource: true)
-                        } else {
-                            OpenIslandIcon(size: 14, isAnimating: hasClosedActivity, tint: scoutTint)
-                                .matchedGeometryEffect(id: "island-icon", in: notchNamespace, isSource: true)
-                        }
 
                         if closedSpotlightSession?.phase.requiresAttention == true {
                             AttentionIndicator(
@@ -524,6 +489,7 @@ struct IslandPanelView: View {
             if isNotificationMode {
                 // Notification mode: NO ScrollView — content sizes naturally
                 sessionListContent(context: context)
+                    .fixedSize(horizontal: false, vertical: true)
                     .padding(.vertical, 2)
                     .background(
                         GeometryReader { geo in
@@ -603,10 +569,7 @@ struct IslandPanelView: View {
     }
 
     private func phaseColor(_ phase: SessionPhase) -> Color {
-        if model.isCustomAppearance {
-            return model.statusColor(for: phase)
-        }
-        return switch phase {
+        switch phase {
         case .running: .mint
         case .waitingForApproval: .orange
         case .waitingForAnswer: .yellow
@@ -1501,6 +1464,7 @@ private struct StructuredQuestionPromptView: View {
     let onAnswer: (QuestionPromptResponse) -> Void
 
     @State private var selections: [String: Set<String>] = [:]
+    @State private var freeformAnswer: String = ""
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -1512,12 +1476,38 @@ private struct StructuredQuestionPromptView: View {
             }
 
             if structuredQuestions.isEmpty {
-                HStack(spacing: 10) {
-                    ForEach(prompt?.options.prefix(3) ?? [], id: \.self) { option in
-                        Button(option) {
-                            onAnswer(QuestionPromptResponse(answer: option))
+                if promptOptions.isEmpty {
+                    VStack(alignment: .leading, spacing: 10) {
+                        TextField(lang.t("question.placeholder"), text: $freeformAnswer)
+                            .textFieldStyle(.plain)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(.white.opacity(0.92))
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 10)
+                            .background(
+                                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                    .fill(Color.white.opacity(0.08))
+                            )
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                    .strokeBorder(.white.opacity(0.08))
+                            )
+                            .onSubmit { submitFreeformAnswer() }
+
+                        Button(lang.t("question.submit")) {
+                            submitFreeformAnswer()
                         }
-                        .buttonStyle(IslandWideButtonStyle(kind: .secondary))
+                        .buttonStyle(IslandWideButtonStyle(kind: .primary))
+                        .disabled(freeformAnswer.trimmedForNotificationCard.isEmpty)
+                    }
+                } else {
+                    HStack(spacing: 10) {
+                        ForEach(promptOptions.prefix(3), id: \.self) { option in
+                            Button(option) {
+                                onAnswer(QuestionPromptResponse(answer: option))
+                            }
+                            .buttonStyle(IslandWideButtonStyle(kind: .secondary))
+                        }
                     }
                 }
             } else {
@@ -1575,6 +1565,10 @@ private struct StructuredQuestionPromptView: View {
         prompt?.questions ?? []
     }
 
+    private var promptOptions: [String] {
+        prompt?.options ?? []
+    }
+
     private var promptTitle: String {
         prompt?.title.trimmedForNotificationCard ?? lang.t("question.answerNeeded")
     }
@@ -1605,6 +1599,15 @@ private struct StructuredQuestionPromptView: View {
 
     private var hasCompleteSelection: Bool {
         structuredQuestions.allSatisfy { !selectedLabels(for: $0).isEmpty }
+    }
+
+    private func submitFreeformAnswer() {
+        let answer = freeformAnswer.trimmedForNotificationCard
+        guard !answer.isEmpty else {
+            return
+        }
+
+        onAnswer(QuestionPromptResponse(answer: answer))
     }
 
     private func selectedLabels(for question: QuestionPromptItem) -> Set<String> {

--- a/Tests/OpenIslandAppTests/OverlayPanelControllerTests.swift
+++ b/Tests/OpenIslandAppTests/OverlayPanelControllerTests.swift
@@ -37,49 +37,6 @@ struct OverlayPanelControllerTests {
     }
 
     @Test
-    func hiddenIdleEdgeClosedWidthStaysAtNotchWidth() {
-        let width = OverlayPanelController.closedPanelWidth(
-            notchWidth: 224,
-            notchHeight: 38,
-            liveSessionCount: 3,
-            hasAttention: true,
-            notchStatus: .closed,
-            showsIdleEdgeWhenCollapsed: true
-        )
-
-        #expect(width == 224)
-    }
-
-    @Test
-    func regularClosedWidthStillIncludesSessionIndicators() {
-        let width = OverlayPanelController.closedPanelWidth(
-            notchWidth: 224,
-            notchHeight: 38,
-            liveSessionCount: 3,
-            hasAttention: true,
-            notchStatus: .closed,
-            showsIdleEdgeWhenCollapsed: false
-        )
-
-        #expect(width == 344)
-    }
-
-    @Test
-    func hiddenIdleEdgeHoverRectAnchorsToTopOfClosedArea() {
-        let notchRect = NSRect(x: 400, y: 1_000, width: 224, height: 38)
-
-        let rect = OverlayPanelController.hiddenIdleEdgeHoverRect(
-            notchRect: notchRect,
-            closedWidth: 224,
-            hoverHitHeight: 8
-        )
-
-        #expect(rect.minX == 400)
-        #expect(rect.maxY == notchRect.maxY)
-        #expect(rect.height == 8)
-    }
-
-    @Test
     func clickOpensActivateThePanel() {
         #expect(OverlayPanelController.shouldActivatePanel(for: .click))
     }


### PR DESCRIPTION
## Summary
* Fix initial height estimation for notification cards to prevent content cutoff on the first frame.
* Add a freeform text input field in `IslandPanelView` for `AskUserQuestion` events that have no predefined options.