### PR TITLE
fix: completion notification content truncated instead of scrollable

### DIFF
--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -23,30 +23,27 @@ private struct AutoHeightScrollView<Content: View>: View {
     @ViewBuilder let content: () -> Content
     @State private var contentHeight: CGFloat = 0
 
-    var body: some View {
-        if contentHeight > maxHeight {
-            // Exceeds max → fixed height, scrollable
-            ScrollView(.vertical) {
-                measuredContent
-            }
-            .scrollIndicators(.hidden)
-            .frame(height: maxHeight)
-        } else {
-            // Fits within max → direct render, auto-height
-            measuredContent
-        }
-    }
+    private var isScrollable: Bool { contentHeight > maxHeight }
 
-    private var measuredContent: some View {
-        content()
-            .background(
-                GeometryReader { geo in
-                    Color.clear.preference(key: ContentHeightKey.self, value: geo.size.height)
+    var body: some View {
+        // Always use ScrollView so the content gets unconstrained vertical
+        // space for measurement.  Without this, a tight parent window can
+        // cap the GeometryReader measurement, making long content appear
+        // truncated instead of scrollable.
+        ScrollView(.vertical) {
+            content()
+                .background(
+                    GeometryReader { geo in
+                        Color.clear.preference(key: ContentHeightKey.self, value: geo.size.height)
+                    }
+                )
+                .onPreferenceChange(ContentHeightKey.self) { height in
+                    if height > 0 { contentHeight = height }
                 }
-            )
-            .onPreferenceChange(ContentHeightKey.self) { height in
-                if height > 0 { contentHeight = height }
-            }
+        }
+        .scrollBounceBehavior(.basedOnSize)
+        .scrollIndicators(isScrollable ? .automatic : .hidden)
+        .frame(height: contentHeight > 0 ? min(contentHeight, maxHeight) : nil)
     }
 }
 


### PR DESCRIPTION
## Summary
- **Fix**: `AutoHeightScrollView` conditionally wrapped content in a `ScrollView` only after measuring `contentHeight > maxHeight`. In notification mode the panel window constrains the layout, so `GeometryReader` reported the capped height — the threshold was never reached and long content was silently clipped.
- **Change**: Always render inside a `ScrollView` so content gets unconstrained vertical space for measurement, and show scroll indicators (`.automatic`) when content is scrollable.

## Test plan
- [ ] Trigger a completion notification with a long assistant message — content should scroll instead of being truncated
- [ ] Verify short completion messages still render without unnecessary blank space
- [ ] Check scroll indicators appear only when content exceeds the max height

🤖 Generated with [Claude Code](https://claude.com/claude-code)