### PR TITLE
chore: add external contributor thanks convention to release template

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -5,8 +5,10 @@ Brief English summary of this release.
 
 ### Changes since vPREV | 自 vPREV 以来的变更
 
-- **Category**: English description (#PR)
+- **Category**: English description (#PR) — Thanks @contributor
   中文描述 (#PR)
+
+> Add `— Thanks @contributor` to entries from external contributors.
 
 ### Contributors | 贡献者
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ Open `Package.swift` in Xcode for the app target. Requires macOS 14+, Swift 6.2.
 
 - **Bilingual required**: Every release MUST include both English and Chinese (Simplified) descriptions. Use the template in `.github/RELEASE_TEMPLATE.md`.
 - Before creating a release, fetch remote `main` and review ALL merged PRs since the last tag to avoid missing changes.
-- Each changelog entry follows the format: `- **Category**: English description (#PR)\n  中文描述 (#PR)`
+- Each changelog entry follows the format: `- **Category**: English description (#PR)\n  中文描述 (#PR)`. For external contributors, append `— Thanks @username` to the English line.
 - The release title follows: `Open Island vX.Y.Z — Short English Title`
 - The Installation section must be bilingual.
 - Release is triggered by pushing a `v*` tag to `main`. The GitHub Actions workflow builds, signs, notarizes, and publishes the DMG automatically.


### PR DESCRIPTION
## Summary
- Add `— Thanks @contributor` convention to `.github/RELEASE_TEMPLATE.md` for external contributor entries
- Document the convention in `CLAUDE.md` Release Policy section

## Test plan
- [ ] Verify template renders correctly in future releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)