### PR TITLE
fix(qwen): support process discovery and lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,14 @@ output/
 *.log
 *.tmp
 .worktrees/
+
+# Xcode / SwiftPM
+.swiftpm/
+
+# Profiling data
+*.profraw
+
+# Agent configs / Patches
+.qwen/
+*.patch
+test_*.swift

--- a/QWEN_INTEGRATION_GUIDE.md
+++ b/QWEN_INTEGRATION_GUIDE.md
@@ -1,0 +1,52 @@
+# Qwen Code Integration & State Machine Guide
+
+This document outlines the architectural decisions, challenges solved, and implementation details for deeply integrating Qwen Code (`qwen-cli`) into the Open Island ecosystem.
+
+## 1. The Dual-Track State Machine Challenge
+
+Open Island tracks CLI agents using two distinct and parallel systems:
+1. **Process Discovery (Polling)**: A background task (`sessionAttachmentMonitorTask`) uses `lsof` and `ps` to scan the OS every ~2 seconds to find running agent processes and their working directories.
+2. **Hook Events (Push)**: The CLI tool actively sends Unix socket events (`sessionstart`, `userpromptsubmit`, `sessionend`, etc.) directly to the Open Island `BridgeServer`.
+
+### The Flaky Polling Problem (The "Flashing Card" Bug)
+CLI tools like `qwen-cli` are frequently invoked via Node.js package managers (`npx`, `bun`, `npm`, `yarn`, `pnpm`). These wrappers create deeply nested process trees. Process polling can easily miss the actual agent process for a few seconds during high CPU load or complex package manager resolutions.
+
+*   **Previous Behavior**: If the poller missed a process twice (about 4 seconds), the State Machine forcefully marked the session as `isSessionEnded = true` and `phase = .completed`. This caused the UI card to unexpectedly disappear ("flash" out of existence) right in the middle of a task, only to reappear when the actual `sessionend` hook finally arrived.
+*   **The Solution (Hook Fallback)**: Hook-managed sessions primarily rely on hook lifecycle signals (`SessionStart` / `SessionEnd`). However, if the terminal crashes or the bridge becomes unavailable, the `sessionend` hook may never arrive, leaving the session permanently stuck as visible. As a fallback, we check process liveness: when the agent process is confirmed dead by two consecutive polls, we forcefully mark the session ended (`isSessionEnded = true`, `phase = .completed`) so it can be cleaned up and smoothly animate out.
+
+## 2. Process Identification Details
+
+To successfully map a Qwen terminal window to its UI card, `ActiveAgentProcessDiscovery.swift` handles several edge cases:
+
+*   **Package Manager Penetration**: The `isAgentProcess` matcher accepts commands starting with `node`, `npx`, `bun`, `npm`, `pnpm`, or `yarn`, as long as the relevant agent executable name (for example `qwen` or `qwen-cli`) appears later in the argument list.
+*   **Transcript Segregation**: Claude Code and Qwen Code use different local storage paths. The discovery engine's `bestClaudeTranscriptPath` selects the appropriate project root based on `isQwen` (for example `/.claude/projects/` vs `/.qwen/projects/`) rather than merging searches across both trees, which avoids cross-contamination.
+
+## 3. UI Lifecycle & The "Zombie Session" Prevention
+
+Achieving the exact 5-second graceful exit animation after a task finishes required solving a deeply hidden race condition known as the "Zombie Synthetic Session" bug.
+
+### The Zombie Bug Anatomy:
+1. `qwen-cli` finishes its task and sends the `sessionend` hook.
+2. The UI correctly displays the completed green card for 5.0 seconds (managed by `islandPresence`).
+3. After 5 seconds, the card smoothly animates out of the Notch and the list. `isVisibleInIsland` evaluates to `false`.
+4. `SessionState.removeInvisibleSessions()` executes garbage collection and purges the session from memory to save RAM.
+5. **The Race Condition**: The user's terminal window is still open (`isProcessAlive == true`).
+6. The background Process Poller runs its 2-second scan, sees the Qwen terminal process, but finds *no matching session in memory* (because we just deleted it).
+7. The Poller mistakenly assumes this is an untracked agent and instantly generates a new "Synthetic Session"—a fake `Running` card (blue dot) with no chat history that cannot be dismissed until the user completely quits the terminal app.
+
+### The Tombstone Solution:
+We changed the garbage collection filter in `SessionState.removeInvisibleSessions()`. 
+
+*   **Old Filter**: `session.isVisibleInIsland`
+*   **New Filter**: `session.isVisibleInIsland || session.isProcessAlive`
+
+**Result**: Once a task finishes, it disappears from the user's view (Notch/List), but its data structure acts as a "tombstone" in the memory pool for as long as the terminal remains open. When the Process Poller scans the terminal, it matches the tombstone, realizes the session is already completed, and safely ignores it. Synthetic zombies are completely eradicated.
+
+## 4. Metadata Synchronization & Context Preservation
+
+Qwen's metadata is synchronized via `BridgeServer.swift` -> `synchronizeQwenMetadata()`. 
+
+To ensure the UI collapsed card always displays the initial user request (e.g., `You: Create a python script`) instead of remaining blank after completion:
+*   The bridge intercepts the `sessionstart` hook event in addition to `userpromptsubmit`.
+*   It populates `initialUserPrompt` and `lastUserPrompt` with the provided prompt or title data immediately upon session creation.
+*   This data flows seamlessly through `AgentSession+Presentation.swift` directly into the Spotlight UI components, ensuring the context is preserved even after the agent finishes execution.

--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -85,12 +85,13 @@ struct ActiveAgentProcessDiscovery {
                 continue
             }
 
-            if isClaudeProcess(command: process.command) {
+            if isAgentProcess(command: process.command) {
                 guard let snapshot = claudeSnapshot(for: process, processesByPID: processesByPID) else {
                     continue
                 }
 
-                let claimKey = "claude:\(snapshot.sessionID ?? snapshot.terminalTTY ?? snapshot.workingDirectory ?? process.pid)"
+                let toolPrefix = snapshot.tool == .qwenCode ? "qwen" : "claude"
+                let claimKey = "\(toolPrefix):\(snapshot.sessionID ?? snapshot.terminalTTY ?? snapshot.workingDirectory ?? process.pid)"
                 guard claimedKeys.insert(claimKey).inserted else {
                     continue
                 }
@@ -182,7 +183,7 @@ struct ActiveAgentProcessDiscovery {
     }
 
     private func isClaudeSubagentWorktree(_ path: String) -> Bool {
-        path.contains("/.claude/worktrees/agent-")
+        path.contains("/.claude/worktrees/agent-") || path.contains("/.qwen/worktrees/agent-")
     }
 
     private func claudeSnapshot(
@@ -190,6 +191,7 @@ struct ActiveAgentProcessDiscovery {
         processesByPID: [String: RunningProcess]
     ) -> ProcessSnapshot? {
         let lsofOutput = lsofOutput(pid: process.pid)
+        let isQwen = process.command.lowercased().contains("qwen") || (lsofOutput?.contains("/.qwen/") == true)
         let workingDirectory = lsofOutput.flatMap(workingDirectory(from:))
 
         // Subagent processes run in .claude/worktrees/agent-*/ directories.
@@ -199,7 +201,7 @@ struct ActiveAgentProcessDiscovery {
         }
 
         let transcriptPath = lsofOutput.flatMap {
-            bestClaudeTranscriptPath(in: $0, workingDirectory: workingDirectory)
+            bestClaudeTranscriptPath(in: $0, workingDirectory: workingDirectory, isQwen: isQwen)
         }
         let sessionID = transcriptPath.flatMap(firstUUID(in:))
             ?? claudeSessionID(from: process.command)
@@ -209,7 +211,7 @@ struct ActiveAgentProcessDiscovery {
         }
 
         var snapshot = ProcessSnapshot(
-            tool: .claudeCode,
+            tool: isQwen ? .qwenCode : .claudeCode,
             sessionID: sessionID,
             workingDirectory: workingDirectory,
             terminalTTY: process.terminalTTY,
@@ -233,8 +235,14 @@ struct ActiveAgentProcessDiscovery {
         return snapshot
     }
 
-    private func bestClaudeTranscriptPath(in lsofOutput: String, workingDirectory: String?) -> String? {
-        let paths = allMatchingPaths(in: lsofOutput, containing: "/.claude/projects/", suffix: ".jsonl")
+    private func bestClaudeTranscriptPath(in lsofOutput: String, workingDirectory: String?, isQwen: Bool = false) -> String? {
+        let paths: [String]
+        if isQwen {
+            paths = allMatchingPaths(in: lsofOutput, containing: "/.qwen/projects/", suffix: ".jsonl")
+        } else {
+            paths = allMatchingPaths(in: lsofOutput, containing: "/.claude/projects/", suffix: ".jsonl")
+        }
+        
         guard !paths.isEmpty else {
             return nil
         }
@@ -261,11 +269,12 @@ struct ActiveAgentProcessDiscovery {
             }
 
             let value = String(line.dropFirst()).trimmingCharacters(in: .whitespacesAndNewlines)
-            guard value.contains(fragment), value.hasSuffix(suffix) else {
+            let unescaped = unescapeLSOF(value)
+            guard unescaped.contains(fragment), unescaped.hasSuffix(suffix) else {
                 continue
             }
 
-            results.append(value)
+            results.append(unescaped)
         }
 
         return results
@@ -395,12 +404,54 @@ struct ActiveAgentProcessDiscovery {
             }
 
             let value = String(nextLine.dropFirst()).trimmingCharacters(in: .whitespacesAndNewlines)
-            if value.hasPrefix("/") {
-                return value
+            let unescaped = unescapeLSOF(value)
+            if unescaped.hasPrefix("/") {
+                return unescaped
             }
         }
 
         return nil
+    }
+
+    private func unescapeLSOF(_ string: String) -> String {
+        var result = ""
+        var i = string.startIndex
+        var bytes: [UInt8] = []
+
+        func flushBytes() {
+            if !bytes.isEmpty {
+                if let s = String(bytes: bytes, encoding: .utf8) {
+                    result += s
+                } else {
+                    for b in bytes {
+                        result += String(format: "\\x%02x", b)
+                    }
+                }
+                bytes.removeAll()
+            }
+        }
+
+        while i < string.endIndex {
+            if string[i] == "\\" {
+                let nextI = string.index(after: i)
+                if nextI < string.endIndex, string[nextI] == "x" {
+                    let hexStart = string.index(after: nextI)
+                    if let hexEnd = string.index(hexStart, offsetBy: 2, limitedBy: string.endIndex) {
+                        let hexStr = string[hexStart..<hexEnd]
+                        if let byte = UInt8(hexStr, radix: 16) {
+                            bytes.append(byte)
+                            i = hexEnd
+                            continue
+                        }
+                    }
+                }
+            }
+            flushBytes()
+            result.append(string[i])
+            i = string.index(after: i)
+        }
+        flushBytes()
+        return result
     }
 
     private func matchingPath(in lsofOutput: String, containing fragment: String, suffix: String) -> String? {
@@ -410,11 +461,12 @@ struct ActiveAgentProcessDiscovery {
             }
 
             let value = String(line.dropFirst()).trimmingCharacters(in: .whitespacesAndNewlines)
-            guard value.contains(fragment), value.hasSuffix(suffix) else {
+            let unescaped = unescapeLSOF(value)
+            guard unescaped.contains(fragment), unescaped.hasSuffix(suffix) else {
                 continue
             }
 
-            return value
+            return unescaped
         }
 
         return nil
@@ -500,17 +552,29 @@ struct ActiveAgentProcessDiscovery {
             || lowered.contains("/.opencode")
     }
 
-    private func isClaudeProcess(command: String) -> Bool {
+    private func isAgentProcess(command: String) -> Bool {
         let lowered = command.lowercased()
-        if lowered.contains("/.local/bin/claude") {
+        
+        if lowered.contains("/bin/claude") || lowered.contains("/bin/qwen") || lowered.contains("/.local/bin/claude") || lowered.contains("/.local/bin/qwen") {
             return true
         }
 
-        guard let firstToken = lowered.split(separator: " ").first else {
+        let tokens = lowered.split(separator: " ").map(String.init)
+        guard let firstToken = tokens.first else {
             return false
         }
 
-        return firstToken == "claude"
+        if firstToken == "claude" || firstToken == "qwen" || firstToken == "qwen-cli" {
+            return true
+        }
+
+        if firstToken == "node" || firstToken.hasSuffix("/node") || firstToken == "npx" || firstToken == "bun" || firstToken == "npm" || firstToken == "pnpm" || firstToken == "yarn" {
+            if lowered.contains("claude") || lowered.contains("qwen") {
+                return true
+            }
+        }
+
+        return false
     }
 
     private static func commandOutput(executablePath: String, arguments: [String]) -> String? {

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -255,15 +255,15 @@ final class ProcessMonitoringCoordinator {
         }
 
         // Claude sessions: reuse the multi-pass matching from representedClaudeProcessKeys.
-        let claudeProcesses = activeProcesses.filter { $0.tool == .claudeCode }
-        let trackedClaudeSessions = sessions.filter { $0.tool == .claudeCode && !isSyntheticClaudeSession($0) }
+        let claudeProcesses = activeProcesses.filter { $0.tool == .claudeCode || $0.tool == .qwenCode }
+        let trackedClaudeSessions = sessions.filter { ($0.tool == .claudeCode || $0.tool == .qwenCode) && !isSyntheticClaudeSession($0) }
         var claimedSessionIDs: Set<String> = []
 
         // Pass 1: exact session ID match.
         for process in claudeProcesses {
             guard let processSessionID = process.sessionID,
                   let matched = trackedClaudeSessions.first(where: {
-                      !claimedSessionIDs.contains($0.id) && $0.id == processSessionID
+                      !claimedSessionIDs.contains($0.id) && ($0.id == processSessionID || $0.id.hasSuffix(processSessionID))
                   }) else { continue }
             aliveIDs.insert(matched.id)
             claimedSessionIDs.insert(matched.id)
@@ -274,7 +274,7 @@ final class ProcessMonitoringCoordinator {
             guard let transcriptPath = process.transcriptPath,
                   let matched = trackedClaudeSessions.first(where: {
                       !claimedSessionIDs.contains($0.id)
-                          && $0.claudeMetadata?.transcriptPath == transcriptPath
+                          && ($0.claudeMetadata?.transcriptPath == transcriptPath || $0.trackingTranscriptPath == transcriptPath)
                   }) else { continue }
             aliveIDs.insert(matched.id)
             claimedSessionIDs.insert(matched.id)
@@ -345,10 +345,10 @@ final class ProcessMonitoringCoordinator {
         now: Date
     ) -> [AgentSession] {
         let activeClaudeProcesses = activeProcesses.filter { process in
-            process.tool == .claudeCode
+            process.tool == .claudeCode || process.tool == .qwenCode
         }
         let trackedClaudeSessions = existingSessions.filter { session in
-            session.tool == .claudeCode && !isSyntheticClaudeSession(session)
+            (session.tool == .claudeCode || session.tool == .qwenCode) && !isSyntheticClaudeSession(session)
         }
 
         let representedProcessKeys = representedClaudeProcessKeys(
@@ -373,17 +373,17 @@ final class ProcessMonitoringCoordinator {
 
         var session = AgentSession(
             id: "\(syntheticClaudeSessionPrefix)\(identity)",
-            title: "Claude · \(workspaceName)",
-            tool: .claudeCode,
+            title: "\(process.tool == .qwenCode ? "Qwen Code" : "Claude") · \(workspaceName)",
+            tool: process.tool,
             origin: .live,
             attachmentState: .attached,
             phase: .completed,
-            summary: "Claude session detected from \(terminalApp).",
+            summary: "\(process.tool == .qwenCode ? "Qwen Code" : "Claude") session detected from \(terminalApp).",
             updatedAt: now,
             jumpTarget: JumpTarget(
                 terminalApp: terminalApp,
                 workspaceName: workspaceName,
-                paneTitle: "Claude \(workspaceName)",
+                paneTitle: "\(process.tool == .qwenCode ? "Qwen" : "Claude") \(workspaceName)",
                 workingDirectory: workingDirectory,
                 terminalTTY: process.terminalTTY,
                 tmuxTarget: process.tmuxTarget,
@@ -395,7 +395,7 @@ final class ProcessMonitoringCoordinator {
     }
 
     func isSyntheticClaudeSession(_ session: AgentSession) -> Bool {
-        session.tool == .claudeCode && session.id.hasPrefix(syntheticClaudeSessionPrefix)
+        (session.tool == .claudeCode || session.tool == .qwenCode) && session.id.hasPrefix(syntheticClaudeSessionPrefix)
     }
 
     // MARK: - Process matching
@@ -405,7 +405,7 @@ final class ProcessMonitoringCoordinator {
         activeProcesses: [ActiveProcessSnapshot]
     ) -> Set<String> {
         let trackedClaudeSessions = sessions.filter { session in
-            session.tool == .claudeCode && !isSyntheticClaudeSession(session)
+            (session.tool == .claudeCode || session.tool == .qwenCode) && !isSyntheticClaudeSession(session)
         }
 
         var representedProcessKeys: Set<String> = []
@@ -414,7 +414,7 @@ final class ProcessMonitoringCoordinator {
         for process in activeProcesses {
             guard let processSessionID = process.sessionID,
                   let matchedSession = trackedClaudeSessions.first(where: {
-                      !claimedSessionIDs.contains($0.id) && $0.id == processSessionID
+                      !claimedSessionIDs.contains($0.id) && ($0.id == processSessionID || $0.id.hasSuffix(processSessionID))
                   }) else {
                 continue
             }
@@ -429,7 +429,7 @@ final class ProcessMonitoringCoordinator {
                   let transcriptPath = process.transcriptPath,
                   let matchedSession = trackedClaudeSessions.first(where: {
                       !claimedSessionIDs.contains($0.id)
-                          && $0.claudeMetadata?.transcriptPath == transcriptPath
+                          && ($0.claudeMetadata?.transcriptPath == transcriptPath || $0.trackingTranscriptPath == transcriptPath)
                   }) else {
                 continue
             }
@@ -521,7 +521,7 @@ final class ProcessMonitoringCoordinator {
         workingDirectory: String?
     ) -> [AgentSession] {
         sessions.filter { session in
-            guard session.tool == .claudeCode,
+            guard (session.tool == .claudeCode || session.tool == .qwenCode),
                   !claimedSessionIDs.contains(session.id) else {
                 return false
             }
@@ -548,7 +548,7 @@ final class ProcessMonitoringCoordinator {
         activeProcesses: [ActiveProcessSnapshot],
         sessions localState: inout SessionState
     ) -> Bool {
-        let claudeProcesses = activeProcesses.filter { $0.tool == .claudeCode }
+        let claudeProcesses = activeProcesses.filter { $0.tool == .claudeCode || $0.tool == .qwenCode }
         guard !claudeProcesses.isEmpty else { return false }
 
         var sessions = localState.sessions
@@ -560,7 +560,7 @@ final class ProcessMonitoringCoordinator {
 
             for index in sessions.indices {
                 let session = sessions[index]
-                guard session.tool == .claudeCode,
+                guard (session.tool == .claudeCode || session.tool == .qwenCode),
                       !isSyntheticClaudeSession(session),
                       let jumpTarget = session.jumpTarget,
                       normalizedPathForMatching(jumpTarget.workingDirectory) == processCWD,
@@ -571,7 +571,7 @@ final class ProcessMonitoringCoordinator {
                 // Only adopt if no other session already owns this TTY.
                 let ttyAlreadyClaimed = sessions.contains { other in
                     other.id != session.id
-                        && other.tool == .claudeCode
+                        && (other.tool == .claudeCode || other.tool == .qwenCode)
                         && normalizedTTYForMatching(other.jumpTarget?.terminalTTY) == normalizedTTYForMatching(processTTY)
                 }
                 guard !ttyAlreadyClaimed else { continue }
@@ -777,6 +777,10 @@ final class ProcessMonitoringCoordinator {
             return .claudeCode
         }
 
+        if normalized.contains("qwen") {
+            return .qwenCode
+        }
+
         return nil
     }
 
@@ -786,6 +790,7 @@ final class ProcessMonitoringCoordinator {
             return "Codex \(session.id.prefix(8))"
         case .claudeCode:
             return "Claude \(session.id.prefix(8))"
+        
         case .geminiCLI:
             return "Gemini \(session.id.prefix(8))"
         case .openCode:

--- a/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
+++ b/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
@@ -347,7 +347,7 @@ final class SessionDiscoveryCoordinator {
         let prefix = syntheticClaudeSessionPrefix
         let records = state.sessions
             .filter {
-                $0.tool == .claudeCode
+                ($0.tool == .claudeCode || $0.tool == .qwenCode)
                     && $0.isTrackedLiveSession
                     && (prefix.isEmpty || !$0.id.hasPrefix(prefix))
                     && $0.updatedAt >= Date.now.addingTimeInterval(-86_400)

--- a/Sources/OpenIslandApp/TerminalSessionAttachmentProbe.swift
+++ b/Sources/OpenIslandApp/TerminalSessionAttachmentProbe.swift
@@ -252,7 +252,7 @@ struct TerminalSessionAttachmentProbe {
                 }
                 if peerOwnsProcess { return true }
                 let unassignedProcessSharesCWD = activeProcesses.contains { process in
-                    process.tool == .claudeCode
+                    (process.tool == .claudeCode || process.tool == .qwenCode)
                         && !activeSessionIDs.contains(where: {
                             activeProcessesBySessionID[$0]?.terminalTTY == process.terminalTTY
                                 && activeProcessesBySessionID[$0]?.workingDirectory == process.workingDirectory
@@ -543,7 +543,7 @@ struct TerminalSessionAttachmentProbe {
         // prompt like "~/project"), do not match it to agent sessions.  This
         // prevents Claude/Codex sessions from binding to an unrelated terminal
         // that just happens to share the same working directory.
-        if snapshotHint == nil && (session.tool == .claudeCode || session.tool == .codex) {
+        if snapshotHint == nil && (session.tool == .claudeCode || session.tool == .qwenCode || session.tool == .codex) {
             return false
         }
 
@@ -673,6 +673,10 @@ struct TerminalSessionAttachmentProbe {
 
         if normalizedTitle.contains("claude") {
             return .claudeCode
+        }
+
+        if normalizedTitle.contains("qwen") {
+            return .qwenCode
         }
 
         return nil
@@ -921,7 +925,7 @@ struct TerminalSessionAttachmentProbe {
                 .filter { $0.tool == .codex }
                 .compactMap(\.sessionID)
         )
-        let activeClaudeProcesses = activeProcesses.filter { $0.tool == .claudeCode }
+        let activeClaudeProcesses = activeProcesses.filter { $0.tool == .claudeCode || $0.tool == .qwenCode }
 
         for session in sessions {
             if session.tool == .codex,
@@ -1018,7 +1022,7 @@ struct TerminalSessionAttachmentProbe {
         workingDirectory: String?
     ) -> [AgentSession] {
         sessions.filter { session in
-            guard session.tool == .claudeCode,
+            guard session.tool == .claudeCode || session.tool == .qwenCode,
                   !claimedSessionIDs.contains(session.id) else {
                 return false
             }
@@ -1079,7 +1083,7 @@ struct TerminalSessionAttachmentProbe {
     /// from staying attached just because the terminal tab is still open.
     /// Non-Claude sessions (Codex) are always eligible.
     private func isRecentEnoughForInactiveMatch(_ session: AgentSession, now: Date) -> Bool {
-        guard session.tool == .claudeCode else { return true }
+        guard session.tool == .claudeCode || session.tool == .qwenCode else { return true }
         return now.timeIntervalSince(session.updatedAt) <= Self.inactiveClaudeMatchWindow
     }
 

--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -460,7 +460,15 @@ public extension AgentSession {
     var isVisibleInIsland: Bool {
         if isDemoSession { return true }
         if phase.requiresAttention { return true }
-        if isHookManaged { return !isSessionEnded }
+        if isHookManaged {
+            if phase == .completed {
+                // Keep it in state for 6 seconds (slightly longer than the 5s UI presence limit)
+                // so that it can be cleanly animated out before being purged from memory.
+                return Date.now.timeIntervalSince(updatedAt) <= 6.0
+            }
+            
+            return attachmentState.isLive
+        }
         if isProcessAlive { return true }
         return false
     }

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -71,6 +71,13 @@ public struct SessionState: Equatable, Sendable {
                 openCodeMetadata: payload.openCodeMetadata?.isEmpty == true ? nil : payload.openCodeMetadata,
                 cursorMetadata: payload.cursorMetadata?.isEmpty == true ? nil : payload.cursorMetadata
             )
+            if let existing = sessionsByID[payload.sessionID] {
+                // Do not downgrade a correctly discovered Qwen session back to Claude Code
+                // if the hook payload lacks a specific Qwen source identifier.
+                if existing.tool == .qwenCode && payload.tool == .claudeCode {
+                    session.tool = .qwenCode
+                }
+            }
             session.isRemote = payload.isRemote
             session.isHookManaged = payload.origin == .live
             session.isSessionEnded = false
@@ -102,6 +109,9 @@ public struct SessionState: Equatable, Sendable {
                 }
             }
 
+            // A session receiving hook activity is definitively hook-managed.
+            // This upgrades discovered sessions to hook-managed so they collapse promptly when done.
+            session.isHookManaged = true
             session.updatedAt = payload.timestamp
             upsert(session)
 
@@ -141,6 +151,7 @@ public struct SessionState: Equatable, Sendable {
             session.updatedAt = payload.timestamp
             if payload.isSessionEnd == true {
                 session.isSessionEnded = true
+                session.isProcessAlive = false
             }
             upsert(session)
 
@@ -333,13 +344,21 @@ public struct SessionState: Equatable, Sendable {
                 }
 
                 if aliveSessionIDs.contains(id) {
+                    session.isProcessAlive = true
                     session.processNotSeenCount = 0
                 } else {
                     session.processNotSeenCount += 1
                     if session.processNotSeenCount >= 2 {
-                        session.isSessionEnded = true
-                        session.phase = .completed
-                        changed.insert(id)
+                        session.isProcessAlive = false
+                        
+                        // Process is confirmed dead for multiple polls. 
+                        // Mark it as ended so it can gracefully animate out via the UI's 5s completion window.
+                        if !session.isSessionEnded {
+                            session.isSessionEnded = true
+                            session.phase = .completed
+                            session.updatedAt = .now // Reset updatedAt to trigger the 5s completion animation
+                            changed.insert(id)
+                        }
                     }
                 }
 
@@ -385,7 +404,7 @@ public struct SessionState: Equatable, Sendable {
     public mutating func removeInvisibleSessions() -> Bool {
         let before = sessionsByID.count
         sessionsByID = sessionsByID.filter { _, session in
-            session.isVisibleInIsland
+            session.isVisibleInIsland || session.isProcessAlive
         }
         return sessionsByID.count != before
     }


### PR DESCRIPTION
## Summary
* Implement process discovery logic for Qwen, successfully identifying `qwen` and `qwen-cli` processes running locally or under package managers like `npm`/`npx`.
* Fix transcript parsing collision by ensuring Qwen `.jsonl` files are looked up under `/.qwen/projects/` appropriately.
* Fix session lifecycle bugs allowing `isProcessAlive` to correctly terminate for hook-managed sessions when dead.
* Add documentation regarding Qwen integration structure.