### PR TITLE
fix: session list not scrollable when content fits panel but exceeds visible area

### DIFF
--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -540,10 +540,14 @@ struct IslandPanelView: View {
                         }
                     }
             } else {
-                // List mode: auto-height (fits content, scrolls only when exceeding max)
-                AutoHeightScrollView(maxHeight: Self.maxSessionListHeight) {
+                // List mode: scroll when content exceeds the panel's available space.
+                // The parent frame constraint (currentHeight - closedNotchHeight - 12)
+                // determines the viewport; ScrollView handles overflow naturally.
+                ScrollView(.vertical) {
                     sessionListContent(context: context)
                 }
+                .scrollIndicators(.hidden)
+                .scrollBounceBehavior(.basedOnSize)
                 .padding(.vertical, 2)
             }
         }


### PR DESCRIPTION
## Summary
- Replace `AutoHeightScrollView(maxHeight: 560)` with plain `ScrollView` + `.scrollBounceBehavior(.basedOnSize)` for the session list in list mode
- `AutoHeightScrollView` only created a `ScrollView` when content exceeded 560pt, but the panel is sized for ~6 rows (~350pt). Sessions beyond 6 were clipped without scroll capability
- Plain `ScrollView` naturally uses the parent frame constraint as viewport, enabling scroll whenever content overflows

## Test plan
- [ ] Open island with 7+ sessions — list should scroll
- [ ] Open island with 2-3 sessions — no bounce, no blank space
- [ ] Notification mode still works as before (not affected by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)