### PR TITLE
feat: add toggle to disable pixel glyph animation

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -14,6 +14,7 @@ final class AppModel {
     private static let islandClosedDisplayStyleDefaultsKey = "appearance.island.closedDisplayStyle"
     private static let islandHideIdleToEdgeDefaultsKey = "appearance.island.hideIdleToEdge"
     private static let islandPixelShapeStyleDefaultsKey = "appearance.island.pixelShapeStyle"
+    private static let islandDisablePixelAnimationDefaultsKey = "appearance.island.disablePixelAnimation"
     private static let islandStatusColorsDefaultsKey = "appearance.island.statusColors"
     private static let showCodexUsageDefaultsKey = "app.showCodexUsage"
     private static let completionReplyEnabledDefaultsKey = "feature.completionReply.enabled"
@@ -271,6 +272,12 @@ final class AppModel {
             UserDefaults.standard.set(islandPixelShapeStyle.rawValue, forKey: Self.islandPixelShapeStyleDefaultsKey)
         }
     }
+    var disablePixelAnimation: Bool = false {
+        didSet {
+            guard disablePixelAnimation != oldValue else { return }
+            UserDefaults.standard.set(disablePixelAnimation, forKey: Self.islandDisablePixelAnimationDefaultsKey)
+        }
+    }
     var statusColorHexes: [SessionPhase: String] = AppModel.defaultStatusColors {
         didSet {
             guard statusColorHexes != oldValue else { return }
@@ -475,6 +482,7 @@ final class AppModel {
         islandPixelShapeStyle = IslandPixelShapeStyle(
             rawValue: UserDefaults.standard.string(forKey: Self.islandPixelShapeStyleDefaultsKey) ?? ""
         ) ?? .bars
+        disablePixelAnimation = UserDefaults.standard.bool(forKey: Self.islandDisablePixelAnimationDefaultsKey)
         customAvatarImage = AvatarImageStore.currentImage()
         if let saved = UserDefaults.standard.dictionary(forKey: Self.islandStatusColorsDefaultsKey) as? [String: String] {
             var colors = Self.defaultStatusColors

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -58,6 +58,8 @@
 "settings.appearance.style.detailed" = "Detailed";
 "settings.appearance.hideIdleToEdge" = "Hide To Edge When Idle";
 "settings.appearance.hideIdleToEdge.help" = "When the island is collapsed without an active notification card, keep only a thin black edge visible. Hovering or clicking still opens it.";
+"settings.appearance.disablePixelAnimation" = "Disable Pixel Animation";
+"settings.appearance.disablePixelAnimation.help" = "Stops the continuous animation of the pixel glyph in the closed island. Reduces CPU and battery usage, especially while a session is active.";
 "settings.appearance.pixelShape" = "Pixel Glyph";
 "settings.appearance.pixelShape.bars" = "Cat";
 "settings.appearance.pixelShape.steps" = "Steps";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -58,6 +58,8 @@
 "settings.appearance.style.detailed" = "详细";
 "settings.appearance.hideIdleToEdge" = "空闲时隐藏到黑边";
 "settings.appearance.hideIdleToEdge.help" = "当岛处于收起状态且没有活跃通知卡片时，只保留一条细黑边。鼠标悬停或点击仍可展开。";
+"settings.appearance.disablePixelAnimation" = "禁用像素动画";
+"settings.appearance.disablePixelAnimation.help" = "停止收起状态下像素图形的持续动画。可降低 CPU 与电池消耗，尤其在会话进行时。";
 "settings.appearance.pixelShape" = "像素图形";
 "settings.appearance.pixelShape.bars" = "猫咪";
 "settings.appearance.pixelShape.steps" = "阶梯";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -58,6 +58,8 @@
 "settings.appearance.style.detailed" = "詳細";
 "settings.appearance.hideIdleToEdge" = "閒置時隱藏至黑邊";
 "settings.appearance.hideIdleToEdge.help" = "當島處於收起狀態且沒有活躍通知卡片時，只保留一條細黑邊。滑鼠懸停或點擊仍可展開。";
+"settings.appearance.disablePixelAnimation" = "停用像素動畫";
+"settings.appearance.disablePixelAnimation.help" = "停止收合狀態下像素圖形的持續動畫。可降低 CPU 與電池消耗，尤其在工作階段進行時。";
 "settings.appearance.pixelShape" = "像素圖形";
 "settings.appearance.pixelShape.bars" = "貓咪";
 "settings.appearance.pixelShape.steps" = "階梯";

--- a/Sources/OpenIslandApp/Views/AppearanceSettingsPane.swift
+++ b/Sources/OpenIslandApp/Views/AppearanceSettingsPane.swift
@@ -139,7 +139,7 @@ struct AppearanceSettingsPane: View {
             IslandPixelGlyph(
                 tint: tint,
                 style: model.islandPixelShapeStyle,
-                isAnimating: previewPhase != .completed,
+                isAnimating: previewPhase != .completed && !model.disablePixelAnimation,
                 customAvatarImage: model.customAvatarImage
             )
 
@@ -276,7 +276,7 @@ struct AppearanceSettingsPane: View {
                             IslandPixelGlyph(
                                 tint: model.statusColor(for: previewPhase),
                                 style: style,
-                                isAnimating: previewPhase != .completed,
+                                isAnimating: previewPhase != .completed && !model.disablePixelAnimation,
                                 width: 30,
                                 height: 18
                             )

--- a/Sources/OpenIslandApp/Views/AppearanceSettingsPane.swift
+++ b/Sources/OpenIslandApp/Views/AppearanceSettingsPane.swift
@@ -47,6 +47,15 @@ struct AppearanceSettingsPane: View {
                 Text(lang.t("settings.appearance.hideIdleToEdge.help"))
                     .font(.caption)
                     .foregroundStyle(.secondary)
+
+                Toggle(lang.t("settings.appearance.disablePixelAnimation"), isOn: Binding(
+                    get: { model.disablePixelAnimation },
+                    set: { model.disablePixelAnimation = $0 }
+                ))
+
+                Text(lang.t("settings.appearance.disablePixelAnimation.help"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             if isCustom {

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -342,17 +342,18 @@ struct IslandPanelView: View {
         } else {
             HStack(spacing: 0) {
                 if hasClosedPresence {
+                    let glyphIsAnimating = hasClosedActivity && !model.disablePixelAnimation
                     HStack(spacing: 4) {
                         if model.isCustomAppearance {
                             IslandPixelGlyph(
                                 tint: scoutTint,
                                 style: model.islandPixelShapeStyle,
-                                isAnimating: hasClosedActivity,
+                                isAnimating: glyphIsAnimating,
                                 customAvatarImage: model.customAvatarImage
                             )
                             .matchedGeometryEffect(id: "island-icon", in: notchNamespace, isSource: true)
                         } else {
-                            OpenIslandIcon(size: 14, isAnimating: hasClosedActivity, tint: scoutTint)
+                            OpenIslandIcon(size: 14, isAnimating: glyphIsAnimating, tint: scoutTint)
                                 .matchedGeometryEffect(id: "island-icon", in: notchNamespace, isSource: true)
                         }
 


### PR DESCRIPTION
## Summary

Adds a Settings > Appearance toggle that freezes the closed pixel glyph on its first frame instead of running the continuous animation loop. The animation currently runs every 0.18s via a `TimelineView` whenever a session is active and turns out to be the main driver of OpenIslandApp CPU usage.

在 Settings > Appearance 下新增一个开关，可将收起状态下的像素图形定格在首帧，不再运行持续动画循环。当前动画通过 `TimelineView` 每 0.18 秒刷新一次（仅在会话进行时），实测发现它是 OpenIslandApp CPU 占用的主要来源。

## Measured impact

Measured with `top -pid` over ~15s on a single machine (macOS 26.4.1, Xcode 26.4, release build), app running passively in the notch with one active Claude session:

| State | Steady-state CPU |
|---|---|
| Animation ON (current) | ~6–7% |
| Animation OFF (this PR) | **~1.5%** |

That's roughly a **75% reduction** in steady-state CPU, which translates into meaningful battery savings for users who keep Open Island running all day. No visual regression — the glyph stays on-screen, it just no longer animates.

单机测量（macOS 26.4.1，Xcode 26.4，release 构建）：开启动画 ~6-7%，关闭后 ~1.5%，CPU 约降 75%。对需要全天运行 Open Island 的用户，电池收益可观；视觉上图标仍然显示，只是不再动。

## Changes

- New `disablePixelAnimation: Bool` property on `AppModel`, persisted via `UserDefaults` key `appearance.island.disablePixelAnimation`. Defaults to `false` (existing behavior preserved).
- New `Toggle` in `AppearanceSettingsPane.swift`, placed right below *Hide To Edge When Idle*, with matching help text.
- `IslandPanelView.headerRow` now gates `isAnimating` on `!model.disablePixelAnimation` for both the custom pixel glyph path and the default `OpenIslandIcon` path.
- i18n strings added for **en**, **zh-Hans**, and **zh-Hant** (following the same key naming convention as `hideIdleToEdge`).

在 `AppModel` 新增 `disablePixelAnimation` 属性，通过 `UserDefaults` 键 `appearance.island.disablePixelAnimation` 持久化，默认 `false`。在 `AppearanceSettingsPane` 新增 Toggle，紧接 *Hide To Edge When Idle* 之下。`IslandPanelView.headerRow` 的两个图标分支都加入了 `!model.disablePixelAnimation` 判断。中英繁三套 i18n 字符串齐全。

## Test plan

- [x] `swift build --product OpenIslandApp` (passes, 27s)
- [x] `zsh scripts/package-app.sh` (passes)
- [x] Toggle OFF → animation loops as before, CPU ~6-7%
- [x] Toggle ON → glyph freezes on first frame, CPU drops to ~1.5%
- [x] Setting persists across relaunches (backed by UserDefaults)
- [x] All three locale files updated with matching keys

## Notes

- No public API changes, no new dependencies.
- Follows the existing `hideIdleIslandToEdge` pattern exactly — same UserDefaults convention, same didSet guard, same placement in the Appearance section.
- Conservative default (`false`) preserves the current look; users opt in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Disable Pixel Animation" toggle in Appearance settings. When enabled, it stops the pixel/glyph animation in idle/closed states (including previews), reducing CPU and battery usage.
  * Setting is persisted across launches.
  * UI text added for English, Simplified Chinese, and Traditional Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->