### PR TITLE
fix: suppress notifications for frontmost terminal sessions

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -415,6 +415,9 @@ final class AppModel {
     @ObservationIgnored
     private let terminalJumpAction: @Sendable (JumpTarget) throws -> String
 
+    @ObservationIgnored
+    private let isNotificationSessionAlreadyFrontmost: @Sendable (AgentSession) -> Bool
+
 
     @ObservationIgnored
     var harnessRuntimeMonitor: HarnessRuntimeMonitor?
@@ -426,9 +429,13 @@ final class AppModel {
     init(
         terminalJumpAction: @escaping @Sendable (JumpTarget) throws -> String = { target in
             try TerminalJumpService().jump(to: target)
+        },
+        isNotificationSessionAlreadyFrontmost: @escaping @Sendable (AgentSession) -> Bool = { session in
+            ForegroundTerminalSessionProbe().matches(session: session)
         }
     ) {
         self.terminalJumpAction = terminalJumpAction
+        self.isNotificationSessionAlreadyFrontmost = isNotificationSessionAlreadyFrontmost
         UserDefaults.standard.register(defaults: [
             Self.showDockIconDefaultsKey: true,
             Self.hapticFeedbackEnabledDefaultsKey: false,
@@ -1155,9 +1162,19 @@ final class AppModel {
            !wasAlreadyCompleted,
            surface.sessionID.flatMap({ state.session(id: $0) }) != nil,
            (ingress == .bridge || !isResolvingInitialLiveSessions),
-           notchStatus == .closed || notchOpenReason == .notification {
+           notchStatus == .closed || notchOpenReason == .notification,
+           !shouldSuppressNotificationSurface(surface) {
             presentNotificationSurface(surface)
         }
+    }
+
+    private func shouldSuppressNotificationSurface(_ surface: IslandSurface) -> Bool {
+        guard let sessionID = surface.sessionID,
+              let session = state.session(id: sessionID) else {
+            return false
+        }
+
+        return isNotificationSessionAlreadyFrontmost(session)
     }
 
     private func synchronizeSelection() {

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -416,7 +416,7 @@ final class AppModel {
     private let terminalJumpAction: @Sendable (JumpTarget) throws -> String
 
     @ObservationIgnored
-    private let isNotificationSessionAlreadyFrontmost: @Sendable (AgentSession) -> Bool
+    private let isNotificationSessionAlreadyFrontmost: @Sendable (AgentSession) async -> Bool
 
 
     @ObservationIgnored
@@ -426,12 +426,15 @@ final class AppModel {
     @ObservationIgnored
     private var jumpTask: Task<Void, Never>?
 
+    @ObservationIgnored
+    private var notificationPresentationTask: Task<Void, Never>?
+
     init(
         terminalJumpAction: @escaping @Sendable (JumpTarget) throws -> String = { target in
             try TerminalJumpService().jump(to: target)
         },
-        isNotificationSessionAlreadyFrontmost: @escaping @Sendable (AgentSession) -> Bool = { session in
-            ForegroundTerminalSessionProbe().matches(session: session)
+        isNotificationSessionAlreadyFrontmost: @escaping @Sendable (AgentSession) async -> Bool = { session in
+            await ForegroundTerminalSessionProbe().matches(session: session)
         }
     ) {
         self.terminalJumpAction = terminalJumpAction
@@ -1158,23 +1161,56 @@ final class AppModel {
             lastActionMessage = describe(event)
         }
 
-        if let surface = IslandSurface.notificationSurface(for: event),
-           !wasAlreadyCompleted,
-           surface.sessionID.flatMap({ state.session(id: $0) }) != nil,
-           (ingress == .bridge || !isResolvingInitialLiveSessions),
-           notchStatus == .closed || notchOpenReason == .notification,
-           !shouldSuppressNotificationSurface(surface) {
-            presentNotificationSurface(surface)
+        if let surface = IslandSurface.notificationSurface(for: event) {
+            scheduleNotificationSurfacePresentationIfNeeded(
+                surface,
+                wasAlreadyCompleted: wasAlreadyCompleted,
+                ingress: ingress
+            )
         }
     }
 
-    private func shouldSuppressNotificationSurface(_ surface: IslandSurface) -> Bool {
+    private func scheduleNotificationSurfacePresentationIfNeeded(
+        _ surface: IslandSurface,
+        wasAlreadyCompleted: Bool,
+        ingress: TrackedEventIngress
+    ) {
+        guard !wasAlreadyCompleted,
+              notificationSurfaceIsEligibleForPresentation(surface, ingress: ingress),
+              let sessionID = surface.sessionID,
+              let session = state.session(id: sessionID) else {
+            return
+        }
+
+        notificationPresentationTask?.cancel()
+        notificationPresentationTask = Task { @MainActor [weak self] in
+            guard let self else {
+                return
+            }
+
+            let shouldSuppress = await self.isNotificationSessionAlreadyFrontmost(session)
+            guard !Task.isCancelled,
+                  !shouldSuppress,
+                  self.notificationSurfaceIsEligibleForPresentation(surface, ingress: ingress) else {
+                return
+            }
+
+            self.presentNotificationSurface(surface)
+        }
+    }
+
+    private func notificationSurfaceIsEligibleForPresentation(
+        _ surface: IslandSurface,
+        ingress: TrackedEventIngress
+    ) -> Bool {
         guard let sessionID = surface.sessionID,
               let session = state.session(id: sessionID) else {
             return false
         }
 
-        return isNotificationSessionAlreadyFrontmost(session)
+        return (ingress == .bridge || !isResolvingInitialLiveSessions)
+            && (notchStatus == .closed || notchOpenReason == .notification)
+            && surface.matchesCurrentState(of: session)
     }
 
     private func synchronizeSelection() {

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -17,6 +17,7 @@ final class AppModel {
     private static let islandStatusColorsDefaultsKey = "appearance.island.statusColors"
     private static let showCodexUsageDefaultsKey = "app.showCodexUsage"
     private static let completionReplyEnabledDefaultsKey = "feature.completionReply.enabled"
+    private static let suppressFrontmostNotificationsDefaultsKey = "app.suppressFrontmostNotifications"
 
     static let defaultStatusColors: [SessionPhase: String] = [
         .running: "#6E9FFF",
@@ -207,6 +208,12 @@ final class AppModel {
             guard hasFinishedInit, completionReplyEnabled != oldValue else { return }
             UserDefaults.standard.set(completionReplyEnabled, forKey: Self.completionReplyEnabledDefaultsKey)
             refreshOverlayPlacementIfVisible()
+        }
+    }
+    var suppressFrontmostNotifications: Bool = true {
+        didSet {
+            guard hasFinishedInit, suppressFrontmostNotifications != oldValue else { return }
+            UserDefaults.standard.set(suppressFrontmostNotifications, forKey: Self.suppressFrontmostNotificationsDefaultsKey)
         }
     }
     var isSoundMuted = false {
@@ -443,11 +450,13 @@ final class AppModel {
             Self.showDockIconDefaultsKey: true,
             Self.hapticFeedbackEnabledDefaultsKey: false,
             Self.completionReplyEnabledDefaultsKey: false,
+            Self.suppressFrontmostNotificationsDefaultsKey: true,
         ])
         isSoundMuted = UserDefaults.standard.bool(forKey: Self.soundMutedDefaultsKey)
         selectedSoundName = NotificationSoundService.selectedSoundName
         showDockIcon = UserDefaults.standard.bool(forKey: Self.showDockIconDefaultsKey)
         hapticFeedbackEnabled = UserDefaults.standard.bool(forKey: Self.hapticFeedbackEnabledDefaultsKey)
+        suppressFrontmostNotifications = UserDefaults.standard.bool(forKey: Self.suppressFrontmostNotificationsDefaultsKey)
         if UserDefaults.standard.object(forKey: Self.showCodexUsageDefaultsKey) != nil {
             showCodexUsage = UserDefaults.standard.bool(forKey: Self.showCodexUsageDefaultsKey)
         } else {
@@ -1179,6 +1188,11 @@ final class AppModel {
               notificationSurfaceIsEligibleForPresentation(surface, ingress: ingress),
               let sessionID = surface.sessionID,
               let session = state.session(id: sessionID) else {
+            return
+        }
+
+        guard suppressFrontmostNotifications else {
+            presentNotificationSurface(surface)
             return
         }
 

--- a/Sources/OpenIslandApp/ForegroundTerminalSessionProbe.swift
+++ b/Sources/OpenIslandApp/ForegroundTerminalSessionProbe.swift
@@ -4,13 +4,56 @@ import OpenIslandCore
 
 struct ForegroundTerminalSessionProbe {
     typealias FrontmostBundleIdentifierProvider = @Sendable () -> String?
-    typealias AppleScriptRunner = @Sendable (String) throws -> String
+    typealias AppleScriptRunner = @Sendable (String) async throws -> String
 
     private static let fieldSeparator = "\u{1f}"
+    private static let appleScriptTimeout: DispatchTimeInterval = .seconds(1)
+
+    private final class ContinuationBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var hasResumed = false
+
+        func resumeOnce(_ action: () -> Void) {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !hasResumed else {
+                return
+            }
+
+            hasResumed = true
+            action()
+        }
+    }
+
+    private final class PipeBox: @unchecked Sendable {
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+
+        func outputString() -> String {
+            String(
+                data: outputPipe.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        }
+
+        func errorString() -> String {
+            String(
+                data: errorPipe.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        }
+
+        func closePipes() {
+            try? outputPipe.fileHandleForReading.close()
+            try? errorPipe.fileHandleForReading.close()
+        }
+    }
 
     private let frontmostBundleIdentifierProvider: FrontmostBundleIdentifierProvider
     private let appleScriptRunner: AppleScriptRunner
 
+    /// Returns `true` when the provided session already owns the focused
+    /// surface of the current frontmost terminal app.
     init(
         frontmostBundleIdentifierProvider: @escaping FrontmostBundleIdentifierProvider = {
             NSWorkspace.shared.frontmostApplication?.bundleIdentifier
@@ -21,11 +64,11 @@ struct ForegroundTerminalSessionProbe {
         self.appleScriptRunner = appleScriptRunner
     }
 
-    func matches(session: AgentSession) -> Bool {
-        matches(jumpTarget: session.jumpTarget)
+    func matches(session: AgentSession) async -> Bool {
+        await matches(jumpTarget: session.jumpTarget)
     }
 
-    func matches(jumpTarget: JumpTarget?) -> Bool {
+    func matches(jumpTarget: JumpTarget?) async -> Bool {
         guard let jumpTarget,
               let frontmostBundleIdentifier = frontmostBundleIdentifierProvider() else {
             return false
@@ -33,21 +76,21 @@ struct ForegroundTerminalSessionProbe {
 
         switch frontmostBundleIdentifier {
         case "com.mitchellh.ghostty":
-            guard let focusedTerminalID = ghosttyFocusedTerminalID(),
+            guard let focusedTerminalID = await ghosttyFocusedTerminalID(),
                   let sessionTerminalID = nonEmptyValue(jumpTarget.terminalSessionID) else {
                 return false
             }
             return focusedTerminalID == sessionTerminalID
 
         case "com.apple.Terminal":
-            guard let focusedTTY = normalizedTTY(terminalFocusedTTY()),
+            guard let focusedTTY = normalizedTTY(await terminalFocusedTTY()),
                   let sessionTTY = normalizedTTY(jumpTarget.terminalTTY) else {
                 return false
             }
             return focusedTTY == sessionTTY
 
         case "com.googlecode.iterm2":
-            let focusedSession = itermFocusedSession()
+            let focusedSession = await itermFocusedSession()
 
             if let focusedSessionID = focusedSession?.sessionID,
                let sessionTerminalID = nonEmptyValue(jumpTarget.terminalSessionID),
@@ -68,7 +111,7 @@ struct ForegroundTerminalSessionProbe {
         }
     }
 
-    private func ghosttyFocusedTerminalID() -> String? {
+    private func ghosttyFocusedTerminalID() async -> String? {
         let script = """
         tell application "Ghostty"
             if not (it is running) then return ""
@@ -76,10 +119,10 @@ struct ForegroundTerminalSessionProbe {
         end tell
         """
 
-        return nonEmptyValue(try? appleScriptRunner(script))
+        return nonEmptyValue(try? await appleScriptRunner(script))
     }
 
-    private func terminalFocusedTTY() -> String? {
+    private func terminalFocusedTTY() async -> String? {
         let script = """
         tell application "Terminal"
             if not (it is running) then return ""
@@ -87,10 +130,10 @@ struct ForegroundTerminalSessionProbe {
         end tell
         """
 
-        return nonEmptyValue(try? appleScriptRunner(script))
+        return nonEmptyValue(try? await appleScriptRunner(script))
     }
 
-    private func itermFocusedSession() -> (sessionID: String?, tty: String?)? {
+    private func itermFocusedSession() async -> (sessionID: String?, tty: String?)? {
         let script = """
         tell application "iTerm"
             if not (it is running) then return ""
@@ -100,7 +143,7 @@ struct ForegroundTerminalSessionProbe {
         end tell
         """
 
-        guard let output = nonEmptyValue(try? appleScriptRunner(script)) else {
+        guard let output = nonEmptyValue(try? await appleScriptRunner(script)) else {
             return nil
         }
 
@@ -132,34 +175,63 @@ struct ForegroundTerminalSessionProbe {
         return trimmed.hasPrefix("/dev/") ? trimmed : "/dev/\(trimmed)"
     }
 
-    private static func runAppleScript(_ script: String) throws -> String {
+    private static func runAppleScript(_ script: String) async throws -> String {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
         process.arguments = ["-e", script]
 
-        let outputPipe = Pipe()
-        let errorPipe = Pipe()
-        process.standardOutput = outputPipe
-        process.standardError = errorPipe
+        let pipeBox = PipeBox()
+        process.standardOutput = pipeBox.outputPipe
+        process.standardError = pipeBox.errorPipe
 
-        try process.run()
-        process.waitUntilExit()
+        return try await withCheckedThrowingContinuation { continuation in
+            let continuationBox = ContinuationBox()
 
-        let output = String(
-            data: outputPipe.fileHandleForReading.readDataToEndOfFile(),
-            encoding: .utf8
-        )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let finish: @Sendable (Result<String, Error>) -> Void = { result in
+                continuationBox.resumeOnce {
+                    continuation.resume(with: result)
+                }
+            }
 
-        guard process.terminationStatus == 0 else {
-            let errorText = String(
-                data: errorPipe.fileHandleForReading.readDataToEndOfFile(),
-                encoding: .utf8
-            )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            throw NSError(domain: "ForegroundTerminalSessionProbe", code: Int(process.terminationStatus), userInfo: [
-                NSLocalizedDescriptionKey: errorText.isEmpty ? "AppleScript probe failed." : errorText,
-            ])
+            process.terminationHandler = { terminatedProcess in
+                let output = pipeBox.outputString()
+                let errorText = pipeBox.errorString()
+                pipeBox.closePipes()
+
+                guard terminatedProcess.terminationStatus == 0 else {
+                    finish(.failure(NSError(
+                        domain: "ForegroundTerminalSessionProbe",
+                        code: Int(terminatedProcess.terminationStatus),
+                        userInfo: [
+                            NSLocalizedDescriptionKey: errorText.isEmpty ? "AppleScript probe failed." : errorText,
+                        ]
+                    )))
+                    return
+                }
+
+                finish(.success(output))
+            }
+
+            do {
+                try process.run()
+            } catch {
+                pipeBox.closePipes()
+                finish(.failure(error))
+                return
+            }
+
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + Self.appleScriptTimeout) {
+                guard process.isRunning else {
+                    return
+                }
+
+                process.terminate()
+                finish(.failure(NSError(
+                    domain: "ForegroundTerminalSessionProbe",
+                    code: 408,
+                    userInfo: [NSLocalizedDescriptionKey: "AppleScript probe timed out."]
+                )))
+            }
         }
-
-        return output
     }
 }

--- a/Sources/OpenIslandApp/ForegroundTerminalSessionProbe.swift
+++ b/Sources/OpenIslandApp/ForegroundTerminalSessionProbe.swift
@@ -1,0 +1,165 @@
+import AppKit
+import Foundation
+import OpenIslandCore
+
+struct ForegroundTerminalSessionProbe {
+    typealias FrontmostBundleIdentifierProvider = @Sendable () -> String?
+    typealias AppleScriptRunner = @Sendable (String) throws -> String
+
+    private static let fieldSeparator = "\u{1f}"
+
+    private let frontmostBundleIdentifierProvider: FrontmostBundleIdentifierProvider
+    private let appleScriptRunner: AppleScriptRunner
+
+    init(
+        frontmostBundleIdentifierProvider: @escaping FrontmostBundleIdentifierProvider = {
+            NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+        },
+        appleScriptRunner: @escaping AppleScriptRunner = Self.runAppleScript
+    ) {
+        self.frontmostBundleIdentifierProvider = frontmostBundleIdentifierProvider
+        self.appleScriptRunner = appleScriptRunner
+    }
+
+    func matches(session: AgentSession) -> Bool {
+        matches(jumpTarget: session.jumpTarget)
+    }
+
+    func matches(jumpTarget: JumpTarget?) -> Bool {
+        guard let jumpTarget,
+              let frontmostBundleIdentifier = frontmostBundleIdentifierProvider() else {
+            return false
+        }
+
+        switch frontmostBundleIdentifier {
+        case "com.mitchellh.ghostty":
+            guard let focusedTerminalID = ghosttyFocusedTerminalID(),
+                  let sessionTerminalID = nonEmptyValue(jumpTarget.terminalSessionID) else {
+                return false
+            }
+            return focusedTerminalID == sessionTerminalID
+
+        case "com.apple.Terminal":
+            guard let focusedTTY = normalizedTTY(terminalFocusedTTY()),
+                  let sessionTTY = normalizedTTY(jumpTarget.terminalTTY) else {
+                return false
+            }
+            return focusedTTY == sessionTTY
+
+        case "com.googlecode.iterm2":
+            let focusedSession = itermFocusedSession()
+
+            if let focusedSessionID = focusedSession?.sessionID,
+               let sessionTerminalID = nonEmptyValue(jumpTarget.terminalSessionID),
+               focusedSessionID == sessionTerminalID {
+                return true
+            }
+
+            if let focusedTTY = normalizedTTY(focusedSession?.tty),
+               let sessionTTY = normalizedTTY(jumpTarget.terminalTTY),
+               focusedTTY == sessionTTY {
+                return true
+            }
+
+            return false
+
+        default:
+            return false
+        }
+    }
+
+    private func ghosttyFocusedTerminalID() -> String? {
+        let script = """
+        tell application "Ghostty"
+            if not (it is running) then return ""
+            return id of focused terminal of selected tab of front window as text
+        end tell
+        """
+
+        return nonEmptyValue(try? appleScriptRunner(script))
+    }
+
+    private func terminalFocusedTTY() -> String? {
+        let script = """
+        tell application "Terminal"
+            if not (it is running) then return ""
+            return tty of selected tab of front window as text
+        end tell
+        """
+
+        return nonEmptyValue(try? appleScriptRunner(script))
+    }
+
+    private func itermFocusedSession() -> (sessionID: String?, tty: String?)? {
+        let script = """
+        tell application "iTerm"
+            if not (it is running) then return ""
+            tell current session of current window
+                return (id as text) & "\(Self.fieldSeparator)" & (tty as text)
+            end tell
+        end tell
+        """
+
+        guard let output = nonEmptyValue(try? appleScriptRunner(script)) else {
+            return nil
+        }
+
+        let values = output.components(separatedBy: Self.fieldSeparator)
+        if values.isEmpty {
+            return nil
+        }
+
+        return (
+            sessionID: values.indices.contains(0) ? nonEmptyValue(values[0]) : nil,
+            tty: values.indices.contains(1) ? nonEmptyValue(values[1]) : nil
+        )
+    }
+
+    private func nonEmptyValue(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+
+        return trimmed
+    }
+
+    private func normalizedTTY(_ value: String?) -> String? {
+        guard let trimmed = nonEmptyValue(value) else {
+            return nil
+        }
+
+        return trimmed.hasPrefix("/dev/") ? trimmed : "/dev/\(trimmed)"
+    }
+
+    private static func runAppleScript(_ script: String) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = ["-e", script]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let output = String(
+            data: outputPipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        guard process.terminationStatus == 0 else {
+            let errorText = String(
+                data: errorPipe.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            throw NSError(domain: "ForegroundTerminalSessionProbe", code: Int(process.terminationStatus), userInfo: [
+                NSLocalizedDescriptionKey: errorText.isEmpty ? "AppleScript probe failed." : errorText,
+            ])
+        }
+
+        return output
+    }
+}

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -25,6 +25,7 @@
 "settings.general.autoCollapse" = "Auto-collapse on mouse exit";
 "settings.general.showDockIcon" = "Show icon in Dock";
 "settings.general.hapticFeedback" = "Haptic feedback on hover";
+"settings.general.suppressFrontmostNotifications" = "Suppress notifications for focused sessions";
 "settings.general.showCodexUsage" = "Show Codex usage";
 "settings.general.completionReply" = "Reply from completion card";
 "settings.general.cliHooks" = "CLI Hooks";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -25,6 +25,7 @@
 "settings.general.autoCollapse" = "鼠标离开时自动收起";
 "settings.general.showDockIcon" = "在 Dock 中显示图标";
 "settings.general.hapticFeedback" = "悬停时震动反馈";
+"settings.general.suppressFrontmostNotifications" = "前台会话不弹出通知";
 "settings.general.showCodexUsage" = "显示 Codex 用量";
 "settings.general.completionReply" = "在完成卡片中回复";
 "settings.general.cliHooks" = "CLI Hooks";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -25,6 +25,7 @@
 "settings.general.autoCollapse" = "滑鼠離開時自動收起";
 "settings.general.showDockIcon" = "在 Dock 中顯示圖示";
 "settings.general.hapticFeedback" = "懸停時震動回饋";
+"settings.general.suppressFrontmostNotifications" = "前台工作階段不彈出通知";
 "settings.general.showCodexUsage" = "顯示 Codex 用量";
 "settings.general.completionReply" = "在完成卡片中回覆";
 "settings.general.cliHooks" = "CLI Hooks";

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -215,6 +215,10 @@ struct GeneralSettingsPane: View {
                     get: { model.completionReplyEnabled },
                     set: { model.completionReplyEnabled = $0 }
                 ))
+                Toggle(lang.t("settings.general.suppressFrontmostNotifications"), isOn: Binding(
+                    get: { model.suppressFrontmostNotifications },
+                    set: { model.suppressFrontmostNotifications = $0 }
+                ))
             }
 
         }

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -372,9 +372,11 @@ struct AppModelSessionListTests {
             .permissionRequested(
                 PermissionRequested(
                     sessionID: "frontmost-session",
-                    title: "Edit",
-                    summary: "main.swift",
-                    affectedPath: "/tmp/main.swift",
+                    request: PermissionRequest(
+                        title: "Edit",
+                        summary: "main.swift",
+                        affectedPath: "/tmp/main.swift"
+                    ),
                     timestamp: now.addingTimeInterval(1)
                 )
             ),
@@ -419,9 +421,11 @@ struct AppModelSessionListTests {
             .permissionRequested(
                 PermissionRequested(
                     sessionID: "background-session",
-                    title: "Edit",
-                    summary: "main.swift",
-                    affectedPath: "/tmp/main.swift",
+                    request: PermissionRequest(
+                        title: "Edit",
+                        summary: "main.swift",
+                        affectedPath: "/tmp/main.swift"
+                    ),
                     timestamp: now.addingTimeInterval(1)
                 )
             ),

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -344,6 +344,92 @@ struct AppModelSessionListTests {
     }
 
     @Test
+    func bridgeNotificationIsSuppressedWhenSessionIsAlreadyFrontmost() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let model = AppModel(
+            isNotificationSessionAlreadyFrontmost: { session in
+                session.id == "frontmost-session"
+            }
+        )
+        model.notchStatus = .closed
+        model.notchOpenReason = nil
+        model.state = SessionState(
+            sessions: [
+                AgentSession(
+                    id: "frontmost-session",
+                    title: "Codex · open-island",
+                    tool: .codex,
+                    origin: .live,
+                    attachmentState: .attached,
+                    phase: .running,
+                    summary: "Already focused in the front terminal.",
+                    updatedAt: now
+                ),
+            ]
+        )
+
+        model.applyTrackedEvent(
+            .permissionRequested(
+                PermissionRequested(
+                    sessionID: "frontmost-session",
+                    title: "Edit",
+                    summary: "main.swift",
+                    affectedPath: "/tmp/main.swift",
+                    timestamp: now.addingTimeInterval(1)
+                )
+            ),
+            updateLastActionMessage: false,
+            ingress: .bridge
+        )
+
+        #expect(model.notchStatus == .closed)
+        #expect(model.notchOpenReason == nil)
+        #expect(model.islandSurface == .sessionList())
+    }
+
+    @Test
+    func bridgeNotificationStillPresentsWhenSessionIsNotFrontmost() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let model = AppModel(
+            isNotificationSessionAlreadyFrontmost: { _ in false }
+        )
+        model.notchStatus = .closed
+        model.notchOpenReason = nil
+        model.state = SessionState(
+            sessions: [
+                AgentSession(
+                    id: "background-session",
+                    title: "Codex · open-island",
+                    tool: .codex,
+                    origin: .live,
+                    attachmentState: .attached,
+                    phase: .running,
+                    summary: "Needs approval.",
+                    updatedAt: now
+                ),
+            ]
+        )
+
+        model.applyTrackedEvent(
+            .permissionRequested(
+                PermissionRequested(
+                    sessionID: "background-session",
+                    title: "Edit",
+                    summary: "main.swift",
+                    affectedPath: "/tmp/main.swift",
+                    timestamp: now.addingTimeInterval(1)
+                )
+            ),
+            updateLastActionMessage: false,
+            ingress: .bridge
+        )
+
+        #expect(model.notchStatus == .opened)
+        #expect(model.notchOpenReason == .notification)
+        #expect(model.islandSurface == .sessionList(actionableSessionID: "background-session"))
+    }
+
+    @Test
     func hoverOpenedSessionListAutoCollapsesOnPointerExit() {
         let model = AppModel()
         model.notchStatus = .opened

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -344,7 +344,7 @@ struct AppModelSessionListTests {
     }
 
     @Test
-    func bridgeNotificationIsSuppressedWhenSessionIsAlreadyFrontmost() {
+    func bridgeNotificationIsSuppressedWhenSessionIsAlreadyFrontmost() async throws {
         let now = Date(timeIntervalSince1970: 2_000)
         let model = AppModel(
             isNotificationSessionAlreadyFrontmost: { session in
@@ -382,13 +382,18 @@ struct AppModelSessionListTests {
             ingress: .bridge
         )
 
+        for _ in 0..<20 {
+            await Task.yield()
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
         #expect(model.notchStatus == .closed)
         #expect(model.notchOpenReason == nil)
         #expect(model.islandSurface == .sessionList())
     }
 
     @Test
-    func bridgeNotificationStillPresentsWhenSessionIsNotFrontmost() {
+    func bridgeNotificationStillPresentsWhenSessionIsNotFrontmost() async throws {
         let now = Date(timeIntervalSince1970: 2_000)
         let model = AppModel(
             isNotificationSessionAlreadyFrontmost: { _ in false }
@@ -423,6 +428,14 @@ struct AppModelSessionListTests {
             updateLastActionMessage: false,
             ingress: .bridge
         )
+
+        for _ in 0..<20 {
+            if model.notchStatus == .opened {
+                break
+            }
+            await Task.yield()
+            try await Task.sleep(for: .milliseconds(10))
+        }
 
         #expect(model.notchStatus == .opened)
         #expect(model.notchOpenReason == .notification)

--- a/Tests/OpenIslandAppTests/ForegroundTerminalSessionProbeTests.swift
+++ b/Tests/OpenIslandAppTests/ForegroundTerminalSessionProbeTests.swift
@@ -3,13 +3,13 @@ import XCTest
 import OpenIslandCore
 
 final class ForegroundTerminalSessionProbeTests: XCTestCase {
-    func testMatchesGhosttyFrontmostTerminalBySessionID() {
+    func testMatchesGhosttyFrontmostTerminalBySessionID() async {
         let probe = ForegroundTerminalSessionProbe(
             frontmostBundleIdentifierProvider: { "com.mitchellh.ghostty" },
             appleScriptRunner: { _ in "ghostty-frontmost" }
         )
 
-        let matches = probe.matches(
+        let matches = await probe.matches(
             jumpTarget: JumpTarget(
                 terminalApp: "Ghostty",
                 workspaceName: "open-island",
@@ -21,13 +21,13 @@ final class ForegroundTerminalSessionProbeTests: XCTestCase {
         XCTAssertTrue(matches)
     }
 
-    func testMatchesTerminalFrontmostTabByTTY() {
+    func testMatchesTerminalFrontmostTabByTTY() async {
         let probe = ForegroundTerminalSessionProbe(
             frontmostBundleIdentifierProvider: { "com.apple.Terminal" },
             appleScriptRunner: { _ in "ttys001" }
         )
 
-        let matches = probe.matches(
+        let matches = await probe.matches(
             jumpTarget: JumpTarget(
                 terminalApp: "Terminal",
                 workspaceName: "open-island",
@@ -39,13 +39,13 @@ final class ForegroundTerminalSessionProbeTests: XCTestCase {
         XCTAssertTrue(matches)
     }
 
-    func testMatchesITermFrontmostSessionByTTYFallback() {
+    func testMatchesITermFrontmostSessionByTTYFallback() async {
         let probe = ForegroundTerminalSessionProbe(
             frontmostBundleIdentifierProvider: { "com.googlecode.iterm2" },
             appleScriptRunner: { _ in "different-session\u{1f}/dev/ttys002" }
         )
 
-        let matches = probe.matches(
+        let matches = await probe.matches(
             jumpTarget: JumpTarget(
                 terminalApp: "iTerm",
                 workspaceName: "open-island",
@@ -58,13 +58,13 @@ final class ForegroundTerminalSessionProbeTests: XCTestCase {
         XCTAssertTrue(matches)
     }
 
-    func testReturnsFalseForUnsupportedFrontmostApp() {
+    func testReturnsFalseForUnsupportedFrontmostApp() async {
         let probe = ForegroundTerminalSessionProbe(
             frontmostBundleIdentifierProvider: { "com.example.Editor" },
             appleScriptRunner: { _ in "" }
         )
 
-        let matches = probe.matches(
+        let matches = await probe.matches(
             jumpTarget: JumpTarget(
                 terminalApp: "Ghostty",
                 workspaceName: "open-island",

--- a/Tests/OpenIslandAppTests/ForegroundTerminalSessionProbeTests.swift
+++ b/Tests/OpenIslandAppTests/ForegroundTerminalSessionProbeTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import OpenIslandApp
+import OpenIslandCore
+
+final class ForegroundTerminalSessionProbeTests: XCTestCase {
+    func testMatchesGhosttyFrontmostTerminalBySessionID() {
+        let probe = ForegroundTerminalSessionProbe(
+            frontmostBundleIdentifierProvider: { "com.mitchellh.ghostty" },
+            appleScriptRunner: { _ in "ghostty-frontmost" }
+        )
+
+        let matches = probe.matches(
+            jumpTarget: JumpTarget(
+                terminalApp: "Ghostty",
+                workspaceName: "open-island",
+                paneTitle: "codex ~/open-island",
+                terminalSessionID: "ghostty-frontmost"
+            )
+        )
+
+        XCTAssertTrue(matches)
+    }
+
+    func testMatchesTerminalFrontmostTabByTTY() {
+        let probe = ForegroundTerminalSessionProbe(
+            frontmostBundleIdentifierProvider: { "com.apple.Terminal" },
+            appleScriptRunner: { _ in "ttys001" }
+        )
+
+        let matches = probe.matches(
+            jumpTarget: JumpTarget(
+                terminalApp: "Terminal",
+                workspaceName: "open-island",
+                paneTitle: "codex ~/open-island",
+                terminalTTY: "/dev/ttys001"
+            )
+        )
+
+        XCTAssertTrue(matches)
+    }
+
+    func testMatchesITermFrontmostSessionByTTYFallback() {
+        let probe = ForegroundTerminalSessionProbe(
+            frontmostBundleIdentifierProvider: { "com.googlecode.iterm2" },
+            appleScriptRunner: { _ in "different-session\u{1f}/dev/ttys002" }
+        )
+
+        let matches = probe.matches(
+            jumpTarget: JumpTarget(
+                terminalApp: "iTerm",
+                workspaceName: "open-island",
+                paneTitle: "codex ~/open-island",
+                terminalSessionID: "tracked-session",
+                terminalTTY: "/dev/ttys002"
+            )
+        )
+
+        XCTAssertTrue(matches)
+    }
+
+    func testReturnsFalseForUnsupportedFrontmostApp() {
+        let probe = ForegroundTerminalSessionProbe(
+            frontmostBundleIdentifierProvider: { "com.example.Editor" },
+            appleScriptRunner: { _ in "" }
+        )
+
+        let matches = probe.matches(
+            jumpTarget: JumpTarget(
+                terminalApp: "Ghostty",
+                workspaceName: "open-island",
+                paneTitle: "codex ~/open-island",
+                terminalSessionID: "ghostty-frontmost"
+            )
+        )
+
+        XCTAssertFalse(matches)
+    }
+}


### PR DESCRIPTION
## Summary
- suppress island notification cards when the target session is already focused in the frontmost terminal window
- add a foreground terminal session probe for Ghostty, Terminal.app, and iTerm2
- cover the notification suppression path and probe matching with tests

## Verification
- `swift build -c debug --product OpenIslandApp`

## Testing Gap
- `swift test` was not run here because the current SwiftPM test environment in this repo fails to resolve the `Testing` module before reaching these new tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user-setting (default: enabled) to suppress notifications for terminal sessions that are already frontmost, reducing redundant alerts.
  * Notification delivery now avoids presenting superseded or duplicate notification surfaces.

* **Settings**
  * New toggle in General settings: "Suppress notifications for focused sessions".

* **Tests**
  * Added tests covering suppression behavior and foreground terminal detection.

* **Localization**
  * English, Simplified Chinese, and Traditional Chinese translations added for the new setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->