### PR TITLE
fix: recognize Claude binaries at non-standard install paths & show hidden files in directory selection

### DIFF
--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -536,11 +536,12 @@ struct ActiveAgentProcessDiscovery {
             return true
         }
 
-        guard let firstToken = lowered.split(separator: " ").first else {
+        guard let firstToken = lowered.split(separator: " ").first.map(String.init) else {
             return false
         }
 
         return firstToken == "claude"
+            || firstToken.hasSuffix("/claude")
     }
 
     private static func commandOutput(executablePath: String, arguments: [String]) -> String? {

--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -530,6 +530,9 @@ struct ActiveAgentProcessDiscovery {
             || lowered.contains("/@google/gemini-cli")
     }
 
+    /// Returns `true` when the given `ps` command string belongs to a Claude Code process.
+    /// Matches the official `~/.local/bin/claude` path as well as any absolute path whose
+    /// last component is `claude` (e.g. `~/.codefuse/.../claude`).
     private func isClaudeProcess(command: String) -> Bool {
         let lowered = command.lowercased()
         if lowered.contains("/.local/bin/claude") {

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -304,6 +304,7 @@ final class AppModel {
         panel.canChooseFiles = true
         panel.canChooseDirectories = false
         panel.allowsMultipleSelection = false
+        panel.showsHiddenFiles = true
         panel.allowedContentTypes = [.png, .jpeg, .heic, .tiff]
         guard panel.runModal() == .OK, let url = panel.url else { return }
         do {

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -690,6 +690,7 @@ struct SetupSettingsPane: View {
                     panel.canChooseDirectories = true
                     panel.canChooseFiles = false
                     panel.canCreateDirectories = true
+                    panel.showsHiddenFiles = true
                     panel.prompt = lang.t("setup.claudeConfigDir.choose")
                     if panel.runModal() == .OK, let url = panel.url {
                         model.updateClaudeConfigDirectory(to: url)


### PR DESCRIPTION
## Summary
- **fix: recognize Claude binaries at non-standard install paths** — `isClaudeProcess()` only matched `~/.local/bin/claude` or a bare `claude` command token. Claude installations at other paths (e.g. `~/.xxx/.../claude`, custom Homebrew prefixes) were invisible to process discovery, causing hook-managed sessions to appear briefly then vanish after ~4 seconds. Added `firstToken.hasSuffix("/claude")` to match any absolute path ending in `/claude`, consistent with how `isCodexProcess` already handles `/codex`.
- **feat: show hidden files in directory selection** — Enable `showsHiddenFiles` in the directory picker for Claude config and custom avatar, so users can select paths inside dotfile directories (e.g. `~/.claude/`).

## Test plan
- [ ] Run Claude Code from a non-standard install path, verify sessions persist in the island
- [ ] Verify standard `~/.local/bin/claude` installs still work
- [ ] Open directory picker for Claude config / custom avatar, verify hidden files are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Claude process detection to recognize alternative installation paths.
  * File pickers now display hidden files and directories when selecting custom avatars and Claude configuration directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->