### PR TITLE
feat: first-run onboarding and hook install intent (#324)

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1279,6 +1279,13 @@ final class AppModel {
                 // Wait for all status reads to complete before checking install state.
                 await self.hooks.refreshAllHookStatusAndWait()
 
+                // Reconcile persisted intent with what is actually on disk. For
+                // legacy users this records existing hooks as `.installed` and
+                // marks first-launch as complete so onboarding does not appear
+                // on upgrade. Must run after status reads and before any
+                // install decision.
+                self.hooks.migrateIntentStoreIfNeeded()
+
                 if !self.claudeHooksInstalled { self.installClaudeHooks() }
                 if !self.codexHooksInstalled { self.installCodexHooks() }
                 if !self.qoderHooksInstalled { self.installQoderHooks() }

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -355,6 +355,14 @@ final class AppModel {
     @ObservationIgnored
     var openSettingsWindow: (() -> Void)?
 
+    /// Whether the first-run onboarding window is on screen. Set when the
+    /// startup flow presents it or when the user taps an empty-state CTA.
+    /// Cleared by the window controller's `windowWillClose` delegate.
+    var isOnboardingPresented: Bool = false
+
+    @ObservationIgnored
+    private var onboardingWindowController: OnboardingWindowController?
+
     @ObservationIgnored
     private var hasFinishedInit = false
 
@@ -937,13 +945,23 @@ final class AppModel {
         NSApp.activate(ignoringOtherApps: true)
     }
 
-    /// Opens the first-run onboarding window. Currently routes to the
-    /// settings window as a fallback — the dedicated window is introduced
-    /// in the next commit (C5). Call sites that want "take me to agent
-    /// setup" should use this instead of `showSettings()` so they pick up
-    /// the real onboarding once it ships.
+    /// Opens the first-run onboarding window. Invoked on first launch (via
+    /// the startup discovery payload) and from the empty-state prompts in
+    /// the island and settings panels. Lazily creates the controller so
+    /// the window resources cost nothing until first use.
     func showOnboarding() {
-        showSettings()
+        isOnboardingPresented = true
+        if onboardingWindowController == nil {
+            onboardingWindowController = OnboardingWindowController(model: self)
+        }
+        onboardingWindowController?.show()
+    }
+
+    /// Closes the onboarding window. Called by the coordinator when the
+    /// user completes the flow or explicitly skips it.
+    func dismissOnboarding() {
+        onboardingWindowController?.close()
+        isOnboardingPresented = false
     }
 
     func showControlCenter() {
@@ -1318,6 +1336,15 @@ final class AppModel {
                 // on upgrade. Must run after status reads and before any
                 // install decision.
                 self.hooks.migrateIntentStoreIfNeeded()
+
+                // True new users (no hooks, no prior onboarding) get the
+                // first-run window instead of the blind auto-install loop
+                // below. Harness scenarios skip session discovery entirely
+                // so this branch is naturally excluded there.
+                if !self.firstLaunchCompleted {
+                    self.showOnboarding()
+                    return
+                }
 
                 // Install only hooks the user has not explicitly opted out of.
                 // `shouldAutoInstall` skips `.uninstalled` agents and agents

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -119,6 +119,15 @@ final class AppModel {
     var geminiHookStatusSummary: String { hooks.geminiHookStatusSummary }
     var codexHookStatusTitle: String { hooks.codexHookStatusTitle }
     var codexHookStatusSummary: String { hooks.codexHookStatusSummary }
+
+    /// Mirrors `AgentIntentStore.firstLaunchCompleted`. Onboarding sets this
+    /// to true after the user completes (or explicitly skips) the flow;
+    /// legacy migration also flips it for users upgrading with existing
+    /// hooks.
+    var firstLaunchCompleted: Bool {
+        get { hooks.intentStore.firstLaunchCompleted }
+        set { hooks.intentStore.firstLaunchCompleted = newValue }
+    }
     func refreshCodexHookStatus() { hooks.refreshCodexHookStatus() }
     func refreshClaudeHookStatus() { hooks.refreshClaudeHookStatus() }
     func refreshOpenCodePluginStatus() { hooks.refreshOpenCodePluginStatus() }
@@ -1286,16 +1295,20 @@ final class AppModel {
                 // install decision.
                 self.hooks.migrateIntentStoreIfNeeded()
 
-                if !self.claudeHooksInstalled { self.installClaudeHooks() }
-                if !self.codexHooksInstalled { self.installCodexHooks() }
-                if !self.qoderHooksInstalled { self.installQoderHooks() }
-                if !self.qwenCodeHooksInstalled { self.installQwenCodeHooks() }
-                if !self.factoryHooksInstalled { self.installFactoryHooks() }
-                if !self.codebuddyHooksInstalled { self.installCodebuddyHooks() }
-                if !self.openCodePluginInstalled { self.installOpenCodePlugin() }
-                if !self.cursorHooksInstalled { self.installCursorHooks() }
-                if !self.geminiHooksInstalled { self.installGeminiHooks() }
-                if !self.claudeUsageInstalled { self.installClaudeUsageBridge() }
+                // Install only hooks the user has not explicitly opted out of.
+                // `shouldAutoInstall` skips `.uninstalled` agents and agents
+                // whose hooks are already present — it is the single checkpoint
+                // that fixes #324.
+                if self.hooks.shouldAutoInstall(.claudeCode) { self.installClaudeHooks() }
+                if self.hooks.shouldAutoInstall(.codex) { self.installCodexHooks() }
+                if self.hooks.shouldAutoInstall(.qoder) { self.installQoderHooks() }
+                if self.hooks.shouldAutoInstall(.qwenCode) { self.installQwenCodeHooks() }
+                if self.hooks.shouldAutoInstall(.factory) { self.installFactoryHooks() }
+                if self.hooks.shouldAutoInstall(.codebuddy) { self.installCodebuddyHooks() }
+                if self.hooks.shouldAutoInstall(.openCode) { self.installOpenCodePlugin() }
+                if self.hooks.shouldAutoInstall(.cursor) { self.installCursorHooks() }
+                if self.hooks.shouldAutoInstall(.gemini) { self.installGeminiHooks() }
+                if self.hooks.shouldAutoInstall(.claudeUsageBridge) { self.installClaudeUsageBridge() }
 
                 // Run health checks after install to detect stale paths, conflicts, etc.
                 try? await Task.sleep(for: .milliseconds(500))

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -128,6 +128,21 @@ final class AppModel {
         get { hooks.intentStore.firstLaunchCompleted }
         set { hooks.intentStore.firstLaunchCompleted = newValue }
     }
+
+    /// True if at least one managed hook is currently present on disk.
+    /// Drives the "configure agents" empty-state prompts in the island and
+    /// the settings window.
+    var hasAnyInstalledAgent: Bool {
+        hooks.claudeHooksInstalled
+            || hooks.codexHooksInstalled
+            || hooks.cursorHooksInstalled
+            || hooks.qoderHooksInstalled
+            || hooks.qwenCodeHooksInstalled
+            || hooks.factoryHooksInstalled
+            || hooks.codebuddyHooksInstalled
+            || hooks.openCodePluginInstalled
+            || hooks.geminiHooksInstalled
+    }
     func refreshCodexHookStatus() { hooks.refreshCodexHookStatus() }
     func refreshClaudeHookStatus() { hooks.refreshClaudeHookStatus() }
     func refreshOpenCodePluginStatus() { hooks.refreshOpenCodePluginStatus() }
@@ -920,6 +935,15 @@ final class AppModel {
             window.makeKey()
         }
         NSApp.activate(ignoringOtherApps: true)
+    }
+
+    /// Opens the first-run onboarding window. Currently routes to the
+    /// settings window as a fallback — the dedicated window is introduced
+    /// in the next commit (C5). Call sites that want "take me to agent
+    /// setup" should use this instead of `showSettings()` so they pick up
+    /// the real onboarding once it ships.
+    func showOnboarding() {
+        showSettings()
     }
 
     func showControlCenter() {

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -708,6 +708,33 @@ final class HookInstallationCoordinator {
         }
     }
 
+    // MARK: - Intent-aware helpers
+
+    /// Reports whether the startup flow should auto-install hooks for the
+    /// given agent. Returns `false` when the user has explicitly opted out
+    /// (`.uninstalled`) or when the hook is already present on disk.
+    /// Untouched and previously-installed-but-missing agents both return
+    /// `true`, preserving legacy auto-install for never-seen users until
+    /// onboarding ships (see C6).
+    func shouldAutoInstall(_ agent: AgentIdentifier) -> Bool {
+        guard intentStore.intent(for: agent) != .uninstalled else {
+            return false
+        }
+
+        switch agent {
+        case .claudeCode: return !claudeHooksInstalled
+        case .codex: return !codexHooksInstalled
+        case .cursor: return !cursorHooksInstalled
+        case .qoder: return !qoderHooksInstalled
+        case .qwenCode: return !qwenCodeHooksInstalled
+        case .factory: return !factoryHooksInstalled
+        case .codebuddy: return !codebuddyHooksInstalled
+        case .openCode: return !openCodePluginInstalled
+        case .gemini: return !geminiHooksInstalled
+        case .claudeUsageBridge: return !claudeUsageInstalled
+        }
+    }
+
     // MARK: - Intent store migration
 
     /// Reconciles the persisted intent store with the hook status currently

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -711,13 +711,17 @@ final class HookInstallationCoordinator {
     // MARK: - Intent-aware helpers
 
     /// Reports whether the startup flow should auto-install hooks for the
-    /// given agent. Returns `false` when the user has explicitly opted out
-    /// (`.uninstalled`) or when the hook is already present on disk.
-    /// Untouched and previously-installed-but-missing agents both return
-    /// `true`, preserving legacy auto-install for never-seen users until
-    /// onboarding ships (see C6).
+    /// given agent.
+    ///
+    /// Post-onboarding, the only case that triggers auto-install is
+    /// `.installed && !present` — i.e. the user asked for this hook in the
+    /// past but it is currently missing (fresh machine, config wiped,
+    /// upgraded binary path, etc). This is a repair, not a surprise
+    /// install. `.untouched` and `.uninstalled` both return false;
+    /// untouched agents are surfaced to the user via the first-run
+    /// onboarding window and the empty-state banner instead.
     func shouldAutoInstall(_ agent: AgentIdentifier) -> Bool {
-        guard intentStore.intent(for: agent) != .uninstalled else {
+        guard intentStore.intent(for: agent) == .installed else {
             return false
         }
 

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -5,6 +5,13 @@ import OpenIslandCore
 @MainActor
 @Observable
 final class HookInstallationCoordinator {
+    @ObservationIgnored
+    let intentStore: AgentIntentStore
+
+    init(intentStore: AgentIntentStore = AgentIntentStore()) {
+        self.intentStore = intentStore
+    }
+
     var codexHookStatus: CodexHookInstallationStatus?
     var claudeHookStatus: ClaudeHookInstallationStatus?
     var qoderHookStatus: ClaudeHookInstallationStatus?
@@ -701,6 +708,30 @@ final class HookInstallationCoordinator {
         }
     }
 
+    // MARK: - Intent store migration
+
+    /// Reconciles the persisted intent store with the hook status currently
+    /// observed on disk. Must be called only after
+    /// `refreshAllHookStatusAndWait()` has returned, otherwise every agent
+    /// will be recorded as `.untouched` and legacy users will have their
+    /// installed hooks silently forgotten.
+    func migrateIntentStoreIfNeeded() {
+        intentStore.migrateFromLegacyStateIfNeeded { [self] agent in
+            switch agent {
+            case .claudeCode: return claudeHooksInstalled
+            case .codex: return codexHooksInstalled
+            case .cursor: return cursorHooksInstalled
+            case .qoder: return qoderHooksInstalled
+            case .qwenCode: return qwenCodeHooksInstalled
+            case .factory: return factoryHooksInstalled
+            case .codebuddy: return codebuddyHooksInstalled
+            case .openCode: return openCodePluginInstalled
+            case .gemini: return geminiHooksInstalled
+            case .claudeUsageBridge: return claudeUsageInstalled
+            }
+        }
+    }
+
     // MARK: - Install / uninstall
 
     func installCodexHooks() {
@@ -709,13 +740,13 @@ final class HookInstallationCoordinator {
             return
         }
 
-        updateCodexHooks(userMessage: "Installing Codex hooks.") { manager in
+        updateCodexHooks(userMessage: "Installing Codex hooks.", intent: .installed) { manager in
             try manager.install(hooksBinaryURL: hooksBinaryURL)
         }
     }
 
     func uninstallCodexHooks() {
-        updateCodexHooks(userMessage: "Removing Codex hooks.") { manager in
+        updateCodexHooks(userMessage: "Removing Codex hooks.", intent: .uninstalled) { manager in
             try manager.uninstall()
         }
     }
@@ -726,52 +757,53 @@ final class HookInstallationCoordinator {
             return
         }
 
-        updateClaudeHooks(userMessage: "Installing Claude hooks.") { manager in
+        updateClaudeHooks(userMessage: "Installing Claude hooks.", intent: .installed) { manager in
             try manager.install(hooksBinaryURL: hooksBinaryURL)
         }
     }
 
     func uninstallClaudeHooks() {
-        updateClaudeHooks(userMessage: "Removing Claude hooks.") { manager in
+        updateClaudeHooks(userMessage: "Removing Claude hooks.", intent: .uninstalled) { manager in
             try manager.uninstall()
         }
     }
 
     func installQoderHooks() {
-        updateCCForkHooks(manager: qoderHookInstallationManager, name: "Qoder", isBusySetter: { [weak self] in self?.isQoderHookSetupBusy = $0 }, statusSetter: { [weak self] in self?.qoderHookStatus = $0 }, install: true)
+        updateCCForkHooks(manager: qoderHookInstallationManager, name: "Qoder", agent: .qoder, isBusySetter: { [weak self] in self?.isQoderHookSetupBusy = $0 }, statusSetter: { [weak self] in self?.qoderHookStatus = $0 }, install: true)
     }
 
     func uninstallQoderHooks() {
-        updateCCForkHooks(manager: qoderHookInstallationManager, name: "Qoder", isBusySetter: { [weak self] in self?.isQoderHookSetupBusy = $0 }, statusSetter: { [weak self] in self?.qoderHookStatus = $0 }, install: false)
+        updateCCForkHooks(manager: qoderHookInstallationManager, name: "Qoder", agent: .qoder, isBusySetter: { [weak self] in self?.isQoderHookSetupBusy = $0 }, statusSetter: { [weak self] in self?.qoderHookStatus = $0 }, install: false)
     }
 
     func installQwenCodeHooks() {
-        updateCCForkHooks(manager: qwenCodeHookInstallationManager, name: "Qwen Code", isBusySetter: { [weak self] in self?.isQwenCodeHookSetupBusy = $0 }, statusSetter: { [weak self] in self?.qwenCodeHookStatus = $0 }, install: true)
+        updateCCForkHooks(manager: qwenCodeHookInstallationManager, name: "Qwen Code", agent: .qwenCode, isBusySetter: { [weak self] in self?.isQwenCodeHookSetupBusy = $0 }, statusSetter: { [weak self] in self?.qwenCodeHookStatus = $0 }, install: true)
     }
 
     func uninstallQwenCodeHooks() {
-        updateCCForkHooks(manager: qwenCodeHookInstallationManager, name: "Qwen Code", isBusySetter: { [weak self] in self?.isQwenCodeHookSetupBusy = $0 }, statusSetter: { [weak self] in self?.qwenCodeHookStatus = $0 }, install: false)
+        updateCCForkHooks(manager: qwenCodeHookInstallationManager, name: "Qwen Code", agent: .qwenCode, isBusySetter: { [weak self] in self?.isQwenCodeHookSetupBusy = $0 }, statusSetter: { [weak self] in self?.qwenCodeHookStatus = $0 }, install: false)
     }
 
     func installFactoryHooks() {
-        updateCCForkHooks(manager: factoryHookInstallationManager, name: "Factory", isBusySetter: { [weak self] in self?.isFactoryHookSetupBusy = $0 }, statusSetter: { [weak self] in self?.factoryHookStatus = $0 }, install: true)
+        updateCCForkHooks(manager: factoryHookInstallationManager, name: "Factory", agent: .factory, isBusySetter: { [weak self] in self?.isFactoryHookSetupBusy = $0 }, statusSetter: { [weak self] in self?.factoryHookStatus = $0 }, install: true)
     }
 
     func uninstallFactoryHooks() {
-        updateCCForkHooks(manager: factoryHookInstallationManager, name: "Factory", isBusySetter: { [weak self] in self?.isFactoryHookSetupBusy = $0 }, statusSetter: { [weak self] in self?.factoryHookStatus = $0 }, install: false)
+        updateCCForkHooks(manager: factoryHookInstallationManager, name: "Factory", agent: .factory, isBusySetter: { [weak self] in self?.isFactoryHookSetupBusy = $0 }, statusSetter: { [weak self] in self?.factoryHookStatus = $0 }, install: false)
     }
 
     func installCodebuddyHooks() {
-        updateCCForkHooks(manager: codebuddyHookInstallationManager, name: "CodeBuddy", isBusySetter: { [weak self] in self?.isCodebuddyHookSetupBusy = $0 }, statusSetter: { [weak self] in self?.codebuddyHookStatus = $0 }, install: true)
+        updateCCForkHooks(manager: codebuddyHookInstallationManager, name: "CodeBuddy", agent: .codebuddy, isBusySetter: { [weak self] in self?.isCodebuddyHookSetupBusy = $0 }, statusSetter: { [weak self] in self?.codebuddyHookStatus = $0 }, install: true)
     }
 
     func uninstallCodebuddyHooks() {
-        updateCCForkHooks(manager: codebuddyHookInstallationManager, name: "CodeBuddy", isBusySetter: { [weak self] in self?.isCodebuddyHookSetupBusy = $0 }, statusSetter: { [weak self] in self?.codebuddyHookStatus = $0 }, install: false)
+        updateCCForkHooks(manager: codebuddyHookInstallationManager, name: "CodeBuddy", agent: .codebuddy, isBusySetter: { [weak self] in self?.isCodebuddyHookSetupBusy = $0 }, statusSetter: { [weak self] in self?.codebuddyHookStatus = $0 }, install: false)
     }
 
     private func updateCCForkHooks(
         manager: ClaudeHookInstallationManager,
         name: String,
+        agent: AgentIdentifier,
         isBusySetter: @MainActor @escaping (Bool) -> Void,
         statusSetter: @MainActor @escaping (ClaudeHookInstallationStatus) -> Void,
         install: Bool
@@ -794,6 +826,7 @@ final class HookInstallationCoordinator {
                     ? try manager.install(hooksBinaryURL: hooksBinaryURL)
                     : try manager.uninstall()
                 statusSetter(status)
+                self.intentStore.setIntent(install ? .installed : .uninstalled, for: agent)
                 if status.managedHooksPresent {
                     self.onStatusMessage?("\(name) hooks are installed and ready.")
                 } else {
@@ -822,6 +855,7 @@ final class HookInstallationCoordinator {
             do {
                 let status = try self.openCodePluginInstallationManager.install(pluginSourceData: pluginData)
                 self.openCodePluginStatus = status
+                self.intentStore.setIntent(.installed, for: .openCode)
                 if status.isInstalled {
                     self.onStatusMessage?("OpenCode plugin is installed. Restart OpenCode to activate.")
                 } else {
@@ -845,6 +879,7 @@ final class HookInstallationCoordinator {
             do {
                 let status = try self.openCodePluginInstallationManager.uninstall()
                 self.openCodePluginStatus = status
+                self.intentStore.setIntent(.uninstalled, for: .openCode)
                 self.onStatusMessage?("OpenCode plugin removed.")
             } catch {
                 self.onStatusMessage?("OpenCode plugin removal failed: \(error.localizedDescription)")
@@ -858,13 +893,13 @@ final class HookInstallationCoordinator {
             return
         }
 
-        updateCursorHooks(userMessage: "Installing Cursor hooks.") { manager in
+        updateCursorHooks(userMessage: "Installing Cursor hooks.", intent: .installed) { manager in
             try manager.install(hooksBinaryURL: hooksBinaryURL)
         }
     }
 
     func uninstallCursorHooks() {
-        updateCursorHooks(userMessage: "Removing Cursor hooks.") { manager in
+        updateCursorHooks(userMessage: "Removing Cursor hooks.", intent: .uninstalled) { manager in
             try manager.uninstall()
         }
     }
@@ -875,19 +910,19 @@ final class HookInstallationCoordinator {
             return
         }
 
-        updateGeminiHooks(userMessage: "Installing Gemini hooks.") { manager in
+        updateGeminiHooks(userMessage: "Installing Gemini hooks.", intent: .installed) { manager in
             try manager.install(hooksBinaryURL: hooksBinaryURL)
         }
     }
 
     func uninstallGeminiHooks() {
-        updateGeminiHooks(userMessage: "Removing Gemini hooks.") { manager in
+        updateGeminiHooks(userMessage: "Removing Gemini hooks.", intent: .uninstalled) { manager in
             try manager.uninstall()
         }
     }
 
     func installClaudeUsageBridge() {
-        updateClaudeUsageBridge(userMessage: "Installing Claude usage bridge.") { manager in
+        updateClaudeUsageBridge(userMessage: "Installing Claude usage bridge.", intent: .installed) { manager in
             do {
                 return try manager.install()
             } catch ClaudeStatusLineInstallationError.existingStatusLineConflict {
@@ -899,7 +934,7 @@ final class HookInstallationCoordinator {
     }
 
     func uninstallClaudeUsageBridge() {
-        updateClaudeUsageBridge(userMessage: "Removing Claude usage bridge.") { manager in
+        updateClaudeUsageBridge(userMessage: "Removing Claude usage bridge.", intent: .uninstalled) { manager in
             try manager.uninstall()
         }
     }
@@ -958,6 +993,7 @@ final class HookInstallationCoordinator {
 
     private func updateCodexHooks(
         userMessage: String,
+        intent: AgentHookIntent,
         operation: @escaping (CodexHookInstallationManager) throws -> CodexHookInstallationStatus
     ) {
         isCodexSetupBusy = true
@@ -971,6 +1007,7 @@ final class HookInstallationCoordinator {
             do {
                 let status = try operation(self.codexHookInstallationManager)
                 self.codexHookStatus = status
+                self.intentStore.setIntent(intent, for: .codex)
                 if status.managedHooksPresent {
                     self.onStatusMessage?("Codex hooks are installed and ready.")
                 } else {
@@ -984,6 +1021,7 @@ final class HookInstallationCoordinator {
 
     private func updateClaudeHooks(
         userMessage: String,
+        intent: AgentHookIntent,
         operation: @escaping (ClaudeHookInstallationManager) throws -> ClaudeHookInstallationStatus
     ) {
         isClaudeHookSetupBusy = true
@@ -997,6 +1035,7 @@ final class HookInstallationCoordinator {
             do {
                 let status = try operation(self.claudeHookInstallationManager)
                 self.claudeHookStatus = status
+                self.intentStore.setIntent(intent, for: .claudeCode)
                 if status.managedHooksPresent {
                     self.onStatusMessage?(status.hasClaudeIslandHooks
                         ? "Claude hooks are installed. claude-island hooks are also still present."
@@ -1012,6 +1051,7 @@ final class HookInstallationCoordinator {
 
     private func updateCursorHooks(
         userMessage: String,
+        intent: AgentHookIntent,
         operation: @escaping (CursorHookInstallationManager) throws -> CursorHookInstallationStatus
     ) {
         isCursorHookSetupBusy = true
@@ -1025,6 +1065,7 @@ final class HookInstallationCoordinator {
             do {
                 let status = try operation(self.cursorHookInstallationManager)
                 self.cursorHookStatus = status
+                self.intentStore.setIntent(intent, for: .cursor)
                 if status.managedHooksPresent {
                     self.onStatusMessage?("Cursor hooks are installed and ready.")
                 } else {
@@ -1038,6 +1079,7 @@ final class HookInstallationCoordinator {
 
     private func updateGeminiHooks(
         userMessage: String,
+        intent: AgentHookIntent,
         operation: @escaping (GeminiHookInstallationManager) throws -> GeminiHookInstallationStatus
     ) {
         isGeminiHookSetupBusy = true
@@ -1051,6 +1093,7 @@ final class HookInstallationCoordinator {
             do {
                 let status = try operation(self.geminiHookInstallationManager)
                 self.geminiHookStatus = status
+                self.intentStore.setIntent(intent, for: .gemini)
                 if status.managedHooksPresent {
                     self.onStatusMessage?("Gemini hooks are installed and ready.")
                 } else {
@@ -1064,6 +1107,7 @@ final class HookInstallationCoordinator {
 
     private func updateClaudeUsageBridge(
         userMessage: String,
+        intent: AgentHookIntent,
         operation: @escaping (ClaudeStatusLineInstallationManager) throws -> ClaudeStatusLineInstallationStatus
     ) {
         isClaudeUsageSetupBusy = true
@@ -1078,6 +1122,7 @@ final class HookInstallationCoordinator {
                 let status = try operation(self.claudeStatusLineInstallationManager)
                 self.claudeStatusLineStatus = status
                 self.claudeUsageSnapshot = try ClaudeUsageLoader.load()
+                self.intentStore.setIntent(intent, for: .claudeUsageBridge)
                 if status.managedStatusLineInstalled {
                     if status.managedStatusLineIsWrapper {
                         self.onStatusMessage?("Claude usage bridge installed in wrapper mode — your existing statusLine is preserved. Start a Claude Code turn to refresh cached rate limits.")

--- a/Sources/OpenIslandApp/OnboardingWindowController.swift
+++ b/Sources/OpenIslandApp/OnboardingWindowController.swift
@@ -1,0 +1,52 @@
+import AppKit
+import SwiftUI
+
+/// AppKit host for the first-run onboarding window.
+///
+/// Uses an `NSWindowController` rather than a SwiftUI `Window` scene so the
+/// window can be opened programmatically from `AppModel` on first launch,
+/// before any SwiftUI view has had a chance to inject an `openWindow`
+/// environment closure (SwiftUI `Window` scenes are lazy).
+@MainActor
+final class OnboardingWindowController: NSWindowController, NSWindowDelegate {
+    private weak var model: AppModel?
+
+    init(model: AppModel) {
+        self.model = model
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 820, height: 560),
+            styleMask: [.titled, .closable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+
+        window.title = ""
+        window.titlebarAppearsTransparent = true
+        window.isMovableByWindowBackground = true
+        window.center()
+        window.setContentSize(NSSize(width: 820, height: 560))
+        window.contentViewController = NSHostingController(rootView: OnboardingView(model: model))
+        window.isReleasedWhenClosed = false
+
+        super.init(window: window)
+        window.delegate = self
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    func show() {
+        guard let window else { return }
+        window.orderFrontRegardless()
+        window.makeKey()
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        model?.isOnboardingPresented = false
+        window?.orderOut(nil)
+    }
+}

--- a/Sources/OpenIslandApp/OpenIslandApp.swift
+++ b/Sources/OpenIslandApp/OpenIslandApp.swift
@@ -149,3 +149,4 @@ private struct SettingsWindowContent: View {
             }
     }
 }
+

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -202,3 +202,55 @@
 /* Window Titles */
 "window.settings" = "Open Island Settings";
 "window.debug" = "Open Island Debug";
+
+/* Onboarding - Common */
+"onboarding.back" = "Back";
+"onboarding.continue" = "Continue";
+
+/* Onboarding - Welcome */
+"onboarding.welcome.title" = "Welcome to Open Island";
+"onboarding.welcome.subtitle" = "A native macOS companion that surfaces your AI coding agents right in the menu bar.";
+"onboarding.welcome.bullet.agents" = "Monitors Claude Code, Codex, Cursor, and other coding agents.";
+"onboarding.welcome.bullet.permissions" = "Shows permission requests and questions without breaking your flow.";
+"onboarding.welcome.bullet.jump" = "Jumps back to the terminal and pane where the session lives.";
+"onboarding.welcome.skip" = "Skip for now";
+"onboarding.welcome.continue" = "Get started";
+
+/* Onboarding - Agents */
+"onboarding.agents.title" = "Which AI coding agents do you use?";
+"onboarding.agents.subtitle" = "Open Island will monitor these agents. Anything you skip can be enabled later from settings.";
+"onboarding.agents.more" = "More agents";
+"onboarding.agents.footnote" = "Leaving unused agents enabled is harmless — hooks only run when the matching agent starts.";
+"onboarding.agents.desc.claudeCode" = "Anthropic's official Claude Code CLI";
+"onboarding.agents.desc.codex" = "OpenAI's official Codex CLI";
+"onboarding.agents.desc.cursor" = "Cursor Agent (CLI mode)";
+"onboarding.agents.desc.openCode" = "opencode.ai";
+"onboarding.agents.desc.qoder" = "Qoder coding agent";
+"onboarding.agents.desc.qwenCode" = "Alibaba Qwen Code CLI";
+"onboarding.agents.desc.factory" = "Factory AI coding agent";
+"onboarding.agents.desc.codebuddy" = "Tencent CodeBuddy";
+"onboarding.agents.desc.gemini" = "Google Gemini CLI";
+
+/* Onboarding - Permissions */
+"onboarding.permissions.title" = "Grant the permissions Open Island needs";
+"onboarding.permissions.subtitle" = "All of these can be granted later from System Settings — nothing here blocks setup.";
+"onboarding.permissions.required" = "Required";
+"onboarding.permissions.recommended" = "Recommended";
+"onboarding.permissions.optional" = "Optional";
+"onboarding.permissions.granted" = "Granted";
+"onboarding.permissions.grant" = "Grant";
+"onboarding.permissions.openSettings" = "Open Settings";
+"onboarding.permissions.skip" = "Skip";
+"onboarding.permissions.notifications.title" = "Notifications";
+"onboarding.permissions.notifications.desc" = "Surface permission requests and completion events even when Open Island is not focused.";
+"onboarding.permissions.accessibility.title" = "Accessibility";
+"onboarding.permissions.accessibility.desc" = "Lets Open Island jump precisely to the terminal pane hosting each session.";
+"onboarding.permissions.automation.title" = "Automation";
+"onboarding.permissions.automation.desc" = "Enables tab-aware jumps for iTerm, Terminal, and other supported terminals.";
+
+/* Onboarding - Completion */
+"onboarding.completion.title" = "You're all set";
+"onboarding.completion.subtitle" = "Start any coding agent in your terminal — Open Island will appear at the top of your screen.";
+"onboarding.completion.hint" = "Look up here";
+"onboarding.completion.revisit" = "You can change these choices any time from Open Island → Settings → Setup.";
+"onboarding.completion.start" = "Start using";

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -107,6 +107,9 @@
 "setup.permissionsTitle" = "Accessibility";
 "setup.permissionsDesc" = "Open Island may need Accessibility permission to detect terminal windows. Grant it in System Settings → Privacy & Security → Accessibility.";
 "setup.installAll" = "Install All";
+"setup.banner.noHooks.title" = "Get started with Open Island";
+"setup.banner.noHooks.message" = "Enable agent hooks so Open Island can monitor your AI coding sessions.";
+"setup.banner.noHooks.action" = "Set up";
 "setup.revealConfigLocation" = "Reveal config in Finder";
 "setup.section.diagnostics" = "Hook Diagnostics";
 "setup.diagnostics.notRun" = "Health check not yet run.";
@@ -133,6 +136,8 @@
 "island.noTerminals" = "No open terminal sessions";
 "island.startAgent" = "Start a coding agent in your terminal";
 "island.recentSessions" = "Recent sessions remain in Control Center until the terminal is open again";
+"island.empty.noAgents.title" = "No agent hooks installed yet";
+"island.empty.noAgents.cta" = "Set up agents";
 
 /* Island Panel - Session List */
 "island.showAll" = "Show all %lld sessions";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -202,3 +202,55 @@
 /* Window Titles */
 "window.settings" = "Open Island 设置";
 "window.debug" = "Open Island 调试";
+
+/* Onboarding - Common */
+"onboarding.back" = "返回";
+"onboarding.continue" = "继续";
+
+/* Onboarding - Welcome */
+"onboarding.welcome.title" = "欢迎使用 Open Island";
+"onboarding.welcome.subtitle" = "原生 macOS 伴侣应用，让你的 AI 编码代理一目了然地出现在菜单栏。";
+"onboarding.welcome.bullet.agents" = "监听 Claude Code、Codex、Cursor 等多种编码代理";
+"onboarding.welcome.bullet.permissions" = "权限请求和待回答问题，实时提醒不打断你";
+"onboarding.welcome.bullet.jump" = "一键跳回对应的终端窗口和面板";
+"onboarding.welcome.skip" = "稍后再说";
+"onboarding.welcome.continue" = "开始设置";
+
+/* Onboarding - Agents */
+"onboarding.agents.title" = "你使用哪些 AI 编码代理？";
+"onboarding.agents.subtitle" = "Open Island 会监听这些代理。未选中的可以随时在设置中启用。";
+"onboarding.agents.more" = "更多代理";
+"onboarding.agents.footnote" = "未使用的代理保持勾选不会有任何影响——hooks 只在对应代理启动时才会被调用。";
+"onboarding.agents.desc.claudeCode" = "Anthropic 官方 Claude Code CLI";
+"onboarding.agents.desc.codex" = "OpenAI 官方 Codex CLI";
+"onboarding.agents.desc.cursor" = "Cursor Agent（CLI 模式）";
+"onboarding.agents.desc.openCode" = "opencode.ai";
+"onboarding.agents.desc.qoder" = "Qoder 编码代理";
+"onboarding.agents.desc.qwenCode" = "阿里通义 Qwen Code CLI";
+"onboarding.agents.desc.factory" = "Factory AI 编码代理";
+"onboarding.agents.desc.codebuddy" = "腾讯 CodeBuddy";
+"onboarding.agents.desc.gemini" = "Google Gemini CLI";
+
+/* Onboarding - Permissions */
+"onboarding.permissions.title" = "授予 Open Island 必要权限";
+"onboarding.permissions.subtitle" = "所有权限都可以稍后在系统设置中授予——这里不会阻塞你的配置。";
+"onboarding.permissions.required" = "必需";
+"onboarding.permissions.recommended" = "推荐";
+"onboarding.permissions.optional" = "可选";
+"onboarding.permissions.granted" = "已授予";
+"onboarding.permissions.grant" = "授予";
+"onboarding.permissions.openSettings" = "打开设置";
+"onboarding.permissions.skip" = "跳过";
+"onboarding.permissions.notifications.title" = "通知";
+"onboarding.permissions.notifications.desc" = "即使 Open Island 不在前台，也能及时收到权限请求和会话完成提醒。";
+"onboarding.permissions.accessibility.title" = "辅助功能";
+"onboarding.permissions.accessibility.desc" = "让 Open Island 精准跳转到承载每个会话的终端面板。";
+"onboarding.permissions.automation.title" = "自动化";
+"onboarding.permissions.automation.desc" = "让 iTerm、Terminal 等终端支持 tab 级别的跳转。";
+
+/* Onboarding - Completion */
+"onboarding.completion.title" = "准备就绪";
+"onboarding.completion.subtitle" = "在终端中启动任何编码代理，Open Island 就会出现在屏幕顶部。";
+"onboarding.completion.hint" = "就在上方";
+"onboarding.completion.revisit" = "你可以随时在 Open Island → 设置 → Setup 中修改这些选项。";
+"onboarding.completion.start" = "开始使用";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -107,6 +107,9 @@
 "setup.permissionsTitle" = "辅助功能";
 "setup.permissionsDesc" = "Open Island 可能需要辅助功能权限来检测终端窗口。请在「系统设置 → 隐私与安全性 → 辅助功能」中授权。";
 "setup.installAll" = "全部安装";
+"setup.banner.noHooks.title" = "开始使用 Open Island";
+"setup.banner.noHooks.message" = "启用 Agent hooks，让 Open Island 监听你的 AI 编码会话。";
+"setup.banner.noHooks.action" = "开始配置";
 "setup.revealConfigLocation" = "在 Finder 中显示配置";
 "setup.section.diagnostics" = "Hooks 诊断";
 "setup.diagnostics.notRun" = "尚未运行健康检查。";
@@ -133,6 +136,8 @@
 "island.noTerminals" = "没有打开的终端会话";
 "island.startAgent" = "在终端中启动编码代理";
 "island.recentSessions" = "最近的会话将保留在控制中心，直到终端重新打开";
+"island.empty.noAgents.title" = "尚未启用任何 Agent 监听";
+"island.empty.noAgents.cta" = "开始配置";
 
 /* Island Panel - Session List */
 "island.showAll" = "显示全部 %lld 个会话";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -201,3 +201,55 @@
 /* Window Titles */
 "window.settings" = "Open Island 設定";
 "window.debug" = "Open Island 除錯";
+
+/* Onboarding - Common */
+"onboarding.back" = "返回";
+"onboarding.continue" = "繼續";
+
+/* Onboarding - Welcome */
+"onboarding.welcome.title" = "歡迎使用 Open Island";
+"onboarding.welcome.subtitle" = "原生 macOS 伴侶應用，讓你的 AI 編碼代理一目了然地出現在選單列。";
+"onboarding.welcome.bullet.agents" = "監聽 Claude Code、Codex、Cursor 等多種編碼代理";
+"onboarding.welcome.bullet.permissions" = "權限請求和待回答問題，即時提醒不打斷你";
+"onboarding.welcome.bullet.jump" = "一鍵跳回對應的終端機視窗和面板";
+"onboarding.welcome.skip" = "稍後再說";
+"onboarding.welcome.continue" = "開始設定";
+
+/* Onboarding - Agents */
+"onboarding.agents.title" = "你使用哪些 AI 編碼代理？";
+"onboarding.agents.subtitle" = "Open Island 會監聽這些代理。未選中的可以隨時在設定中啟用。";
+"onboarding.agents.more" = "更多代理";
+"onboarding.agents.footnote" = "未使用的代理保持勾選不會有任何影響——hooks 只會在對應代理啟動時才被呼叫。";
+"onboarding.agents.desc.claudeCode" = "Anthropic 官方 Claude Code CLI";
+"onboarding.agents.desc.codex" = "OpenAI 官方 Codex CLI";
+"onboarding.agents.desc.cursor" = "Cursor Agent（CLI 模式）";
+"onboarding.agents.desc.openCode" = "opencode.ai";
+"onboarding.agents.desc.qoder" = "Qoder 編碼代理";
+"onboarding.agents.desc.qwenCode" = "阿里通義 Qwen Code CLI";
+"onboarding.agents.desc.factory" = "Factory AI 編碼代理";
+"onboarding.agents.desc.codebuddy" = "騰訊 CodeBuddy";
+"onboarding.agents.desc.gemini" = "Google Gemini CLI";
+
+/* Onboarding - Permissions */
+"onboarding.permissions.title" = "授予 Open Island 所需權限";
+"onboarding.permissions.subtitle" = "所有權限都可以之後在系統設定中授予——這裡不會阻擋你的設定。";
+"onboarding.permissions.required" = "必需";
+"onboarding.permissions.recommended" = "推薦";
+"onboarding.permissions.optional" = "可選";
+"onboarding.permissions.granted" = "已授予";
+"onboarding.permissions.grant" = "授予";
+"onboarding.permissions.openSettings" = "開啟設定";
+"onboarding.permissions.skip" = "略過";
+"onboarding.permissions.notifications.title" = "通知";
+"onboarding.permissions.notifications.desc" = "即使 Open Island 不在前景，也能即時收到權限請求和工作階段完成提醒。";
+"onboarding.permissions.accessibility.title" = "輔助使用";
+"onboarding.permissions.accessibility.desc" = "讓 Open Island 精準跳轉到承載每個工作階段的終端機面板。";
+"onboarding.permissions.automation.title" = "自動化";
+"onboarding.permissions.automation.desc" = "讓 iTerm、Terminal 等終端機支援 tab 層級的跳轉。";
+
+/* Onboarding - Completion */
+"onboarding.completion.title" = "準備就緒";
+"onboarding.completion.subtitle" = "在終端機中啟動任何編碼代理，Open Island 就會出現在螢幕頂端。";
+"onboarding.completion.hint" = "就在上方";
+"onboarding.completion.revisit" = "你可以隨時在 Open Island → 設定 → Setup 中修改這些選項。";
+"onboarding.completion.start" = "開始使用";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -107,6 +107,9 @@
 "setup.permissionsTitle" = "輔助使用";
 "setup.permissionsDesc" = "Open Island 可能需要輔助使用權限來偵測終端機視窗。請在「系統設定 → 隱私權與安全性 → 輔助使用」中授權。";
 "setup.installAll" = "全部安裝";
+"setup.banner.noHooks.title" = "開始使用 Open Island";
+"setup.banner.noHooks.message" = "啟用 Agent hooks，讓 Open Island 監聽你的 AI 編碼工作階段。";
+"setup.banner.noHooks.action" = "開始設定";
 "setup.revealConfigLocation" = "在 Finder 中顯示設定";
 "setup.section.diagnostics" = "Hooks 診斷";
 "setup.diagnostics.notRun" = "尚未執行健康檢查。";
@@ -133,6 +136,8 @@
 "island.noTerminals" = "沒有已開啟的終端機工作階段";
 "island.startAgent" = "在終端機中啟動編碼代理";
 "island.recentSessions" = "最近的工作階段將保留在控制中心，直到終端機重新開啟";
+"island.empty.noAgents.title" = "尚未啟用任何 Agent 監聽";
+"island.empty.noAgents.cta" = "開始設定";
 
 /* Island Panel - Session List */
 "island.showAll" = "顯示全部 %lld 個工作階段";

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -493,14 +493,34 @@ struct IslandPanelView: View {
     private var emptyState: some View {
         VStack(spacing: 12) {
             Spacer()
-            Text(model.lang.t("island.noTerminals"))
-                .font(.system(size: 14, weight: .medium))
-                .foregroundStyle(.white.opacity(0.4))
-            Text(model.recentSessions.isEmpty
-                ? model.lang.t("island.startAgent")
-                : model.lang.t("island.recentSessions"))
-                .font(.system(size: 12))
-                .foregroundStyle(.white.opacity(0.25))
+            if !model.hasAnyInstalledAgent {
+                Text(model.lang.t("island.empty.noAgents.title"))
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.6))
+                Button {
+                    model.showOnboarding()
+                } label: {
+                    Text(model.lang.t("island.empty.noAgents.cta"))
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 6)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                .fill(Color.accentColor.opacity(0.85))
+                        )
+                }
+                .buttonStyle(.plain)
+            } else {
+                Text(model.lang.t("island.noTerminals"))
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.4))
+                Text(model.recentSessions.isEmpty
+                    ? model.lang.t("island.startAgent")
+                    : model.lang.t("island.recentSessions"))
+                    .font(.system(size: 12))
+                    .foregroundStyle(.white.opacity(0.25))
+            }
             Spacer()
         }
         .frame(maxWidth: .infinity)

--- a/Sources/OpenIslandApp/Views/Onboarding/OnboardingAgentsScreen.swift
+++ b/Sources/OpenIslandApp/Views/Onboarding/OnboardingAgentsScreen.swift
@@ -1,0 +1,133 @@
+import SwiftUI
+import OpenIslandCore
+
+struct OnboardingAgentsScreen: View {
+    var coordinator: OnboardingCoordinator
+    var lang: LanguageManager
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Text(lang.t("onboarding.agents.title"))
+                .font(.system(size: 22, weight: .bold))
+
+            Text(lang.t("onboarding.agents.subtitle"))
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            ScrollView {
+                VStack(spacing: 8) {
+                    ForEach(OnboardingCoordinator.primaryAgents, id: \.self) { agent in
+                        agentRow(agent)
+                    }
+
+                    DisclosureGroup(isExpanded: Binding(
+                        get: { coordinator.moreAgentsExpanded },
+                        set: { coordinator.moreAgentsExpanded = $0 }
+                    )) {
+                        VStack(spacing: 8) {
+                            ForEach(OnboardingCoordinator.secondaryAgents, id: \.self) { agent in
+                                agentRow(agent)
+                            }
+                        }
+                        .padding(.top, 8)
+                    } label: {
+                        Text(lang.t("onboarding.agents.more"))
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                }
+            }
+            .frame(maxHeight: 320)
+
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "info.circle")
+                    .foregroundStyle(.secondary)
+                Text(lang.t("onboarding.agents.footnote"))
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 0)
+
+            HStack {
+                Button(lang.t("onboarding.back")) { coordinator.goBack() }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                Button(lang.t("onboarding.continue")) {
+                    coordinator.advance()
+                }
+                .keyboardShortcut(.defaultAction)
+                .controlSize(.large)
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(40)
+    }
+
+    @ViewBuilder
+    private func agentRow(_ agent: AgentIdentifier) -> some View {
+        let selected = coordinator.isSelected(agent)
+        HStack(spacing: 12) {
+            Image(systemName: agentIcon(agent))
+                .font(.system(size: 16))
+                .foregroundStyle(.tint)
+                .frame(width: 28, height: 28)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(agentDisplayName(agent))
+                    .font(.system(size: 13, weight: .semibold))
+                Text(lang.t("onboarding.agents.desc.\(agent.rawValue)"))
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Toggle("", isOn: Binding(
+                get: { selected },
+                set: { _ in coordinator.toggleSelection(agent) }
+            ))
+            .toggleStyle(.switch)
+            .labelsHidden()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.secondary.opacity(0.08))
+        )
+    }
+
+    private func agentDisplayName(_ agent: AgentIdentifier) -> String {
+        switch agent {
+        case .claudeCode: return "Claude Code"
+        case .codex: return "Codex"
+        case .cursor: return "Cursor"
+        case .openCode: return "OpenCode"
+        case .qoder: return "Qoder"
+        case .qwenCode: return "Qwen Code"
+        case .factory: return "Factory"
+        case .codebuddy: return "CodeBuddy"
+        case .gemini: return "Gemini CLI"
+        case .claudeUsageBridge: return "Claude Usage Bridge"
+        }
+    }
+
+    private func agentIcon(_ agent: AgentIdentifier) -> String {
+        switch agent {
+        case .claudeCode, .qoder, .qwenCode, .factory, .codebuddy: return "terminal"
+        case .codex: return "chevron.left.slash.chevron.right"
+        case .cursor: return "cursorarrow.rays"
+        case .openCode: return "curlybraces"
+        case .gemini: return "sparkles"
+        case .claudeUsageBridge: return "chart.bar"
+        }
+    }
+}

--- a/Sources/OpenIslandApp/Views/Onboarding/OnboardingCompletionScreen.swift
+++ b/Sources/OpenIslandApp/Views/Onboarding/OnboardingCompletionScreen.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct OnboardingCompletionScreen: View {
+    var coordinator: OnboardingCoordinator
+    var lang: LanguageManager
+
+    var body: some View {
+        VStack(spacing: 22) {
+            Spacer(minLength: 0)
+
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 48, weight: .light))
+                .foregroundStyle(.green)
+
+            Text(lang.t("onboarding.completion.title"))
+                .font(.system(size: 24, weight: .bold))
+
+            Text(lang.t("onboarding.completion.subtitle"))
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 500)
+
+            ZStack {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(Color.secondary.opacity(0.08))
+                    .frame(width: 320, height: 96)
+
+                VStack(spacing: 6) {
+                    Image(systemName: "chevron.up")
+                        .font(.system(size: 20, weight: .bold))
+                        .foregroundStyle(.tint)
+                    Text(lang.t("onboarding.completion.hint"))
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.top, 4)
+
+            Text(lang.t("onboarding.completion.revisit"))
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 440)
+
+            Spacer(minLength: 0)
+
+            HStack {
+                Button(lang.t("onboarding.back")) { coordinator.goBack() }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                Button(lang.t("onboarding.completion.start")) {
+                    coordinator.complete()
+                }
+                .keyboardShortcut(.defaultAction)
+                .controlSize(.large)
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(40)
+    }
+}

--- a/Sources/OpenIslandApp/Views/Onboarding/OnboardingCoordinator.swift
+++ b/Sources/OpenIslandApp/Views/Onboarding/OnboardingCoordinator.swift
@@ -1,0 +1,174 @@
+import AppKit
+import Foundation
+import Observation
+import OpenIslandCore
+import UserNotifications
+
+/// Drives the first-run onboarding window: tracks the current screen,
+/// the user's agent selection, and the status of the three optional
+/// permission requests. Agent install side-effects fire only on
+/// completion so mid-flow cancellation leaves nothing behind.
+@MainActor
+@Observable
+final class OnboardingCoordinator {
+    enum Step: Int, CaseIterable {
+        case welcome
+        case agents
+        case permissions
+        case completion
+    }
+
+    enum PermissionStatus: Equatable {
+        case unknown
+        case granted
+        case denied
+        case pending
+    }
+
+    private weak var model: AppModel?
+
+    var step: Step = .welcome
+    /// Agents the user has ticked in Screen 2. Default: all managed agents
+    /// except the Claude usage bridge (handled silently alongside Claude).
+    var selectedAgents: Set<AgentIdentifier>
+    var notificationStatus: PermissionStatus = .unknown
+    var accessibilityStatus: PermissionStatus = .unknown
+    var automationStatus: PermissionStatus = .unknown
+    /// Expanded state for the "More agents" fold on Screen 2.
+    var moreAgentsExpanded: Bool = false
+
+    init(model: AppModel? = nil) {
+        self.model = model
+        self.selectedAgents = Set(Self.userFacingAgents)
+    }
+
+    // MARK: - Screen 2 model
+
+    /// Agents shown unfolded at the top of Screen 2.
+    static let primaryAgents: [AgentIdentifier] = [.claudeCode, .codex, .cursor, .openCode]
+
+    /// Agents hidden behind the "More agents" disclosure on Screen 2.
+    static let secondaryAgents: [AgentIdentifier] = [.qoder, .qwenCode, .factory, .codebuddy, .gemini]
+
+    /// The union, in display order — excludes `claudeUsageBridge` because it
+    /// is coupled to Claude Code and installed silently alongside it.
+    static var userFacingAgents: [AgentIdentifier] {
+        primaryAgents + secondaryAgents
+    }
+
+    func isSelected(_ agent: AgentIdentifier) -> Bool {
+        selectedAgents.contains(agent)
+    }
+
+    func toggleSelection(_ agent: AgentIdentifier) {
+        if selectedAgents.contains(agent) {
+            selectedAgents.remove(agent)
+        } else {
+            selectedAgents.insert(agent)
+        }
+    }
+
+    // MARK: - Navigation
+
+    func advance() {
+        guard let next = Step(rawValue: step.rawValue + 1) else { return }
+        step = next
+    }
+
+    func goBack() {
+        guard let prev = Step(rawValue: step.rawValue - 1) else { return }
+        step = prev
+    }
+
+    // MARK: - Permission flow
+
+    func refreshNotificationStatus() {
+        Task { [weak self] in
+            let settings = await UNUserNotificationCenter.current().notificationSettings()
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                switch settings.authorizationStatus {
+                case .authorized, .provisional, .ephemeral:
+                    self.notificationStatus = .granted
+                case .denied:
+                    self.notificationStatus = .denied
+                case .notDetermined:
+                    self.notificationStatus = .unknown
+                @unknown default:
+                    self.notificationStatus = .unknown
+                }
+            }
+        }
+    }
+
+    func requestNotificationPermission() {
+        notificationStatus = .pending
+        Task { [weak self] in
+            let granted = (try? await UNUserNotificationCenter.current()
+                .requestAuthorization(options: [.alert, .sound, .badge])) ?? false
+            await MainActor.run { [weak self] in
+                self?.notificationStatus = granted ? .granted : .denied
+            }
+        }
+    }
+
+    func openAccessibilitySettings() {
+        accessibilityStatus = .pending
+        openSystemSettings(url: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
+    }
+
+    func openAutomationSettings() {
+        automationStatus = .pending
+        openSystemSettings(url: "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation")
+    }
+
+    private func openSystemSettings(url urlString: String) {
+        guard let url = URL(string: urlString) else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    // MARK: - Completion
+
+    /// Called by the final screen's primary button. Writes intents for every
+    /// agent (selected → `.installed`, unselected → `.uninstalled`), marks
+    /// first launch complete, and kicks off the real installs. Does not
+    /// block — install is fire-and-forget; failures surface on the
+    /// individual agent cards in settings.
+    func complete() {
+        guard let model else { return }
+
+        for agent in Self.userFacingAgents {
+            let intent: AgentHookIntent = selectedAgents.contains(agent) ? .installed : .uninstalled
+            model.hooks.intentStore.setIntent(intent, for: agent)
+        }
+
+        // Claude usage bridge: install it alongside Claude Code so existing
+        // behaviour is preserved. If user deselected Claude Code, keep the
+        // bridge uninstalled too.
+        let bridgeIntent: AgentHookIntent = selectedAgents.contains(.claudeCode) ? .installed : .uninstalled
+        model.hooks.intentStore.setIntent(bridgeIntent, for: .claudeUsageBridge)
+
+        model.firstLaunchCompleted = true
+
+        if selectedAgents.contains(.claudeCode) { model.installClaudeHooks() }
+        if selectedAgents.contains(.codex) { model.installCodexHooks() }
+        if selectedAgents.contains(.cursor) { model.installCursorHooks() }
+        if selectedAgents.contains(.qoder) { model.installQoderHooks() }
+        if selectedAgents.contains(.qwenCode) { model.installQwenCodeHooks() }
+        if selectedAgents.contains(.factory) { model.installFactoryHooks() }
+        if selectedAgents.contains(.codebuddy) { model.installCodebuddyHooks() }
+        if selectedAgents.contains(.openCode) { model.installOpenCodePlugin() }
+        if selectedAgents.contains(.gemini) { model.installGeminiHooks() }
+        if selectedAgents.contains(.claudeCode) { model.installClaudeUsageBridge() }
+
+        model.dismissOnboarding()
+    }
+
+    /// Called when the user closes the window mid-flow.
+    func skip() {
+        // Leave intents as `.untouched`, do not mark first launch complete.
+        // Next launch may show onboarding again; the empty-state banner is
+        // the backstop.
+        model?.dismissOnboarding()
+    }
+}

--- a/Sources/OpenIslandApp/Views/Onboarding/OnboardingPermissionsScreen.swift
+++ b/Sources/OpenIslandApp/Views/Onboarding/OnboardingPermissionsScreen.swift
@@ -1,0 +1,151 @@
+import SwiftUI
+
+struct OnboardingPermissionsScreen: View {
+    var coordinator: OnboardingCoordinator
+    var lang: LanguageManager
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Text(lang.t("onboarding.permissions.title"))
+                .font(.system(size: 22, weight: .bold))
+
+            Text(lang.t("onboarding.permissions.subtitle"))
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(spacing: 10) {
+                permissionRow(
+                    icon: "bell",
+                    title: lang.t("onboarding.permissions.notifications.title"),
+                    subtitle: lang.t("onboarding.permissions.notifications.desc"),
+                    badge: lang.t("onboarding.permissions.required"),
+                    badgeTint: .orange,
+                    status: coordinator.notificationStatus
+                ) {
+                    coordinator.requestNotificationPermission()
+                }
+
+                permissionRow(
+                    icon: "accessibility",
+                    title: lang.t("onboarding.permissions.accessibility.title"),
+                    subtitle: lang.t("onboarding.permissions.accessibility.desc"),
+                    badge: lang.t("onboarding.permissions.recommended"),
+                    badgeTint: .blue,
+                    status: coordinator.accessibilityStatus
+                ) {
+                    coordinator.openAccessibilitySettings()
+                }
+
+                permissionRow(
+                    icon: "applescript",
+                    title: lang.t("onboarding.permissions.automation.title"),
+                    subtitle: lang.t("onboarding.permissions.automation.desc"),
+                    badge: lang.t("onboarding.permissions.optional"),
+                    badgeTint: .secondary,
+                    status: coordinator.automationStatus
+                ) {
+                    coordinator.openAutomationSettings()
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            HStack {
+                Button(lang.t("onboarding.back")) { coordinator.goBack() }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                Button(lang.t("onboarding.permissions.skip")) {
+                    coordinator.advance()
+                }
+                .controlSize(.regular)
+
+                Button(lang.t("onboarding.continue")) {
+                    coordinator.advance()
+                }
+                .keyboardShortcut(.defaultAction)
+                .controlSize(.large)
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(40)
+        .onAppear {
+            coordinator.refreshNotificationStatus()
+        }
+    }
+
+    @ViewBuilder
+    private func permissionRow(
+        icon: String,
+        title: String,
+        subtitle: String,
+        badge: String,
+        badgeTint: Color,
+        status: OnboardingCoordinator.PermissionStatus,
+        action: @escaping () -> Void
+    ) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 18))
+                .foregroundStyle(.tint)
+                .frame(width: 32, height: 32)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Text(title)
+                        .font(.system(size: 13, weight: .semibold))
+                    Text(badge)
+                        .font(.system(size: 10, weight: .medium))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(badgeTint.opacity(0.18), in: Capsule())
+                        .foregroundStyle(badgeTint)
+                }
+                Text(subtitle)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer()
+
+            actionControl(status: status, action: action)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.secondary.opacity(0.08))
+        )
+    }
+
+    @ViewBuilder
+    private func actionControl(
+        status: OnboardingCoordinator.PermissionStatus,
+        action: @escaping () -> Void
+    ) -> some View {
+        switch status {
+        case .granted:
+            HStack(spacing: 4) {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                Text(lang.t("onboarding.permissions.granted"))
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+            }
+        case .pending:
+            ProgressView()
+                .controlSize(.small)
+        case .denied:
+            Button(lang.t("onboarding.permissions.openSettings")) { action() }
+                .controlSize(.small)
+        case .unknown:
+            Button(lang.t("onboarding.permissions.grant")) { action() }
+                .controlSize(.small)
+                .buttonStyle(.bordered)
+        }
+    }
+}

--- a/Sources/OpenIslandApp/Views/Onboarding/OnboardingProgressDots.swift
+++ b/Sources/OpenIslandApp/Views/Onboarding/OnboardingProgressDots.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct OnboardingProgressDots: View {
+    let current: Int
+    let total: Int
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(0..<total, id: \.self) { idx in
+                Circle()
+                    .fill(idx == current ? Color.accentColor : Color.secondary.opacity(0.3))
+                    .frame(width: 8, height: 8)
+            }
+        }
+    }
+}

--- a/Sources/OpenIslandApp/Views/Onboarding/OnboardingView.swift
+++ b/Sources/OpenIslandApp/Views/Onboarding/OnboardingView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct OnboardingView: View {
+    var model: AppModel
+    @State private var coordinator: OnboardingCoordinator
+
+    init(model: AppModel) {
+        self.model = model
+        _coordinator = State(initialValue: OnboardingCoordinator(model: model))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            OnboardingProgressDots(
+                current: coordinator.step.rawValue,
+                total: OnboardingCoordinator.Step.allCases.count
+            )
+            .padding(.top, 20)
+
+            Group {
+                switch coordinator.step {
+                case .welcome:
+                    OnboardingWelcomeScreen(
+                        coordinator: coordinator,
+                        lang: model.lang,
+                        onSkip: { coordinator.skip() }
+                    )
+                case .agents:
+                    OnboardingAgentsScreen(coordinator: coordinator, lang: model.lang)
+                case .permissions:
+                    OnboardingPermissionsScreen(coordinator: coordinator, lang: model.lang)
+                case .completion:
+                    OnboardingCompletionScreen(coordinator: coordinator, lang: model.lang)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(minWidth: 720, minHeight: 520)
+    }
+}

--- a/Sources/OpenIslandApp/Views/Onboarding/OnboardingWelcomeScreen.swift
+++ b/Sources/OpenIslandApp/Views/Onboarding/OnboardingWelcomeScreen.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+struct OnboardingWelcomeScreen: View {
+    var coordinator: OnboardingCoordinator
+    var lang: LanguageManager
+    var onSkip: () -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer(minLength: 0)
+
+            Image(systemName: "sparkles")
+                .font(.system(size: 52, weight: .light))
+                .foregroundStyle(.tint)
+                .padding(.bottom, 4)
+
+            Text(lang.t("onboarding.welcome.title"))
+                .font(.system(size: 26, weight: .bold))
+
+            Text(lang.t("onboarding.welcome.subtitle"))
+                .font(.system(size: 14))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 500)
+
+            VStack(alignment: .leading, spacing: 10) {
+                bullet(lang.t("onboarding.welcome.bullet.agents"))
+                bullet(lang.t("onboarding.welcome.bullet.permissions"))
+                bullet(lang.t("onboarding.welcome.bullet.jump"))
+            }
+            .frame(maxWidth: 440, alignment: .leading)
+            .padding(.top, 8)
+
+            Spacer(minLength: 0)
+
+            HStack {
+                Button(lang.t("onboarding.welcome.skip")) { onSkip() }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                Button(lang.t("onboarding.welcome.continue")) {
+                    coordinator.advance()
+                }
+                .keyboardShortcut(.defaultAction)
+                .controlSize(.large)
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(40)
+    }
+
+    private func bullet(_ text: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.tint)
+                .font(.system(size: 14))
+            Text(text)
+                .font(.system(size: 13))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -419,6 +419,10 @@ struct SetupSettingsPane: View {
 
     var body: some View {
         Form {
+            if !model.hasAnyInstalledAgent {
+                emptyStateBanner
+            }
+
             claudeConfigDirectorySection
 
             Section(lang.t("setup.section.hooks")) {
@@ -714,6 +718,37 @@ struct SetupSettingsPane: View {
         model.claudeHooksInstalled && model.codexHooksInstalled && model.openCodePluginInstalled
             && model.qoderHooksInstalled && model.qwenCodeHooksInstalled && model.factoryHooksInstalled && model.codebuddyHooksInstalled
             && model.cursorHooksInstalled && model.geminiHooksInstalled && model.claudeUsageInstalled
+    }
+
+    @ViewBuilder
+    private var emptyStateBanner: some View {
+        Section {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: "sparkles")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(.tint)
+                    .frame(width: 28)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(lang.t("setup.banner.noHooks.title"))
+                        .font(.system(size: 13, weight: .semibold))
+                    Text(lang.t("setup.banner.noHooks.message"))
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer()
+
+                Button(lang.t("setup.banner.noHooks.action")) {
+                    model.showOnboarding()
+                }
+                .controlSize(.regular)
+                .buttonStyle(.borderedProminent)
+                .disabled(model.hooksBinaryURL == nil)
+            }
+            .padding(.vertical, 4)
+        }
     }
 
     private var codexHookConfigURL: URL? {

--- a/Sources/OpenIslandCore/AgentHookIntent.swift
+++ b/Sources/OpenIslandCore/AgentHookIntent.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Tri-state record of whether the user wants a given agent's hooks installed.
+///
+/// `untouched` is the default for a never-seen agent. Once the user makes a
+/// decision — in onboarding or control center — the value becomes either
+/// `installed` or `uninstalled`. The startup flow must honour `uninstalled`
+/// and never silently reinstall.
+public enum AgentHookIntent: String, Codable, Sendable, CaseIterable {
+    case untouched
+    case installed
+    case uninstalled
+}
+
+/// Canonical identifier for every agent whose hooks Open Island manages.
+///
+/// Raw values are stable on-disk keys (used in UserDefaults); do not rename
+/// existing cases without a migration.
+public enum AgentIdentifier: String, Codable, Sendable, CaseIterable {
+    case claudeCode
+    case codex
+    case cursor
+    case qoder
+    case qwenCode
+    case factory
+    case codebuddy
+    case openCode
+    case gemini
+    case claudeUsageBridge
+}

--- a/Sources/OpenIslandCore/AgentIntentStore.swift
+++ b/Sources/OpenIslandCore/AgentIntentStore.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// Persists the user's per-agent hook install intent across launches.
+///
+/// Backed by `UserDefaults`. Tests inject a throwaway suite so production
+/// preferences aren't touched. `AgentIntentStore` is the single source of
+/// truth for whether the startup flow should auto-install, skip, or prompt.
+public final class AgentIntentStore: @unchecked Sendable {
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    // MARK: - Per-agent intent
+
+    public func intent(for agent: AgentIdentifier) -> AgentHookIntent {
+        guard
+            let raw = defaults.string(forKey: Self.intentKey(for: agent)),
+            let intent = AgentHookIntent(rawValue: raw)
+        else {
+            return .untouched
+        }
+        return intent
+    }
+
+    public func setIntent(_ intent: AgentHookIntent, for agent: AgentIdentifier) {
+        defaults.set(intent.rawValue, forKey: Self.intentKey(for: agent))
+    }
+
+    /// Returns every agent whose recorded intent is `.installed`.
+    public func installedAgents() -> [AgentIdentifier] {
+        AgentIdentifier.allCases.filter { intent(for: $0) == .installed }
+    }
+
+    // MARK: - First-launch tracking
+
+    /// True once the user has completed (or explicitly skipped) onboarding, or
+    /// has been migrated as a legacy user with existing hooks.
+    public var firstLaunchCompleted: Bool {
+        get { defaults.bool(forKey: Self.firstLaunchCompletedKey) }
+        set { defaults.set(newValue, forKey: Self.firstLaunchCompletedKey) }
+    }
+
+    // MARK: - Legacy migration
+
+    /// Reconciles intent state with what is actually on disk the first time a
+    /// post-onboarding build launches.
+    ///
+    /// - For every agent whose hook is currently present, records `.installed`.
+    /// - For every agent whose hook is absent, records `.untouched`.
+    /// - If any agent was detected as installed, assumes this is a legacy user
+    ///   and flips `firstLaunchCompleted` to `true` so onboarding does not
+    ///   appear on upgrade.
+    ///
+    /// Idempotent: guarded by ``migrationVersion`` so subsequent launches are
+    /// no-ops until the version bumps.
+    ///
+    /// - Parameter detectInstalled: caller-supplied closure that reports
+    ///   whether a given agent's managed hooks are currently present. Should
+    ///   only be called after all hook status reads have completed.
+    /// - Returns: `true` if migration ran and at least one agent was found to
+    ///   be installed. Callers may use this to trigger additional legacy
+    ///   bookkeeping.
+    @discardableResult
+    public func migrateFromLegacyStateIfNeeded(
+        detectInstalled: (AgentIdentifier) -> Bool
+    ) -> Bool {
+        guard migrationVersion < Self.currentMigrationVersion else {
+            return false
+        }
+
+        var anyInstalled = false
+        for agent in AgentIdentifier.allCases {
+            let installed = detectInstalled(agent)
+            setIntent(installed ? .installed : .untouched, for: agent)
+            if installed { anyInstalled = true }
+        }
+
+        if anyInstalled {
+            firstLaunchCompleted = true
+        }
+
+        defaults.set(Self.currentMigrationVersion, forKey: Self.migrationVersionKey)
+        return anyInstalled
+    }
+
+    public var migrationVersion: Int {
+        defaults.integer(forKey: Self.migrationVersionKey)
+    }
+
+    // MARK: - Keys
+
+    private static func intentKey(for agent: AgentIdentifier) -> String {
+        "agentIntent.\(agent.rawValue)"
+    }
+
+    private static let firstLaunchCompletedKey = "firstLaunchCompleted"
+    private static let migrationVersionKey = "agentIntentMigrationVersion"
+    private static let currentMigrationVersion = 1
+}

--- a/Tests/OpenIslandCoreTests/AgentIntentStoreTests.swift
+++ b/Tests/OpenIslandCoreTests/AgentIntentStoreTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+struct AgentIntentStoreTests {
+    @Test
+    func intentDefaultsToUntouchedForNewStore() {
+        let (store, _) = makeStore()
+
+        for agent in AgentIdentifier.allCases {
+            #expect(store.intent(for: agent) == .untouched)
+        }
+    }
+
+    @Test
+    func setIntentPersistsAndReadsBack() {
+        let (store, defaults) = makeStore()
+        store.setIntent(.installed, for: .claudeCode)
+        store.setIntent(.uninstalled, for: .cursor)
+
+        #expect(store.intent(for: .claudeCode) == .installed)
+        #expect(store.intent(for: .cursor) == .uninstalled)
+        #expect(store.intent(for: .codex) == .untouched)
+
+        let reopened = AgentIntentStore(defaults: defaults)
+        #expect(reopened.intent(for: .claudeCode) == .installed)
+        #expect(reopened.intent(for: .cursor) == .uninstalled)
+    }
+
+    @Test
+    func installedAgentsReportsOnlyInstalled() {
+        let (store, _) = makeStore()
+        store.setIntent(.installed, for: .claudeCode)
+        store.setIntent(.installed, for: .codex)
+        store.setIntent(.uninstalled, for: .cursor)
+
+        let installed = Set(store.installedAgents())
+        #expect(installed == Set([.claudeCode, .codex]))
+    }
+
+    @Test
+    func migrationStampsInstalledForAgentsAlreadyOnDisk() {
+        let (store, defaults) = makeStore()
+        let present: Set<AgentIdentifier> = [.claudeCode, .cursor]
+
+        let ranWithInstalled = store.migrateFromLegacyStateIfNeeded { present.contains($0) }
+
+        #expect(ranWithInstalled == true)
+        #expect(store.intent(for: .claudeCode) == .installed)
+        #expect(store.intent(for: .cursor) == .installed)
+        #expect(store.intent(for: .codex) == .untouched)
+        #expect(store.firstLaunchCompleted == true)
+        #expect(defaults.integer(forKey: "agentIntentMigrationVersion") == 1)
+    }
+
+    @Test
+    func migrationLeavesFirstLaunchUnsetWhenNoHooksPresent() {
+        let (store, _) = makeStore()
+
+        let ranWithInstalled = store.migrateFromLegacyStateIfNeeded { _ in false }
+
+        #expect(ranWithInstalled == false)
+        for agent in AgentIdentifier.allCases {
+            #expect(store.intent(for: agent) == .untouched)
+        }
+        #expect(store.firstLaunchCompleted == false)
+    }
+
+    @Test
+    func migrationIsIdempotent() {
+        let (store, _) = makeStore()
+        var calls = 0
+        store.migrateFromLegacyStateIfNeeded { agent in
+            calls += 1
+            return agent == .claudeCode
+        }
+        let firstCallCount = calls
+
+        store.setIntent(.uninstalled, for: .claudeCode)
+
+        store.migrateFromLegacyStateIfNeeded { _ in
+            calls += 1
+            return true
+        }
+
+        #expect(calls == firstCallCount, "second migration must not invoke detector")
+        #expect(store.intent(for: .claudeCode) == .uninstalled, "user override must survive")
+    }
+
+    @Test
+    func firstLaunchCompletedFlagRoundTrips() {
+        let (store, defaults) = makeStore()
+
+        #expect(store.firstLaunchCompleted == false)
+        store.firstLaunchCompleted = true
+
+        let reopened = AgentIntentStore(defaults: defaults)
+        #expect(reopened.firstLaunchCompleted == true)
+    }
+
+    // MARK: - Helpers
+
+    /// Creates a store backed by an ephemeral UserDefaults suite so each test
+    /// gets a clean slate without touching production preferences.
+    private func makeStore() -> (AgentIntentStore, UserDefaults) {
+        let suiteName = "open-island-intent-tests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return (AgentIntentStore(defaults: defaults), defaults)
+    }
+}

--- a/scripts/clean-user-env.sh
+++ b/scripts/clean-user-env.sh
@@ -47,13 +47,17 @@ echo "==> Cleaning Open Island artifacts"
 # --- Hook configurations ---
 echo "--- Hook configs ---"
 
-# Claude: remove Open Island hook entries from settings.json
-claude_settings=~/.claude/settings.json
-if [[ -f "$claude_settings" ]]; then
-    if $DRY_RUN; then
-        yellow "[dry-run] would strip OpenIsland hooks from: $claude_settings"
-    else
-        python3 -c "
+# Claude-style forks (.claude / .qoder / .qwen / .factory / .codebuddy / .gemini):
+# each has a settings.json that may contain Open Island hook entries, plus
+# sidecar manifests and backups.
+strip_claude_style() {
+    local dir="$1"
+    local settings="$dir/settings.json"
+    if [[ -f "$settings" ]]; then
+        if $DRY_RUN; then
+            yellow "[dry-run] would strip OpenIsland hooks from: $settings"
+        else
+            python3 -c "
 import json, sys, pathlib
 p = pathlib.Path(sys.argv[1])
 d = json.loads(p.read_text())
@@ -61,6 +65,7 @@ hooks = d.get('hooks', {})
 changed = False
 for event in list(hooks.keys()):
     original = hooks[event]
+    if not isinstance(original, list): continue
     filtered = [h for h in original
                 if not any('OpenIslandHooks' in (c.get('command',''))
                            for c in h.get('hooks',[]))]
@@ -79,12 +84,17 @@ if changed:
         del d['hooks']
     p.write_text(json.dumps(d, indent=2, ensure_ascii=False) + '\n')
     print('stripped OpenIsland hooks/statusLine from', sys.argv[1])
-" "$claude_settings" 2>/dev/null && green "cleaned hooks in $claude_settings" || true
+" "$settings" 2>/dev/null && green "cleaned hooks in $settings" || true
+        fi
     fi
-fi
-clean_path ~/.claude/open-island-claude-hooks-install.json
-clean_path ~/.claude/vibe-island-claude-hooks-install.json
-clean_glob ~/.claude/'settings.json.backup.*'
+    clean_path "$dir/open-island-claude-hooks-install.json"
+    clean_path "$dir/vibe-island-claude-hooks-install.json"
+    clean_glob "$dir/settings.json.backup.*"
+}
+
+for d in ~/.claude ~/.qoder ~/.qwen ~/.factory ~/.codebuddy ~/.gemini; do
+    strip_claude_style "$d"
+done
 
 # Codex: remove Open Island entries from hooks.json
 codex_hooks=~/.codex/hooks.json
@@ -120,6 +130,43 @@ fi
 clean_path ~/.codex/open-island-codex-hooks-install.json
 clean_glob ~/.codex/'config.toml.backup.*'
 clean_glob ~/.codex/'hooks.json.backup.*'
+
+# Cursor: remove Open Island hook entries from ~/.cursor/hooks.json
+cursor_hooks=~/.cursor/hooks.json
+if [[ -f "$cursor_hooks" ]]; then
+    if $DRY_RUN; then
+        yellow "[dry-run] would strip OpenIsland hooks from: $cursor_hooks"
+    else
+        python3 -c "
+import json, sys, pathlib
+p = pathlib.Path(sys.argv[1])
+d = json.loads(p.read_text())
+hooks = d.get('hooks', d)
+changed = False
+for event in list(hooks.keys()):
+    original = hooks[event]
+    if not isinstance(original, list): continue
+    filtered = [h for h in original
+                if not any('OpenIslandHooks' in c.get('command','')
+                           for c in h.get('hooks',[]))]
+    if len(filtered) != len(original):
+        changed = True
+        if filtered:
+            hooks[event] = filtered
+        else:
+            del hooks[event]
+if changed:
+    p.write_text(json.dumps(d, indent=2, ensure_ascii=False) + '\n')
+    print('stripped OpenIsland hooks from', sys.argv[1])
+" "$cursor_hooks" 2>/dev/null && green "cleaned hooks in $cursor_hooks" || true
+    fi
+fi
+clean_path ~/.cursor/open-island-cursor-hooks-install.json
+clean_glob ~/.cursor/'hooks.json.backup.*'
+
+# OpenCode: remove the bundled plugin + install manifest
+clean_path ~/.config/opencode/plugins/open-island-opencode.js
+clean_path ~/.config/opencode/open-island-opencode-plugin-install.json
 
 # --- Installed hooks binary ---
 echo "--- Hooks binary ---"


### PR DESCRIPTION
## Summary

Replaces the "auto-install every missing hook on every launch" startup behaviour with a tri-state `AgentHookIntent` (`untouched` / `installed` / `uninstalled`) plus a first-run onboarding window. Fixes #324 — users who uninstall Cursor / Qoder / … hooks will no longer see them silently reappear after relaunch or app upgrade.

**Before**: `AppModel.applyStartupDiscoveryPayload` ran `if !xxxInstalled { installXxx() }` for every agent on every launch. Uninstalls did not survive restarts.

**After**:

- Every install / uninstall records the user's intent in `UserDefaults` (C2).
- Startup now only auto-installs when intent is `.installed` **and** the hook is currently missing — a deliberate repair, never a surprise (C3 + C6).
- Brand-new users land in a 4-screen onboarding window: Welcome → Agents (default-all-checked, 5 folded under "More agents") → Permissions (notifications / accessibility / automation, all skippable) → Completion (C5).
- Users who skip or close onboarding mid-flow see an empty-state banner in settings and an island CTA — no more invisible app (C4).
- Legacy users upgrading with existing hooks are migrated silently: existing hooks are back-filled as `.installed` and `firstLaunchCompleted` flips to `true`, so onboarding does not appear on upgrade (C1 + C2).

## Commit map

| Commit | Change |
|---|---|
| `9f8da20` | C1 — `AgentHookIntent`, `AgentIntentStore` + 7 unit tests for migration semantics |
| `e5c202a` | C2 — intent writes wired into all 10 install/uninstall flows, migration hook in `applyStartupDiscoveryPayload` |
| `eefc1bf` | C3 — startup skips `.uninstalled` agents, fixes #324 |
| `015c1c1` | C4 — empty-state banner in settings, "Set up agents" CTA in island empty state, en/zh-Hans/zh-Hant |
| `d90e8d2` | C5 — onboarding window (4 screens) hosted by `OnboardingWindowController` via AppKit (SwiftUI `Window` scenes are lazy, unusable for programmatic first launch) |
| `ef36687` | C6 — `shouldAutoInstall` now only fires for `.installed + missing`; `.untouched` agents stay untouched |
| `7dbd32b` | scripts/clean-user-env.sh — extended to strip hooks for every supported agent so reviewer can reproduce the first-run flow |

## Test plan

- [x] `swift build` clean
- [x] `swift test` green — 213 tests across 23 suites including 7 new `AgentIntentStoreTests`
- [ ] **Reproduce #324** — install Cursor hooks in a legacy build, uninstall via control center, relaunch on this branch, confirm they stay uninstalled and `defaults read app.openisland.dev agentIntent.cursor` prints `uninstalled`
- [ ] **Legacy upgrade** — launch on this branch with existing hooks but no `agentIntent.*` keys, confirm island appears without onboarding and all 10 `agentIntent.*` keys are backfilled correctly (`.installed` where hook is present, `.untouched` otherwise)
- [ ] **New user path** — run `zsh scripts/clean-user-env.sh` to reset, relaunch via `zsh scripts/launch-dev-app.sh`, confirm 4-screen onboarding appears, walk through, confirm selected hooks install
- [ ] **Skip-onboarding path** — reset as above, close the onboarding window on Screen 1, confirm empty-state banner shows in Settings → Setup and "Set up agents" CTA shows in the island's empty state
- [ ] **Localisation** — cycle through en / zh-Hans / zh-Hant in Settings; confirm every new string renders (no key leakage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive onboarding experience for first-time users with multi-step setup flow
  * Introduced agent selection screen allowing users to choose which development tools to enable
  * Added permissions guidance screen during initial setup
  * Enhanced empty state UI with clear call-to-action to launch onboarding when no agents are installed
  * Added setup banner in settings for users with no active hooks

* **Documentation**
  * Added full localization support for English, Simplified Chinese, and Traditional Chinese across all onboarding screens and setup messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->