### PR TITLE
feat: add Claude OAuth usage display via Anthropic api/oauth/usage

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -101,6 +101,10 @@ final class AppModel {
     var codexUsageStatusTitle: String { hooks.codexUsageStatusTitle }
     var codexUsageStatusSummary: String { hooks.codexUsageStatusSummary }
     var codexUsageSummaryText: String? { hooks.codexUsageSummaryText }
+    var anthropicOAuthUsageSnapshot: AnthropicOAuthUsageSnapshot? { hooks.anthropicOAuthUsageSnapshot }
+    var anthropicOAuthUsageStatusTitle: String { hooks.anthropicOAuthUsageStatusTitle }
+    var anthropicOAuthUsageStatusSummary: String { hooks.anthropicOAuthUsageStatusSummary }
+    var anthropicOAuthUsageSummaryText: String? { hooks.anthropicOAuthUsageSummaryText }
     var openCodePluginStatus: OpenCodePluginInstallationStatus? { hooks.openCodePluginStatus }
     var isOpenCodeSetupBusy: Bool { hooks.isOpenCodeSetupBusy }
     var openCodePluginStatusTitle: String { hooks.openCodePluginStatusTitle }
@@ -125,6 +129,7 @@ final class AppModel {
     func refreshCursorHookStatus() { hooks.refreshCursorHookStatus() }
     func refreshClaudeUsageState() { hooks.refreshClaudeUsageState() }
     func refreshCodexUsageState() { hooks.refreshCodexUsageState() }
+    func refreshAnthropicOAuthUsageState() { hooks.refreshAnthropicOAuthUsageState() }
     func installCodexHooks() { hooks.installCodexHooks() }
     func uninstallCodexHooks() { hooks.uninstallCodexHooks() }
     func installClaudeHooks() { hooks.installClaudeHooks() }
@@ -749,6 +754,8 @@ final class AppModel {
                 hooks.refreshCodexUsageState()
                 hooks.startCodexUsageMonitoringIfNeeded()
             }
+            hooks.refreshAnthropicOAuthUsageState()
+            hooks.startAnthropicOAuthUsageMonitoringIfNeeded()
             updateChecker.startIfNeeded()
 
         } else {

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -16,6 +16,7 @@ final class HookInstallationCoordinator {
     var geminiHookStatus: GeminiHookInstallationStatus?
     var claudeStatusLineStatus: ClaudeStatusLineInstallationStatus?
     var claudeUsageSnapshot: ClaudeUsageSnapshot?
+    var anthropicOAuthUsageSnapshot: AnthropicOAuthUsageSnapshot?
     var codexUsageSnapshot: CodexUsageSnapshot?
     var hooksBinaryURL: URL?
     var isCodexSetupBusy = false
@@ -83,6 +84,9 @@ final class HookInstallationCoordinator {
 
     @ObservationIgnored
     private var codexUsageMonitorTask: Task<Void, Never>?
+
+    @ObservationIgnored
+    private var anthropicOAuthUsageMonitorTask: Task<Void, Never>?
 
     @ObservationIgnored
     private var relativeTimestampFormatter: RelativeDateTimeFormatter {
@@ -262,6 +266,46 @@ final class HookInstallationCoordinator {
             components.append("updated \(relativeTimestampFormatter.localizedString(for: capturedAt, relativeTo: .now))")
         }
 
+        return components.isEmpty ? nil : components.joined(separator: " · ")
+    }
+
+    // MARK: - Anthropic OAuth Usage
+
+    var anthropicOAuthUsageStatusTitle: String {
+        if anthropicOAuthUsageSnapshot?.isEmpty == false {
+            return "Anthropic usage detected"
+        }
+        return "Waiting for Anthropic usage"
+    }
+
+    var anthropicOAuthUsageStatusSummary: String {
+        if let summary = anthropicOAuthUsageSummaryText {
+            return "Reading Claude subscription usage from Anthropic API · \(summary)"
+        }
+        return "Resolving local OAuth token and fetching usage from api.anthropic.com/api/oauth/usage."
+    }
+
+    var anthropicOAuthUsageSummaryText: String? {
+        guard let snapshot = anthropicOAuthUsageSnapshot else {
+            return nil
+        }
+
+        var components: [String] = []
+        if let fiveHour = snapshot.fiveHour {
+            components.append("5h \(fiveHour.roundedUsedPercentage)%")
+        }
+        if let sevenDay = snapshot.sevenDay {
+            components.append("7d \(sevenDay.roundedUsedPercentage)%")
+        }
+        if let remaining = snapshot.remaining {
+            components.append("remaining \(remaining)")
+        }
+        if let monthlyLimit = snapshot.monthlyLimit {
+            components.append("limit \(monthlyLimit)")
+        }
+        if let fetchedAt = snapshot.fetchedAt {
+            components.append("updated \(relativeTimestampFormatter.localizedString(for: fetchedAt, relativeTo: .now))")
+        }
         return components.isEmpty ? nil : components.joined(separator: " · ")
     }
 
@@ -929,6 +973,30 @@ final class HookInstallationCoordinator {
                 self.refreshCodexUsageState()
                 try? await Task.sleep(for: .seconds(120))
             }
+        }
+    }
+
+    func startAnthropicOAuthUsageMonitoringIfNeeded() {
+        guard anthropicOAuthUsageMonitorTask == nil else { return }
+
+        anthropicOAuthUsageMonitorTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            while !Task.isCancelled {
+                self.refreshAnthropicOAuthUsageState()
+                try? await Task.sleep(for: .seconds(300))
+            }
+        }
+    }
+
+    func refreshAnthropicOAuthUsageState() {
+        Task { [weak self] in
+            guard let self else { return }
+
+            let snapshot = await Task.detached(priority: .utility) {
+                await AnthropicOAuthUsageLoader.loadWithFallback()
+            }.value
+            self.anthropicOAuthUsageSnapshot = snapshot
         }
     }
 

--- a/Sources/OpenIslandApp/Views/ControlCenterView.swift
+++ b/Sources/OpenIslandApp/Views/ControlCenterView.swift
@@ -188,6 +188,40 @@ struct ControlCenterView: View {
                     }
                 }
 
+                usageDebugCard(
+                    title: "Anthropic OAuth Usage",
+                    statusTitle: model.anthropicOAuthUsageStatusTitle,
+                    statusSummary: model.anthropicOAuthUsageStatusSummary,
+                    isActive: model.anthropicOAuthUsageSnapshot?.isEmpty == false,
+                    accentColor: model.anthropicOAuthUsageSnapshot?.isEmpty == false ? .mint : .purple
+                ) {
+                    if let summary = model.anthropicOAuthUsageSummaryText {
+                        metadataRow(title: "usage", value: summary)
+                    }
+
+                    if let snapshot = model.anthropicOAuthUsageSnapshot {
+                        if let remaining = snapshot.remaining {
+                            metadataRow(title: "remaining", value: "\(remaining)")
+                        }
+                        if let monthlyLimit = snapshot.monthlyLimit {
+                            metadataRow(title: "monthly limit", value: "\(monthlyLimit)")
+                        }
+                        if let fetchedAt = snapshot.fetchedAt {
+                            metadataRow(
+                                title: "fetched",
+                                value: fetchedAt.formatted(date: .abbreviated, time: .standard)
+                            )
+                        }
+                    }
+                } actions: {
+                    HStack(spacing: 10) {
+                        Button(lang.t("debug.refresh")) {
+                            model.refreshAnthropicOAuthUsageState()
+                        }
+                        .buttonStyle(DebugActionButtonStyle(kind: .secondary))
+                    }
+                }
+
                 actionCard
                 transcriptCard
                 liveOverlayCard

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -708,6 +708,43 @@ struct IslandPanelView: View {
             }
         }
 
+        if let snapshot = model.anthropicOAuthUsageSnapshot,
+           snapshot.isEmpty == false {
+            var windows: [UsageWindowPresentation] = []
+
+            if let fiveHour = snapshot.fiveHour {
+                windows.append(
+                    UsageWindowPresentation(
+                        id: "anth-oauth-5h",
+                        label: "5h",
+                        usedPercentage: fiveHour.usedPercentage,
+                        resetsAt: fiveHour.resetsAt
+                    )
+                )
+            }
+
+            if let sevenDay = snapshot.sevenDay {
+                windows.append(
+                    UsageWindowPresentation(
+                        id: "anth-oauth-7d",
+                        label: "7d",
+                        usedPercentage: sevenDay.usedPercentage,
+                        resetsAt: sevenDay.resetsAt
+                    )
+                )
+            }
+
+            if windows.isEmpty == false {
+                providers.append(
+                    UsageProviderPresentation(
+                        id: "anthropic-oauth",
+                        title: "Anthropic",
+                        windows: windows
+                    )
+                )
+            }
+        }
+
         return providers
     }
 
@@ -918,6 +955,8 @@ private struct UsageProviderPresentation: Identifiable {
             "Cl"
         case "codex":
             "Cx"
+        case "anthropic-oauth":
+            "An"
         default:
             String(title.prefix(2))
         }

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -613,6 +613,25 @@ struct SetupSettingsPane: View {
                     get: { model.showCodexUsage },
                     set: { model.showCodexUsage = $0 }
                 ))
+
+                HStack {
+                    Label("Anthropic OAuth Usage", systemImage: "creditcard")
+                    Spacer()
+                    if let snapshot = model.anthropicOAuthUsageSnapshot, !snapshot.isEmpty {
+                        HStack(spacing: 4) {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(.green)
+                            Text("Active")
+                                .foregroundStyle(.secondary)
+                        }
+                    } else {
+                        Text("Auto-detect")
+                            .foregroundStyle(.secondary)
+                    }
+                    Button("Refresh") {
+                        model.refreshAnthropicOAuthUsageState()
+                    }
+                }
             } header: {
                 HStack(spacing: 4) {
                     Text(lang.t("setup.section.usage"))

--- a/Sources/OpenIslandCore/AnthropicOAuthTokenResolver.swift
+++ b/Sources/OpenIslandCore/AnthropicOAuthTokenResolver.swift
@@ -1,0 +1,173 @@
+import Foundation
+import Security
+#if canImport(CryptoKit)
+import CryptoKit
+#endif
+
+/// Resolves an Anthropic OAuth access token from local credential stores.
+///
+/// Tries multiple sources in order:
+/// 1. Claude Code CLI Keychain entry ("Claude Code-credentials")
+/// 2. Claude Desktop app config (encrypted token cache — best-effort)
+public enum AnthropicOAuthTokenResolver {
+    public enum Error: Swift.Error {
+        case noCredentialsFound
+        case invalidCredentialFormat
+        case keychainError(OSStatus)
+    }
+
+    /// Attempts to resolve an OAuth access token from local stores.
+    public static func resolve() throws -> String {
+        // Layer 1: Claude Code CLI credentials in Keychain
+        if let token = try? resolveFromClaudeCodeKeychain() {
+            return token
+        }
+
+        // Layer 2: Claude Desktop config (best-effort)
+        if let token = try? resolveFromClaudeDesktopConfig() {
+            return token
+        }
+
+        throw Error.noCredentialsFound
+    }
+
+    // MARK: - Layer 1: Claude Code CLI Keychain
+
+    private static func resolveFromClaudeCodeKeychain() throws -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "Claude Code-credentials",
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess else {
+            throw Error.keychainError(status)
+        }
+
+        guard let data = result as? Data,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let oauth = json["claudeAiOauth"] as? [String: Any],
+              let token = oauth["accessToken"] as? String,
+              !token.isEmpty
+        else {
+            throw Error.invalidCredentialFormat
+        }
+
+        return token
+    }
+
+    // MARK: - Layer 2: Claude Desktop config
+
+    private static func resolveFromClaudeDesktopConfig() throws -> String? {
+        let configURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/Claude/config.json")
+
+        guard FileManager.default.fileExists(atPath: configURL.path) else {
+            return nil
+        }
+
+        let data = try Data(contentsOf: configURL)
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+
+        // The oauth:tokenCache value is encrypted (prefixed with "v10").
+        // Decryption requires the "Claude Safe Storage" Keychain key.
+        // This is best-effort; if decryption fails we return nil.
+        guard let tokenCache = json["oauth:tokenCache"] as? String else {
+            return nil
+        }
+
+        return try? decryptClaudeDesktopTokenCache(tokenCache)
+    }
+
+    /// Attempts to decrypt Claude Desktop's oauth:tokenCache.
+    ///
+    /// The cache format is: base64("v10" + encrypted_data)
+    /// The encryption key is stored in Keychain under "Claude Safe Storage" / "Claude Key".
+    ///
+    /// This is a best-effort implementation based on reverse-engineering.
+    /// If the format changes this may fail silently.
+    private static func decryptClaudeDesktopTokenCache(_ tokenCache: String) throws -> String? {
+        // 1. Base64 decode
+        guard let data = Data(base64Encoded: tokenCache) else {
+            return nil
+        }
+
+        // 2. Check version prefix
+        let versionPrefix = Data("v10".utf8)
+        guard data.count > versionPrefix.count,
+              data.prefix(versionPrefix.count) == versionPrefix
+        else {
+            return nil
+        }
+
+        let ciphertext = data.dropFirst(versionPrefix.count)
+
+        // 3. Retrieve encryption key from Keychain
+        let keyQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "Claude Safe Storage",
+            kSecAttrAccount as String: "Claude Key",
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var keyResult: AnyObject?
+        let keyStatus = SecItemCopyMatching(keyQuery as CFDictionary, &keyResult)
+        guard keyStatus == errSecSuccess,
+              let keyData = keyResult as? Data
+        else {
+            return nil
+        }
+
+        // 4. Decode key (base64)
+        guard let keyString = String(data: keyData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let key = Data(base64Encoded: keyString)
+        else {
+            return nil
+        }
+
+        // 5. Decrypt using AES-256-GCM (Electron safeStorage format)
+        //    Format: 12-byte nonce || ciphertext || 16-byte auth tag
+        guard ciphertext.count > 28 else { return nil }
+        let nonce = ciphertext.prefix(12)
+        let sealedBox = ciphertext.dropFirst(12)
+
+        return try aesGCMDecrypt(sealedBox: Data(sealedBox), key: key, nonce: Data(nonce))
+    }
+}
+
+// MARK: - AES-256-GCM Decryption
+
+#if canImport(CryptoKit)
+private func aesGCMDecrypt(sealedBox: Data, key: Data, nonce: Data) throws -> String? {
+    guard key.count == 32,
+          nonce.count == 12,
+          sealedBox.count >= 16
+    else {
+        return nil
+    }
+
+    let symmetricKey = SymmetricKey(data: key)
+    _ = try AES.GCM.Nonce(data: nonce)
+
+    // sealedBox = ciphertext || tag(16 bytes)
+    let ciphertext = sealedBox.dropLast(16)
+    let tag = sealedBox.suffix(16)
+    let combined = ciphertext + tag
+
+    let sealedBoxObj = try AES.GCM.SealedBox(combined: combined)
+    let decrypted = try AES.GCM.open(sealedBoxObj, using: symmetricKey)
+
+    return String(data: decrypted, encoding: .utf8)
+}
+#else
+private func aesGCMDecrypt(sealedBox: Data, key: Data, nonce: Data) throws -> String? {
+    // Fallback when CryptoKit is unavailable
+    return nil
+}
+#endif

--- a/Sources/OpenIslandCore/AnthropicOAuthUsage.swift
+++ b/Sources/OpenIslandCore/AnthropicOAuthUsage.swift
@@ -1,0 +1,195 @@
+import Foundation
+
+#if canImport(CryptoKit)
+import CryptoKit
+#endif
+
+// MARK: - Data Models
+
+public struct AnthropicOAuthUsageWindow: Equatable, Codable, Sendable {
+    public var usedPercentage: Double
+    public var resetsAt: Date?
+
+    public init(usedPercentage: Double, resetsAt: Date?) {
+        self.usedPercentage = usedPercentage
+        self.resetsAt = resetsAt
+    }
+
+    public var roundedUsedPercentage: Int {
+        Int(usedPercentage.rounded())
+    }
+}
+
+public struct AnthropicOAuthUsageSnapshot: Equatable, Codable, Sendable {
+    public var fiveHour: AnthropicOAuthUsageWindow?
+    public var sevenDay: AnthropicOAuthUsageWindow?
+    public var sevenDayOAuthApps: AnthropicOAuthUsageWindow?
+    public var sevenDaySonnet: AnthropicOAuthUsageWindow?
+    public var sevenDayOpus: AnthropicOAuthUsageWindow?
+    public var monthlyLimit: Int?
+    public var remaining: Int?
+    public var fetchedAt: Date?
+
+    public init(
+        fiveHour: AnthropicOAuthUsageWindow? = nil,
+        sevenDay: AnthropicOAuthUsageWindow? = nil,
+        sevenDayOAuthApps: AnthropicOAuthUsageWindow? = nil,
+        sevenDaySonnet: AnthropicOAuthUsageWindow? = nil,
+        sevenDayOpus: AnthropicOAuthUsageWindow? = nil,
+        monthlyLimit: Int? = nil,
+        remaining: Int? = nil,
+        fetchedAt: Date? = nil
+    ) {
+        self.fiveHour = fiveHour
+        self.sevenDay = sevenDay
+        self.sevenDayOAuthApps = sevenDayOAuthApps
+        self.sevenDaySonnet = sevenDaySonnet
+        self.sevenDayOpus = sevenDayOpus
+        self.monthlyLimit = monthlyLimit
+        self.remaining = remaining
+        self.fetchedAt = fetchedAt
+    }
+
+    public var isEmpty: Bool {
+        fiveHour == nil && sevenDay == nil && monthlyLimit == nil && remaining == nil
+    }
+}
+
+// MARK: - API Client
+
+public enum AnthropicOAuthUsageError: Error, Sendable {
+    case noTokenAvailable
+    case networkError(Error)
+    case invalidResponse
+    case apiError(String)
+    case httpError(statusCode: Int, message: String)
+}
+
+public actor AnthropicOAuthUsageClient {
+    private let session: URLSession
+    private let apiURL = URL(string: "https://api.anthropic.com/api/oauth/usage")!
+
+    public init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    public func fetchUsage(token: String) async throws -> AnthropicOAuthUsageSnapshot {
+        var request = URLRequest(url: apiURL)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = 30
+
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw AnthropicOAuthUsageError.networkError(error)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw AnthropicOAuthUsageError.invalidResponse
+        }
+
+        guard (200...299).contains(httpResponse.statusCode) else {
+            let message = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw AnthropicOAuthUsageError.httpError(statusCode: httpResponse.statusCode, message: message)
+        }
+
+        let snapshot = try parseResponse(data: data)
+        return snapshot
+    }
+
+    private func parseResponse(data: Data) throws -> AnthropicOAuthUsageSnapshot {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            if let timestamp = try? container.decode(Double.self) {
+                return Date(timeIntervalSince1970: timestamp)
+            }
+            let string = try container.decode(String.self)
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let date = formatter.date(from: string) {
+                return date
+            }
+            formatter.formatOptions = [.withInternetDateTime]
+            if let date = formatter.date(from: string) {
+                return date
+            }
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid date format")
+        }
+
+        do {
+            return try decoder.decode(AnthropicOAuthUsageSnapshot.self, from: data)
+        } catch {
+            // Fallback: try parsing as generic JSON to extract known fields
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                throw AnthropicOAuthUsageError.invalidResponse
+            }
+            return snapshotFromDictionary(json)
+        }
+    }
+
+    private func snapshotFromDictionary(_ dict: [String: Any]) -> AnthropicOAuthUsageSnapshot {
+        AnthropicOAuthUsageSnapshot(
+            fiveHour: usageWindow(from: dict["five_hour"]),
+            sevenDay: usageWindow(from: dict["seven_day"]),
+            sevenDayOAuthApps: usageWindow(from: dict["seven_day_oauth_apps"]),
+            sevenDaySonnet: usageWindow(from: dict["seven_day_sonnet"]),
+            sevenDayOpus: usageWindow(from: dict["seven_day_opus"]),
+            monthlyLimit: dict["monthly_limit"] as? Int,
+            remaining: dict["remaining"] as? Int,
+            fetchedAt: Date()
+        )
+    }
+
+    private func usageWindow(from value: Any?) -> AnthropicOAuthUsageWindow? {
+        guard let dict = value as? [String: Any] else { return nil }
+        let percentage = (dict["used_percentage"] as? Double)
+            ?? (dict["usedPercentage"] as? Double)
+            ?? (dict["utilization"] as? Double)
+        guard let percentage else { return nil }
+
+        let resetsAt: Date?
+        if let timestamp = dict["resets_at"] as? Double {
+            resetsAt = Date(timeIntervalSince1970: timestamp)
+        } else if let timestampString = dict["resets_at"] as? String,
+                  let timestamp = Double(timestampString) {
+            resetsAt = Date(timeIntervalSince1970: timestamp)
+        } else {
+            resetsAt = nil
+        }
+
+        return AnthropicOAuthUsageWindow(usedPercentage: percentage, resetsAt: resetsAt)
+    }
+}
+
+// MARK: - Loader
+
+public enum AnthropicOAuthUsageLoader {
+    public static let defaultCacheURL = URL(fileURLWithPath: "/tmp/open-island-oauth-usage.json")
+
+    public static func load(token: String? = nil) async throws -> AnthropicOAuthUsageSnapshot? {
+        let resolvedToken: String
+        if let token {
+            resolvedToken = token
+        } else {
+            resolvedToken = try AnthropicOAuthTokenResolver.resolve()
+        }
+
+        let client = AnthropicOAuthUsageClient()
+        let snapshot = try await client.fetchUsage(token: resolvedToken)
+        return snapshot.isEmpty ? nil : snapshot
+    }
+
+    public static func loadWithFallback() async -> AnthropicOAuthUsageSnapshot? {
+        do {
+            return try await load()
+        } catch {
+            // Silently fail — hooks fail open
+            return nil
+        }
+    }
+}


### PR DESCRIPTION
## Summary

参考 Vibe Island 的逆向分析，实现了 Claude 订阅额度显示功能。

## 逆向发现

- Vibe Island 调用 `GET https://api.anthropic.com/api/oauth/usage`
- Token 来源：Claude Code CLI Keychain 条目 (`Claude Code-credentials`)
- 也尝试从 Claude Desktop `config.json` 的加密 `oauth:tokenCache` 获取

## 实现内容

- **AnthropicOAuthTokenResolver**: 从本地凭证存储解析 OAuth token
  - Layer 1: Claude Code CLI Keychain (`Claude Code-credentials`)
  - Layer 2: Claude Desktop `config.json` + AES-256-GCM 解密
- **AnthropicOAuthUsageClient**: 调用 `api/oauth/usage`
- **HookInstallationCoordinator**: 5 分钟轮询监控
- **IslandPanelView**: 在 notch header 显示 Anthropic 额度
- **ControlCenterView**: 调试卡片
- **SettingsView**: Setup 页状态显示

## 注意

当前 `api/oauth/usage` 对 `sk-ant-oat` token 返回：
```json
{"error": {"type": "authentication_error", "message": "OAuth authentication is currently not supported."}}
```

此实现提供了完整的框架；当 Anthropic 重新开放该 endpoint 或用户使用特定 token 类型时，功能会自动生效。

## 测试

- `swift build` ✅
- `swift test` (206 tests) ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic Anthropic OAuth usage monitoring that refreshes periodically.
  * Usage metrics now visible in Control Center (remaining quota, monthly limit) with manual refresh button.
  * Anthropic OAuth usage status added to Settings with activity indicator.
  * New Anthropic usage provider integrated into usage tracking panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->