### PR TITLE
Feat/kiro cli support

### DIFF
--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -129,6 +129,20 @@ struct ActiveAgentProcessDiscovery {
                     terminalApp: terminalApp(for: process, processesByPID: processesByPID)
                 ))
             }
+
+            if isKiroProcess(command: process.command) {
+                let claimKey = "kiro:\(process.pid)"
+                guard claimedKeys.insert(claimKey).inserted else {
+                    continue
+                }
+
+                snapshots.append(ProcessSnapshot(
+                    tool: .kiro,
+                    sessionID: nil,
+                    workingDirectory: nil,
+                    terminalTTY: process.terminalTTY
+                ))
+            }
         }
 
         return snapshots
@@ -541,6 +555,11 @@ struct ActiveAgentProcessDiscovery {
         }
 
         return firstToken == "claude"
+    }
+
+    private func isKiroProcess(command: String) -> Bool {
+        let lowered = command.lowercased()
+        return lowered.contains("kiro-cli-chat") || lowered.contains("kiro-cli chat")
     }
 
     private static func commandOutput(executablePath: String, arguments: [String]) -> String? {

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1164,6 +1164,7 @@ final class AppModel {
                 case let .geminiSessionMetadataUpdated(p): return p.sessionID
                 case let .openCodeSessionMetadataUpdated(p): return p.sessionID
                 case let .cursorSessionMetadataUpdated(p): return p.sessionID
+                case let .kiroSessionMetadataUpdated(p): return p.sessionID
                 case let .actionableStateResolved(p): return p.sessionID
                 }
             }()
@@ -1425,6 +1426,8 @@ final class AppModel {
             }
 
             return payload.cursorMetadata.lastAssistantMessage ?? "Cursor session metadata updated."
+        case let .kiroSessionMetadataUpdated(payload):
+            return payload.kiroMetadata.lastAssistantMessage ?? "Kiro session metadata updated."
         case let .actionableStateResolved(payload):
             return "Actionable state resolved for session \(payload.sessionID)."
         }

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -82,14 +82,17 @@ final class AppModel {
     var qwenCodeHooksInstalled: Bool { hooks.qwenCodeHooksInstalled }
     var factoryHooksInstalled: Bool { hooks.factoryHooksInstalled }
     var codebuddyHooksInstalled: Bool { hooks.codebuddyHooksInstalled }
+    var kiroHooksInstalled: Bool { hooks.kiroHooksInstalled }
     var qoderHookStatus: ClaudeHookInstallationStatus? { hooks.qoderHookStatus }
     var qwenCodeHookStatus: ClaudeHookInstallationStatus? { hooks.qwenCodeHookStatus }
     var factoryHookStatus: ClaudeHookInstallationStatus? { hooks.factoryHookStatus }
     var codebuddyHookStatus: ClaudeHookInstallationStatus? { hooks.codebuddyHookStatus }
+    var kiroHookStatus: ClaudeHookInstallationStatus? { hooks.kiroHookStatus }
     var isQoderHookSetupBusy: Bool { hooks.isQoderHookSetupBusy }
     var isQwenCodeHookSetupBusy: Bool { hooks.isQwenCodeHookSetupBusy }
     var isFactoryHookSetupBusy: Bool { hooks.isFactoryHookSetupBusy }
     var isCodebuddyHookSetupBusy: Bool { hooks.isCodebuddyHookSetupBusy }
+    var isKiroHookSetupBusy: Bool { hooks.isKiroHookSetupBusy }
     var openCodePluginInstalled: Bool { hooks.openCodePluginInstalled }
     var claudeUsageInstalled: Bool { hooks.claudeUsageInstalled }
     var claudeHookStatusTitle: String { hooks.claudeHookStatusTitle }
@@ -136,6 +139,8 @@ final class AppModel {
     func uninstallFactoryHooks() { hooks.uninstallFactoryHooks() }
     func installCodebuddyHooks() { hooks.installCodebuddyHooks() }
     func uninstallCodebuddyHooks() { hooks.uninstallCodebuddyHooks() }
+    func installKiroHooks() { hooks.installKiroHooks() }
+    func uninstallKiroHooks() { hooks.uninstallKiroHooks() }
     func refreshCCForkHookStatuses() { hooks.refreshCCForkHookStatuses() }
     func installOpenCodePlugin() { hooks.installOpenCodePlugin() }
     func uninstallOpenCodePlugin() { hooks.uninstallOpenCodePlugin() }
@@ -1265,6 +1270,7 @@ final class AppModel {
                 if !self.qwenCodeHooksInstalled { self.installQwenCodeHooks() }
                 if !self.factoryHooksInstalled { self.installFactoryHooks() }
                 if !self.codebuddyHooksInstalled { self.installCodebuddyHooks() }
+                if !self.kiroHooksInstalled { self.installKiroHooks() }
                 if !self.openCodePluginInstalled { self.installOpenCodePlugin() }
                 if !self.cursorHooksInstalled { self.installCursorHooks() }
                 if !self.geminiHooksInstalled { self.installGeminiHooks() }

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -11,6 +11,7 @@ final class HookInstallationCoordinator {
     var qwenCodeHookStatus: ClaudeHookInstallationStatus?
     var factoryHookStatus: ClaudeHookInstallationStatus?
     var codebuddyHookStatus: ClaudeHookInstallationStatus?
+    var kiroHookStatus: ClaudeHookInstallationStatus?
     var openCodePluginStatus: OpenCodePluginInstallationStatus?
     var cursorHookStatus: CursorHookInstallationStatus?
     var geminiHookStatus: GeminiHookInstallationStatus?
@@ -24,6 +25,7 @@ final class HookInstallationCoordinator {
     var isQwenCodeHookSetupBusy = false
     var isFactoryHookSetupBusy = false
     var isCodebuddyHookSetupBusy = false
+    var isKiroHookSetupBusy = false
     var isOpenCodeSetupBusy = false
     var isCursorHookSetupBusy = false
     var isGeminiHookSetupBusy = false
@@ -62,6 +64,12 @@ final class HookInstallationCoordinator {
     private let codebuddyHookInstallationManager = ClaudeHookInstallationManager(
         claudeDirectory: FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".codebuddy", isDirectory: true),
         hookSource: "codebuddy"
+    )
+
+    @ObservationIgnored
+    private let kiroHookInstallationManager = ClaudeHookInstallationManager(
+        claudeDirectory: FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".kiro", isDirectory: true),
+        hookSource: "kiro"
     )
 
     @ObservationIgnored
@@ -115,6 +123,10 @@ final class HookInstallationCoordinator {
 
     var codebuddyHooksInstalled: Bool {
         codebuddyHookStatus?.managedHooksPresent == true
+    }
+
+    var kiroHooksInstalled: Bool {
+        kiroHookStatus?.managedHooksPresent == true
     }
 
     var openCodePluginInstalled: Bool {
@@ -527,6 +539,7 @@ final class HookInstallationCoordinator {
         refreshCCForkHookStatus(manager: qwenCodeHookInstallationManager, name: "Qwen Code") { [weak self] in self?.qwenCodeHookStatus = $0 }
         refreshCCForkHookStatus(manager: factoryHookInstallationManager, name: "Factory") { [weak self] in self?.factoryHookStatus = $0 }
         refreshCCForkHookStatus(manager: codebuddyHookInstallationManager, name: "CodeBuddy") { [weak self] in self?.codebuddyHookStatus = $0 }
+        refreshCCForkHookStatus(manager: kiroHookInstallationManager, name: "Kiro") { [weak self] in self?.kiroHookStatus = $0 }
     }
 
     private func refreshCCForkHookStatus(
@@ -598,6 +611,7 @@ final class HookInstallationCoordinator {
                     (self.qwenCodeHookInstallationManager, "Qwen Code", { [weak self] (s: ClaudeHookInstallationStatus) in self?.qwenCodeHookStatus = s }),
                     (self.factoryHookInstallationManager, "Factory", { [weak self] (s: ClaudeHookInstallationStatus) in self?.factoryHookStatus = s }),
                     (self.codebuddyHookInstallationManager, "CodeBuddy", { [weak self] (s: ClaudeHookInstallationStatus) in self?.codebuddyHookStatus = s }),
+                    (self.kiroHookInstallationManager, "Kiro", { [weak self] (s: ClaudeHookInstallationStatus) in self?.kiroHookStatus = s }),
                 ] {
                     do {
                         let status = try manager.status(hooksBinaryURL: self.hooksBinaryURL)
@@ -767,6 +781,14 @@ final class HookInstallationCoordinator {
 
     func uninstallCodebuddyHooks() {
         updateCCForkHooks(manager: codebuddyHookInstallationManager, name: "CodeBuddy", isBusySetter: { [weak self] in self?.isCodebuddyHookSetupBusy = $0 }, statusSetter: { [weak self] in self?.codebuddyHookStatus = $0 }, install: false)
+    }
+
+    func installKiroHooks() {
+        updateCCForkHooks(manager: kiroHookInstallationManager, name: "Kiro", isBusySetter: { [weak self] in self?.isKiroHookSetupBusy = $0 }, statusSetter: { [weak self] in self?.kiroHookStatus = $0 }, install: true)
+    }
+
+    func uninstallKiroHooks() {
+        updateCCForkHooks(manager: kiroHookInstallationManager, name: "Kiro", isBusySetter: { [weak self] in self?.isKiroHookSetupBusy = $0 }, statusSetter: { [weak self] in self?.kiroHookStatus = $0 }, install: false)
     }
 
     private func updateCCForkHooks(

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -334,6 +334,16 @@ final class ProcessMonitoringCoordinator {
             }
         }
 
+        // Kiro sessions: kiro-cli spawns a new shell for each hook call,
+        // so we cannot match by session ID. Keep all Kiro sessions alive
+        // as long as any kiro-cli process exists.
+        let hasKiroProcess = activeProcesses.contains { $0.tool == .kiro }
+        if hasKiroProcess {
+            for session in sessions where session.tool == .kiro && !session.isDemoSession {
+                aliveIDs.insert(session.id)
+            }
+        }
+
         // Synthetic sessions: always alive if the process exists.
         let syntheticSessions = sessions.filter { isSyntheticClaudeSession($0) }
         for session in syntheticSessions {
@@ -869,6 +879,8 @@ final class ProcessMonitoringCoordinator {
             return "CodeBuddy \(session.id.prefix(8))"
         case .cursor:
             return "Cursor \(session.id.prefix(8))"
+        case .kiro:
+            return "Kiro \(session.id.prefix(8))"
         }
     }
 }

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -230,6 +230,8 @@ final class ProcessMonitoringCoordinator {
             payload.sessionID
         case let .cursorSessionMetadataUpdated(payload):
             payload.sessionID
+        case let .kiroSessionMetadataUpdated(payload):
+            payload.sessionID
         case let .actionableStateResolved(payload):
             payload.sessionID
         }
@@ -334,12 +336,11 @@ final class ProcessMonitoringCoordinator {
             }
         }
 
-        // Kiro sessions: kiro-cli spawns a new shell for each hook call,
-        // so we cannot match by session ID. Keep all Kiro sessions alive
-        // as long as any kiro-cli process exists.
-        let hasKiroProcess = activeProcesses.contains { $0.tool == .kiro }
-        if hasKiroProcess {
-            for session in sessions where session.tool == .kiro && !session.isDemoSession {
+        // Kiro sessions: session ID is TTY-based ("kiro-tty-{hash}").
+        // Match by checking if any kiro-cli-chat process shares the same TTY.
+        let kiroProcessTTYs = Set(activeProcesses.filter { $0.tool == .kiro }.compactMap(\.terminalTTY))
+        for session in sessions where session.tool == .kiro && !session.isDemoSession {
+            if let tty = session.jumpTarget?.terminalTTY, kiroProcessTTYs.contains(tty) {
                 aliveIDs.insert(session.id)
             }
         }

--- a/Sources/OpenIslandApp/Views/ControlCenterView.swift
+++ b/Sources/OpenIslandApp/Views/ControlCenterView.swift
@@ -115,6 +115,8 @@ struct ControlCenterView: View {
 
                 ccForkHookCard(title: "CodeBuddy Hooks", installed: model.codebuddyHooksInstalled, status: model.codebuddyHookStatus, isBusy: model.isCodebuddyHookSetupBusy, install: model.installCodebuddyHooks, uninstall: model.uninstallCodebuddyHooks)
 
+                ccForkHookCard(title: "Kiro Hooks", installed: model.kiroHooksInstalled, status: model.kiroHookStatus, isBusy: model.isKiroHookSetupBusy, install: model.installKiroHooks, uninstall: model.uninstallKiroHooks)
+
                 geminiHookCard
 
                 usageDebugCard(

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -411,6 +411,7 @@ struct SetupSettingsPane: View {
     @State private var confirmingUninstallQwenCode = false
     @State private var confirmingUninstallFactory = false
     @State private var confirmingUninstallCodebuddy = false
+    @State private var confirmingUninstallKiro = false
     @State private var confirmingUninstallCursor = false
     @State private var confirmingUninstallGemini = false
     @State private var confirmingUninstallClaudeUsage = false
@@ -543,6 +544,23 @@ struct SetupSettingsPane: View {
                 }
 
                 hookRow(
+                    name: "Kiro CLI",
+                    installed: model.kiroHooksInstalled,
+                    busy: model.isKiroHookSetupBusy,
+                    configLocationURL: model.kiroHookStatus?.settingsURL,
+                    installAction: { model.installKiroHooks() },
+                    uninstallAction: { confirmingUninstallKiro = true }
+                )
+                .alert(lang.t("settings.general.uninstallConfirmTitle"), isPresented: $confirmingUninstallKiro) {
+                    Button(lang.t("settings.general.uninstallConfirmAction"), role: .destructive) {
+                        model.uninstallKiroHooks()
+                    }
+                    Button(lang.t("settings.general.cancel"), role: .cancel) {}
+                } message: {
+                    Text("This will remove Open Island hooks from ~/.kiro/settings.json.")
+                }
+
+                hookRow(
                     name: "Cursor",
                     installed: model.cursorHooksInstalled,
                     busy: model.isCursorHookSetupBusy,
@@ -650,6 +668,7 @@ struct SetupSettingsPane: View {
                     if !model.qwenCodeHooksInstalled { model.installQwenCodeHooks() }
                     if !model.factoryHooksInstalled { model.installFactoryHooks() }
                     if !model.codebuddyHooksInstalled { model.installCodebuddyHooks() }
+                    if !model.kiroHooksInstalled { model.installKiroHooks() }
                     if !model.cursorHooksInstalled { model.installCursorHooks() }
                     if !model.geminiHooksInstalled { model.installGeminiHooks() }
                     if !model.claudeUsageInstalled { model.installClaudeUsageBridge() }
@@ -712,7 +731,7 @@ struct SetupSettingsPane: View {
     private var allReady: Bool {
         model.claudeHooksInstalled && model.codexHooksInstalled && model.openCodePluginInstalled
             && model.qoderHooksInstalled && model.qwenCodeHooksInstalled && model.factoryHooksInstalled && model.codebuddyHooksInstalled
-            && model.cursorHooksInstalled && model.geminiHooksInstalled && model.claudeUsageInstalled
+            && model.kiroHooksInstalled && model.cursorHooksInstalled && model.geminiHooksInstalled && model.claudeUsageInstalled
     }
 
     private var codexHookConfigURL: URL? {

--- a/Sources/OpenIslandCore/AgentEvent.swift
+++ b/Sources/OpenIslandCore/AgentEvent.swift
@@ -222,6 +222,22 @@ public struct CursorSessionMetadataUpdated: Equatable, Codable, Sendable {
     }
 }
 
+public struct KiroSessionMetadataUpdated: Equatable, Codable, Sendable {
+    public var sessionID: String
+    public var kiroMetadata: KiroSessionMetadata
+    public var timestamp: Date
+
+    public init(
+        sessionID: String,
+        kiroMetadata: KiroSessionMetadata,
+        timestamp: Date
+    ) {
+        self.sessionID = sessionID
+        self.kiroMetadata = kiroMetadata
+        self.timestamp = timestamp
+    }
+}
+
 public struct ActionableStateResolved: Equatable, Codable, Sendable {
     public var sessionID: String
     public var summary: String
@@ -250,6 +266,7 @@ public enum AgentEvent: Equatable, Codable, Sendable {
     case geminiSessionMetadataUpdated(GeminiSessionMetadataUpdated)
     case openCodeSessionMetadataUpdated(OpenCodeSessionMetadataUpdated)
     case cursorSessionMetadataUpdated(CursorSessionMetadataUpdated)
+    case kiroSessionMetadataUpdated(KiroSessionMetadataUpdated)
     case actionableStateResolved(ActionableStateResolved)
 
     private enum CodingKeys: String, CodingKey {
@@ -265,6 +282,7 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case geminiSessionMetadataUpdated
         case openCodeSessionMetadataUpdated
         case cursorSessionMetadataUpdated
+        case kiroSessionMetadataUpdated
         case actionableStateResolved
     }
 
@@ -280,6 +298,7 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case geminiSessionMetadataUpdated
         case openCodeSessionMetadataUpdated
         case cursorSessionMetadataUpdated
+        case kiroSessionMetadataUpdated
         case actionableStateResolved
     }
 
@@ -317,6 +336,10 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case .cursorSessionMetadataUpdated:
             self = .cursorSessionMetadataUpdated(
                 try container.decode(CursorSessionMetadataUpdated.self, forKey: .cursorSessionMetadataUpdated)
+            )
+        case .kiroSessionMetadataUpdated:
+            self = .kiroSessionMetadataUpdated(
+                try container.decode(KiroSessionMetadataUpdated.self, forKey: .kiroSessionMetadataUpdated)
             )
         case .actionableStateResolved:
             self = .actionableStateResolved(
@@ -362,6 +385,9 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case let .cursorSessionMetadataUpdated(payload):
             try container.encode(EventType.cursorSessionMetadataUpdated, forKey: .type)
             try container.encode(payload, forKey: .cursorSessionMetadataUpdated)
+        case let .kiroSessionMetadataUpdated(payload):
+            try container.encode(EventType.kiroSessionMetadataUpdated, forKey: .type)
+            try container.encode(payload, forKey: .kiroSessionMetadataUpdated)
         case let .actionableStateResolved(payload):
             try container.encode(EventType.actionableStateResolved, forKey: .type)
             try container.encode(payload, forKey: .actionableStateResolved)

--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -64,7 +64,7 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
 
     public var isClaudeCodeFork: Bool {
         switch self {
-        case .claudeCode, .qoder, .qwenCode, .factory, .codebuddy, .kiro:
+        case .claudeCode, .qoder, .qwenCode, .factory, .codebuddy:
             true
         default:
             false

--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -409,6 +409,7 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
         case geminiMetadata
         case openCodeMetadata
         case cursorMetadata
+        case kiroMetadata
     }
 
     public init(from decoder: any Decoder) throws {
@@ -429,6 +430,7 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
         geminiMetadata = try container.decodeIfPresent(GeminiSessionMetadata.self, forKey: .geminiMetadata)
         openCodeMetadata = try container.decodeIfPresent(OpenCodeSessionMetadata.self, forKey: .openCodeMetadata)
         cursorMetadata = try container.decodeIfPresent(CursorSessionMetadata.self, forKey: .cursorMetadata)
+        kiroMetadata = try container.decodeIfPresent(KiroSessionMetadata.self, forKey: .kiroMetadata)
     }
 
     public func encode(to encoder: any Encoder) throws {
@@ -449,6 +451,7 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
         try container.encodeIfPresent(geminiMetadata, forKey: .geminiMetadata)
         try container.encodeIfPresent(openCodeMetadata, forKey: .openCodeMetadata)
         try container.encodeIfPresent(cursorMetadata, forKey: .cursorMetadata)
+        try container.encodeIfPresent(kiroMetadata, forKey: .kiroMetadata)
     }
 }
 

--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -333,6 +333,7 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
     public var geminiMetadata: GeminiSessionMetadata?
     public var openCodeMetadata: OpenCodeSessionMetadata?
     public var cursorMetadata: CursorSessionMetadata?
+    public var kiroMetadata: KiroSessionMetadata?
 
     /// Whether this session originates from a remote (SSH) connection.
     public var isRemote: Bool = false
@@ -457,7 +458,7 @@ public extension AgentSession {
     }
 
     var isTrackedLiveSession: Bool {
-        !isDemoSession && (tool == .codex || tool == .claudeCode || tool == .geminiCLI || tool == .openCode || tool == .qoder || tool == .qwenCode || tool == .factory || tool == .codebuddy || tool == .cursor)
+        !isDemoSession && (tool == .codex || tool == .claudeCode || tool == .geminiCLI || tool == .openCode || tool == .qoder || tool == .qwenCode || tool == .factory || tool == .codebuddy || tool == .cursor || tool == .kiro)
     }
 
     var isTrackedLiveCodexSession: Bool {
@@ -480,11 +481,17 @@ public extension AgentSession {
     }
 
     var currentToolName: String? {
-        codexMetadata?.currentTool ?? claudeMetadata?.currentTool ?? openCodeMetadata?.currentTool ?? cursorMetadata?.currentTool
+        codexMetadata?.currentTool ?? claudeMetadata?.currentTool ?? openCodeMetadata?.currentTool ?? cursorMetadata?.currentTool ?? kiroMetadata?.currentTool
     }
 
     var lastAssistantMessageText: String? {
-        codexMetadata?.lastAssistantMessage ?? claudeMetadata?.lastAssistantMessage ?? geminiMetadata?.lastAssistantMessage ?? openCodeMetadata?.lastAssistantMessage ?? cursorMetadata?.lastAssistantMessage
+        if let v = codexMetadata?.lastAssistantMessage { return v }
+        if let v = claudeMetadata?.lastAssistantMessage { return v }
+        if let v = geminiMetadata?.lastAssistantMessage { return v }
+        if let v = openCodeMetadata?.lastAssistantMessage { return v }
+        if let v = cursorMetadata?.lastAssistantMessage { return v }
+        if let v = kiroMetadata?.lastAssistantMessage { return v }
+        return nil
     }
 
     var completionAssistantMessageText: String? {
@@ -506,11 +513,23 @@ public extension AgentSession {
     }
 
     var latestUserPromptText: String? {
-        codexMetadata?.lastUserPrompt ?? claudeMetadata?.lastUserPrompt ?? geminiMetadata?.lastUserPrompt ?? openCodeMetadata?.lastUserPrompt ?? cursorMetadata?.lastUserPrompt
+        if let v = codexMetadata?.lastUserPrompt { return v }
+        if let v = claudeMetadata?.lastUserPrompt { return v }
+        if let v = geminiMetadata?.lastUserPrompt { return v }
+        if let v = openCodeMetadata?.lastUserPrompt { return v }
+        if let v = cursorMetadata?.lastUserPrompt { return v }
+        if let v = kiroMetadata?.lastUserPrompt { return v }
+        return nil
     }
 
     var initialUserPromptText: String? {
-        codexMetadata?.initialUserPrompt ?? claudeMetadata?.initialUserPrompt ?? geminiMetadata?.initialUserPrompt ?? openCodeMetadata?.initialUserPrompt ?? cursorMetadata?.initialUserPrompt
+        if let v = codexMetadata?.initialUserPrompt { return v }
+        if let v = claudeMetadata?.initialUserPrompt { return v }
+        if let v = geminiMetadata?.initialUserPrompt { return v }
+        if let v = openCodeMetadata?.initialUserPrompt { return v }
+        if let v = cursorMetadata?.initialUserPrompt { return v }
+        if let v = kiroMetadata?.initialUserPrompt { return v }
+        return nil
     }
 
     var currentCommandPreviewText: String? {

--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -10,6 +10,7 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
     case factory
     case codebuddy
     case cursor
+    case kiro
 
     public var displayName: String {
         switch self {
@@ -31,6 +32,8 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
             "CodeBuddy"
         case .cursor:
             "Cursor"
+        case .kiro:
+            "Kiro CLI"
         }
     }
 
@@ -54,12 +57,14 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
             "CODEBUDDY"
         case .cursor:
             "CURSOR"
+        case .kiro:
+            "KIRO"
         }
     }
 
     public var isClaudeCodeFork: Bool {
         switch self {
-        case .claudeCode, .qoder, .qwenCode, .factory, .codebuddy:
+        case .claudeCode, .qoder, .qwenCode, .factory, .codebuddy, .kiro:
             true
         default:
             false

--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -536,7 +536,7 @@ public extension AgentSession {
     }
 
     var currentCommandPreviewText: String? {
-        codexMetadata?.currentCommandPreview ?? claudeMetadata?.currentToolInputPreview ?? openCodeMetadata?.currentToolInputPreview ?? cursorMetadata?.currentToolInputPreview
+        codexMetadata?.currentCommandPreview ?? claudeMetadata?.currentToolInputPreview ?? openCodeMetadata?.currentToolInputPreview ?? cursorMetadata?.currentToolInputPreview ?? kiroMetadata?.currentToolInputPreview
     }
 }
 

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -1529,8 +1529,8 @@ public final class BridgeServer: @unchecked Sendable {
             initialUserPrompt: existing?.initialUserPrompt ?? update.initialUserPrompt,
             lastUserPrompt: update.lastUserPrompt ?? existing?.lastUserPrompt,
             lastAssistantMessage: update.lastAssistantMessage ?? existing?.lastAssistantMessage,
-            currentTool: update.currentTool ?? existing?.currentTool,
-            currentToolInputPreview: update.currentToolInputPreview ?? existing?.currentToolInputPreview
+            currentTool: update.currentTool,
+            currentToolInputPreview: update.currentToolInputPreview
         )
         guard !merged.isEmpty, existing != merged else { return }
 

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -1408,6 +1408,7 @@ public final class BridgeServer: @unchecked Sendable {
 
         case .userPromptSubmit:
             ensureKiroSessionExists(for: payload, sessionID: sessionID)
+            synchronizeKiroMetadata(for: payload, sessionID: sessionID)
             emit(
                 .activityUpdated(
                     SessionActivityUpdated(
@@ -1422,6 +1423,7 @@ public final class BridgeServer: @unchecked Sendable {
 
         case .preToolUse:
             ensureKiroSessionExists(for: payload, sessionID: sessionID)
+            synchronizeKiroMetadata(for: payload, sessionID: sessionID)
             let tool = payload.toolName ?? "a tool"
             emit(
                 .activityUpdated(
@@ -1437,6 +1439,7 @@ public final class BridgeServer: @unchecked Sendable {
 
         case .postToolUse, .postToolUseFailure:
             ensureKiroSessionExists(for: payload, sessionID: sessionID)
+            synchronizeKiroMetadata(for: payload, sessionID: sessionID)
             let tool = payload.toolName ?? "a tool"
             emit(
                 .activityUpdated(
@@ -1452,6 +1455,7 @@ public final class BridgeServer: @unchecked Sendable {
 
         case .stop:
             ensureKiroSessionExists(for: payload, sessionID: sessionID)
+            synchronizeKiroMetadata(for: payload, sessionID: sessionID)
             emit(
                 .sessionCompleted(
                     SessionCompleted(
@@ -1464,17 +1468,32 @@ public final class BridgeServer: @unchecked Sendable {
             send(.response(.acknowledged), to: clientID)
 
         case .agentStop:
-            // agentStop is redundant with stop — suppress it.
+            ensureKiroSessionExists(for: payload, sessionID: sessionID)
+            emit(
+                .sessionCompleted(
+                    SessionCompleted(
+                        sessionID: sessionID,
+                        summary: "Kiro CLI session ended.",
+                        timestamp: .now,
+                        isSessionEnd: true
+                    )
+                )
+            )
             send(.response(.acknowledged), to: clientID)
         }
     }
 
-    /// Generates a stable session ID for Kiro CLI based on the cwd.
-    /// The actual kiro-cli PID is resolved by the hook CLI process.
+    /// Generates a stable session ID for Kiro CLI using the terminal TTY.
+    /// Same TTY = same kiro-cli session (matching Vibe Island behavior).
     private func kiroSessionID(for payload: KiroHookPayload) -> String {
-        let cwd = payload.cwd ?? ""
-        let hash = String(abs(cwd.hashValue) % 0xFFFF_FFFF, radix: 16)
-        return "kiro-\(hash)"
+        if let tty = payload.terminalTTY, !tty.isEmpty {
+            var hash: UInt32 = 5381
+            for byte in tty.utf8 { hash = hash &* 33 &+ UInt32(byte) }
+            return "kiro-tty-\(String(hash, radix: 16))"
+        }
+        var hash: UInt32 = 5381
+        for byte in (payload.cwd ?? "").utf8 { hash = hash &* 33 &+ UInt32(byte) }
+        return "kiro-cwd-\(String(hash, radix: 16))"
     }
 
     private func ensureKiroSessionExists(for payload: KiroHookPayload, sessionID: String) {
@@ -1491,6 +1510,29 @@ public final class BridgeServer: @unchecked Sendable {
                     summary: payload.implicitStartSummary,
                     timestamp: .now,
                     jumpTarget: payload.defaultJumpTarget
+                )
+            )
+        )
+    }
+
+    private func synchronizeKiroMetadata(for payload: KiroHookPayload, sessionID: String) {
+        let existing = localState.session(id: sessionID)?.kiroMetadata
+        let update = payload.defaultKiroMetadata
+        let merged = KiroSessionMetadata(
+            initialUserPrompt: existing?.initialUserPrompt ?? update.initialUserPrompt,
+            lastUserPrompt: update.lastUserPrompt ?? existing?.lastUserPrompt,
+            lastAssistantMessage: update.lastAssistantMessage ?? existing?.lastAssistantMessage,
+            currentTool: update.currentTool ?? existing?.currentTool,
+            currentToolInputPreview: update.currentToolInputPreview ?? existing?.currentToolInputPreview
+        )
+        guard !merged.isEmpty, existing != merged else { return }
+
+        emit(
+            .kiroSessionMetadataUpdated(
+                KiroSessionMetadataUpdated(
+                    sessionID: sessionID,
+                    kiroMetadata: merged,
+                    timestamp: .now
                 )
             )
         )

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -1516,6 +1516,13 @@ public final class BridgeServer: @unchecked Sendable {
     }
 
     private func synchronizeKiroMetadata(for payload: KiroHookPayload, sessionID: String) {
+        // Reconcile jump target in case TTY was unavailable at session creation.
+        let jumpTarget = payload.defaultJumpTarget
+        if let existing = localState.session(id: sessionID)?.jumpTarget,
+           existing != jumpTarget {
+            emit(.jumpTargetUpdated(JumpTargetUpdated(sessionID: sessionID, jumpTarget: jumpTarget, timestamp: .now)))
+        }
+
         let existing = localState.session(id: sessionID)?.kiroMetadata
         let update = payload.defaultKiroMetadata
         let merged = KiroSessionMetadata(

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -434,6 +434,9 @@ public final class BridgeServer: @unchecked Sendable {
 
         case let .processGeminiHook(payload):
             handleGeminiHook(payload, from: clientID)
+
+        case let .processKiroHook(payload):
+            handleKiroHook(payload, from: clientID)
         }
     }
 
@@ -1375,6 +1378,119 @@ public final class BridgeServer: @unchecked Sendable {
                     sessionID: payload.sessionID,
                     geminiMetadata: merged,
                     timestamp: .now
+                )
+            )
+        )
+    }
+
+    // MARK: - Kiro CLI hooks
+
+    private func handleKiroHook(_ payload: KiroHookPayload, from clientID: UUID) {
+        let sessionID = kiroSessionID(for: payload)
+
+        switch payload.hookEventName {
+        case .agentSpawn:
+            emit(
+                .sessionStarted(
+                    SessionStarted(
+                        sessionID: sessionID,
+                        title: payload.sessionTitle,
+                        tool: .kiro,
+                        origin: .live,
+                        initialPhase: .running,
+                        summary: payload.implicitStartSummary,
+                        timestamp: .now,
+                        jumpTarget: payload.defaultJumpTarget
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .userPromptSubmit:
+            ensureKiroSessionExists(for: payload, sessionID: sessionID)
+            emit(
+                .activityUpdated(
+                    SessionActivityUpdated(
+                        sessionID: sessionID,
+                        summary: payload.promptPreview.map { "Prompt: \($0)" } ?? payload.implicitStartSummary,
+                        phase: .running,
+                        timestamp: .now
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .preToolUse:
+            ensureKiroSessionExists(for: payload, sessionID: sessionID)
+            let tool = payload.toolName ?? "a tool"
+            emit(
+                .activityUpdated(
+                    SessionActivityUpdated(
+                        sessionID: sessionID,
+                        summary: payload.toolInputPreview.map { "Running \(tool): \($0)" } ?? "Running \(tool)",
+                        phase: .running,
+                        timestamp: .now
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .postToolUse, .postToolUseFailure:
+            ensureKiroSessionExists(for: payload, sessionID: sessionID)
+            let tool = payload.toolName ?? "a tool"
+            emit(
+                .activityUpdated(
+                    SessionActivityUpdated(
+                        sessionID: sessionID,
+                        summary: "\(tool) finished.",
+                        phase: .running,
+                        timestamp: .now
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .stop:
+            ensureKiroSessionExists(for: payload, sessionID: sessionID)
+            emit(
+                .sessionCompleted(
+                    SessionCompleted(
+                        sessionID: sessionID,
+                        summary: payload.assistantResponse ?? payload.assistantResponsePreview ?? "Kiro CLI completed the turn.",
+                        timestamp: .now
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .agentStop:
+            // agentStop is redundant with stop — suppress it.
+            send(.response(.acknowledged), to: clientID)
+        }
+    }
+
+    /// Generates a stable session ID for Kiro CLI based on the cwd.
+    /// The actual kiro-cli PID is resolved by the hook CLI process.
+    private func kiroSessionID(for payload: KiroHookPayload) -> String {
+        let cwd = payload.cwd ?? ""
+        let hash = String(abs(cwd.hashValue) % 0xFFFF_FFFF, radix: 16)
+        return "kiro-\(hash)"
+    }
+
+    private func ensureKiroSessionExists(for payload: KiroHookPayload, sessionID: String) {
+        guard !hasSession(id: sessionID) else { return }
+
+        emit(
+            .sessionStarted(
+                SessionStarted(
+                    sessionID: sessionID,
+                    title: payload.sessionTitle,
+                    tool: .kiro,
+                    origin: .live,
+                    initialPhase: .running,
+                    summary: payload.implicitStartSummary,
+                    timestamp: .now,
+                    jumpTarget: payload.defaultJumpTarget
                 )
             )
         )

--- a/Sources/OpenIslandCore/BridgeTransport.swift
+++ b/Sources/OpenIslandCore/BridgeTransport.swift
@@ -89,6 +89,7 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
     case processOpenCodeHook(OpenCodeHookPayload)
     case processCursorHook(CursorHookPayload)
     case processGeminiHook(GeminiHookPayload)
+    case processKiroHook(KiroHookPayload)
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -102,6 +103,7 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
         case openCodeHook
         case cursorHook
         case geminiHook
+        case kiroHook
     }
 
     private enum CommandType: String, Codable {
@@ -114,6 +116,7 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
         case processOpenCodeHook
         case processCursorHook
         case processGeminiHook
+        case processKiroHook
     }
 
     public init(from decoder: any Decoder) throws {
@@ -148,6 +151,8 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
             self = .processCursorHook(try container.decode(CursorHookPayload.self, forKey: .cursorHook))
         case .processGeminiHook:
             self = .processGeminiHook(try container.decode(GeminiHookPayload.self, forKey: .geminiHook))
+        case .processKiroHook:
+            self = .processKiroHook(try container.decode(KiroHookPayload.self, forKey: .kiroHook))
         }
     }
 
@@ -185,6 +190,9 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
         case let .processGeminiHook(payload):
             try container.encode(CommandType.processGeminiHook, forKey: .type)
             try container.encode(payload, forKey: .geminiHook)
+        case let .processKiroHook(payload):
+            try container.encode(CommandType.processKiroHook, forKey: .type)
+            try container.encode(payload, forKey: .kiroHook)
         }
     }
 }

--- a/Sources/OpenIslandCore/ClaudeHooks.swift
+++ b/Sources/OpenIslandCore/ClaudeHooks.swift
@@ -404,7 +404,6 @@ public struct ClaudeHookPayload: Equatable, Codable, Sendable {
         case terminalTitle = "terminal_title"
         case warpPaneUUID = "warp_pane_uuid"
         case remote
-        case hookSource = "hook_source"
     }
 
     public init(
@@ -868,8 +867,6 @@ public extension ClaudeHookPayload {
             return .factory
         case "codebuddy":
             return .codebuddy
-        case "kiro":
-            return .kiro
         default:
             return .claudeCode
         }

--- a/Sources/OpenIslandCore/ClaudeHooks.swift
+++ b/Sources/OpenIslandCore/ClaudeHooks.swift
@@ -404,6 +404,7 @@ public struct ClaudeHookPayload: Equatable, Codable, Sendable {
         case terminalTitle = "terminal_title"
         case warpPaneUUID = "warp_pane_uuid"
         case remote
+        case hookSource = "hook_source"
     }
 
     public init(
@@ -867,6 +868,8 @@ public extension ClaudeHookPayload {
             return .factory
         case "codebuddy":
             return .codebuddy
+        case "kiro":
+            return .kiro
         default:
             return .claudeCode
         }

--- a/Sources/OpenIslandCore/KiroHooks.swift
+++ b/Sources/OpenIslandCore/KiroHooks.swift
@@ -17,6 +17,8 @@ public struct KiroHookPayload: Equatable, Codable, Sendable {
     public var assistantResponse: String?
     public var toolName: String?
     public var toolInput: KiroHookJSONValue?
+    /// Terminal TTY path, set by the hook CLI for session grouping.
+    public var terminalTTY: String?
 
     private enum CodingKeys: String, CodingKey {
         case hookEventName = "hook_event_name"
@@ -25,6 +27,7 @@ public struct KiroHookPayload: Equatable, Codable, Sendable {
         case assistantResponse = "assistant_response"
         case toolName = "tool_name"
         case toolInput = "tool_input"
+        case terminalTTY = "terminal_tty"
     }
 
     public init(
@@ -33,7 +36,8 @@ public struct KiroHookPayload: Equatable, Codable, Sendable {
         prompt: String? = nil,
         assistantResponse: String? = nil,
         toolName: String? = nil,
-        toolInput: KiroHookJSONValue? = nil
+        toolInput: KiroHookJSONValue? = nil,
+        terminalTTY: String? = nil
     ) {
         self.hookEventName = hookEventName
         self.cwd = cwd
@@ -41,6 +45,7 @@ public struct KiroHookPayload: Equatable, Codable, Sendable {
         self.assistantResponse = assistantResponse
         self.toolName = toolName
         self.toolInput = toolInput
+        self.terminalTTY = terminalTTY
     }
 }
 
@@ -117,7 +122,8 @@ public extension KiroHookPayload {
             terminalApp: "Unknown",
             workspaceName: workspaceName,
             paneTitle: "Kiro CLI",
-            workingDirectory: cwd ?? ""
+            workingDirectory: cwd ?? "",
+            terminalTTY: terminalTTY
         )
     }
 

--- a/Sources/OpenIslandCore/KiroHooks.swift
+++ b/Sources/OpenIslandCore/KiroHooks.swift
@@ -1,0 +1,181 @@
+import Foundation
+
+public enum KiroHookEventName: String, Codable, Sendable {
+    case agentSpawn
+    case agentStop
+    case userPromptSubmit
+    case preToolUse
+    case postToolUse
+    case postToolUseFailure
+    case stop
+}
+
+public struct KiroHookPayload: Equatable, Codable, Sendable {
+    public var hookEventName: KiroHookEventName
+    public var cwd: String?
+    public var prompt: String?
+    public var assistantResponse: String?
+    public var toolName: String?
+    public var toolInput: KiroHookJSONValue?
+
+    private enum CodingKeys: String, CodingKey {
+        case hookEventName = "hook_event_name"
+        case cwd
+        case prompt
+        case assistantResponse = "assistant_response"
+        case toolName = "tool_name"
+        case toolInput = "tool_input"
+    }
+
+    public init(
+        hookEventName: KiroHookEventName,
+        cwd: String? = nil,
+        prompt: String? = nil,
+        assistantResponse: String? = nil,
+        toolName: String? = nil,
+        toolInput: KiroHookJSONValue? = nil
+    ) {
+        self.hookEventName = hookEventName
+        self.cwd = cwd
+        self.prompt = prompt
+        self.assistantResponse = assistantResponse
+        self.toolName = toolName
+        self.toolInput = toolInput
+    }
+}
+
+/// Minimal JSON value type for Kiro tool_input.
+public enum KiroHookJSONValue: Equatable, Codable, Sendable {
+    case string(String)
+    case object([String: String])
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let str = try? container.decode(String.self) {
+            self = .string(str)
+            return
+        }
+        if let obj = try? container.decode([String: String].self) {
+            self = .object(obj)
+            return
+        }
+        self = .string("")
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case let .string(s): try container.encode(s)
+        case let .object(o): try container.encode(o)
+        }
+    }
+}
+
+public struct KiroSessionMetadata: Equatable, Codable, Sendable {
+    public var initialUserPrompt: String?
+    public var lastUserPrompt: String?
+    public var lastAssistantMessage: String?
+    public var currentTool: String?
+    public var currentToolInputPreview: String?
+
+    public init(
+        initialUserPrompt: String? = nil,
+        lastUserPrompt: String? = nil,
+        lastAssistantMessage: String? = nil,
+        currentTool: String? = nil,
+        currentToolInputPreview: String? = nil
+    ) {
+        self.initialUserPrompt = initialUserPrompt
+        self.lastUserPrompt = lastUserPrompt
+        self.lastAssistantMessage = lastAssistantMessage
+        self.currentTool = currentTool
+        self.currentToolInputPreview = currentToolInputPreview
+    }
+
+    public var isEmpty: Bool {
+        initialUserPrompt == nil
+            && lastUserPrompt == nil
+            && lastAssistantMessage == nil
+            && currentTool == nil
+            && currentToolInputPreview == nil
+    }
+}
+
+// MARK: - Payload Convenience Extensions
+
+public extension KiroHookPayload {
+    var workspaceName: String {
+        WorkspaceNameResolver.workspaceName(for: cwd ?? "")
+    }
+
+    var sessionTitle: String {
+        "Kiro CLI · \(workspaceName)"
+    }
+
+    var defaultJumpTarget: JumpTarget {
+        JumpTarget(
+            terminalApp: "Unknown",
+            workspaceName: workspaceName,
+            paneTitle: "Kiro CLI",
+            workingDirectory: cwd ?? ""
+        )
+    }
+
+    var defaultKiroMetadata: KiroSessionMetadata {
+        KiroSessionMetadata(
+            initialUserPrompt: promptPreview,
+            lastUserPrompt: promptPreview,
+            lastAssistantMessage: assistantResponsePreview,
+            currentTool: toolName,
+            currentToolInputPreview: toolInputPreview
+        )
+    }
+
+    var implicitStartSummary: String {
+        switch hookEventName {
+        case .agentSpawn:
+            "Started Kiro CLI session in \(workspaceName)."
+        case .agentStop:
+            "Kiro CLI session ended in \(workspaceName)."
+        case .userPromptSubmit:
+            "Kiro CLI received a new prompt in \(workspaceName)."
+        case .preToolUse:
+            "Kiro CLI is preparing \(toolName ?? "a tool") in \(workspaceName)."
+        case .postToolUse:
+            "Kiro CLI finished \(toolName ?? "a tool") in \(workspaceName)."
+        case .postToolUseFailure:
+            "Kiro CLI tool failed in \(workspaceName)."
+        case .stop:
+            "Kiro CLI completed a turn in \(workspaceName)."
+        }
+    }
+
+    var promptPreview: String? {
+        clipped(prompt)
+    }
+
+    var assistantResponsePreview: String? {
+        clipped(assistantResponse)
+    }
+
+    var toolInputPreview: String? {
+        switch toolInput {
+        case let .string(s): return clipped(s)
+        case let .object(o): return clipped(o["command"] ?? o.values.first)
+        case nil: return nil
+        }
+    }
+
+    private func clipped(_ value: String?, limit: Int = 110) -> String? {
+        guard let value else { return nil }
+        let collapsed = value
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\t", with: " ")
+            .split(separator: " ", omittingEmptySubsequences: true)
+            .joined(separator: " ")
+        guard !collapsed.isEmpty else { return nil }
+        guard collapsed.count > limit else { return collapsed }
+        let endIndex = collapsed.index(collapsed.startIndex, offsetBy: limit - 1)
+        return "\(collapsed[..<endIndex])…"
+    }
+}

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -199,6 +199,15 @@ public struct SessionState: Equatable, Sendable {
             session.updatedAt = payload.timestamp
             upsert(session)
 
+        case let .kiroSessionMetadataUpdated(payload):
+            guard var session = sessionsByID[payload.sessionID] else {
+                return
+            }
+
+            session.kiroMetadata = payload.kiroMetadata.isEmpty ? nil : payload.kiroMetadata
+            session.updatedAt = payload.timestamp
+            upsert(session)
+
         case let .actionableStateResolved(payload):
             guard var session = sessionsByID[payload.sessionID] else {
                 return

--- a/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
+++ b/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
@@ -73,7 +73,10 @@ struct OpenIslandHooksCLI {
                     FileHandle.standardOutput.write(output)
                 }
             case .kiro:
-                let payload = try decoder.decode(KiroHookPayload.self, from: input)
+                var payload = try decoder.decode(KiroHookPayload.self, from: input)
+                if payload.terminalTTY == nil {
+                    payload.terminalTTY = Self.currentTTY()
+                }
 
                 guard (try? client.send(.processKiroHook(payload), timeout: 45)) != nil else {
                     logStderr("bridge unavailable for kiro hook (\(payload.hookEventName.rawValue))")
@@ -138,5 +141,21 @@ struct OpenIslandHooksCLI {
         }
 
         return nil
+    }
+
+    /// Get the TTY of the current process via ps (works even when stdin is a pipe).
+    private static func currentTTY() -> String? {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/ps")
+        proc.arguments = ["-o", "tty=", "-p", "\(getpid())"]
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = FileHandle.nullDevice
+        try? proc.run()
+        proc.waitUntilExit()
+        let raw = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !raw.isEmpty, raw != "??" else { return nil }
+        return raw.hasPrefix("/dev/") ? raw : "/dev/\(raw)"
     }
 }

--- a/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
+++ b/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
@@ -73,27 +73,11 @@ struct OpenIslandHooksCLI {
                     FileHandle.standardOutput.write(output)
                 }
             case .kiro:
-                // kiro-cli sends camelCase events; agentStop is suppressed (redundant with stop)
-                if let raw = try? JSONSerialization.jsonObject(with: input) as? [String: Any],
-                   let event = raw["hook_event_name"] as? String,
-                   event == "agentStop" {
-                    return
-                }
+                let payload = try decoder.decode(KiroHookPayload.self, from: input)
 
-                var payload = try Self.kiroToClaudePayload(from: input, environment: ProcessInfo.processInfo.environment)
-                payload.hookSource = "kiro"
-
-                let timeout: TimeInterval = payload.hookEventName == .permissionRequest
-                    ? interactiveClaudeHookTimeout
-                    : 45
-
-                guard let response = try? client.send(.processClaudeHook(payload), timeout: timeout) else {
+                guard (try? client.send(.processKiroHook(payload), timeout: 45)) != nil else {
                     logStderr("bridge unavailable for kiro hook (\(payload.hookEventName.rawValue))")
                     return
-                }
-
-                if let output = try ClaudeHookOutputEncoder.standardOutput(for: response) {
-                    FileHandle.standardOutput.write(output)
                 }
             case .cursor:
                 let payload = try decoder.decode(CursorHookPayload.self, from: input)
@@ -153,86 +137,6 @@ struct OpenIslandHooksCLI {
             index += 1
         }
 
-        return nil
-    }
-
-    // MARK: - Kiro CLI payload translation
-
-    /// Kiro CLI sends camelCase event names and a minimal payload.
-    /// This translates it into a ClaudeHookPayload the bridge understands.
-    private static let kiroEventMap: [String: String] = [
-        "agentSpawn": "SessionStart",
-        "agentStop": "SessionEnd",
-        "userPromptSubmit": "UserPromptSubmit",
-        "preToolUse": "PreToolUse",
-        "postToolUse": "PostToolUse",
-        "postToolUseFailure": "PostToolUseFailure",
-        "stop": "Stop",
-        "notification": "Notification",
-        "permissionRequest": "PermissionRequest",
-        "sessionStart": "SessionStart",
-        "sessionEnd": "SessionEnd",
-    ]
-
-    private static func kiroToClaudePayload(
-        from input: Data,
-        environment: [String: String]
-    ) throws -> ClaudeHookPayload {
-        guard var raw = try JSONSerialization.jsonObject(with: input) as? [String: Any] else {
-            throw ClaudeHookInstallerError.invalidSettingsJSON
-        }
-
-        // Map camelCase event name → PascalCase (matching vibe-island-bridge behavior)
-        if let eventName = raw["hook_event_name"] as? String,
-           let mapped = kiroEventMap[eventName] {
-            raw["hook_event_name"] = mapped
-        }
-
-        // Generate stable session_id by walking up the process tree to find the
-        // kiro-cli process (matching vibe-island-bridge behavior).
-        if raw["session_id"] == nil {
-            let kiroPID = findAncestorPID(named: "kiro-cli") ?? getppid()
-            let cwd = raw["cwd"] as? String ?? ""
-            let hash = String(abs(cwd.hashValue) % 0xFFFFFFFF, radix: 16)
-            raw["session_id"] = "kiro-\(kiroPID)-\(hash)"
-        }
-
-        // Map assistant_response → last_assistant_message
-        if let resp = raw["assistant_response"] as? String, raw["last_assistant_message"] == nil {
-            raw["last_assistant_message"] = resp
-        }
-
-        // Map tool_name "shell" → "Bash" to match vibe-island-bridge
-        if let toolName = raw["tool_name"] as? String, toolName == "shell" {
-            raw["tool_name"] = "Bash"
-        }
-
-        let patched = try JSONSerialization.data(withJSONObject: raw)
-        return try JSONDecoder().decode(ClaudeHookPayload.self, from: patched)
-            .withRuntimeContext(environment: environment)
-    }
-
-    /// Walk up the process tree to find an ancestor whose name contains the given string.
-    private static func findAncestorPID(named target: String) -> pid_t? {
-        var pid = getppid()
-        for _ in 0..<20 {
-            guard pid > 1 else { return nil }
-            let proc = Process()
-            proc.executableURL = URL(fileURLWithPath: "/bin/ps")
-            proc.arguments = ["-p", "\(pid)", "-o", "ppid=,comm="]
-            let pipe = Pipe()
-            proc.standardOutput = pipe
-            proc.standardError = FileHandle.nullDevice
-            try? proc.run()
-            proc.waitUntilExit()
-            let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            let parts = output.split(separator: " ", maxSplits: 1)
-            let comm = parts.count > 1 ? String(parts[1]) : ""
-            if comm.contains(target) { return pid }
-            guard let parentPID = parts.first.flatMap({ pid_t($0) }), parentPID > 0 else { return nil }
-            pid = parentPID
-        }
         return nil
     }
 }

--- a/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
+++ b/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
@@ -15,12 +15,13 @@ struct OpenIslandHooksCLI {
         case codebuddy
         case cursor
         case gemini
+        case kiro
 
         var isClaudeFormat: Bool {
             switch self {
             case .claude, .qoder, .qwen, .factory, .droid, .codebuddy:
                 return true
-            case .codex, .cursor, .gemini:
+            case .codex, .cursor, .gemini, .kiro:
                 return false
             }
         }
@@ -65,6 +66,29 @@ struct OpenIslandHooksCLI {
 
                 guard let response = try? client.send(.processClaudeHook(payload), timeout: timeout) else {
                     logStderr("bridge unavailable for claude hook (\(payload.hookEventName.rawValue))")
+                    return
+                }
+
+                if let output = try ClaudeHookOutputEncoder.standardOutput(for: response) {
+                    FileHandle.standardOutput.write(output)
+                }
+            case .kiro:
+                // kiro-cli sends camelCase events; agentStop is suppressed (redundant with stop)
+                if let raw = try? JSONSerialization.jsonObject(with: input) as? [String: Any],
+                   let event = raw["hook_event_name"] as? String,
+                   event == "agentStop" {
+                    return
+                }
+
+                var payload = try Self.kiroToClaudePayload(from: input, environment: ProcessInfo.processInfo.environment)
+                payload.hookSource = "kiro"
+
+                let timeout: TimeInterval = payload.hookEventName == .permissionRequest
+                    ? interactiveClaudeHookTimeout
+                    : 45
+
+                guard let response = try? client.send(.processClaudeHook(payload), timeout: timeout) else {
+                    logStderr("bridge unavailable for kiro hook (\(payload.hookEventName.rawValue))")
                     return
                 }
 
@@ -129,6 +153,86 @@ struct OpenIslandHooksCLI {
             index += 1
         }
 
+        return nil
+    }
+
+    // MARK: - Kiro CLI payload translation
+
+    /// Kiro CLI sends camelCase event names and a minimal payload.
+    /// This translates it into a ClaudeHookPayload the bridge understands.
+    private static let kiroEventMap: [String: String] = [
+        "agentSpawn": "SessionStart",
+        "agentStop": "SessionEnd",
+        "userPromptSubmit": "UserPromptSubmit",
+        "preToolUse": "PreToolUse",
+        "postToolUse": "PostToolUse",
+        "postToolUseFailure": "PostToolUseFailure",
+        "stop": "Stop",
+        "notification": "Notification",
+        "permissionRequest": "PermissionRequest",
+        "sessionStart": "SessionStart",
+        "sessionEnd": "SessionEnd",
+    ]
+
+    private static func kiroToClaudePayload(
+        from input: Data,
+        environment: [String: String]
+    ) throws -> ClaudeHookPayload {
+        guard var raw = try JSONSerialization.jsonObject(with: input) as? [String: Any] else {
+            throw ClaudeHookInstallerError.invalidSettingsJSON
+        }
+
+        // Map camelCase event name → PascalCase (matching vibe-island-bridge behavior)
+        if let eventName = raw["hook_event_name"] as? String,
+           let mapped = kiroEventMap[eventName] {
+            raw["hook_event_name"] = mapped
+        }
+
+        // Generate stable session_id by walking up the process tree to find the
+        // kiro-cli process (matching vibe-island-bridge behavior).
+        if raw["session_id"] == nil {
+            let kiroPID = findAncestorPID(named: "kiro-cli") ?? getppid()
+            let cwd = raw["cwd"] as? String ?? ""
+            let hash = String(abs(cwd.hashValue) % 0xFFFFFFFF, radix: 16)
+            raw["session_id"] = "kiro-\(kiroPID)-\(hash)"
+        }
+
+        // Map assistant_response → last_assistant_message
+        if let resp = raw["assistant_response"] as? String, raw["last_assistant_message"] == nil {
+            raw["last_assistant_message"] = resp
+        }
+
+        // Map tool_name "shell" → "Bash" to match vibe-island-bridge
+        if let toolName = raw["tool_name"] as? String, toolName == "shell" {
+            raw["tool_name"] = "Bash"
+        }
+
+        let patched = try JSONSerialization.data(withJSONObject: raw)
+        return try JSONDecoder().decode(ClaudeHookPayload.self, from: patched)
+            .withRuntimeContext(environment: environment)
+    }
+
+    /// Walk up the process tree to find an ancestor whose name contains the given string.
+    private static func findAncestorPID(named target: String) -> pid_t? {
+        var pid = getppid()
+        for _ in 0..<20 {
+            guard pid > 1 else { return nil }
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: "/bin/ps")
+            proc.arguments = ["-p", "\(pid)", "-o", "ppid=,comm="]
+            let pipe = Pipe()
+            proc.standardOutput = pipe
+            proc.standardError = FileHandle.nullDevice
+            try? proc.run()
+            proc.waitUntilExit()
+            let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let parts = output.split(separator: " ", maxSplits: 1)
+            let comm = parts.count > 1 ? String(parts[1]) : ""
+            if comm.contains(target) { return pid }
+            guard let parentPID = parts.first.flatMap({ pid_t($0) }), parentPID > 0 else { return nil }
+            pid = parentPID
+        }
         return nil
     }
 }

--- a/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
+++ b/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
@@ -144,18 +144,23 @@ struct OpenIslandHooksCLI {
     }
 
     /// Get the TTY of the current process via ps (works even when stdin is a pipe).
+    /// Falls back to the parent process TTY if the current process has none.
     private static func currentTTY() -> String? {
-        let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: "/bin/ps")
-        proc.arguments = ["-o", "tty=", "-p", "\(getpid())"]
-        let pipe = Pipe()
-        proc.standardOutput = pipe
-        proc.standardError = FileHandle.nullDevice
-        try? proc.run()
-        proc.waitUntilExit()
-        let raw = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        guard !raw.isEmpty, raw != "??" else { return nil }
-        return raw.hasPrefix("/dev/") ? raw : "/dev/\(raw)"
+        for pid in [getpid(), getppid()] {
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: "/bin/ps")
+            proc.arguments = ["-o", "tty=", "-p", "\(pid)"]
+            let pipe = Pipe()
+            proc.standardOutput = pipe
+            proc.standardError = FileHandle.nullDevice
+            try? proc.run()
+            proc.waitUntilExit()
+            let raw = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if !raw.isEmpty, raw != "??" {
+                return raw.hasPrefix("/dev/") ? raw : "/dev/\(raw)"
+            }
+        }
+        return nil
     }
 }


### PR DESCRIPTION
添加 Kiro CLI 的 hook 支持

Kiro CLI 有自己的 hook 协议（camelCase 事件名、无 session_id），因此作为独立的 hook source 实现，不复用 Claude 的处理路径。

主要改动：
- 新增 KiroHookPayload 和 BridgeCommand.processKiroHook
- BridgeServer.handleKiroHook 处理完整 session 生命周期
- Session ID 基于终端 TTY 生成
- 进程保活通过 TTY 匹配 kiro-cli-chat 进程
- Settings/ControlCenter UI 中添加 Kiro CLI 安装卡片

不影响 Claude Code、Codex、Cursor、Gemini、OpenCode 的现有逻辑。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kiro CLI processes are automatically detected and de-duplicated during process discovery.
  * Install/uninstall Kiro hooks from Control Center and Settings (includes an “Install All” integration).
  * Kiro sessions are tracked with rich metadata, live session liveness detection, readable session titles, and updated session lifecycle events.
  * Bridge/CLI support added to ingest Kiro hook events for seamless session synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->