### PR TITLE
feat+fix: wrapper-mode usage bridge, visible hook sessions, reliable sound

### DIFF
--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -888,7 +888,13 @@ final class HookInstallationCoordinator {
 
     func installClaudeUsageBridge() {
         updateClaudeUsageBridge(userMessage: "Installing Claude usage bridge.") { manager in
-            try manager.install()
+            do {
+                return try manager.install()
+            } catch ClaudeStatusLineInstallationError.existingStatusLineConflict {
+                // User already has a custom statusLine (e.g. claude-hud). Install as a
+                // wrapper so their script keeps running and we still get rate_limits.
+                return try manager.installAsWrapper()
+            }
         }
     }
 
@@ -1073,7 +1079,11 @@ final class HookInstallationCoordinator {
                 self.claudeStatusLineStatus = status
                 self.claudeUsageSnapshot = try ClaudeUsageLoader.load()
                 if status.managedStatusLineInstalled {
-                    self.onStatusMessage?("Claude usage bridge is installed. Start a Claude Code turn to refresh cached rate limits.")
+                    if status.managedStatusLineIsWrapper {
+                        self.onStatusMessage?("Claude usage bridge installed in wrapper mode — your existing statusLine is preserved. Start a Claude Code turn to refresh cached rate limits.")
+                    } else {
+                        self.onStatusMessage?("Claude usage bridge is installed. Start a Claude Code turn to refresh cached rate limits.")
+                    }
                 } else {
                     self.onStatusMessage?("Claude usage bridge is not installed.")
                 }

--- a/Sources/OpenIslandApp/NotificationSoundService.swift
+++ b/Sources/OpenIslandApp/NotificationSoundService.swift
@@ -1,11 +1,20 @@
 import AppKit
+import AudioToolbox
 
 /// Manages notification sound playback using macOS system sounds.
+///
+/// Uses AudioToolbox's `AudioServicesPlaySystemSound` instead of `NSSound`
+/// because the latter relies on bundle context and silently fails when the
+/// app is launched via `swift run` or any other non-bundled path.
 @MainActor
 struct NotificationSoundService {
     private static let soundsDirectory = "/System/Library/Sounds"
     private static let defaultsKey = "notification.sound.name"
     static let defaultSoundName = "Bottle"
+
+    /// Cache of registered system sound IDs so we don't re-register the same
+    /// file on every notification. Keyed by sound name (e.g. "Bottle").
+    private static var soundIDCache: [String: SystemSoundID] = [:]
 
     /// Returns the list of available system sound names (without file extension).
     static func availableSounds() -> [String] {
@@ -31,11 +40,24 @@ struct NotificationSoundService {
 
     /// Plays a system sound by name.
     static func play(_ name: String) {
-        guard let sound = NSSound(named: NSSound.Name(name)) else {
-            return
+        let soundID: SystemSoundID
+        if let cached = soundIDCache[name] {
+            soundID = cached
+        } else {
+            let url = URL(fileURLWithPath: soundsDirectory)
+                .appendingPathComponent("\(name).aiff")
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                return
+            }
+            var id: SystemSoundID = 0
+            let status = AudioServicesCreateSystemSoundID(url as CFURL, &id)
+            guard status == kAudioServicesNoError else {
+                return
+            }
+            soundIDCache[name] = id
+            soundID = id
         }
-        sound.stop()
-        sound.play()
+        AudioServicesPlaySystemSound(soundID)
     }
 
     /// Plays the user-selected notification sound, respecting the mute setting.

--- a/Sources/OpenIslandApp/NotificationSoundService.swift
+++ b/Sources/OpenIslandApp/NotificationSoundService.swift
@@ -1,20 +1,19 @@
 import AppKit
-import AudioToolbox
 
 /// Manages notification sound playback using macOS system sounds.
 ///
-/// Uses AudioToolbox's `AudioServicesPlaySystemSound` instead of `NSSound`
-/// because the latter relies on bundle context and silently fails when the
-/// app is launched via `swift run` or any other non-bundled path.
+/// Shells out to `/usr/bin/afplay` to play the sound. Both `NSSound` and
+/// `AudioServicesPlaySystemSound` silently fail when the app is launched
+/// outside of a signed `.app` bundle (e.g. `swift run` for local dev, or
+/// any dev-signed bundle whose cdhash has drifted). `afplay` is a tiny
+/// command-line tool shipped with macOS that has no such constraint and
+/// reliably plays .aiff/.wav/.mp3 at the current system volume.
 @MainActor
 struct NotificationSoundService {
     private static let soundsDirectory = "/System/Library/Sounds"
     private static let defaultsKey = "notification.sound.name"
+    private static let afplayPath = "/usr/bin/afplay"
     static let defaultSoundName = "Bottle"
-
-    /// Cache of registered system sound IDs so we don't re-register the same
-    /// file on every notification. Keyed by sound name (e.g. "Bottle").
-    private static var soundIDCache: [String: SystemSoundID] = [:]
 
     /// Returns the list of available system sound names (without file extension).
     static func availableSounds() -> [String] {
@@ -40,24 +39,22 @@ struct NotificationSoundService {
 
     /// Plays a system sound by name.
     static func play(_ name: String) {
-        let soundID: SystemSoundID
-        if let cached = soundIDCache[name] {
-            soundID = cached
-        } else {
-            let url = URL(fileURLWithPath: soundsDirectory)
-                .appendingPathComponent("\(name).aiff")
-            guard FileManager.default.fileExists(atPath: url.path) else {
-                return
-            }
-            var id: SystemSoundID = 0
-            let status = AudioServicesCreateSystemSoundID(url as CFURL, &id)
-            guard status == kAudioServicesNoError else {
-                return
-            }
-            soundIDCache[name] = id
-            soundID = id
+        let url = URL(fileURLWithPath: soundsDirectory)
+            .appendingPathComponent("\(name).aiff")
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return
         }
-        AudioServicesPlaySystemSound(soundID)
+
+        // Detach on a background queue so the Process.run + short-lived
+        // afplay child doesn't block the main actor. Fire-and-forget.
+        DispatchQueue.global(qos: .userInitiated).async {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: afplayPath)
+            process.arguments = [url.path]
+            process.standardOutput = nil
+            process.standardError = nil
+            try? process.run()
+        }
     }
 
     /// Plays the user-selected notification sound, respecting the mute setting.

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -130,7 +130,7 @@
 "island.checkingTerminals" = "Checking open terminal sessions";
 "island.terminalOwnership" = "Open Island will show live agents after terminal ownership is confirmed";
 "island.noTerminals" = "No open terminal sessions";
-"island.startAgent" = "Start Codex in your terminal";
+"island.startAgent" = "Start a coding agent in your terminal";
 "island.recentSessions" = "Recent sessions remain in Control Center until the terminal is open again";
 
 /* Island Panel - Session List */

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -130,7 +130,7 @@
 "island.checkingTerminals" = "正在检查打开的终端会话";
 "island.terminalOwnership" = "Open Island 将在确认终端归属后显示实时代理";
 "island.noTerminals" = "没有打开的终端会话";
-"island.startAgent" = "在终端中启动 Codex";
+"island.startAgent" = "在终端中启动编码 Agent";
 "island.recentSessions" = "最近的会话将保留在控制中心，直到终端重新打开";
 
 /* Island Panel - Session List */

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -130,7 +130,7 @@
 "island.checkingTerminals" = "正在檢查已開啟的終端機工作階段";
 "island.terminalOwnership" = "Open Island 將在確認終端機歸屬後顯示即時代理";
 "island.noTerminals" = "沒有已開啟的終端機工作階段";
-"island.startAgent" = "在終端機中啟動 Codex";
+"island.startAgent" = "在終端機中啟動編碼 Agent";
 "island.recentSessions" = "最近的工作階段將保留在控制中心，直到終端機重新開啟";
 
 /* Island Panel - Session List */

--- a/Sources/OpenIslandApp/UpdateChecker.swift
+++ b/Sources/OpenIslandApp/UpdateChecker.swift
@@ -34,6 +34,14 @@ final class UpdateChecker: NSObject {
     /// Start Sparkle's automatic update checking schedule.
     /// Call once after app launch.
     func startIfNeeded() {
+        #if DEBUG
+        // Dev builds run from a local branch that often carries fixes not yet in
+        // the upstream appcast. Letting Sparkle prompt the user to "update" to
+        // 1.0.21 would overwrite the bundle and silently discard those fixes.
+        // Skip the auto-check entirely in debug — release bundles still update.
+        print("[UpdateChecker] skipped in DEBUG build")
+        return
+        #else
         let updater = updaterController.updater
         updater.automaticallyChecksForUpdates = true
         updater.updateCheckInterval = 60 * 60 // 1 hour
@@ -50,6 +58,7 @@ final class UpdateChecker: NSObject {
             .sink { [weak self] value in
                 self?.canCheckForUpdates = value
             }
+        #endif
     }
 
     /// Manually trigger an update check (from Settings UI).

--- a/Sources/OpenIslandCore/ClaudeStatusLineInstallationManager.swift
+++ b/Sources/OpenIslandCore/ClaudeStatusLineInstallationManager.swift
@@ -12,6 +12,9 @@ public struct ClaudeStatusLineInstallationStatus: Equatable, Sendable {
     public var managedStatusLineInstalled: Bool
     public var managedStatusLineNeedsRepair: Bool
     public var hasConflictingStatusLine: Bool
+    /// `true` when the managed script is installed in wrapper mode, preserving
+    /// the user's existing `statusLine.command` under `_openIslandOriginalStatusLine`.
+    public var managedStatusLineIsWrapper: Bool
 
     public init(
         claudeDirectory: URL,
@@ -24,7 +27,8 @@ public struct ClaudeStatusLineInstallationStatus: Equatable, Sendable {
         managedStatusLineConfigured: Bool,
         managedStatusLineInstalled: Bool,
         managedStatusLineNeedsRepair: Bool,
-        hasConflictingStatusLine: Bool
+        hasConflictingStatusLine: Bool,
+        managedStatusLineIsWrapper: Bool = false
     ) {
         self.claudeDirectory = claudeDirectory
         self.settingsURL = settingsURL
@@ -37,12 +41,14 @@ public struct ClaudeStatusLineInstallationStatus: Equatable, Sendable {
         self.managedStatusLineInstalled = managedStatusLineInstalled
         self.managedStatusLineNeedsRepair = managedStatusLineNeedsRepair
         self.hasConflictingStatusLine = hasConflictingStatusLine
+        self.managedStatusLineIsWrapper = managedStatusLineIsWrapper
     }
 }
 
 public enum ClaudeStatusLineInstallationError: LocalizedError, Sendable {
     case existingStatusLineConflict(command: String?)
     case invalidSettingsRoot
+    case wrappableCommandMissing
 
     public var errorDescription: String? {
         switch self {
@@ -53,12 +59,17 @@ public enum ClaudeStatusLineInstallationError: LocalizedError, Sendable {
             return "Claude Code already has a custom status line."
         case .invalidSettingsRoot:
             return "Claude Code settings.json must contain a top-level object."
+        case .wrappableCommandMissing:
+            return "No existing statusLine command was found to wrap."
         }
     }
 }
 
+public let openIslandOriginalStatusLineKey = "_openIslandOriginalStatusLine"
+
 public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
     public static let managedScriptName = "open-island-statusline"
+    public static let wrappedDelegateScriptName = "open-island-statusline-delegate"
     public static let legacyManagedScriptName = "vibe-island-statusline"
     public static let managedCacheURL = ClaudeUsageLoader.defaultCacheURL
 
@@ -98,6 +109,8 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
         let managedStatusLineNeedsRepair = managedStatusLineConfigured && !managedStatusLineInstalled
         let hasStatusLine = statusLine != nil
         let hasConflictingStatusLine = hasStatusLine && !managedStatusLineConfigured
+        let managedStatusLineIsWrapper = managedStatusLineConfigured
+            && settings[openIslandOriginalStatusLineKey] != nil
 
         return ClaudeStatusLineInstallationStatus(
             claudeDirectory: claudeDirectory,
@@ -110,7 +123,8 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
             managedStatusLineConfigured: managedStatusLineConfigured,
             managedStatusLineInstalled: managedStatusLineInstalled,
             managedStatusLineNeedsRepair: managedStatusLineNeedsRepair,
-            hasConflictingStatusLine: hasConflictingStatusLine
+            hasConflictingStatusLine: hasConflictingStatusLine,
+            managedStatusLineIsWrapper: managedStatusLineIsWrapper
         )
     }
 
@@ -149,15 +163,69 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
         return try status()
     }
 
+    /// Install in "wrap mode": keep the user's existing statusLine command working,
+    /// but prepend our cache-writing shim. The original command is saved under
+    /// `_openIslandOriginalStatusLine` so `uninstall()` can restore it verbatim.
+    @discardableResult
+    public func installAsWrapper() throws -> ClaudeStatusLineInstallationStatus {
+        let currentStatus = try status()
+        guard currentStatus.hasConflictingStatusLine,
+              let originalCommand = currentStatus.statusLineCommand,
+              !originalCommand.isEmpty
+        else {
+            throw ClaudeStatusLineInstallationError.wrappableCommandMissing
+        }
+
+        try fileManager.createDirectory(at: claudeDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: scriptDirectoryURL, withIntermediateDirectories: true)
+
+        let settingsURL = currentStatus.settingsURL
+        let scriptURL = currentStatus.scriptURL
+        let delegateScriptURL = scriptDirectoryURL.appendingPathComponent(Self.wrappedDelegateScriptName)
+        var mutatedSettings = try loadSettings(at: settingsURL)
+
+        // Preserve the user's original statusLine dict so uninstall can restore it verbatim.
+        if let originalStatusLine = mutatedSettings["statusLine"] {
+            mutatedSettings[openIslandOriginalStatusLineKey] = originalStatusLine
+        }
+        mutatedSettings["statusLine"] = managedStatusLine(for: scriptURL)
+
+        let settingsData = try serializeSettings(mutatedSettings)
+        if fileManager.fileExists(atPath: settingsURL.path) {
+            try backupFile(at: settingsURL)
+        }
+
+        let wrapperContents = Self.wrappedScript(
+            cacheURL: currentStatus.cacheURL,
+            delegateScriptURL: delegateScriptURL
+        )
+        let delegateContents = Self.wrappedDelegateScript(originalCommand: originalCommand)
+
+        try settingsData.write(to: settingsURL, options: .atomic)
+        try wrapperContents.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+        try delegateContents.write(to: delegateScriptURL, atomically: true, encoding: .utf8)
+        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: delegateScriptURL.path)
+
+        return try status()
+    }
+
     @discardableResult
     public func uninstall() throws -> ClaudeStatusLineInstallationStatus {
         let currentStatus = try status()
         let settingsURL = currentStatus.settingsURL
         let scriptURL = currentStatus.scriptURL
+        let delegateScriptURL = scriptDirectoryURL.appendingPathComponent(Self.wrappedDelegateScriptName)
 
         if currentStatus.managedStatusLineConfigured {
             var settings = try loadSettings(at: settingsURL)
-            settings.removeValue(forKey: "statusLine")
+            // Restore the user's original statusLine when we were running in wrapper mode.
+            if let savedOriginal = settings[openIslandOriginalStatusLineKey] {
+                settings["statusLine"] = savedOriginal
+                settings.removeValue(forKey: openIslandOriginalStatusLineKey)
+            } else {
+                settings.removeValue(forKey: "statusLine")
+            }
             if fileManager.fileExists(atPath: settingsURL.path) {
                 try backupFile(at: settingsURL)
             }
@@ -167,6 +235,9 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
 
         if fileManager.fileExists(atPath: scriptURL.path) {
             try fileManager.removeItem(at: scriptURL)
+        }
+        if fileManager.fileExists(atPath: delegateScriptURL.path) {
+            try fileManager.removeItem(at: delegateScriptURL)
         }
         let legacyScriptURL = legacyScriptDirectoryURL.appendingPathComponent(Self.legacyManagedScriptName)
         if fileManager.fileExists(atPath: legacyScriptURL.path) {
@@ -214,6 +285,32 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
             try fileManager.removeItem(at: backupURL)
         }
         try fileManager.copyItem(at: url, to: backupURL)
+    }
+
+    /// The wrapper script executed as Claude Code's `statusLine.command` in wrap mode.
+    /// It reads stdin once, writes `.rate_limits` to the cache (best-effort), then forwards
+    /// the same stdin to the delegate script which runs the user's original command.
+    /// The delegate's stdout is what Claude Code displays, so the user's custom statusLine
+    /// is unchanged visually — we're just teeing the payload to the cache file.
+    public static func wrappedScript(cacheURL: URL, delegateScriptURL: URL) -> String {
+        #"""
+        #!/bin/bash
+        # Claude Code StatusLine Script (wrapper mode)
+        # Auto-configured by Open Island.
+        # The delegate script holds the user's original statusLine.command.
+        # Keep the rate_limits cache line intact — it feeds the notch usage panel.
+        input=$(cat)
+        _rl=$(printf '%s' "$input" | jq -c '.rate_limits // empty' 2>/dev/null)
+        [ -n "$_rl" ] && printf '%s\n' "$_rl" > "\#(cacheURL.path)"
+        printf '%s' "$input" | "\#(delegateScriptURL.path)"
+        """#
+    }
+
+    /// The delegate script. Written verbatim — `originalCommand` is a shell command string
+    /// from `settings.json`, so embedding it as a script body runs with identical semantics
+    /// without the escaping problems of `bash -c "$ORIG"`.
+    public static func wrappedDelegateScript(originalCommand: String) -> String {
+        "#!/bin/bash\n# Original Claude Code statusLine.command preserved by Open Island.\n\(originalCommand)\n"
     }
 
     public static func managedScript(cacheURL: URL = managedCacheURL) -> String {

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -1,6 +1,13 @@
 import Foundation
 
 public struct SessionState: Equatable, Sendable {
+    /// Number of consecutive process-discovery misses before a hook-managed
+    /// session is assumed crashed and marked ended. Raised from 2 — the old
+    /// threshold killed live Claude Code sessions within seconds of any
+    /// discovery hiccup. Any incoming hook event (activity, permission,
+    /// question, turn completion) resets this counter to 0.
+    static let hookManagedProcessDiscoveryMissThreshold = 30
+
     public private(set) var sessionsByID: [String: AgentSession]
 
     public init(sessions: [AgentSession] = []) {
@@ -150,6 +157,12 @@ public struct SessionState: Equatable, Sendable {
             session.updatedAt = payload.timestamp
             if payload.isSessionEnd == true {
                 session.isSessionEnded = true
+            } else {
+                // Claude's Stop/PostToolUse "turn complete" hook is NOT a
+                // session end — the agent is still running and can accept
+                // a new prompt. Reset the process-liveness counter so
+                // subsequent discovery misses don't kill it.
+                session.processNotSeenCount = 0
             }
             upsert(session)
 
@@ -354,11 +367,15 @@ public struct SessionState: Equatable, Sendable {
                     session.processNotSeenCount = 0
                 } else {
                     session.processNotSeenCount += 1
-                    // Never mark a session ended while it's actively waiting on the
-                    // user — a stale process-discovery miss must not nuke a visible
-                    // permission/question prompt the user still needs to answer.
+                    // Process discovery for Claude Code is unreliable — node
+                    // processes expose no session hint on the command line, so
+                    // the heuristic misses frequently. Only use this as a last-
+                    // resort crash detector: require a long streak of misses
+                    // (was 2, wildly too aggressive) AND never kill a session
+                    // still blocking on the user.
                     let blocksOnUser = session.phase.requiresAttention
-                    if session.processNotSeenCount >= 2, !blocksOnUser {
+                    if session.processNotSeenCount >= Self.hookManagedProcessDiscoveryMissThreshold,
+                       !blocksOnUser {
                         session.isSessionEnded = true
                         session.phase = .completed
                         changed.insert(id)

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -103,6 +103,10 @@ public struct SessionState: Equatable, Sendable {
                 }
             }
 
+            // Any activity hook proves the agent is alive. Revive the session
+            // even if a prior process-liveness sweep had marked it ended.
+            session.isSessionEnded = false
+            session.processNotSeenCount = 0
             session.updatedAt = payload.timestamp
             upsert(session)
 
@@ -115,6 +119,8 @@ public struct SessionState: Equatable, Sendable {
             session.summary = payload.request.summary
             session.permissionRequest = payload.request
             session.questionPrompt = nil
+            session.isSessionEnded = false
+            session.processNotSeenCount = 0
             session.updatedAt = payload.timestamp
             upsert(session)
 
@@ -127,6 +133,8 @@ public struct SessionState: Equatable, Sendable {
             session.summary = payload.prompt.title
             session.questionPrompt = payload.prompt
             session.permissionRequest = nil
+            session.isSessionEnded = false
+            session.processNotSeenCount = 0
             session.updatedAt = payload.timestamp
             upsert(session)
 
@@ -346,7 +354,11 @@ public struct SessionState: Equatable, Sendable {
                     session.processNotSeenCount = 0
                 } else {
                     session.processNotSeenCount += 1
-                    if session.processNotSeenCount >= 2 {
+                    // Never mark a session ended while it's actively waiting on the
+                    // user — a stale process-discovery miss must not nuke a visible
+                    // permission/question prompt the user still needs to answer.
+                    let blocksOnUser = session.phase.requiresAttention
+                    if session.processNotSeenCount >= 2, !blocksOnUser {
                         session.isSessionEnded = true
                         session.phase = .completed
                         changed.insert(id)

--- a/Tests/OpenIslandCoreTests/ClaudeUsageTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeUsageTests.swift
@@ -288,6 +288,112 @@ struct ClaudeUsageTests {
             }
         }
     }
+
+    @Test
+    func claudeStatusLineInstallationManagerWrapsExistingCustomStatusLine() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-claude-wrap-\(UUID().uuidString)", isDirectory: true)
+        let claudeDirectory = rootURL.appendingPathComponent(".claude", isDirectory: true)
+        let scriptDirectory = rootURL
+            .appendingPathComponent(".open-island", isDirectory: true)
+            .appendingPathComponent("bin", isDirectory: true)
+        let manager = ClaudeStatusLineInstallationManager(
+            claudeDirectory: claudeDirectory,
+            scriptDirectoryURL: scriptDirectory
+        )
+        let settingsURL = claudeDirectory.appendingPathComponent("settings.json")
+
+        defer {
+            try? FileManager.default.removeItem(at: rootURL)
+        }
+
+        let originalCommand = "/usr/local/bin/custom-status --flag"
+        let originalStatusLine: [String: Any] = [
+            "type": "command",
+            "command": originalCommand,
+            "padding": 0,
+        ]
+
+        try FileManager.default.createDirectory(at: claudeDirectory, withIntermediateDirectories: true)
+        try JSONSerialization.data(
+            withJSONObject: [
+                "theme": "dark",
+                "statusLine": originalStatusLine,
+            ],
+            options: [.prettyPrinted, .sortedKeys]
+        ).write(to: settingsURL, options: .atomic)
+
+        let wrapped = try manager.installAsWrapper()
+
+        #expect(wrapped.managedStatusLineInstalled)
+        #expect(wrapped.managedStatusLineIsWrapper)
+        #expect(wrapped.statusLineCommand == wrapped.scriptURL.path)
+
+        let delegateURL = scriptDirectory
+            .appendingPathComponent(ClaudeStatusLineInstallationManager.wrappedDelegateScriptName)
+        #expect(FileManager.default.fileExists(atPath: wrapped.scriptURL.path))
+        #expect(FileManager.default.fileExists(atPath: delegateURL.path))
+
+        let wrapperContents = try String(contentsOf: wrapped.scriptURL, encoding: .utf8)
+        #expect(wrapperContents.contains(wrapped.cacheURL.path))
+        #expect(wrapperContents.contains(delegateURL.path))
+
+        let delegateContents = try String(contentsOf: delegateURL, encoding: .utf8)
+        #expect(delegateContents.contains(originalCommand))
+
+        let settingsAfterInstall = try jsonObject(from: Data(contentsOf: settingsURL))
+        let savedOriginal = settingsAfterInstall[openIslandOriginalStatusLineKey] as? [String: Any]
+        #expect(savedOriginal?["command"] as? String == originalCommand)
+        #expect((settingsAfterInstall["statusLine"] as? [String: Any])?["command"] as? String == wrapped.scriptURL.path)
+
+        let uninstalled = try manager.uninstall()
+        #expect(!uninstalled.managedStatusLineInstalled)
+        #expect(!uninstalled.managedStatusLineIsWrapper)
+        #expect(!FileManager.default.fileExists(atPath: wrapped.scriptURL.path))
+        #expect(!FileManager.default.fileExists(atPath: delegateURL.path))
+
+        let settingsAfterUninstall = try jsonObject(from: Data(contentsOf: settingsURL))
+        #expect(settingsAfterUninstall[openIslandOriginalStatusLineKey] == nil)
+        let restored = settingsAfterUninstall["statusLine"] as? [String: Any]
+        #expect(restored?["command"] as? String == originalCommand)
+        #expect(restored?["padding"] as? Int == 0)
+    }
+
+    @Test
+    func claudeStatusLineInstallAutoFallsBackToWrapperViaHandler() throws {
+        // Simulates HookInstallationCoordinator's catch-and-fall-back behavior.
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-claude-fallback-\(UUID().uuidString)", isDirectory: true)
+        let claudeDirectory = rootURL.appendingPathComponent(".claude", isDirectory: true)
+        let scriptDirectory = rootURL
+            .appendingPathComponent(".open-island", isDirectory: true)
+            .appendingPathComponent("bin", isDirectory: true)
+        let manager = ClaudeStatusLineInstallationManager(
+            claudeDirectory: claudeDirectory,
+            scriptDirectoryURL: scriptDirectory
+        )
+        let settingsURL = claudeDirectory.appendingPathComponent("settings.json")
+
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        try FileManager.default.createDirectory(at: claudeDirectory, withIntermediateDirectories: true)
+        try JSONSerialization.data(
+            withJSONObject: [
+                "statusLine": ["type": "command", "command": "/usr/local/bin/custom-status"],
+            ],
+            options: [.prettyPrinted, .sortedKeys]
+        ).write(to: settingsURL, options: .atomic)
+
+        let finalStatus: ClaudeStatusLineInstallationStatus
+        do {
+            finalStatus = try manager.install()
+        } catch ClaudeStatusLineInstallationError.existingStatusLineConflict {
+            finalStatus = try manager.installAsWrapper()
+        }
+
+        #expect(finalStatus.managedStatusLineIsWrapper)
+        #expect(finalStatus.managedStatusLineInstalled)
+    }
 }
 
 private func jsonObject(from data: Data) throws -> [String: Any] {


### PR DESCRIPTION
## Summary / 概述

This PR bundles one new feature and four fixes that surfaced when running the
app from a fresh fork install. Each commit stands alone and targets a
separate symptom. All 203 unit tests pass.

本 PR 合并了一项新功能和四处修复，都是作者从新 fork 本地跑起来时遇到的问题，每个 commit 都可单独 review。全部 203 个单元测试通过。

---

### 1. `feat: install Claude usage bridge in wrapper mode when statusLine is occupied` (ee49078)

**Problem.** The "Install" button under Settings → Claude usage bridge throws
`existingStatusLineConflict` and refuses to do anything if the user already has
a custom `statusLine.command` in `~/.claude/settings.json` (e.g. claude-hud).
Many Claude Code users have one — they get a dead button with no useful
feedback.

**Fix.** Added `installAsWrapper()`, which:

1. Saves the user's original `statusLine` dict verbatim under a new
   `_openIslandOriginalStatusLine` key in settings.json.
2. Writes `~/.open-island/bin/open-island-statusline` (the wrapper) and
   `open-island-statusline-delegate` (contains the user's original command).
3. Points `statusLine.command` at the wrapper.

The wrapper reads Claude Code's stdin once, writes `.rate_limits` to the
cache file, and pipes the same stdin through the delegate script so the
user's custom statusline keeps rendering. `uninstall()` restores the
original from `_openIslandOriginalStatusLine` verbatim.

`HookInstallationCoordinator.installClaudeUsageBridge()` catches
`existingStatusLineConflict` and transparently falls back to wrapper
mode, so the existing UI button "just works" without changing the UX.

Two new tests cover the wrapper install/uninstall round-trip and the
auto-fallback behavior.

**中文。** 用户原先有自定义 statusLine（如 claude-hud）时，装用量桥接会静默失败。新增 wrapper 模式：保留原脚本、在外面套一层 shim 同时写 rate_limits 缓存。装/卸都能完整还原。

---

### 2. `fix: generalize empty-state prompt to not hardcode Codex` (d0614d4)

**Problem.** When no sessions are visible, the island shows
\"Start Codex in your terminal\" — regardless of whether the user even uses
Codex. With a Claude-only setup, seeing a Claude usage header above a
\"Start Codex\" hint is misleading.

**Fix.** All three locales now say \"Start a coding agent in your terminal\"
(\"在终端中启动编码 Agent\" / \"在終端機中啟動編碼 Agent\").

**中文。** 空状态硬编码 \"Codex\" 对只用 Claude Code 的用户很奇怪，改成通用文案。

---

### 3. `fix: keep hook-managed sessions visible when process discovery can't match them` (ab154b1)

**Problem.** Active hook-managed Claude Code sessions would vanish from the
island list even though hook events were flowing. Permission prompts would
flash on screen and then disappear on their own a few seconds later, before
the user could click Yes / No — visually this made it look like hovering the
card caused it to close.

**Root cause.** `ActiveAgentProcessDiscovery` tries to pair each state session
to a live OS process. Claude Code's Node process doesn't expose the session
id on its command line, so the heuristic misses frequently. After **two**
consecutive misses, `SessionState.updateLiveness(aliveSessionIDs:)` was
stamping the session with `isSessionEnded=true, phase=.completed`, which
drops it out of `isVisibleInIsland`. Nothing in the activity / permission /
question reducers was clearing those flags when a later hook event proved the
agent was still running. For permission prompts the damage was worse: the
card would show briefly because `phase.requiresAttention` bypasses the
visibility check, then the very next tick flipped phase back to `.completed`
and nuked the card.

**Fix.** Two changes in `SessionState.swift`:

- `.activityUpdated`, `.permissionRequested`, `.questionAsked` reducers now
  clear `isSessionEnded` and reset `processNotSeenCount = 0`. An incoming
  hook event is authoritative proof the agent is alive.
- The hook-managed branch of `updateLiveness(aliveSessionIDs:)` refuses to
  mark a session ended while `phase.requiresAttention` — a stale discovery
  miss must never remove a prompt the user still has to answer.

**中文。** hook 管理的会话被进程发现误杀，导致权限卡片一闪就消失。修复 reducer 上所有活动事件复活 session，且对正在等待用户响应的会话禁止被清理。

---

### 4. `fix: raise hook-managed process-miss threshold and reset it on Stop hook` (f174ec3)

**Problem.** Follow-up to #3. With only that fix, an idle Claude Code
session between turns (phase=`.completed` after Stop hook) would still be
killed within seconds: Stop is "turn complete," not "session ended," yet the
next process-discovery tick saw phase=.completed and went ahead with
`isSessionEnded=true`.

**Fix.**

- `.sessionCompleted` reducer resets `processNotSeenCount = 0` unless the
  payload has `isSessionEnd=true`. Claude's Stop hook carries
  `isSessionEnd=nil`, so idle-between-turns now stays alive.
- Raise the hook-managed miss threshold from **2** to **30**. It's still a
  last-resort crash-detection fallback, but discovery hiccups no longer
  cost a live session.

**中文。** Stop hook 是"回合结束"不是"会话结束"，原先每次 Stop 后进程发现仍可能把 session 打死。阈值从 2 放宽到 30，且 Stop 重置计数。

---

### 5 + 6. `fix: sound — NSSound → AudioServices → afplay` (8cbe344, 89941dd)

**Problem.** Notification sounds don't play when the app is launched from
`swift run OpenIslandApp` — even with mute off, volume up, and the sound
file present. `NSSound(named:).play()` returns a valid NSSound instance
and `play()` returns true, but the speakers stay silent.

**Investigation.** Started with the obvious suspect: NSSound's bundle
dependency. Rewrote to `AudioServicesPlaySystemSound` (lower-level C API,
supposedly no bundle coupling). On macOS 26.3 that **also** silently
no-ops from an unbundled context: `AudioServicesCreateSystemSoundID`
returns `kAudioServicesNoError`, `AudioServicesPlaySystemSound` runs, and
nothing plays. Both APIs route through HIServices / CoreAudio's
per-process registration which quietly refuses un-registered hosts.

**Fix.** Shell out to `/usr/bin/afplay` on a background queue. It's a
tiny CLI shipped with every macOS install, has no bundle dependency,
respects system volume, and was ground-truth evidence earlier that the
audio stack itself was healthy. Fire-and-forget — we don't wait.

Left both commits in the history so the investigation trail is
reviewable. A squash-merge collapses them to one line if preferred.

**中文。** `swift run` 起的 App 里 NSSound 和 AudioServices 都会静默失败，原因是 macOS 的音频注册机制要求正规 .app bundle。改为 fork `/usr/bin/afplay` 子进程，绕开该限制。

---

## Test plan / 测试

- [x] `swift build` — clean
- [x] `swift test` — all 203 tests pass (includes 2 new tests for wrapper mode)
- [x] Manual: install wrapper mode while claude-hud is the existing
      statusLine; confirmed both the claude-hud line and the Open Island
      usage header render correctly in a fresh Claude Code turn
- [x] Manual: Claude sessions across two different cwds (with and without
      `--dangerously-skip-permissions`) stay visible during idle between
      turns and don't vanish on hover
- [x] Manual: notification sound plays reliably on Stop hook from
      `swift run` build on macOS 26.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wrapper installation mode for existing status line configurations, preserving them instead of failing installation.

* **Bug Fixes**
  * Improved session stability and crash detection for managed processes.

* **Documentation**
  * Updated UI terminology from "Codex" to "coding agent" across English, Simplified Chinese, and Traditional Chinese localizations.

* **Tests**
  * Added test coverage for wrapper installation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->