### PR TITLE
fix: auto-install gemini hooks on startup

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1154,6 +1154,7 @@ final class AppModel {
                 if !self.codebuddyHooksInstalled { self.installCodebuddyHooks() }
                 if !self.openCodePluginInstalled { self.installOpenCodePlugin() }
                 if !self.cursorHooksInstalled { self.installCursorHooks() }
+                if !self.geminiHooksInstalled { self.installGeminiHooks() }
                 if !self.claudeUsageInstalled { self.installClaudeUsageBridge() }
 
                 // Run health checks after install to detect stale paths, conflicts, etc.


### PR DESCRIPTION
## Summary
- include Gemini in the startup auto-install pass for managed integrations
- keep Gemini behavior aligned with the install-all setup action

## Verification
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer CLANG_MODULE_CACHE_PATH=/tmp/open-island-clang-cache SWIFTPM_MODULECACHE_OVERRIDE=/tmp/open-island-swiftpm-cache /usr/bin/xcrun swift test --filter OpenIslandCoreTests.GeminiHookTests
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer CLANG_MODULE_CACHE_PATH=/tmp/open-island-clang-cache SWIFTPM_MODULECACHE_OVERRIDE=/tmp/open-island-swiftpm-cache /usr/bin/xcrun swift test --filter OpenIslandAppTests.AppModelSessionListTests
