### PR TITLE
feat: show 5h/7d Claude usage percentages in closed notch pill

### DIFF
--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -377,27 +377,29 @@ struct IslandPanelView: View {
                     .frame(width: sideWidth + 8 + (closedSpotlightSession?.phase.requiresAttention == true ? 18 : 0))
                 }
 
-                if !hasClosedPresence {
-                    Rectangle()
-                        .fill(Color.clear)
-                        .frame(width: closedNotchWidth - 20)
-                } else {
-                    Rectangle()
-                        .fill(Color.black)
-                        .frame(width: closedNotchWidth - NotchShape.closedTopRadius + (isPopping ? 18 : 0))
-                        .overlay(
-                            CentralActivityLabel(
-                                toolName: closedSpotlightSession?.currentToolName,
-                                preview: closedSpotlightSession?.currentCommandPreviewText,
-                                isVisible: isExternalDisplayPlacement && hasClosedPresence
+                Group {
+                    if !hasClosedPresence {
+                        Rectangle()
+                            .fill(Color.clear)
+                            .frame(width: closedNotchWidth - 20)
+                    } else {
+                        Rectangle()
+                            .fill(Color.black)
+                            .frame(width: closedNotchWidth - NotchShape.closedTopRadius + (isPopping ? 18 : 0))
+                            .overlay(
+                                CentralActivityLabel(
+                                    toolName: closedSpotlightSession?.currentToolName,
+                                    preview: closedSpotlightSession?.currentCommandPreviewText,
+                                    isVisible: isExternalDisplayPlacement && hasClosedPresence
+                                )
                             )
-                        )
-                        .overlay {
-                            ClaudeUsageBadge(
-                                fiveHourPercent: model.claudeUsageSnapshot?.fiveHour?.roundedUsedPercentage,
-                                sevenDayPercent: model.claudeUsageSnapshot?.sevenDay?.roundedUsedPercentage
-                            )
-                        }
+                    }
+                }
+                .overlay {
+                    ClaudeUsageBadge(
+                        fiveHourPercent: model.claudeUsageSnapshot?.fiveHour?.roundedUsedPercentage,
+                        sevenDayPercent: model.claudeUsageSnapshot?.sevenDay?.roundedUsedPercentage
+                    )
                 }
 
                 if hasClosedPresence {

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -392,6 +392,12 @@ struct IslandPanelView: View {
                                 isVisible: isExternalDisplayPlacement && hasClosedPresence
                             )
                         )
+                        .overlay {
+                            ClaudeUsageBadge(
+                                fiveHourPercent: model.claudeUsageSnapshot?.fiveHour?.roundedUsedPercentage,
+                                sevenDayPercent: model.claudeUsageSnapshot?.sevenDay?.roundedUsedPercentage
+                            )
+                        }
                 }
 
                 if hasClosedPresence {
@@ -2056,6 +2062,50 @@ private struct CentralActivityLabel: View {
             return "sparkles"
         }
         return "wrench.and.screwdriver"
+    }
+}
+
+// MARK: - Claude usage badge (5h / 7d percentages in the closed pill)
+
+private struct ClaudeUsageBadge: View {
+    let fiveHourPercent: Int?
+    let sevenDayPercent: Int?
+
+    var body: some View {
+        if fiveHourPercent == nil && sevenDayPercent == nil {
+            EmptyView()
+        } else {
+            HStack(spacing: 6) {
+                segment(label: "5h", percent: fiveHourPercent)
+                segment(label: "7d", percent: sevenDayPercent)
+            }
+            .font(.system(size: 10, weight: .semibold))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 2)
+            .background(Color(red: 0.14, green: 0.14, blue: 0.15), in: Capsule())
+        }
+    }
+
+    private func segment(label: String, percent: Int?) -> some View {
+        HStack(spacing: 2) {
+            Text(label).foregroundStyle(.secondary)
+            Text("\u{2022}").foregroundStyle(.secondary)
+            Text(format(percent)).foregroundStyle(color(for: percent))
+        }
+    }
+
+    private func format(_ p: Int?) -> String {
+        guard let p else { return "--" }
+        return "\(p)"
+    }
+
+    private func color(for p: Int?) -> Color {
+        guard let p else { return .secondary }
+        switch p {
+        case ..<50: return .green
+        case ..<80: return .orange
+        default: return .red
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Surfaces the existing Claude usage data (5-hour and 7-day windows) directly inside the closed island, so users can see their rate-limit headroom at a glance without opening the Control Center.

The data is already collected and published through `AppModel.claudeUsageSnapshot`; this PR only adds a small presentational badge that reads it.

在关闭状态的灵动岛里直接显示 Claude 的 5 小时 / 7 天用量百分比，无需打开 Control Center 也能一眼看到剩余额度。数据本身已经通过 `AppModel.claudeUsageSnapshot` 暴露，本 PR 只新增了一个读取它的展示徽章。

## Changes

- New `ClaudeUsageBadge` view in `Sources/OpenIslandApp/Views/IslandPanelView.swift`, placed just after `ClosedCountBadge`.
- Badge reads `claudeUsageSnapshot?.fiveHour?.roundedUsedPercentage` and `…?.sevenDay?.roundedUsedPercentage`.
- Renders as an overlay of the existing central black rectangle — **no chrome metric is touched**, so layout on notch / non-notch Macs is unchanged.
- Renders `EmptyView()` when both percentages are nil (fail-safe during cold start / when no Claude hooks are installed).
- Per-value `--` placeholder when only one window is available.
- Threshold coloring: green < 50%, orange < 80%, red ≥ 80%.

在 `IslandPanelView.swift` 的 `ClosedCountBadge` 之后新增 `ClaudeUsageBadge`，通过 `overlay` 挂在已有的中央黑色矩形上，不修改任何现有布局参数。无数据时返回 `EmptyView()`（安全兜底），单侧缺失时显示 `--`。阈值着色：<50% 绿、<80% 橙、≥80% 红。

## Visual

Compact format `5h•NN 7d•NN` at 10pt semibold, reusing the existing capsule background color `Color(red: 0.14, green: 0.14, blue: 0.15)` for visual consistency with `ClosedCountBadge`.

紧凑格式 `5h•NN 7d•NN`，字号 10pt semibold，胶囊背景复用 `ClosedCountBadge` 的配色，保持视觉一致。

## Test plan

- [x] Debug build: `swift build --product OpenIslandApp` (passes, 30s)
- [x] Release build + package via `zsh scripts/package-app.sh` (passes)
- [x] Fail-safe verified: badge disappears when `/tmp/open-island-rl.json` is absent
- [x] Rendered with real Claude usage data (5h ≈ 22%, 7d ≈ 35%) on macOS 26.4.1 / Xcode 26.4
- [x] Threshold color transitions verified by swapping test values

## Notes

- Only one file is modified: `Sources/OpenIslandApp/Views/IslandPanelView.swift` (+50 lines).
- No new public API, no dependency change.
- Follows the project's worktree + feature-branch workflow; commit message uses conventional-commits `feat:`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a compact "5h / 7d" usage badge on the closed header to surface recent API usage.
  * Badge hides when no usage data is available and shows "--" for missing values.
  * Usage percentages are color-coded: green (<50%), orange (50–79%), red (≥80%).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->