### PR TITLE
feat: reply to agent from completion card

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -16,6 +16,7 @@ final class AppModel {
     private static let islandPixelShapeStyleDefaultsKey = "appearance.island.pixelShapeStyle"
     private static let islandStatusColorsDefaultsKey = "appearance.island.statusColors"
     private static let showCodexUsageDefaultsKey = "app.showCodexUsage"
+    private static let completionReplyEnabledDefaultsKey = "feature.completionReply.enabled"
 
     static let defaultStatusColors: [SessionPhase: String] = [
         .running: "#6E9FFF",
@@ -199,6 +200,12 @@ final class AppModel {
         didSet {
             guard hasFinishedInit, showCodexUsage != oldValue else { return }
             UserDefaults.standard.set(showCodexUsage, forKey: Self.showCodexUsageDefaultsKey)
+        }
+    }
+    var completionReplyEnabled: Bool = false {
+        didSet {
+            guard hasFinishedInit, completionReplyEnabled != oldValue else { return }
+            UserDefaults.standard.set(completionReplyEnabled, forKey: Self.completionReplyEnabledDefaultsKey)
         }
     }
     var isSoundMuted = false {
@@ -424,6 +431,7 @@ final class AppModel {
         UserDefaults.standard.register(defaults: [
             Self.showDockIconDefaultsKey: true,
             Self.hapticFeedbackEnabledDefaultsKey: false,
+            Self.completionReplyEnabledDefaultsKey: false,
         ])
         isSoundMuted = UserDefaults.standard.bool(forKey: Self.soundMutedDefaultsKey)
         selectedSoundName = NotificationSoundService.selectedSoundName
@@ -436,6 +444,7 @@ final class AppModel {
                 atPath: CodexRolloutDiscovery.defaultRootURL.path
             )
         }
+        completionReplyEnabled = UserDefaults.standard.bool(forKey: Self.completionReplyEnabledDefaultsKey)
         islandAppearanceMode = IslandAppearanceMode(
             rawValue: UserDefaults.standard.string(forKey: Self.islandAppearanceModeDefaultsKey) ?? ""
         ) ?? .default
@@ -1032,6 +1041,24 @@ final class AppModel {
             .answerQuestion(sessionID: session.id, response: answer),
             userMessage: "Sending answer for \(session.title)."
         )
+    }
+
+    func replyToSession(_ session: AgentSession, text: String) {
+        dismissNotificationSurfaceIfPresent(for: session.id)
+        synchronizeSelection()
+        refreshOverlayPlacementIfVisible()
+
+        lastActionMessage = "Sending reply to \(session.title)…"
+
+        Task { [weak self] in
+            let success = await Task.detached(priority: .userInitiated) {
+                TerminalTextSender.send(text, to: session)
+            }.value
+
+            self?.lastActionMessage = success
+                ? "Sent reply to \(session.title)."
+                : "Failed to send reply to \(session.title)."
+        }
     }
 
 

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -206,6 +206,7 @@ final class AppModel {
         didSet {
             guard hasFinishedInit, completionReplyEnabled != oldValue else { return }
             UserDefaults.standard.set(completionReplyEnabled, forKey: Self.completionReplyEnabledDefaultsKey)
+            refreshOverlayPlacementIfVisible()
         }
     }
     var isSoundMuted = false {

--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -596,14 +596,14 @@ final class OverlayPanelController {
         case .waitingForAnswer:
             return questionCardHeight(for: session.questionPrompt) - 44
         case .completed:
-            return completionBodyHeight(for: session)
+            return completionBodyHeight(for: session, model: model)
         case .running:
             return 0
         }
     }
 
     /// Height of the inline completion expansion area (not the old full-card height).
-    private func completionBodyHeight(for session: AgentSession) -> CGFloat {
+    private func completionBodyHeight(for session: AgentSession, model: AppModel) -> CGFloat {
         let headerHeight: CGFloat = 44
 
         let text = (session.completionAssistantMessageText ?? session.summary)
@@ -621,7 +621,9 @@ final class OverlayPanelController {
             attributes: [.font: font]
         )
         let markdownHeight = min(260, ceil(textSize.height) + 20)
-        return headerHeight + 1 + markdownHeight
+        // Reply input: divider (1) + input bar padding+content (~52)
+        let replyInputHeight: CGFloat = TerminalTextSender.canReply(to: session, enabled: model.completionReplyEnabled) ? 53 : 0
+        return headerHeight + 1 + markdownHeight + replyInputHeight
     }
 
     private func questionCardHeight(for prompt: QuestionPrompt?) -> CGFloat {

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -26,6 +26,7 @@
 "settings.general.showDockIcon" = "Show icon in Dock";
 "settings.general.hapticFeedback" = "Haptic feedback on hover";
 "settings.general.showCodexUsage" = "Show Codex usage";
+"settings.general.completionReply" = "Reply from completion card";
 "settings.general.cliHooks" = "CLI Hooks";
 "settings.general.activated" = "Activated";
 "settings.general.install" = "Install";
@@ -149,6 +150,7 @@
 
 /* Island Panel - Completion */
 "completion.done" = "Done";
+"completion.replyPlaceholder" = "Reply to Claude…";
 
 /* Menu Bar */
 "menu.status" = "%lld live · %lld attention";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -26,6 +26,7 @@
 "settings.general.showDockIcon" = "在 Dock 中显示图标";
 "settings.general.hapticFeedback" = "悬停时震动反馈";
 "settings.general.showCodexUsage" = "显示 Codex 用量";
+"settings.general.completionReply" = "在完成卡片中回复";
 "settings.general.cliHooks" = "CLI Hooks";
 "settings.general.activated" = "已激活";
 "settings.general.install" = "安装";
@@ -149,6 +150,7 @@
 
 /* Island Panel - Completion */
 "completion.done" = "完成";
+"completion.replyPlaceholder" = "回复 Claude…";
 
 /* Menu Bar */
 "menu.status" = "%lld 活跃 · %lld 待处理";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -26,6 +26,7 @@
 "settings.general.showDockIcon" = "在 Dock 中顯示圖示";
 "settings.general.hapticFeedback" = "懸停時震動回饋";
 "settings.general.showCodexUsage" = "顯示 Codex 用量";
+"settings.general.completionReply" = "在完成卡片中回覆";
 "settings.general.cliHooks" = "CLI Hooks";
 "settings.general.activated" = "已啟用";
 "settings.general.install" = "安裝";
@@ -148,6 +149,7 @@
 
 /* Island Panel - Completion */
 "completion.done" = "完成";
+"completion.replyPlaceholder" = "回覆 Claude…";
 
 /* Menu Bar */
 "menu.status" = "%lld 活躍 · %lld 待處理";

--- a/Sources/OpenIslandApp/TerminalTextSender.swift
+++ b/Sources/OpenIslandApp/TerminalTextSender.swift
@@ -1,0 +1,223 @@
+import Foundation
+import OpenIslandCore
+
+/// Sends reply text to a terminal where an agent session is running.
+///
+/// Currently supported:
+/// - **tmux**: `tmux send-keys -l "text" Enter`
+/// - **Ghostty**: AppleScript `input text` (requires Automation permission)
+///
+/// The static ``canReply(to:)`` method gates the UI — the reply input field
+/// is only shown when the session's terminal supports text injection.
+struct TerminalTextSender {
+
+    // MARK: - Capability check
+
+    static func canReply(to session: AgentSession, enabled: Bool) -> Bool {
+        guard enabled else { return false }
+        guard session.phase == .completed else { return false }
+        guard let target = session.jumpTarget else { return false }
+
+        // tmux sessions: any terminal can receive send-keys.
+        if target.tmuxTarget != nil { return true }
+
+        // Ghostty: native AppleScript input text (1.3.0+).
+        let app = target.terminalApp.lowercased()
+        if app == "ghostty" { return true }
+
+        return false
+    }
+
+    // MARK: - Send
+
+    /// Send `text` followed by Enter to the terminal that owns `session`.
+    /// Returns `true` on success.
+    @discardableResult
+    static func send(_ text: String, to session: AgentSession) -> Bool {
+        guard let target = session.jumpTarget else { return false }
+
+        // Prefer tmux when available — it targets a specific pane without
+        // needing to activate/focus the terminal window.
+        if let tmuxTarget = target.tmuxTarget {
+            return sendViaTmux(text, tmuxTarget: tmuxTarget, socketPath: target.tmuxSocketPath)
+        }
+
+        let app = target.terminalApp.lowercased()
+        if app == "ghostty" {
+            return sendViaGhostty(text, target: target)
+        }
+
+        return false
+    }
+
+    // MARK: - tmux
+
+    private static func sendViaTmux(_ text: String, tmuxTarget: String, socketPath: String?) -> Bool {
+        guard let tmuxPath = resolveTmuxPath() else { return false }
+
+        var baseArgs: [String] = []
+        if let socketPath, !socketPath.isEmpty {
+            baseArgs = ["-S", socketPath]
+        }
+
+        // Send the literal text (no Enter yet).
+        let textResult = runProcess(tmuxPath, arguments: baseArgs + ["send-keys", "-t", tmuxTarget, "-l", text])
+        guard textResult else { return false }
+
+        // Send Enter as a separate command.
+        return runProcess(tmuxPath, arguments: baseArgs + ["send-keys", "-t", tmuxTarget, "Enter"])
+    }
+
+    // MARK: - Ghostty
+
+    private static func sendViaGhostty(_ text: String, target: JumpTarget) -> Bool {
+        // Build an AppleScript that:
+        //   1. Finds the correct terminal (by session id, working directory, or name)
+        //   2. Focuses it
+        //   3. Sends the reply text + newline via `input text`
+        let script = ghosttySendScript(text: text, target: target)
+        return runAppleScript(script)
+    }
+
+    private static func ghosttySendScript(text: String, target: JumpTarget) -> String {
+        let terminalSessionID = escapeAppleScript(target.terminalSessionID)
+        let workingDirectory = escapeAppleScript(target.workingDirectory)
+        let paneTitle = escapeAppleScript(target.paneTitle)
+        let escapedText = escapeAppleScript(text)
+
+        return """
+        tell application "Ghostty"
+            if not (it is running) then return "error"
+
+            set targetTerminal to missing value
+
+            -- Match by terminal session ID (most precise)
+            if "\(terminalSessionID)" is not "" then
+                repeat with aWindow in windows
+                    repeat with aTab in tabs of aWindow
+                        repeat with aTerminal in terminals of aTab
+                            if (id of aTerminal as text) is "\(terminalSessionID)" then
+                                set targetTerminal to aTerminal
+                                exit repeat
+                            end if
+                        end repeat
+                        if targetTerminal is not missing value then exit repeat
+                    end repeat
+                    if targetTerminal is not missing value then exit repeat
+                end repeat
+            end if
+
+            -- Fallback: match by working directory
+            if targetTerminal is missing value and "\(workingDirectory)" is not "" then
+                repeat with aWindow in windows
+                    repeat with aTab in tabs of aWindow
+                        repeat with aTerminal in terminals of aTab
+                            if (working directory of aTerminal as text) is "\(workingDirectory)" then
+                                set targetTerminal to aTerminal
+                                exit repeat
+                            end if
+                        end repeat
+                        if targetTerminal is not missing value then exit repeat
+                    end repeat
+                    if targetTerminal is not missing value then exit repeat
+                end repeat
+            end if
+
+            -- Fallback: match by pane title
+            if targetTerminal is missing value and "\(paneTitle)" is not "" then
+                repeat with aWindow in windows
+                    repeat with aTab in tabs of aWindow
+                        repeat with aTerminal in terminals of aTab
+                            if (name of aTerminal as text) contains "\(paneTitle)" then
+                                set targetTerminal to aTerminal
+                                exit repeat
+                            end if
+                        end repeat
+                        if targetTerminal is not missing value then exit repeat
+                    end repeat
+                    if targetTerminal is not missing value then exit repeat
+                end repeat
+            end if
+
+            if targetTerminal is missing value then return "error"
+
+            -- Send the text, then press Enter as a separate key event.
+            -- `input text` sends characters; `send key` simulates a key press.
+            input text "\(escapedText)" to targetTerminal
+            send key "enter" to targetTerminal
+            return "ok"
+        end tell
+        """
+    }
+
+    // MARK: - Helpers
+
+    private static func escapeAppleScript(_ value: String?) -> String {
+        guard let value else { return "" }
+        return value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    private static func runAppleScript(_ script: String) -> Bool {
+        var error: NSDictionary?
+        guard let appleScript = NSAppleScript(source: script) else {
+            NSLog("[OpenIsland] TerminalTextSender: AppleScript compilation failed")
+            return false
+        }
+        let result = appleScript.executeAndReturnError(&error)
+        if let error {
+            NSLog("[OpenIsland] TerminalTextSender AppleScript error: %@", String(describing: error))
+            return false
+        }
+        return result.stringValue == "ok"
+    }
+
+    private static func resolveTmuxPath() -> String? {
+        let candidates = [
+            "/opt/homebrew/bin/tmux",
+            "/usr/local/bin/tmux",
+            "/usr/bin/tmux",
+        ]
+        for path in candidates {
+            if FileManager.default.isExecutableFile(atPath: path) {
+                return path
+            }
+        }
+
+        // Fallback: `which tmux`
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        task.arguments = ["tmux"]
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = FileHandle.nullDevice
+        do {
+            try task.run()
+            task.waitUntilExit()
+            guard task.terminationStatus == 0 else { return nil }
+            let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if let output, FileManager.default.isExecutableFile(atPath: output) {
+                return output
+            }
+        } catch {}
+        return nil
+    }
+
+    @discardableResult
+    private static func runProcess(_ path: String, arguments: [String]) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: path)
+        process.arguments = arguments
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0
+        } catch {
+            return false
+        }
+    }
+}

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -563,6 +563,8 @@ struct IslandPanelView: View {
                     lang: model.lang,
                     onApprove: { model.approvePermission(for: session.id, action: $0) },
                     onAnswer: { model.answerQuestion(for: session.id, answer: $0) },
+                    onReply: TerminalTextSender.canReply(to: session, enabled: model.completionReplyEnabled)
+                        ? { model.replyToSession(session, text: $0) } : nil,
                     onJump: { model.jumpToSession(session) }
                 )
 
@@ -590,6 +592,8 @@ struct IslandPanelView: View {
                         lang: model.lang,
                         onApprove: { model.approvePermission(for: session.id, action: $0) },
                         onAnswer: { model.answerQuestion(for: session.id, answer: $0) },
+                        onReply: TerminalTextSender.canReply(to: session, enabled: model.completionReplyEnabled)
+                            ? { model.replyToSession(session, text: $0) } : nil,
                         onJump: { model.jumpToSession(session) },
                         onDismiss: session.isRemote ? { model.dismissSession(session.id) } : nil
                     )
@@ -1017,11 +1021,13 @@ private struct IslandSessionRow: View {
     var lang: LanguageManager = .shared
     var onApprove: ((ApprovalAction) -> Void)?
     var onAnswer: ((QuestionPromptResponse) -> Void)?
+    var onReply: ((String) -> Void)?
     let onJump: () -> Void
     var onDismiss: (() -> Void)?
 
     @State private var isHighlighted = false
     @State private var isManuallyExpanded = false
+    @State private var replyText: String = ""
 
     var body: some View {
         rowBody(referenceDate: referenceDate)
@@ -1322,6 +1328,14 @@ private struct IslandSessionRow: View {
                     .padding(.horizontal, 14)
                     .padding(.vertical, 10)
             }
+
+            if onReply != nil {
+                Rectangle()
+                    .fill(.white.opacity(0.04))
+                    .frame(height: 1)
+
+                completionReplyInput
+            }
         }
         .background(
             RoundedRectangle(cornerRadius: 18, style: .continuous)
@@ -1331,6 +1345,38 @@ private struct IslandSessionRow: View {
             RoundedRectangle(cornerRadius: 18, style: .continuous)
                 .strokeBorder(.white.opacity(0.08))
         )
+    }
+
+    @ViewBuilder
+    private var completionReplyInput: some View {
+        HStack(spacing: 8) {
+            ReplyTextField(
+                placeholder: lang.t("completion.replyPlaceholder"),
+                text: $replyText,
+                onSubmit: { submitReply() }
+            )
+            .frame(height: 32)
+
+            Button {
+                submitReply()
+            } label: {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.system(size: 24))
+                    .foregroundColor(replyText.trimmingCharacters(in: .whitespaces).isEmpty
+                        ? .white.opacity(0.2) : .white.opacity(0.9))
+            }
+            .buttonStyle(.plain)
+            .disabled(replyText.trimmingCharacters(in: .whitespaces).isEmpty)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+    }
+
+    private func submitReply() {
+        let text = replyText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        replyText = ""
+        onReply?(text)
     }
 
     // MARK: - Actionable helpers
@@ -1632,6 +1678,71 @@ private struct StructuredQuestionPromptView: View {
         }
 
         selections[question.question] = selected
+    }
+}
+
+// MARK: - Reply TextField (NSTextField wrapper for IME-safe Enter handling)
+
+/// NSTextField wrapper that fires `onSubmit` only when the IME composition
+/// is finished — pressing Enter during Chinese/Japanese IME composition
+/// confirms the candidate instead of submitting.
+private struct ReplyTextField: NSViewRepresentable {
+    var placeholder: String
+    @Binding var text: String
+    var onSubmit: () -> Void
+
+    func makeNSView(context: Context) -> NSTextField {
+        let field = NSTextField()
+        field.isBordered = false
+        field.drawsBackground = false
+        field.focusRingType = .none
+        field.font = .systemFont(ofSize: 13)
+        field.textColor = .white
+        field.placeholderAttributedString = NSAttributedString(
+            string: placeholder,
+            attributes: [
+                .foregroundColor: NSColor.white.withAlphaComponent(0.35),
+                .font: NSFont.systemFont(ofSize: 13),
+            ]
+        )
+        field.delegate = context.coordinator
+        field.cell?.lineBreakMode = .byTruncatingTail
+        field.cell?.usesSingleLineMode = true
+        return field
+    }
+
+    func updateNSView(_ nsView: NSTextField, context: Context) {
+        if nsView.stringValue != text {
+            nsView.stringValue = text
+        }
+        context.coordinator.onSubmit = onSubmit
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text, onSubmit: onSubmit)
+    }
+
+    final class Coordinator: NSObject, NSTextFieldDelegate {
+        var text: Binding<String>
+        var onSubmit: () -> Void
+
+        init(text: Binding<String>, onSubmit: @escaping () -> Void) {
+            self.text = text
+            self.onSubmit = onSubmit
+        }
+
+        func controlTextDidChange(_ obj: Notification) {
+            guard let field = obj.object as? NSTextField else { return }
+            text.wrappedValue = field.stringValue
+        }
+
+        func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+            if commandSelector == #selector(NSResponder.insertNewline(_:)) {
+                onSubmit()
+                return true
+            }
+            return false
+        }
     }
 }
 

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1738,6 +1738,9 @@ private struct ReplyTextField: NSViewRepresentable {
 
         func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
             if commandSelector == #selector(NSResponder.insertNewline(_:)) {
+                // Let AppKit handle Enter during IME composition (e.g. confirming
+                // a Chinese/Japanese candidate). Only submit when no marked text.
+                guard !textView.hasMarkedText() else { return false }
                 onSubmit()
                 return true
             }

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -211,6 +211,10 @@ struct GeneralSettingsPane: View {
                     get: { model.hapticFeedbackEnabled },
                     set: { model.hapticFeedbackEnabled = $0 }
                 ))
+                Toggle(lang.t("settings.general.completionReply"), isOn: Binding(
+                    get: { model.completionReplyEnabled },
+                    set: { model.completionReplyEnabled = $0 }
+                ))
             }
 
         }


### PR DESCRIPTION
## Summary
- Add an opt-in reply input field to the completion notification card — users can type a follow-up prompt directly from the Island and send it to the terminal without switching windows
- Supported terminals: **Ghostty** (AppleScript `input text` + `send key "enter"`) and **tmux** sessions (any terminal, via `send-keys`)
- Feature gated by a toggle in Settings → Behavior → "Reply from completion card" (off by default)
- Uses NSTextField wrapper (`ReplyTextField`) for proper Chinese/Japanese IME compatibility — Enter confirms IME composition first, then submits
- Also includes the `AutoHeightScrollView` fix for reliable content scrolling in notification panels

## New files
- `Sources/OpenIslandApp/TerminalTextSender.swift` — terminal text injection service with `canReply` capability check

## Test plan
- [ ] Enable "Reply from completion card" in Settings → Behavior
- [ ] Trigger a completion in Ghostty — reply input should appear at the bottom of the card
- [ ] Type a reply and press Enter — text should be sent to Ghostty and Claude Code should start processing
- [ ] Verify Chinese IME works correctly (Enter confirms candidate, second Enter submits)
- [ ] Verify input field does NOT appear for unsupported terminals (e.g. Terminal.app without tmux)
- [ ] Verify input field does NOT appear when setting is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reply functionality to completion cards, allowing users to send messages directly from completions.
  * Added a settings toggle to enable or disable completion replies.

* **Localization**
  * Added translations for reply feature in English, Simplified Chinese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->