### PR TITLE
chore: disable Sparkle auto-update check in DEBUG builds

### DIFF
--- a/Sources/OpenIslandApp/UpdateChecker.swift
+++ b/Sources/OpenIslandApp/UpdateChecker.swift
@@ -34,6 +34,14 @@ final class UpdateChecker: NSObject {
     /// Start Sparkle's automatic update checking schedule.
     /// Call once after app launch.
     func startIfNeeded() {
+        #if DEBUG
+        // Dev builds run from a local branch that often carries fixes not yet in
+        // the upstream appcast. Letting Sparkle prompt the user to "update" to
+        // 1.0.21 would overwrite the bundle and silently discard those fixes.
+        // Skip the auto-check entirely in debug — release bundles still update.
+        print("[UpdateChecker] skipped in DEBUG build")
+        return
+        #else
         let updater = updaterController.updater
         updater.automaticallyChecksForUpdates = true
         updater.updateCheckInterval = 60 * 60 // 1 hour
@@ -50,6 +58,7 @@ final class UpdateChecker: NSObject {
             .sink { [weak self] value in
                 self?.canCheckForUpdates = value
             }
+        #endif
     }
 
     /// Manually trigger an update check (from Settings UI).


### PR DESCRIPTION
Split out of #328.

## Problem

Dev builds produced via `swift run` or `scripts/launch-dev-app.sh` typically carry local branch work not in the upstream appcast. The Sparkle updater was happily prompting users to "update" their dev bundle to the latest official release, which would overwrite the bundle and silently drop their uncommitted work.

dev build 经常带有本地未合并的改动，Sparkle 弹窗让用户"更新"到上游最新 release 会覆盖 bundle、丢失改动。

## Fix

Early-return in `UpdateChecker.startIfNeeded()` behind `#if DEBUG`. Release bundles (signed, notarized DMG from the release workflow) build without DEBUG and retain the full auto-update behavior unchanged.

## Test plan

- [x] `swift build` / `swift test` (203 passing)
- [x] Manual: no more "v1.0.22 is available" prompt when running `zsh scripts/launch-dev-app.sh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to modify update checker behavior in debug builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->