### PR TITLE
fix: generalize empty-state prompt to not hardcode Codex

### DIFF
--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -131,7 +131,7 @@
 "island.checkingTerminals" = "Checking open terminal sessions";
 "island.terminalOwnership" = "Open Island will show live agents after terminal ownership is confirmed";
 "island.noTerminals" = "No open terminal sessions";
-"island.startAgent" = "Start Codex in your terminal";
+"island.startAgent" = "Start a coding agent in your terminal";
 "island.recentSessions" = "Recent sessions remain in Control Center until the terminal is open again";
 
 /* Island Panel - Session List */

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -131,7 +131,7 @@
 "island.checkingTerminals" = "正在检查打开的终端会话";
 "island.terminalOwnership" = "Open Island 将在确认终端归属后显示实时代理";
 "island.noTerminals" = "没有打开的终端会话";
-"island.startAgent" = "在终端中启动 Codex";
+"island.startAgent" = "在终端中启动编码代理";
 "island.recentSessions" = "最近的会话将保留在控制中心，直到终端重新打开";
 
 /* Island Panel - Session List */

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -131,7 +131,7 @@
 "island.checkingTerminals" = "正在檢查已開啟的終端機工作階段";
 "island.terminalOwnership" = "Open Island 將在確認終端機歸屬後顯示即時代理";
 "island.noTerminals" = "沒有已開啟的終端機工作階段";
-"island.startAgent" = "在終端機中啟動 Codex";
+"island.startAgent" = "在終端機中啟動編碼代理";
 "island.recentSessions" = "最近的工作階段將保留在控制中心，直到終端機重新開啟";
 
 /* Island Panel - Session List */


### PR DESCRIPTION
Split out of #328.

## Problem

The island empty-state CTA (`island.startAgent`) was hardcoded to suggest starting Codex. A Claude-only user sees "Start Codex in your terminal" right next to a Claude usage header, which is misleading.

Also addresses @coderabbitai's nitpick: the zh-Hans / zh-Hant translations mixed English and Chinese (`编码 Agent` / `編碼 Agent`) — now fully localized as `编码代理` / `編碼代理`.

硬编码 "Codex" 对只用 Claude Code 的用户很奇怪；顺带把中文本地化的"Agent"混拼改成纯中文"代理"。

## Test plan

- [x] `swift build` / `swift test` (203 passing)