### PR TITLE
feat: immediate session refresh on new terminal detection

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -106,6 +106,13 @@ final class AppModel {
     func uninstallOpenCodePlugin() { hooks.uninstallOpenCodePlugin() }
     func installClaudeUsageBridge() { hooks.installClaudeUsageBridge() }
     func uninstallClaudeUsageBridge() { hooks.uninstallClaudeUsageBridge() }
+
+    /// Force an immediate process scan + terminal reconciliation.
+    /// Call from UI (e.g. a refresh button) to detect newly opened terminals.
+    func refreshSessions() {
+        monitoring.triggerImmediateReconciliation()
+    }
+
     var isBridgeReady = false
     var lastActionMessage = "Waiting for agent hook events..." {
         didSet {
@@ -842,6 +849,13 @@ final class AppModel {
         if ingress == .bridge {
             monitoring.markSessionAttached(for: event)
             monitoring.markSessionProcessAlive(for: event)
+
+            // When a new session arrives via hook, trigger an immediate process
+            // scan so that terminal attachment and jump-target resolution happen
+            // right away instead of waiting for the next 2-second polling cycle.
+            if case .sessionStarted = event {
+                monitoring.triggerImmediateReconciliation()
+            }
         }
         synchronizeSelection()
         discovery.refreshCodexRolloutTracking()

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -42,7 +42,36 @@ final class ProcessMonitoringCoordinator {
         set { stateUpdater?(newValue) }
     }
 
+    @ObservationIgnored
+    private var immediateReconciliationTask: Task<Void, Never>?
+
     // MARK: - Monitoring lifecycle
+
+    /// Trigger an immediate process discovery + reconciliation cycle off the
+    /// normal 2-second polling schedule.  Safe to call repeatedly — concurrent
+    /// requests are coalesced (the second call is a no-op while a scan is
+    /// already in-flight).
+    func triggerImmediateReconciliation() {
+        guard immediateReconciliationTask == nil else { return }
+
+        immediateReconciliationTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let discovery = self.activeAgentProcessDiscovery
+            let probe = self.terminalSessionAttachmentProbe
+            let (snapshots, ghosttyAvail, terminalAvail) = await Task.detached(priority: .userInitiated) {
+                let s = discovery.discover()
+                let g = probe.ghosttySnapshotAvailability()
+                let t = probe.terminalSnapshotAvailability()
+                return (s, g, t)
+            }.value
+            self.reconcileSessionAttachments(
+                activeProcesses: snapshots,
+                ghosttyAvailability: ghosttyAvail,
+                terminalAvailability: terminalAvail
+            )
+            self.immediateReconciliationTask = nil
+        }
+    }
 
     func startMonitoringIfNeeded() {
         guard sessionAttachmentMonitorTask == nil else {

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -386,6 +386,10 @@ struct IslandPanelView: View {
                 model.toggleSoundMuted()
             }
 
+            headerIconButton(systemName: "arrow.clockwise", tint: .white.opacity(0.62)) {
+                model.refreshSessions()
+            }
+
             headerIconButton(systemName: "gearshape.fill", tint: .white.opacity(0.62)) {
                 model.showSettings()
             }


### PR DESCRIPTION
## Summary
- Hook 事件（sessionStarted）到达时立即触发进程扫描+终端匹配，不再等待 2 秒轮询周期
- 在 island 面板头部增加刷新按钮（↻），支持手动触发会话重新扫描
- AppModel 暴露 `refreshSessions()` 方法供 UI 调用

## 改动文件
- **ProcessMonitoringCoordinator.swift** — 新增 `triggerImmediateReconciliation()`，并发安全（重复调用自动合并）
- **AppModel.swift** — sessionStarted 时调用立即 reconciliation；暴露 `refreshSessions()` 
- **IslandPanelView.swift** — header 按钮区添加 `arrow.clockwise` 刷新按钮

## Test plan
- [x] `swift build` 编译通过
- [x] `swift test` 全部 121 个测试通过
- [ ] 手动验证：启动 app → 新开终端运行 claude → 确认立即出现在会话列表
- [ ] 手动验证：点击刷新按钮后新终端会话被识别

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual refresh button in the header to update session information on-demand.

* **Improvements**
  * Session updates now trigger immediately when a new session starts, eliminating wait times between polling cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->