### PR TITLE
fix: include boundary edges in island hit testing

### DIFF
--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -348,11 +348,11 @@ final class OverlayPanelController {
         guard let model else { return false }
 
         if let closedSurfaceRect = closedSurfaceRect(for: model) {
-            return closedSurfaceRect.contains(screenPoint)
+            return Self.rectContainsIncludingEdges(closedSurfaceRect, point: screenPoint)
         }
 
         let expandedNotch = notchRect.insetBy(dx: -20, dy: -10)
-        return expandedNotch.contains(screenPoint)
+        return Self.rectContainsIncludingEdges(expandedNotch, point: screenPoint)
     }
 
     func isPointInExpandedArea(_ screenPoint: NSPoint) -> Bool {
@@ -370,7 +370,7 @@ final class OverlayPanelController {
             return false
         }
 
-        return contentRect.contains(screenPoint)
+        return Self.rectContainsIncludingEdges(contentRect, point: screenPoint)
     }
 
     func openedPanelWidth(for screen: NSScreen?) -> CGFloat {
@@ -425,6 +425,13 @@ final class OverlayPanelController {
             width: closedWidth,
             height: effectiveHeight
         )
+    }
+
+    nonisolated static func rectContainsIncludingEdges(_ rect: NSRect, point: NSPoint) -> Bool {
+        point.x >= rect.minX
+            && point.x <= rect.maxX
+            && point.y >= rect.minY
+            && point.y <= rect.maxY
     }
 
     nonisolated static func closedPanelWidth(

--- a/Tests/OpenIslandAppTests/OverlayPanelControllerTests.swift
+++ b/Tests/OpenIslandAppTests/OverlayPanelControllerTests.swift
@@ -37,6 +37,15 @@ struct OverlayPanelControllerTests {
     }
 
     @Test
+    func edgeInclusiveHitTestingTreatsMaxBoundaryAsInside() {
+        let rect = NSRect(x: 100, y: 200, width: 224, height: 8)
+        #expect(OverlayPanelController.rectContainsIncludingEdges(rect, point: NSPoint(x: 150, y: 208)))
+        #expect(OverlayPanelController.rectContainsIncludingEdges(rect, point: NSPoint(x: 324, y: 205)))
+        #expect(!OverlayPanelController.rectContainsIncludingEdges(rect, point: NSPoint(x: 325, y: 205)))
+        #expect(!OverlayPanelController.rectContainsIncludingEdges(rect, point: NSPoint(x: 150, y: 209)))
+    }
+
+    @Test
     func hiddenIdleEdgeClosedWidthStaysAtNotchWidth() {
         let width = OverlayPanelController.closedPanelWidth(
             notchWidth: 224,


### PR DESCRIPTION
## Summary
- fix hover hit-testing by treating rectangle edges as inside
- apply edge-inclusive checks to closed and expanded island hit-testing
- add unit test coverage for max-edge boundary behavior

## Verification
- swift test --filter OverlayPanelControllerTests

## Context
This addresses the case where the pointer is exactly on the display top boundary (for example ), which  treats as outside.