### PR TITLE
feat: add Finder reveal shortcut for installed hook configs

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -105,6 +105,7 @@ final class AppModel {
     var codexHealthReport: HookHealthReport? { hooks.codexHealthReport }
     var cursorHooksInstalled: Bool { hooks.cursorHooksInstalled }
     var isCursorHookSetupBusy: Bool { hooks.isCursorHookSetupBusy }
+    var cursorHookStatus: CursorHookInstallationStatus? { hooks.cursorHookStatus }
     var cursorHookStatusTitle: String { hooks.cursorHookStatusTitle }
     var cursorHookStatusSummary: String { hooks.cursorHookStatusSummary }
     var geminiHooksInstalled: Bool { hooks.geminiHooksInstalled }

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -103,6 +103,7 @@
 "setup.permissionsTitle" = "Accessibility";
 "setup.permissionsDesc" = "Open Island may need Accessibility permission to detect terminal windows. Grant it in System Settings → Privacy & Security → Accessibility.";
 "setup.installAll" = "Install All";
+"setup.revealConfigLocation" = "Reveal config in Finder";
 "setup.section.diagnostics" = "Hook Diagnostics";
 "setup.diagnostics.notRun" = "Health check not yet run.";
 "setup.diagnostics.runCheck" = "Run Check";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -103,6 +103,7 @@
 "setup.permissionsTitle" = "辅助功能";
 "setup.permissionsDesc" = "Open Island 可能需要辅助功能权限来检测终端窗口。请在「系统设置 → 隐私与安全性 → 辅助功能」中授权。";
 "setup.installAll" = "全部安装";
+"setup.revealConfigLocation" = "在 Finder 中显示配置";
 "setup.section.diagnostics" = "Hooks 诊断";
 "setup.diagnostics.notRun" = "尚未运行健康检查。";
 "setup.diagnostics.runCheck" = "运行检查";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -103,6 +103,7 @@
 "setup.permissionsTitle" = "輔助使用";
 "setup.permissionsDesc" = "Open Island 可能需要輔助使用權限來偵測終端機視窗。請在「系統設定 → 隱私權與安全性 → 輔助使用」中授權。";
 "setup.installAll" = "全部安裝";
+"setup.revealConfigLocation" = "在 Finder 中顯示設定";
 "setup.section.diagnostics" = "Hooks 診斷";
 "setup.diagnostics.notRun" = "尚未執行健康檢查。";
 "setup.diagnostics.runCheck" = "執行檢查";

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -417,6 +417,7 @@ struct SetupSettingsPane: View {
                     name: "Claude Code",
                     installed: model.claudeHooksInstalled,
                     busy: model.isClaudeHookSetupBusy,
+                    configLocationURL: model.claudeHookStatus?.settingsURL,
                     installAction: { model.installClaudeHooks() },
                     uninstallAction: { confirmingUninstallClaude = true }
                 )
@@ -433,6 +434,7 @@ struct SetupSettingsPane: View {
                     name: "Codex",
                     installed: model.codexHooksInstalled,
                     busy: model.isCodexSetupBusy,
+                    configLocationURL: codexHookConfigURL,
                     installAction: { model.installCodexHooks() },
                     uninstallAction: { confirmingUninstallCodex = true }
                 )
@@ -450,6 +452,7 @@ struct SetupSettingsPane: View {
                     installed: model.openCodePluginInstalled,
                     busy: model.isOpenCodeSetupBusy,
                     requiresBinary: false,
+                    configLocationURL: model.openCodePluginStatus?.configURL,
                     installAction: { model.installOpenCodePlugin() },
                     uninstallAction: { confirmingUninstallOpenCode = true }
                 )
@@ -466,6 +469,7 @@ struct SetupSettingsPane: View {
                     name: "Qoder",
                     installed: model.qoderHooksInstalled,
                     busy: model.isQoderHookSetupBusy,
+                    configLocationURL: model.qoderHookStatus?.settingsURL,
                     installAction: { model.installQoderHooks() },
                     uninstallAction: { confirmingUninstallQoder = true }
                 )
@@ -482,6 +486,7 @@ struct SetupSettingsPane: View {
                     name: "Qwen Code",
                     installed: model.qwenCodeHooksInstalled,
                     busy: model.isQwenCodeHookSetupBusy,
+                    configLocationURL: model.qwenCodeHookStatus?.settingsURL,
                     installAction: { model.installQwenCodeHooks() },
                     uninstallAction: { confirmingUninstallQwenCode = true }
                 )
@@ -498,6 +503,7 @@ struct SetupSettingsPane: View {
                     name: "Factory",
                     installed: model.factoryHooksInstalled,
                     busy: model.isFactoryHookSetupBusy,
+                    configLocationURL: model.factoryHookStatus?.settingsURL,
                     installAction: { model.installFactoryHooks() },
                     uninstallAction: { confirmingUninstallFactory = true }
                 )
@@ -514,6 +520,7 @@ struct SetupSettingsPane: View {
                     name: "CodeBuddy",
                     installed: model.codebuddyHooksInstalled,
                     busy: model.isCodebuddyHookSetupBusy,
+                    configLocationURL: model.codebuddyHookStatus?.settingsURL,
                     installAction: { model.installCodebuddyHooks() },
                     uninstallAction: { confirmingUninstallCodebuddy = true }
                 )
@@ -531,6 +538,7 @@ struct SetupSettingsPane: View {
                     installed: model.cursorHooksInstalled,
                     busy: model.isCursorHookSetupBusy,
                     requiresBinary: true,
+                    configLocationURL: model.cursorHookStatus?.hooksURL,
                     installAction: { model.installCursorHooks() },
                     uninstallAction: { confirmingUninstallCursor = true }
                 )
@@ -547,6 +555,7 @@ struct SetupSettingsPane: View {
                     name: "Gemini CLI",
                     installed: model.geminiHooksInstalled,
                     busy: model.isGeminiHookSetupBusy,
+                    configLocationURL: geminiHookConfigURL,
                     installAction: { model.installGeminiHooks() },
                     uninstallAction: { confirmingUninstallGemini = true }
                 )
@@ -681,6 +690,18 @@ struct SetupSettingsPane: View {
             && model.cursorHooksInstalled && model.geminiHooksInstalled && model.claudeUsageInstalled
     }
 
+    private var codexHookConfigURL: URL? {
+        if let hooksURL = model.codexHookStatus?.hooksURL, FileManager.default.fileExists(atPath: hooksURL.path) {
+            return hooksURL
+        }
+        return model.codexHookStatus?.configURL ?? model.codexHookStatus?.hooksURL
+    }
+
+    private var geminiHookConfigURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".gemini/settings.json")
+    }
+
     private var hasErrors: Bool {
         let claudeErrors = model.claudeHealthReport?.errors.count ?? 0
         let codexErrors = model.codexHealthReport?.errors.count ?? 0
@@ -805,6 +826,7 @@ struct SetupSettingsPane: View {
         installed: Bool,
         busy: Bool,
         requiresBinary: Bool = true,
+        configLocationURL: URL? = nil,
         installAction: @escaping () -> Void,
         uninstallAction: @escaping () -> Void
     ) -> some View {
@@ -813,6 +835,16 @@ struct SetupSettingsPane: View {
             Spacer()
             if installed {
                 HStack(spacing: 8) {
+                    if let configLocationURL {
+                        Button {
+                            revealInFinder(configLocationURL)
+                        } label: {
+                            Image(systemName: "arrow.up.forward.square")
+                                .foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                        .help(lang.t("setup.revealConfigLocation"))
+                    }
                     HStack(spacing: 4) {
                         Image(systemName: "checkmark.circle.fill")
                             .foregroundStyle(.green)
@@ -833,6 +865,21 @@ struct SetupSettingsPane: View {
                 }
                 .disabled(requiresBinary && model.hooksBinaryURL == nil)
             }
+        }
+    }
+
+    private func revealInFinder(_ url: URL) {
+        let fileManager = FileManager.default
+        let standardizedURL = url.standardizedFileURL
+
+        if fileManager.fileExists(atPath: standardizedURL.path) {
+            NSWorkspace.shared.activateFileViewerSelecting([standardizedURL])
+            return
+        }
+
+        let directoryURL = standardizedURL.deletingLastPathComponent()
+        if fileManager.fileExists(atPath: directoryURL.path) {
+            NSWorkspace.shared.open(directoryURL)
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR adds a small Finder reveal shortcut to the Setup page hook list.

When a hook integration is already activated, a jump icon now appears to the left of the activated status. Clicking it reveals the corresponding config file in Finder. If the file does not exist yet, it falls back to opening the parent directory.

## Changes
- Add a reveal button to installed hook rows in the Setup settings page
- Wire each supported integration to its config location
- Add localized tooltip text for the reveal action

## Supported targets
- Claude Code
- Codex
- OpenCode
- Qoder
- Qwen Code
- Factory
- CodeBuddy
- Cursor
- Gemini CLI

## Verification
- Built successfully with [0/1] Planning build
Building for debugging...
[0/9] Copying Localizable.strings
[1/9] Write sources
[2/11] Copying Localizable.strings
[4/11] Write swift-version--58304C5D6DBC2206.txt
[6/10] Emitting module OpenIslandApp
[7/10] Compiling OpenIslandApp SettingsView.swift
[8/10] Compiling OpenIslandApp AppModel.swift
Build complete! (3.76s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Reveal config in Finder" button in settings, enabling quick access to hook configuration file locations. Intelligently opens the parent directory if the config file is missing.
  * Extended localization support with full translations for English, Simplified Chinese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->