### PR TITLE
feat: add quit button to island header

### DIFF
--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -123,6 +123,9 @@
 "settings.about.version" = "Version %@";
 "settings.about.checkForUpdates" = "Check for Updates…";
 "settings.about.quitApp" = "Quit Open Island";
+"island.quit.confirmTitle" = "Quit Open Island?";
+"island.quit.confirmAction" = "Quit";
+"island.quit.confirmMessage" = "Are you sure you want to quit?";
 
 /* Settings - Update */
 "settings.update.available" = "v%@ Available — Update";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -123,6 +123,9 @@
 "settings.about.version" = "版本 %@";
 "settings.about.checkForUpdates" = "检查更新…";
 "settings.about.quitApp" = "退出 Open Island";
+"island.quit.confirmTitle" = "退出 Open Island？";
+"island.quit.confirmAction" = "退出";
+"island.quit.confirmMessage" = "确定要退出吗？";
 
 /* Settings - Update */
 "settings.update.available" = "v%@ 可更新 — 点击更新";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -123,6 +123,9 @@
 "settings.about.version" = "版本 %@";
 "settings.about.checkForUpdates" = "檢查更新…";
 "settings.about.quitApp" = "結束 Open Island";
+"island.quit.confirmTitle" = "結束 Open Island？";
+"island.quit.confirmAction" = "結束";
+"island.quit.confirmMessage" = "確定要結束嗎？";
 
 /* Settings - Update */
 "settings.update.available" = "v%@ 可更新 — 點擊更新";

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -110,6 +110,7 @@ struct IslandPanelView: View {
 
     @Namespace private var notchNamespace
     @State private var isHovering = false
+    @State private var showingQuitConfirmation = false
 
     private var isOpened: Bool {
         model.notchStatus == .opened
@@ -210,7 +211,7 @@ struct IslandPanelView: View {
     }
 
     private var openedHeaderButtonsWidth: CGFloat {
-        (Self.headerControlButtonSize * 2) + Self.headerControlSpacing
+        (Self.headerControlButtonSize * 3) + (Self.headerControlSpacing * 2)
     }
 
     var body: some View {
@@ -225,6 +226,14 @@ struct IslandPanelView: View {
         }
         .ignoresSafeArea()
         .preferredColorScheme(.dark)
+        .alert(model.lang.t("island.quit.confirmTitle"), isPresented: $showingQuitConfirmation) {
+            Button(model.lang.t("island.quit.confirmAction"), role: .destructive) {
+                model.quitApplication()
+            }
+            Button(model.lang.t("settings.general.cancel"), role: .cancel) {}
+        } message: {
+            Text(model.lang.t("island.quit.confirmMessage"))
+        }
     }
 
     @ViewBuilder
@@ -440,8 +449,12 @@ struct IslandPanelView: View {
                 model.showSettings()
             }
 
-            headerIconButton(systemName: "power", tint: .white.opacity(0.62)) {
-                model.quitApplication()
+            headerIconButton(
+                systemName: "power",
+                tint: .white.opacity(0.62),
+                accessibilityLabel: model.lang.t("island.quit.confirmTitle")
+            ) {
+                showingQuitConfirmation = true
             }
         }
     }
@@ -449,6 +462,7 @@ struct IslandPanelView: View {
     private func headerIconButton(
         systemName: String,
         tint: Color,
+        accessibilityLabel: String? = nil,
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
@@ -459,6 +473,7 @@ struct IslandPanelView: View {
                 .background(.white.opacity(0.08), in: Circle())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel ?? systemName)
     }
 
     private var openedContent: some View {

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -439,6 +439,10 @@ struct IslandPanelView: View {
             headerIconButton(systemName: "gearshape.fill", tint: .white.opacity(0.62)) {
                 model.showSettings()
             }
+
+            headerIconButton(systemName: "power", tint: .white.opacity(0.62)) {
+                model.quitApplication()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Add a power icon next to the settings gear in the opened island header so users can quit the app directly from the overlay.
<img width="188" height="60" alt="image" src="https://github.com/user-attachments/assets/401f759c-9099-48c6-8eb1-1b9f70462580" />

## Changes
- `Sources/OpenIslandApp/Views/IslandPanelView.swift`: add `power` SF Symbol button to `openedHeaderButtons`, wired to `model.quitApplication()`

## Verification
- `swift build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a power button to the header for quitting the application
  * Added a confirmation dialog that appears when attempting to quit, with destructive "Quit" and "Cancel" options

* **Localization**
  * Added quit confirmation dialog strings in English, Simplified Chinese, and Traditional Chinese

<!-- end of auto-generated comment: release notes by coderabbit.ai -->