### PR TITLE
feat: detect Cursor AskQuestion via transcript monitoring

### DIFF
--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -63,6 +63,7 @@ public final class BridgeServer: @unchecked Sendable {
     private var pendingClaudeInteractions: [String: PendingClaudeInteraction] = [:]
     private var pendingOpenCodeInteractions: [String: PendingOpenCodeInteraction] = [:]
     private var pendingCursorInteractions: [String: PendingCursorInteraction] = [:]
+    private var cursorTranscriptWatchers: [String: CursorTranscriptWatcher] = [:]
     /// Caches Agent tool description from preToolUse for use by the next subagentStart.
     private var pendingAgentDescriptions: [String: String] = [:]
     /// Maps toolUseID → temporary task ID for TaskCreate, so postToolUse can update with real ID.
@@ -177,6 +178,11 @@ public final class BridgeServer: @unchecked Sendable {
         pendingClaudeToolContexts.removeAll()
         pendingOpenCodeInteractions.removeAll()
         pendingCursorInteractions.removeAll()
+
+        for (_, watcher) in cursorTranscriptWatchers {
+            watcher.stop()
+        }
+        cursorTranscriptWatchers.removeAll()
 
         let activeConnections = Array(clients.values)
         activeConnections.forEach { $0.readSource.cancel() }
@@ -1190,6 +1196,7 @@ public final class BridgeServer: @unchecked Sendable {
             ensureCursorSessionExists(for: payload)
             synchronizeCursorJumpTarget(for: payload)
             synchronizeCursorMetadata(for: payload)
+            stopCursorTranscriptWatcher(for: payload.sessionID)
             let stopSummary: String
             switch payload.status {
             case "error":
@@ -1469,6 +1476,44 @@ public final class BridgeServer: @unchecked Sendable {
                 CursorSessionMetadataUpdated(
                     sessionID: payload.sessionID,
                     cursorMetadata: merged,
+                    timestamp: .now
+                )
+            )
+        )
+
+        startCursorTranscriptWatcherIfNeeded(sessionID: payload.sessionID, transcriptPath: resolvedTranscriptPath)
+    }
+
+    private func startCursorTranscriptWatcherIfNeeded(sessionID: String, transcriptPath: String?) {
+        guard let path = transcriptPath,
+              cursorTranscriptWatchers[sessionID] == nil else {
+            return
+        }
+
+        let watcher = CursorTranscriptWatcher(
+            sessionID: sessionID,
+            transcriptPath: path
+        ) { [weak self] sessionID, prompt in
+            self?.handleCursorQuestionDetected(sessionID: sessionID, prompt: prompt)
+        }
+
+        cursorTranscriptWatchers[sessionID] = watcher
+        watcher.start()
+    }
+
+    private func stopCursorTranscriptWatcher(for sessionID: String) {
+        guard let watcher = cursorTranscriptWatchers.removeValue(forKey: sessionID) else {
+            return
+        }
+        watcher.stop()
+    }
+
+    private func handleCursorQuestionDetected(sessionID: String, prompt: QuestionPrompt) {
+        emit(
+            .questionAsked(
+                QuestionAsked(
+                    sessionID: sessionID,
+                    prompt: prompt,
                     timestamp: .now
                 )
             )

--- a/Sources/OpenIslandCore/CursorTranscriptWatcher.swift
+++ b/Sources/OpenIslandCore/CursorTranscriptWatcher.swift
@@ -1,0 +1,196 @@
+import Foundation
+
+/// Watches a Cursor transcript JSONL file for AskQuestion tool-use entries.
+///
+/// Cursor does not fire hook events for its built-in AskQuestion tool, so this
+/// watcher monitors the transcript file as an alternative detection path.
+/// When an AskQuestion entry is found, the watcher emits a `QuestionPrompt`
+/// through its callback so the caller can display it in the UI.
+public final class CursorTranscriptWatcher: @unchecked Sendable {
+    public typealias QuestionHandler = @Sendable (String, QuestionPrompt) -> Void
+
+    private let sessionID: String
+    private let filePath: String
+    private let onQuestion: QuestionHandler
+
+    private var fileOffset: UInt64 = 0
+    private var dispatchSource: DispatchSourceFileSystemObject?
+    private let queue = DispatchQueue(label: "app.openisland.cursor-transcript-watcher")
+
+    /// Set of AskQuestion tool_use_id values already processed, to avoid duplicates.
+    private var seenToolUseIDs: Set<String> = []
+
+    public init(sessionID: String, transcriptPath: String, onQuestion: @escaping QuestionHandler) {
+        self.sessionID = sessionID
+        self.filePath = transcriptPath
+        self.onQuestion = onQuestion
+    }
+
+    deinit {
+        stop()
+    }
+
+    // MARK: - Lifecycle
+
+    public func start() {
+        queue.async { [weak self] in
+            self?.setupWatcher()
+        }
+    }
+
+    public func stop() {
+        queue.async { [weak self] in
+            self?.dispatchSource?.cancel()
+            self?.dispatchSource = nil
+        }
+    }
+
+    // MARK: - File watching
+
+    private func setupWatcher() {
+        guard FileManager.default.fileExists(atPath: filePath) else { return }
+
+        // Seek to the end so we only process new content from this point forward.
+        if let handle = FileHandle(forReadingAtPath: filePath) {
+            handle.seekToEndOfFile()
+            fileOffset = handle.offsetInFile
+            handle.closeFile()
+        }
+
+        guard let fd = open(filePath, O_RDONLY | O_EVTONLY) else { return }
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .extend],
+            queue: queue
+        )
+
+        source.setEventHandler { [weak self] in
+            self?.readNewContent()
+        }
+
+        source.setCancelHandler {
+            close(fd)
+        }
+
+        dispatchSource = source
+        source.resume()
+    }
+
+    private func readNewContent() {
+        guard let handle = FileHandle(forReadingAtPath: filePath) else { return }
+        defer { handle.closeFile() }
+
+        handle.seek(toFileOffset: fileOffset)
+        let data = handle.readDataToEndOfFile()
+        guard !data.isEmpty else { return }
+
+        fileOffset = handle.offsetInFile
+
+        guard let text = String(data: data, encoding: .utf8) else { return }
+
+        let lines = text.components(separatedBy: "\n")
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            processLine(trimmed)
+        }
+    }
+
+    // MARK: - Parsing
+
+    private func processLine(_ jsonLine: String) {
+        guard let lineData = jsonLine.data(using: .utf8),
+              let entry = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+              entry["role"] as? String == "assistant",
+              let message = entry["message"] as? [String: Any],
+              let content = message["content"] as? [[String: Any]] else {
+            return
+        }
+
+        for block in content {
+            guard block["type"] as? String == "tool_use",
+                  block["name"] as? String == "AskQuestion",
+                  let input = block["input"] as? [String: Any] else {
+                continue
+            }
+
+            let toolUseID = block["id"] as? String ?? UUID().uuidString
+            guard !seenToolUseIDs.contains(toolUseID) else { continue }
+            seenToolUseIDs.insert(toolUseID)
+
+            if let prompt = Self.parseQuestionPrompt(from: input) {
+                onQuestion(sessionID, prompt)
+            }
+        }
+    }
+
+    /// Parses a Cursor AskQuestion tool input into a `QuestionPrompt`.
+    ///
+    /// The input shape mirrors Cursor's AskQuestion tool schema:
+    /// ```json
+    /// {
+    ///   "title": "...",
+    ///   "questions": [
+    ///     {
+    ///       "id": "...",
+    ///       "prompt": "...",
+    ///       "options": [{"id": "...", "label": "..."}],
+    ///       "allow_multiple": false
+    ///     }
+    ///   ]
+    /// }
+    /// ```
+    public static func parseQuestionPrompt(from input: [String: Any]) -> QuestionPrompt? {
+        guard let rawQuestions = input["questions"] as? [[String: Any]],
+              !rawQuestions.isEmpty else {
+            return nil
+        }
+
+        let questions = rawQuestions.compactMap { rawQuestion -> QuestionPromptItem? in
+            guard let prompt = rawQuestion["prompt"] as? String,
+                  let rawOptions = rawQuestion["options"] as? [[String: Any]],
+                  !rawOptions.isEmpty else {
+                return nil
+            }
+
+            let header = rawQuestion["id"] as? String ?? ""
+            let multiSelect = rawQuestion["allow_multiple"] as? Bool ?? false
+
+            let options = rawOptions.compactMap { rawOption -> QuestionOption? in
+                guard let label = rawOption["label"] as? String else { return nil }
+                let description = rawOption["id"] as? String ?? ""
+                return QuestionOption(label: label, description: description)
+            }
+
+            guard !options.isEmpty else { return nil }
+
+            return QuestionPromptItem(
+                question: prompt,
+                header: header,
+                options: options,
+                multiSelect: multiSelect
+            )
+        }
+
+        guard !questions.isEmpty else { return nil }
+
+        let title: String
+        if let explicitTitle = input["title"] as? String, !explicitTitle.isEmpty {
+            title = explicitTitle
+        } else if questions.count == 1, let firstQuestion = questions.first?.question {
+            title = firstQuestion
+        } else {
+            title = "Cursor has \(questions.count) questions for you."
+        }
+
+        return QuestionPrompt(title: title, questions: questions)
+    }
+}
+
+// MARK: - open() helper
+
+private func open(_ path: String, _ flags: Int32) -> Int32? {
+    let fd = Darwin.open(path, flags)
+    return fd >= 0 ? fd : nil
+}

--- a/Tests/OpenIslandCoreTests/CursorTranscriptWatcherTests.swift
+++ b/Tests/OpenIslandCoreTests/CursorTranscriptWatcherTests.swift
@@ -1,0 +1,265 @@
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+struct CursorTranscriptWatcherTests {
+
+    // MARK: - parseQuestionPrompt
+
+    @Test
+    func parseSingleQuestion() throws {
+        let input: [String: Any] = [
+            "title": "Pick a framework",
+            "questions": [
+                [
+                    "id": "q1",
+                    "prompt": "Which framework do you prefer?",
+                    "options": [
+                        ["id": "react", "label": "React"],
+                        ["id": "vue", "label": "Vue"],
+                    ],
+                ] as [String: Any],
+            ],
+        ]
+
+        let prompt = CursorTranscriptWatcher.parseQuestionPrompt(from: input)
+        #expect(prompt != nil)
+        #expect(prompt?.title == "Pick a framework")
+        #expect(prompt?.questions.count == 1)
+        #expect(prompt?.questions.first?.question == "Which framework do you prefer?")
+        #expect(prompt?.questions.first?.options.count == 2)
+        #expect(prompt?.questions.first?.options[0].label == "React")
+        #expect(prompt?.questions.first?.options[1].label == "Vue")
+        #expect(prompt?.questions.first?.multiSelect == false)
+    }
+
+    @Test
+    func parseMultipleQuestions() throws {
+        let input: [String: Any] = [
+            "title": "Setup preferences",
+            "questions": [
+                [
+                    "id": "lang",
+                    "prompt": "Language?",
+                    "options": [
+                        ["id": "ts", "label": "TypeScript"],
+                        ["id": "py", "label": "Python"],
+                    ],
+                ] as [String: Any],
+                [
+                    "id": "db",
+                    "prompt": "Database?",
+                    "options": [
+                        ["id": "pg", "label": "PostgreSQL"],
+                        ["id": "mysql", "label": "MySQL"],
+                    ],
+                    "allow_multiple": true,
+                ] as [String: Any],
+            ],
+        ]
+
+        let prompt = CursorTranscriptWatcher.parseQuestionPrompt(from: input)
+        #expect(prompt != nil)
+        #expect(prompt?.title == "Setup preferences")
+        #expect(prompt?.questions.count == 2)
+        #expect(prompt?.questions[1].multiSelect == true)
+    }
+
+    @Test
+    func parseQuestionWithNoTitle() throws {
+        let input: [String: Any] = [
+            "questions": [
+                [
+                    "id": "q1",
+                    "prompt": "Continue?",
+                    "options": [
+                        ["id": "yes", "label": "Yes"],
+                        ["id": "no", "label": "No"],
+                    ],
+                ] as [String: Any],
+            ],
+        ]
+
+        let prompt = CursorTranscriptWatcher.parseQuestionPrompt(from: input)
+        #expect(prompt != nil)
+        #expect(prompt?.title == "Continue?")
+    }
+
+    @Test
+    func parseEmptyQuestionsReturnsNil() throws {
+        let input: [String: Any] = ["questions": [] as [[String: Any]]]
+        let prompt = CursorTranscriptWatcher.parseQuestionPrompt(from: input)
+        #expect(prompt == nil)
+    }
+
+    @Test
+    func parseMissingQuestionsReturnsNil() throws {
+        let input: [String: Any] = ["title": "No questions here"]
+        let prompt = CursorTranscriptWatcher.parseQuestionPrompt(from: input)
+        #expect(prompt == nil)
+    }
+
+    @Test
+    func parseQuestionWithEmptyOptionsReturnsNil() throws {
+        let input: [String: Any] = [
+            "questions": [
+                [
+                    "id": "q1",
+                    "prompt": "Pick one",
+                    "options": [] as [[String: Any]],
+                ] as [String: Any],
+            ],
+        ]
+        let prompt = CursorTranscriptWatcher.parseQuestionPrompt(from: input)
+        #expect(prompt == nil)
+    }
+
+    // MARK: - File watching integration
+
+    @Test
+    func watcherDetectsAskQuestionInNewContent() async throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cursor-watcher-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let transcriptPath = tmpDir.appendingPathComponent("transcript.jsonl").path
+
+        FileManager.default.createFile(atPath: transcriptPath, contents: Data())
+
+        let expectation = Expectation()
+        var receivedPrompt: QuestionPrompt?
+        var receivedSessionID: String?
+
+        let watcher = CursorTranscriptWatcher(
+            sessionID: "test-session-123",
+            transcriptPath: transcriptPath
+        ) { sessionID, prompt in
+            receivedSessionID = sessionID
+            receivedPrompt = prompt
+            expectation.fulfill()
+        }
+
+        watcher.start()
+
+        try await Task.sleep(for: .milliseconds(200))
+
+        let askQuestionLine = """
+        {"role":"assistant","message":{"content":[{"type":"tool_use","name":"AskQuestion","id":"tool-1","input":{"title":"Test Question","questions":[{"id":"q1","prompt":"Pick one","options":[{"id":"a","label":"Option A"},{"id":"b","label":"Option B"}]}]}}]}}
+        """
+        let handle = FileHandle(forWritingAtPath: transcriptPath)!
+        handle.seekToEndOfFile()
+        handle.write(Data((askQuestionLine + "\n").utf8))
+        handle.closeFile()
+
+        await expectation.fulfillment(within: .seconds(3))
+
+        #expect(receivedSessionID == "test-session-123")
+        #expect(receivedPrompt != nil)
+        #expect(receivedPrompt?.title == "Test Question")
+        #expect(receivedPrompt?.questions.count == 1)
+        #expect(receivedPrompt?.questions.first?.options.count == 2)
+
+        watcher.stop()
+    }
+
+    @Test
+    func watcherIgnoresNonAskQuestionLines() async throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cursor-watcher-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let transcriptPath = tmpDir.appendingPathComponent("transcript.jsonl").path
+        FileManager.default.createFile(atPath: transcriptPath, contents: Data())
+
+        var questionCount = 0
+
+        let watcher = CursorTranscriptWatcher(
+            sessionID: "test-session",
+            transcriptPath: transcriptPath
+        ) { _, _ in
+            questionCount += 1
+        }
+
+        watcher.start()
+        try await Task.sleep(for: .milliseconds(200))
+
+        let shellLine = """
+        {"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"ls"}}]}}
+        """
+        let readLine = """
+        {"role":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"path":"/tmp/test.txt"}}]}}
+        """
+        let handle = FileHandle(forWritingAtPath: transcriptPath)!
+        handle.seekToEndOfFile()
+        handle.write(Data((shellLine + "\n" + readLine + "\n").utf8))
+        handle.closeFile()
+
+        try await Task.sleep(for: .seconds(1))
+        #expect(questionCount == 0)
+
+        watcher.stop()
+    }
+
+    @Test
+    func watcherDoesNotDuplicateQuestions() async throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cursor-watcher-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let transcriptPath = tmpDir.appendingPathComponent("transcript.jsonl").path
+        FileManager.default.createFile(atPath: transcriptPath, contents: Data())
+
+        var questionCount = 0
+
+        let watcher = CursorTranscriptWatcher(
+            sessionID: "test-session",
+            transcriptPath: transcriptPath
+        ) { _, _ in
+            questionCount += 1
+        }
+
+        watcher.start()
+        try await Task.sleep(for: .milliseconds(200))
+
+        let askQuestionLine = """
+        {"role":"assistant","message":{"content":[{"type":"tool_use","name":"AskQuestion","id":"tool-same-id","input":{"title":"Q","questions":[{"id":"q1","prompt":"Pick","options":[{"id":"a","label":"A"},{"id":"b","label":"B"}]}]}}]}}
+        """
+
+        let handle1 = FileHandle(forWritingAtPath: transcriptPath)!
+        handle1.seekToEndOfFile()
+        handle1.write(Data((askQuestionLine + "\n").utf8))
+        handle1.closeFile()
+
+        try await Task.sleep(for: .seconds(1))
+        #expect(questionCount == 1)
+
+        watcher.stop()
+    }
+
+    // MARK: - Expectation helper
+
+    private final class Expectation: @unchecked Sendable {
+        private var fulfilled = false
+        private let lock = NSLock()
+
+        func fulfill() {
+            lock.lock()
+            fulfilled = true
+            lock.unlock()
+        }
+
+        func fulfillment(within duration: Duration) async {
+            let deadline = ContinuousClock.now + duration
+            while ContinuousClock.now < deadline {
+                lock.lock()
+                let done = fulfilled
+                lock.unlock()
+                if done { return }
+                try? await Task.sleep(for: .milliseconds(50))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Cursor's built-in `AskQuestion` tool does **not** trigger any Cursor hooks (`preToolUse`, `postToolUse`, etc.), but it **is** recorded in the transcript JSONL file. This PR adds a lightweight transcript file watcher that detects `AskQuestion` entries and surfaces them in the notch — clicking jumps to Cursor so the user can answer in the native UI.

### Changes

- **`CursorTranscriptWatcher.swift`** (new): Monitors a Cursor transcript JSONL file using `DispatchSource.makeFileSystemObjectSource`. Incrementally reads new content, detects `AskQuestion` tool_use entries, parses them into `QuestionPrompt`, and invokes a callback. Deduplicates by `tool_use_id`.
- **`BridgeServer.swift`** (+45 lines): Integrates watcher lifecycle — starts monitoring when Cursor session metadata is synced (transcript path available), stops on session end or server shutdown. Emits `questionAsked` event on detection.
- **`CursorTranscriptWatcherTests.swift`** (new): 7 unit tests covering `parseQuestionPrompt` for single-select, multi-select, title-only, and malformed inputs.

### How it works

1. Cursor session starts → hook fires → `BridgeServer` receives session metadata including transcript path
2. `CursorTranscriptWatcher` begins monitoring the transcript file
3. Agent calls `AskQuestion` → written to transcript → watcher detects it
4. Notch pops up showing the question title (yellow `waitingForAnswer` state)
5. User clicks the notch → jumps to Cursor → answers in native AskQuestion UI
6. Session ends → watcher stops automatically

### Design decisions

- **No view code changes**: Zero modifications to `IslandPanelView`, `StructuredQuestionPromptView`, or any SwiftUI views. Uses existing `questionAsked` event path.
- **Minimal surface area**: Only 3 files changed, all in `OpenIslandCore` (plus tests).
- **Incremental reading**: Reads from last file offset, not full re-parse — efficient for large transcripts.

## Test plan

- [x] `parseQuestionPrompt` unit tests pass (single-select, multi-select, title-only, malformed)
- [x] `OpenIslandCore` target compiles cleanly
- [x] Manual testing: notch pops up with question title, click-to-jump works

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transcript monitoring to detect questions in real-time from Cursor sessions.
  * Questions trigger events with parsed details and timestamps when detected.

* **Tests**
  * Added comprehensive test coverage for question detection, including single/multiple question parsing and duplicate prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->