### PR TITLE
fix: keep hook-managed sessions visible when process discovery can't match them

### DIFF
--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -1,6 +1,13 @@
 import Foundation
 
 public struct SessionState: Equatable, Sendable {
+    /// Number of consecutive process-discovery misses before a hook-managed
+    /// session is assumed crashed and marked ended. Raised from 2 — the old
+    /// threshold killed live Claude Code sessions within seconds of any
+    /// discovery hiccup. Any incoming hook event (activity, permission,
+    /// question, turn completion) resets this counter to 0.
+    static let hookManagedProcessDiscoveryMissThreshold = 30
+
     public private(set) var sessionsByID: [String: AgentSession]
 
     public init(sessions: [AgentSession] = []) {
@@ -150,6 +157,12 @@ public struct SessionState: Equatable, Sendable {
             session.updatedAt = payload.timestamp
             if payload.isSessionEnd == true {
                 session.isSessionEnded = true
+            } else {
+                // Claude's Stop/PostToolUse "turn complete" hook is NOT a
+                // session end — the agent is still running and can accept
+                // a new prompt. Reset the process-liveness counter so
+                // subsequent discovery misses don't kill it.
+                session.processNotSeenCount = 0
             }
             upsert(session)
 
@@ -354,11 +367,15 @@ public struct SessionState: Equatable, Sendable {
                     session.processNotSeenCount = 0
                 } else {
                     session.processNotSeenCount += 1
-                    // Never mark a session ended while it's actively waiting on the
-                    // user — a stale process-discovery miss must not nuke a visible
-                    // permission/question prompt the user still needs to answer.
+                    // Process discovery for Claude Code is unreliable — node
+                    // processes expose no session hint on the command line, so
+                    // the heuristic misses frequently. Only use this as a last-
+                    // resort crash detector: require a long streak of misses
+                    // (was 2, wildly too aggressive) AND never kill a session
+                    // still blocking on the user.
                     let blocksOnUser = session.phase.requiresAttention
-                    if session.processNotSeenCount >= 2, !blocksOnUser {
+                    if session.processNotSeenCount >= Self.hookManagedProcessDiscoveryMissThreshold,
+                       !blocksOnUser {
                         session.isSessionEnded = true
                         session.phase = .completed
                         changed.insert(id)

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -103,6 +103,10 @@ public struct SessionState: Equatable, Sendable {
                 }
             }
 
+            // Any activity hook proves the agent is alive. Revive the session
+            // even if a prior process-liveness sweep had marked it ended.
+            session.isSessionEnded = false
+            session.processNotSeenCount = 0
             session.updatedAt = payload.timestamp
             upsert(session)
 
@@ -115,6 +119,8 @@ public struct SessionState: Equatable, Sendable {
             session.summary = payload.request.summary
             session.permissionRequest = payload.request
             session.questionPrompt = nil
+            session.isSessionEnded = false
+            session.processNotSeenCount = 0
             session.updatedAt = payload.timestamp
             upsert(session)
 
@@ -127,6 +133,8 @@ public struct SessionState: Equatable, Sendable {
             session.summary = payload.prompt.title
             session.questionPrompt = payload.prompt
             session.permissionRequest = nil
+            session.isSessionEnded = false
+            session.processNotSeenCount = 0
             session.updatedAt = payload.timestamp
             upsert(session)
 
@@ -346,7 +354,11 @@ public struct SessionState: Equatable, Sendable {
                     session.processNotSeenCount = 0
                 } else {
                     session.processNotSeenCount += 1
-                    if session.processNotSeenCount >= 2 {
+                    // Never mark a session ended while it's actively waiting on the
+                    // user — a stale process-discovery miss must not nuke a visible
+                    // permission/question prompt the user still needs to answer.
+                    let blocksOnUser = session.phase.requiresAttention
+                    if session.processNotSeenCount >= 2, !blocksOnUser {
                         session.isSessionEnded = true
                         session.phase = .completed
                         changed.insert(id)


### PR DESCRIPTION
Split out of #328.

## Problem

Active hook-managed Claude Code sessions vanished from the island list even though hook events were flowing. Permission prompts would flash on screen and then disappear a few seconds later, before the user could click Yes/No — visually this looked like hovering the card caused it to close.

## Root cause

`ActiveAgentProcessDiscovery` tries to pair each state session to a live OS process. Claude Code's Node process doesn't expose the session id on its command line, so the heuristic misses frequently. After **two** consecutive misses, `SessionState.updateLiveness(aliveSessionIDs:)` stamped the session with `isSessionEnded=true, phase=.completed` — dropping it out of `isVisibleInIsland`. Nothing in the activity / permission / question / completed reducers was clearing those flags when a later hook event proved the agent still alive.

For permission prompts the damage was worse: the card briefly showed via `phase.requiresAttention` bypassing the visibility check, then the very next tick flipped phase back to `.completed` and nuked the card.

## Fix

Two commits:

1. **`fix: keep hook-managed sessions visible when process discovery can't match them`**
   - `.activityUpdated`, `.permissionRequested`, `.questionAsked` reducers clear `isSessionEnded` and reset `processNotSeenCount`. Any hook event = agent is alive.
   - `updateLiveness(aliveSessionIDs:)` refuses to mark a session ended while `phase.requiresAttention`.

2. **`fix: raise hook-managed process-miss threshold and reset it on Stop hook`**
   - Claude's `Stop` hook fires `sessionCompleted` without `isSessionEnd=true` (it's "turn complete," not "session ended" — the agent is still running). The reducer now resets `processNotSeenCount` in that case.
   - Bump the hook-managed miss threshold from **2** to **30**. Still a crash-detection fallback, but discovery hiccups no longer cost a live session.

修复 hook-managed session 被进程发现误杀：所有 hook 事件复活 session；正在等待用户的 session 禁止被清理；Stop 不视为 session 结束；阈值 2→30。

## Test plan

- [x] `swift build` / `swift test` (203 passing — existing SessionState tests cover the reducer changes)
- [x] Manual: Claude Code sessions (including `--dangerously-skip-permissions`) stay visible across idle periods; permission prompts no longer self-dismiss.