### PR TITLE
feat: install Claude usage bridge in wrapper mode when statusLine is occupied

### DIFF
--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -888,7 +888,13 @@ final class HookInstallationCoordinator {
 
     func installClaudeUsageBridge() {
         updateClaudeUsageBridge(userMessage: "Installing Claude usage bridge.") { manager in
-            try manager.install()
+            do {
+                return try manager.install()
+            } catch ClaudeStatusLineInstallationError.existingStatusLineConflict {
+                // User already has a custom statusLine (e.g. claude-hud). Install as a
+                // wrapper so their script keeps running and we still get rate_limits.
+                return try manager.installAsWrapper()
+            }
         }
     }
 
@@ -1073,7 +1079,11 @@ final class HookInstallationCoordinator {
                 self.claudeStatusLineStatus = status
                 self.claudeUsageSnapshot = try ClaudeUsageLoader.load()
                 if status.managedStatusLineInstalled {
-                    self.onStatusMessage?("Claude usage bridge is installed. Start a Claude Code turn to refresh cached rate limits.")
+                    if status.managedStatusLineIsWrapper {
+                        self.onStatusMessage?("Claude usage bridge installed in wrapper mode — your existing statusLine is preserved. Start a Claude Code turn to refresh cached rate limits.")
+                    } else {
+                        self.onStatusMessage?("Claude usage bridge is installed. Start a Claude Code turn to refresh cached rate limits.")
+                    }
                 } else {
                     self.onStatusMessage?("Claude usage bridge is not installed.")
                 }

--- a/Sources/OpenIslandCore/ClaudeStatusLineInstallationManager.swift
+++ b/Sources/OpenIslandCore/ClaudeStatusLineInstallationManager.swift
@@ -12,6 +12,9 @@ public struct ClaudeStatusLineInstallationStatus: Equatable, Sendable {
     public var managedStatusLineInstalled: Bool
     public var managedStatusLineNeedsRepair: Bool
     public var hasConflictingStatusLine: Bool
+    /// `true` when the managed script is installed in wrapper mode, preserving
+    /// the user's existing `statusLine.command` under `_openIslandOriginalStatusLine`.
+    public var managedStatusLineIsWrapper: Bool
 
     public init(
         claudeDirectory: URL,
@@ -24,7 +27,8 @@ public struct ClaudeStatusLineInstallationStatus: Equatable, Sendable {
         managedStatusLineConfigured: Bool,
         managedStatusLineInstalled: Bool,
         managedStatusLineNeedsRepair: Bool,
-        hasConflictingStatusLine: Bool
+        hasConflictingStatusLine: Bool,
+        managedStatusLineIsWrapper: Bool = false
     ) {
         self.claudeDirectory = claudeDirectory
         self.settingsURL = settingsURL
@@ -37,12 +41,14 @@ public struct ClaudeStatusLineInstallationStatus: Equatable, Sendable {
         self.managedStatusLineInstalled = managedStatusLineInstalled
         self.managedStatusLineNeedsRepair = managedStatusLineNeedsRepair
         self.hasConflictingStatusLine = hasConflictingStatusLine
+        self.managedStatusLineIsWrapper = managedStatusLineIsWrapper
     }
 }
 
 public enum ClaudeStatusLineInstallationError: LocalizedError, Sendable {
     case existingStatusLineConflict(command: String?)
     case invalidSettingsRoot
+    case wrappableCommandMissing
 
     public var errorDescription: String? {
         switch self {
@@ -53,12 +59,17 @@ public enum ClaudeStatusLineInstallationError: LocalizedError, Sendable {
             return "Claude Code already has a custom status line."
         case .invalidSettingsRoot:
             return "Claude Code settings.json must contain a top-level object."
+        case .wrappableCommandMissing:
+            return "No existing statusLine command was found to wrap."
         }
     }
 }
 
+public let openIslandOriginalStatusLineKey = "_openIslandOriginalStatusLine"
+
 public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
     public static let managedScriptName = "open-island-statusline"
+    public static let wrappedDelegateScriptName = "open-island-statusline-delegate"
     public static let legacyManagedScriptName = "vibe-island-statusline"
     public static let managedCacheURL = ClaudeUsageLoader.defaultCacheURL
 
@@ -98,6 +109,8 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
         let managedStatusLineNeedsRepair = managedStatusLineConfigured && !managedStatusLineInstalled
         let hasStatusLine = statusLine != nil
         let hasConflictingStatusLine = hasStatusLine && !managedStatusLineConfigured
+        let managedStatusLineIsWrapper = managedStatusLineConfigured
+            && settings[openIslandOriginalStatusLineKey] != nil
 
         return ClaudeStatusLineInstallationStatus(
             claudeDirectory: claudeDirectory,
@@ -110,7 +123,8 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
             managedStatusLineConfigured: managedStatusLineConfigured,
             managedStatusLineInstalled: managedStatusLineInstalled,
             managedStatusLineNeedsRepair: managedStatusLineNeedsRepair,
-            hasConflictingStatusLine: hasConflictingStatusLine
+            hasConflictingStatusLine: hasConflictingStatusLine,
+            managedStatusLineIsWrapper: managedStatusLineIsWrapper
         )
     }
 
@@ -149,15 +163,69 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
         return try status()
     }
 
+    /// Install in "wrap mode": keep the user's existing statusLine command working,
+    /// but prepend our cache-writing shim. The original command is saved under
+    /// `_openIslandOriginalStatusLine` so `uninstall()` can restore it verbatim.
+    @discardableResult
+    public func installAsWrapper() throws -> ClaudeStatusLineInstallationStatus {
+        let currentStatus = try status()
+        guard currentStatus.hasConflictingStatusLine,
+              let originalCommand = currentStatus.statusLineCommand,
+              !originalCommand.isEmpty
+        else {
+            throw ClaudeStatusLineInstallationError.wrappableCommandMissing
+        }
+
+        try fileManager.createDirectory(at: claudeDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: scriptDirectoryURL, withIntermediateDirectories: true)
+
+        let settingsURL = currentStatus.settingsURL
+        let scriptURL = currentStatus.scriptURL
+        let delegateScriptURL = scriptDirectoryURL.appendingPathComponent(Self.wrappedDelegateScriptName)
+        var mutatedSettings = try loadSettings(at: settingsURL)
+
+        // Preserve the user's original statusLine dict so uninstall can restore it verbatim.
+        if let originalStatusLine = mutatedSettings["statusLine"] {
+            mutatedSettings[openIslandOriginalStatusLineKey] = originalStatusLine
+        }
+        mutatedSettings["statusLine"] = managedStatusLine(for: scriptURL)
+
+        let settingsData = try serializeSettings(mutatedSettings)
+        if fileManager.fileExists(atPath: settingsURL.path) {
+            try backupFile(at: settingsURL)
+        }
+
+        let wrapperContents = Self.wrappedScript(
+            cacheURL: currentStatus.cacheURL,
+            delegateScriptURL: delegateScriptURL
+        )
+        let delegateContents = Self.wrappedDelegateScript(originalCommand: originalCommand)
+
+        try settingsData.write(to: settingsURL, options: .atomic)
+        try wrapperContents.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+        try delegateContents.write(to: delegateScriptURL, atomically: true, encoding: .utf8)
+        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: delegateScriptURL.path)
+
+        return try status()
+    }
+
     @discardableResult
     public func uninstall() throws -> ClaudeStatusLineInstallationStatus {
         let currentStatus = try status()
         let settingsURL = currentStatus.settingsURL
         let scriptURL = currentStatus.scriptURL
+        let delegateScriptURL = scriptDirectoryURL.appendingPathComponent(Self.wrappedDelegateScriptName)
 
         if currentStatus.managedStatusLineConfigured {
             var settings = try loadSettings(at: settingsURL)
-            settings.removeValue(forKey: "statusLine")
+            // Restore the user's original statusLine when we were running in wrapper mode.
+            if let savedOriginal = settings[openIslandOriginalStatusLineKey] {
+                settings["statusLine"] = savedOriginal
+                settings.removeValue(forKey: openIslandOriginalStatusLineKey)
+            } else {
+                settings.removeValue(forKey: "statusLine")
+            }
             if fileManager.fileExists(atPath: settingsURL.path) {
                 try backupFile(at: settingsURL)
             }
@@ -167,6 +235,9 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
 
         if fileManager.fileExists(atPath: scriptURL.path) {
             try fileManager.removeItem(at: scriptURL)
+        }
+        if fileManager.fileExists(atPath: delegateScriptURL.path) {
+            try fileManager.removeItem(at: delegateScriptURL)
         }
         let legacyScriptURL = legacyScriptDirectoryURL.appendingPathComponent(Self.legacyManagedScriptName)
         if fileManager.fileExists(atPath: legacyScriptURL.path) {
@@ -214,6 +285,32 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
             try fileManager.removeItem(at: backupURL)
         }
         try fileManager.copyItem(at: url, to: backupURL)
+    }
+
+    /// The wrapper script executed as Claude Code's `statusLine.command` in wrap mode.
+    /// It reads stdin once, writes `.rate_limits` to the cache (best-effort), then forwards
+    /// the same stdin to the delegate script which runs the user's original command.
+    /// The delegate's stdout is what Claude Code displays, so the user's custom statusLine
+    /// is unchanged visually — we're just teeing the payload to the cache file.
+    public static func wrappedScript(cacheURL: URL, delegateScriptURL: URL) -> String {
+        #"""
+        #!/bin/bash
+        # Claude Code StatusLine Script (wrapper mode)
+        # Auto-configured by Open Island.
+        # The delegate script holds the user's original statusLine.command.
+        # Keep the rate_limits cache line intact — it feeds the notch usage panel.
+        input=$(cat)
+        _rl=$(printf '%s' "$input" | jq -c '.rate_limits // empty' 2>/dev/null)
+        [ -n "$_rl" ] && printf '%s\n' "$_rl" > "\#(cacheURL.path)"
+        printf '%s' "$input" | "\#(delegateScriptURL.path)"
+        """#
+    }
+
+    /// The delegate script. Written verbatim — `originalCommand` is a shell command string
+    /// from `settings.json`, so embedding it as a script body runs with identical semantics
+    /// without the escaping problems of `bash -c "$ORIG"`.
+    public static func wrappedDelegateScript(originalCommand: String) -> String {
+        "#!/bin/bash\n# Original Claude Code statusLine.command preserved by Open Island.\n\(originalCommand)\n"
     }
 
     public static func managedScript(cacheURL: URL = managedCacheURL) -> String {

--- a/Tests/OpenIslandCoreTests/ClaudeUsageTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeUsageTests.swift
@@ -288,6 +288,112 @@ struct ClaudeUsageTests {
             }
         }
     }
+
+    @Test
+    func claudeStatusLineInstallationManagerWrapsExistingCustomStatusLine() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-claude-wrap-\(UUID().uuidString)", isDirectory: true)
+        let claudeDirectory = rootURL.appendingPathComponent(".claude", isDirectory: true)
+        let scriptDirectory = rootURL
+            .appendingPathComponent(".open-island", isDirectory: true)
+            .appendingPathComponent("bin", isDirectory: true)
+        let manager = ClaudeStatusLineInstallationManager(
+            claudeDirectory: claudeDirectory,
+            scriptDirectoryURL: scriptDirectory
+        )
+        let settingsURL = claudeDirectory.appendingPathComponent("settings.json")
+
+        defer {
+            try? FileManager.default.removeItem(at: rootURL)
+        }
+
+        let originalCommand = "/usr/local/bin/custom-status --flag"
+        let originalStatusLine: [String: Any] = [
+            "type": "command",
+            "command": originalCommand,
+            "padding": 0,
+        ]
+
+        try FileManager.default.createDirectory(at: claudeDirectory, withIntermediateDirectories: true)
+        try JSONSerialization.data(
+            withJSONObject: [
+                "theme": "dark",
+                "statusLine": originalStatusLine,
+            ],
+            options: [.prettyPrinted, .sortedKeys]
+        ).write(to: settingsURL, options: .atomic)
+
+        let wrapped = try manager.installAsWrapper()
+
+        #expect(wrapped.managedStatusLineInstalled)
+        #expect(wrapped.managedStatusLineIsWrapper)
+        #expect(wrapped.statusLineCommand == wrapped.scriptURL.path)
+
+        let delegateURL = scriptDirectory
+            .appendingPathComponent(ClaudeStatusLineInstallationManager.wrappedDelegateScriptName)
+        #expect(FileManager.default.fileExists(atPath: wrapped.scriptURL.path))
+        #expect(FileManager.default.fileExists(atPath: delegateURL.path))
+
+        let wrapperContents = try String(contentsOf: wrapped.scriptURL, encoding: .utf8)
+        #expect(wrapperContents.contains(wrapped.cacheURL.path))
+        #expect(wrapperContents.contains(delegateURL.path))
+
+        let delegateContents = try String(contentsOf: delegateURL, encoding: .utf8)
+        #expect(delegateContents.contains(originalCommand))
+
+        let settingsAfterInstall = try jsonObject(from: Data(contentsOf: settingsURL))
+        let savedOriginal = settingsAfterInstall[openIslandOriginalStatusLineKey] as? [String: Any]
+        #expect(savedOriginal?["command"] as? String == originalCommand)
+        #expect((settingsAfterInstall["statusLine"] as? [String: Any])?["command"] as? String == wrapped.scriptURL.path)
+
+        let uninstalled = try manager.uninstall()
+        #expect(!uninstalled.managedStatusLineInstalled)
+        #expect(!uninstalled.managedStatusLineIsWrapper)
+        #expect(!FileManager.default.fileExists(atPath: wrapped.scriptURL.path))
+        #expect(!FileManager.default.fileExists(atPath: delegateURL.path))
+
+        let settingsAfterUninstall = try jsonObject(from: Data(contentsOf: settingsURL))
+        #expect(settingsAfterUninstall[openIslandOriginalStatusLineKey] == nil)
+        let restored = settingsAfterUninstall["statusLine"] as? [String: Any]
+        #expect(restored?["command"] as? String == originalCommand)
+        #expect(restored?["padding"] as? Int == 0)
+    }
+
+    @Test
+    func claudeStatusLineInstallAutoFallsBackToWrapperViaHandler() throws {
+        // Simulates HookInstallationCoordinator's catch-and-fall-back behavior.
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-claude-fallback-\(UUID().uuidString)", isDirectory: true)
+        let claudeDirectory = rootURL.appendingPathComponent(".claude", isDirectory: true)
+        let scriptDirectory = rootURL
+            .appendingPathComponent(".open-island", isDirectory: true)
+            .appendingPathComponent("bin", isDirectory: true)
+        let manager = ClaudeStatusLineInstallationManager(
+            claudeDirectory: claudeDirectory,
+            scriptDirectoryURL: scriptDirectory
+        )
+        let settingsURL = claudeDirectory.appendingPathComponent("settings.json")
+
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        try FileManager.default.createDirectory(at: claudeDirectory, withIntermediateDirectories: true)
+        try JSONSerialization.data(
+            withJSONObject: [
+                "statusLine": ["type": "command", "command": "/usr/local/bin/custom-status"],
+            ],
+            options: [.prettyPrinted, .sortedKeys]
+        ).write(to: settingsURL, options: .atomic)
+
+        let finalStatus: ClaudeStatusLineInstallationStatus
+        do {
+            finalStatus = try manager.install()
+        } catch ClaudeStatusLineInstallationError.existingStatusLineConflict {
+            finalStatus = try manager.installAsWrapper()
+        }
+
+        #expect(finalStatus.managedStatusLineIsWrapper)
+        #expect(finalStatus.managedStatusLineInstalled)
+    }
 }
 
 private func jsonObject(from data: Data) throws -> [String: Any] {


### PR DESCRIPTION
Split out of #328 per @Octane0411's request.

## Problem

Settings → "Install" under *Claude usage bridge* refuses to do anything when the user already has a custom `statusLine.command` in `~/.claude/settings.json` (e.g. claude-hud). It throws `existingStatusLineConflict` and the UI surfaces only a generic "update failed" toast — the button looks dead.

本项当用户已经有自定义 statusLine（如 claude-hud）时，装用量桥接会因 `existingStatusLineConflict` 静默失败，UI 只显示泛泛的错误消息。

## Fix

Added `installAsWrapper()` which:

1. Preserves the user's original `statusLine` dict verbatim under a new `_openIslandOriginalStatusLine` key in `settings.json`.
2. Writes `~/.open-island/bin/open-island-statusline` (the wrapper) and `open-island-statusline-delegate` (verbatim copy of user's original command — separate file to avoid bash-escaping the command string through `bash -c`).
3. Points `statusLine.command` at the wrapper.

The wrapper reads Claude Code's stdin once, writes `.rate_limits` to the cache file (same behavior as the managed script), and pipes the same stdin through the delegate so the user's custom statusline keeps rendering unchanged. `uninstall()` restores the original from `_openIslandOriginalStatusLine`.

`HookInstallationCoordinator.installClaudeUsageBridge()` catches `existingStatusLineConflict` and transparently falls back to wrapper mode, so the existing UI button "just works" — the success banner mentions wrapper mode so the user knows their original script still runs.

新增 wrapper 模式：不替换用户的 statusLine，而是把原脚本存成 delegate，外层套一层 shim 同时写 rate_limits 缓存。`uninstall` 能完整还原。UI 按钮自动回退不改 UX。

## Test plan

- [x] `swift build`
- [x] `swift test` (203 passing, includes 2 new tests for wrapper install/uninstall round-trip and auto-fallback)
- [x] Manual: installed with claude-hud as the existing statusLine; both claude-hud and Open Island's usage header render correctly.