### PR TITLE
feat: Codex CLI Full Control mode for per-command approval

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -16,6 +16,7 @@ final class AppModel {
     private static let islandPixelShapeStyleDefaultsKey = "appearance.island.pixelShapeStyle"
     private static let islandStatusColorsDefaultsKey = "appearance.island.statusColors"
     private static let showCodexUsageDefaultsKey = "app.showCodexUsage"
+    private static let codexHookInstallModeDefaultsKey = "app.codexHookInstallMode"
     private static let completionReplyEnabledDefaultsKey = "feature.completionReply.enabled"
     private static let suppressFrontmostNotificationsDefaultsKey = "app.suppressFrontmostNotifications"
 
@@ -125,7 +126,7 @@ final class AppModel {
     func refreshCursorHookStatus() { hooks.refreshCursorHookStatus() }
     func refreshClaudeUsageState() { hooks.refreshClaudeUsageState() }
     func refreshCodexUsageState() { hooks.refreshCodexUsageState() }
-    func installCodexHooks() { hooks.installCodexHooks() }
+    func installCodexHooks() { hooks.installCodexHooks(mode: codexHookInstallMode) }
     func uninstallCodexHooks() { hooks.uninstallCodexHooks() }
     func installClaudeHooks() { hooks.installClaudeHooks() }
     func uninstallClaudeHooks() { hooks.uninstallClaudeHooks() }
@@ -202,6 +203,18 @@ final class AppModel {
         didSet {
             guard hasFinishedInit, showCodexUsage != oldValue else { return }
             UserDefaults.standard.set(showCodexUsage, forKey: Self.showCodexUsageDefaultsKey)
+        }
+    }
+    /// User-chosen integration footprint for Codex CLI. Defaults to
+    /// `.notifyOnly` — the historical quiet surface — so upgrading users
+    /// don't see a flood of per-command prompts. Writes flow through
+    /// `HookInstallationCoordinator.reapplyCodexHookMode` so the hooks.json
+    /// reflects the new mode immediately without waiting for a reinstall.
+    var codexHookInstallMode: CodexHookInstallMode = .default {
+        didSet {
+            guard hasFinishedInit, codexHookInstallMode != oldValue else { return }
+            UserDefaults.standard.set(codexHookInstallMode.rawValue, forKey: Self.codexHookInstallModeDefaultsKey)
+            hooks.reapplyCodexHookMode(codexHookInstallMode)
         }
     }
     var completionReplyEnabled: Bool = false {
@@ -465,6 +478,15 @@ final class AppModel {
             showCodexUsage = FileManager.default.fileExists(
                 atPath: CodexRolloutDiscovery.defaultRootURL.path
             )
+        }
+        // Preference order: persisted UserDefaults > manifest-recorded mode
+        // (covers pre-preference upgrades where the user re-installed under
+        // full-control externally) > default.
+        if let raw = UserDefaults.standard.string(forKey: Self.codexHookInstallModeDefaultsKey),
+           let mode = CodexHookInstallMode(rawValue: raw) {
+            codexHookInstallMode = mode
+        } else {
+            codexHookInstallMode = .default
         }
         completionReplyEnabled = UserDefaults.standard.bool(forKey: Self.completionReplyEnabledDefaultsKey)
         islandAppearanceMode = IslandAppearanceMode(

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -703,14 +703,14 @@ final class HookInstallationCoordinator {
 
     // MARK: - Install / uninstall
 
-    func installCodexHooks() {
+    func installCodexHooks(mode: CodexHookInstallMode = .default) {
         guard let hooksBinaryURL else {
             onStatusMessage?("Could not find a local OpenIslandHooks binary. Build the package first.")
             return
         }
 
         updateCodexHooks(userMessage: "Installing Codex hooks.") { manager in
-            try manager.install(hooksBinaryURL: hooksBinaryURL)
+            try manager.install(hooksBinaryURL: hooksBinaryURL, mode: mode)
         }
     }
 
@@ -718,6 +718,14 @@ final class HookInstallationCoordinator {
         updateCodexHooks(userMessage: "Removing Codex hooks.") { manager in
             try manager.uninstall()
         }
+    }
+
+    /// Re-installs Codex hooks with the given mode when they're already
+    /// installed. No-op otherwise — the user will pick the mode the next
+    /// time they hit the Install button.
+    func reapplyCodexHookMode(_ mode: CodexHookInstallMode) {
+        guard codexHookStatus?.managedHooksPresent == true else { return }
+        installCodexHooks(mode: mode)
     }
 
     func installClaudeHooks() {

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -36,6 +36,11 @@
 "settings.general.uninstallConfirmAction" = "Uninstall";
 "settings.general.uninstallConfirmMessage.claude" = "This will remove Open Island hooks from Claude Code. You can reinstall them at any time.";
 "settings.general.uninstallConfirmMessage.codex" = "This will remove Open Island hooks from Codex. You can reinstall them at any time.";
+"settings.codex.hookMode.title" = "Codex Integration";
+"settings.codex.hookMode.notifyOnly" = "Notify Only";
+"settings.codex.hookMode.fullControl" = "Full Control";
+"settings.codex.hookMode.notifyOnly.description" = "Surface Codex session events and prompts in the island. Tool execution runs without interception.";
+"settings.codex.hookMode.fullControl.description" = "Approve or deny each Bash command before Codex runs it, matching Claude Code. Raises per-turn notification volume.";
 "settings.general.uninstallConfirmMessage.claudeUsage" = "This will remove the Claude usage bridge. You can reinstall it at any time.";
 "settings.general.cancel" = "Cancel";
 "settings.general.language" = "Language";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -36,6 +36,11 @@
 "settings.general.uninstallConfirmAction" = "卸载";
 "settings.general.uninstallConfirmMessage.claude" = "这将从 Claude Code 中移除 Open Island 的 hooks。你可以随时重新安装。";
 "settings.general.uninstallConfirmMessage.codex" = "这将从 Codex 中移除 Open Island 的 hooks。你可以随时重新安装。";
+"settings.codex.hookMode.title" = "Codex 集成模式";
+"settings.codex.hookMode.notifyOnly" = "仅通知";
+"settings.codex.hookMode.fullControl" = "完全控制";
+"settings.codex.hookMode.notifyOnly.description" = "在灵动岛中展示 Codex 会话事件与提示词，不拦截工具执行。";
+"settings.codex.hookMode.fullControl.description" = "在 Codex 执行每条 Bash 命令前先在灵动岛中批准或拒绝，对齐 Claude Code 体验。每一轮交互的通知量会更高。";
 "settings.general.uninstallConfirmMessage.claudeUsage" = "这将移除 Claude 用量桥接。你可以随时重新安装。";
 "settings.general.cancel" = "取消";
 "settings.general.language" = "语言";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -36,6 +36,11 @@
 "settings.general.uninstallConfirmAction" = "移除";
 "settings.general.uninstallConfirmMessage.claude" = "這將從 Claude Code 中移除 Open Island 的 hooks。您可以隨時重新安裝。";
 "settings.general.uninstallConfirmMessage.codex" = "這將從 Codex 中移除 Open Island 的 hooks。您可以隨時重新安裝。";
+"settings.codex.hookMode.title" = "Codex 整合模式";
+"settings.codex.hookMode.notifyOnly" = "僅通知";
+"settings.codex.hookMode.fullControl" = "完全控制";
+"settings.codex.hookMode.notifyOnly.description" = "在靈動島中展示 Codex 會話事件與提示詞，不攔截工具執行。";
+"settings.codex.hookMode.fullControl.description" = "在 Codex 執行每條 Bash 命令前先於靈動島中批准或拒絕，對齊 Claude Code 體驗。每一輪互動的通知量會更高。";
 "settings.general.uninstallConfirmMessage.claudeUsage" = "這將移除 Claude 用量橋接。您可以隨時重新安裝。";
 "settings.general.cancel" = "取消";
 "settings.general.language" = "語言";

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -456,6 +456,8 @@ struct SetupSettingsPane: View {
                     Text(lang.t("settings.general.uninstallConfirmMessage.codex"))
                 }
 
+                codexHookModeRow
+
                 hookRow(
                     name: "OpenCode",
                     installed: model.openCodePluginInstalled,
@@ -721,6 +723,40 @@ struct SetupSettingsPane: View {
             return hooksURL
         }
         return model.codexHookStatus?.configURL ?? model.codexHookStatus?.hooksURL
+    }
+
+    @ViewBuilder
+    private var codexHookModeRow: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Picker(
+                lang.t("settings.codex.hookMode.title"),
+                selection: Binding(
+                    get: { model.codexHookInstallMode },
+                    set: { model.codexHookInstallMode = $0 }
+                )
+            ) {
+                Text(lang.t("settings.codex.hookMode.notifyOnly"))
+                    .tag(CodexHookInstallMode.notifyOnly)
+                Text(lang.t("settings.codex.hookMode.fullControl"))
+                    .tag(CodexHookInstallMode.fullControl)
+            }
+            .pickerStyle(.segmented)
+
+            Text(codexHookModeDescription)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.leading, 24)
+    }
+
+    private var codexHookModeDescription: String {
+        switch model.codexHookInstallMode {
+        case .notifyOnly:
+            return lang.t("settings.codex.hookMode.notifyOnly.description")
+        case .fullControl:
+            return lang.t("settings.codex.hookMode.fullControl.description")
+        }
     }
 
     private var geminiHookConfigURL: URL {

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -2251,9 +2251,14 @@ public final class BridgeServer: @unchecked Sendable {
             return
         }
 
+        // Only Codex's PreToolUse path uses `pendingApprovals`; returning a
+        // codex directive is safe here. Allow is explicit (instead of
+        // `.acknowledged` → empty stdout → Codex default-continue) so the
+        // hook command emits the PreToolUse permission envelope and stays
+        // unambiguous against future Codex schema changes.
         let response: BridgeResponse
         if approved {
-            response = .acknowledged
+            response = .codexHookDirective(.allow)
         } else {
             response = .codexHookDirective(.deny(reason: "Permission denied in Open Island."))
         }

--- a/Sources/OpenIslandCore/CodexHookInstallMode.swift
+++ b/Sources/OpenIslandCore/CodexHookInstallMode.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Controls how aggressively Open Island integrates with Codex CLI.
+///
+/// - `notifyOnly` (default): mirrors the historical footprint — `SessionStart`,
+///   `UserPromptSubmit`, `Stop`. Surfaces activity without intercepting tool
+///   execution.
+/// - `fullControl`: additionally registers `PreToolUse` (blocking approval) and
+///   `PostToolUse` (fire-and-forget notification) so the user can approve or
+///   deny each shell command before Codex runs it. This raises per-turn
+///   notification volume and requires the app to be running to answer
+///   approvals within the 1h PreToolUse hook timeout.
+public enum CodexHookInstallMode: String, Codable, Sendable, CaseIterable {
+    case notifyOnly
+    case fullControl
+
+    public static let `default`: CodexHookInstallMode = .notifyOnly
+}

--- a/Sources/OpenIslandCore/CodexHookInstallationManager.swift
+++ b/Sources/OpenIslandCore/CodexHookInstallationManager.swift
@@ -74,7 +74,10 @@ public final class CodexHookInstallationManager: @unchecked Sendable {
     }
 
     @discardableResult
-    public func install(hooksBinaryURL: URL) throws -> CodexHookInstallationStatus {
+    public func install(
+        hooksBinaryURL: URL,
+        mode: CodexHookInstallMode = .default
+    ) throws -> CodexHookInstallationStatus {
         try fileManager.createDirectory(at: codexDirectory, withIntermediateDirectories: true)
 
         let configURL = codexDirectory.appendingPathComponent("config.toml")
@@ -92,7 +95,11 @@ public final class CodexHookInstallationManager: @unchecked Sendable {
 
         let command = CodexHookInstaller.hookCommand(for: installedHooksBinaryURL.path)
         let featureMutation = CodexHookInstaller.enableCodexHooksFeature(in: existingConfig)
-        let hooksMutation = try CodexHookInstaller.installHooksJSON(existingData: existingHooks, hookCommand: command)
+        let hooksMutation = try CodexHookInstaller.installHooksJSON(
+            existingData: existingHooks,
+            hookCommand: command,
+            mode: mode
+        )
 
         if featureMutation.changed, fileManager.fileExists(atPath: configURL.path) {
             try backupFile(at: configURL)
@@ -108,7 +115,8 @@ public final class CodexHookInstallationManager: @unchecked Sendable {
 
         let manifest = CodexHookInstallerManifest(
             hookCommand: command,
-            enabledCodexHooksFeature: featureMutation.featureEnabledByInstaller
+            enabledCodexHooksFeature: featureMutation.featureEnabledByInstaller,
+            installMode: mode
         )
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601

--- a/Sources/OpenIslandCore/CodexHookInstaller.swift
+++ b/Sources/OpenIslandCore/CodexHookInstaller.swift
@@ -7,15 +7,25 @@ public struct CodexHookInstallerManifest: Equatable, Codable, Sendable {
     public var hookCommand: String
     public var enabledCodexHooksFeature: Bool
     public var installedAt: Date
+    /// Optional so manifests written before full-control mode existed still
+    /// decode. `effectiveInstallMode` normalizes a missing value to
+    /// `.notifyOnly`, which matches the pre-upgrade footprint.
+    public var installMode: CodexHookInstallMode?
+
+    public var effectiveInstallMode: CodexHookInstallMode {
+        installMode ?? .default
+    }
 
     public init(
         hookCommand: String,
         enabledCodexHooksFeature: Bool,
-        installedAt: Date = .now
+        installedAt: Date = .now,
+        installMode: CodexHookInstallMode? = nil
     ) {
         self.hookCommand = hookCommand
         self.enabledCodexHooksFeature = enabledCodexHooksFeature
         self.installedAt = installedAt
+        self.installMode = installMode
     }
 }
 
@@ -59,15 +69,49 @@ public enum CodexHookInstaller {
     public static let managedStatusMessage = "Managed by Open Island"
     public static let legacyManagedStatusMessage = "Managed by Vibe Island"
     public static let managedTimeout = 45
+    /// PreToolUse waits on the user for an approval decision. Codex kills the
+    /// hook at this timeout; 1 hour effectively means "wait until the user
+    /// answers" without making the process eternally unkillable if the app
+    /// crashes mid-approval.
+    public static let managedPreToolUseTimeout = 3600
 
-    // Keep the managed Codex install aligned with the original app's low-noise footprint.
-    // The bridge still understands richer hook events, but we do not install them by default
-    // because per-command Bash hooks produce a large amount of terminal log spam.
-    private static let eventSpecs: [(name: String, matcher: String?)] = [
-        ("SessionStart", "startup|resume"),
-        ("UserPromptSubmit", nil),
-        ("Stop", nil),
+    /// Union of every event name this installer may register, across all
+    /// `CodexHookInstallMode` variants. Used during uninstall and mode
+    /// switches so entries written under a previous mode are always cleaned
+    /// up, even if the current mode would not register that event itself.
+    public static let allManagedEventNames: [String] = [
+        "SessionStart",
+        "UserPromptSubmit",
+        "Stop",
+        "PreToolUse",
+        "PostToolUse",
     ]
+
+    public struct EventSpec: Equatable, Sendable {
+        public let name: String
+        public let matcher: String?
+        public let timeout: Int
+    }
+
+    // The bridge dispatches on `hook_event_name` from stdin, so every event
+    // uses the same hook command — mode only decides which events we tell
+    // Codex to fire.
+    public static func eventSpecs(for mode: CodexHookInstallMode) -> [EventSpec] {
+        var specs: [EventSpec] = [
+            EventSpec(name: "SessionStart", matcher: "startup|resume", timeout: managedTimeout),
+            EventSpec(name: "UserPromptSubmit", matcher: nil, timeout: managedTimeout),
+            EventSpec(name: "Stop", matcher: nil, timeout: managedTimeout),
+        ]
+
+        if mode == .fullControl {
+            // PreToolUse blocks Codex on the user's approval decision, so it
+            // needs a long timeout. PostToolUse is fire-and-forget.
+            specs.append(EventSpec(name: "PreToolUse", matcher: nil, timeout: managedPreToolUseTimeout))
+            specs.append(EventSpec(name: "PostToolUse", matcher: nil, timeout: managedTimeout))
+        }
+
+        return specs
+    }
 
     public static func hookCommand(for binaryPath: String) -> String {
         shellQuote(binaryPath)
@@ -75,7 +119,8 @@ public enum CodexHookInstaller {
 
     public static func installHooksJSON(
         existingData: Data?,
-        hookCommand: String
+        hookCommand: String,
+        mode: CodexHookInstallMode = .default
     ) throws -> CodexHookFileMutation {
         var rootObject = try loadRootObject(from: existingData)
         let existingHooksObject = rootObject["hooks"] as? [String: Any] ?? [:]
@@ -90,10 +135,10 @@ public enum CodexHookInstaller {
             }
         }
 
-        for spec in eventSpecs {
+        for spec in eventSpecs(for: mode) {
             let existingGroups = hooksObject[spec.name] as? [Any] ?? []
             let cleanedGroups = sanitizeForInstall(groups: existingGroups, replacingCommand: hookCommand)
-            hooksObject[spec.name] = cleanedGroups + [managedGroup(matcher: spec.matcher, hookCommand: hookCommand)]
+            hooksObject[spec.name] = cleanedGroups + [managedGroup(matcher: spec.matcher, hookCommand: hookCommand, timeout: spec.timeout)]
         }
 
         rootObject["hooks"] = hooksObject
@@ -114,8 +159,12 @@ public enum CodexHookInstaller {
         var hooksObject = rootObject["hooks"] as? [String: Any] ?? [:]
         var mutated = false
 
-        for spec in eventSpecs {
-            let existingGroups = hooksObject[spec.name] as? [Any] ?? []
+        // Walk the superset of event names we might have written under any
+        // mode, so switching fullControl → notifyOnly or full uninstall
+        // always drops PreToolUse/PostToolUse entries even if the current
+        // mode wouldn't list them.
+        for eventName in allManagedEventNames {
+            let existingGroups = hooksObject[eventName] as? [Any] ?? []
             let cleanedGroups = sanitize(groups: existingGroups, managedCommand: managedCommand)
 
             if cleanedGroups.count != existingGroups.count || containsManagedHook(in: existingGroups, managedCommand: managedCommand) {
@@ -123,9 +172,9 @@ public enum CodexHookInstaller {
             }
 
             if cleanedGroups.isEmpty {
-                hooksObject.removeValue(forKey: spec.name)
+                hooksObject.removeValue(forKey: eventName)
             } else {
-                hooksObject[spec.name] = cleanedGroups
+                hooksObject[eventName] = cleanedGroups
             }
         }
 
@@ -292,12 +341,12 @@ public enum CodexHookInstaller {
         }
     }
 
-    private static func managedGroup(matcher: String?, hookCommand: String) -> [String: Any] {
+    private static func managedGroup(matcher: String?, hookCommand: String, timeout: Int = managedTimeout) -> [String: Any] {
         var group: [String: Any] = [
             "hooks": [[
                 "type": "command",
                 "command": hookCommand,
-                "timeout": managedTimeout,
+                "timeout": timeout,
             ]]
         ]
 

--- a/Sources/OpenIslandCore/CodexHooks.swift
+++ b/Sources/OpenIslandCore/CodexHooks.swift
@@ -192,6 +192,7 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
 }
 
 public enum CodexHookDirective: Equatable, Codable, Sendable {
+    case allow
     case deny(reason: String)
 
     private enum CodingKeys: String, CodingKey {
@@ -200,6 +201,7 @@ public enum CodexHookDirective: Equatable, Codable, Sendable {
     }
 
     private enum DirectiveType: String, Codable {
+        case allow
         case deny
     }
 
@@ -208,6 +210,8 @@ public enum CodexHookDirective: Equatable, Codable, Sendable {
         let type = try container.decode(DirectiveType.self, forKey: .type)
 
         switch type {
+        case .allow:
+            self = .allow
         case .deny:
             self = .deny(reason: try container.decode(String.self, forKey: .reason))
         }
@@ -217,6 +221,8 @@ public enum CodexHookDirective: Equatable, Codable, Sendable {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         switch self {
+        case .allow:
+            try container.encode(DirectiveType.allow, forKey: .type)
         case let .deny(reason):
             try container.encode(DirectiveType.deny, forKey: .type)
             try container.encode(reason, forKey: .reason)
@@ -225,9 +231,25 @@ public enum CodexHookDirective: Equatable, Codable, Sendable {
 }
 
 public enum CodexHookOutputEncoder {
-    private struct LegacyBlockOutput: Codable {
+    /// Codex CLI accepts the Claude-compatible `{"decision":"block",...}`
+    /// shape for Stop/PreToolUse blocking. Allow emits an explicit
+    /// `{"hookSpecificOutput":{"permissionDecision":"allow"}}` plus
+    /// `continue:true` per the PreToolUse output schema bundled with the
+    /// Codex binary; `decision` is intentionally omitted because Codex
+    /// currently rejects `decision:"approve"` on PreToolUse.
+    private struct BlockOutput: Encodable {
         var decision = "block"
         var reason: String
+    }
+
+    private struct AllowOutput: Encodable {
+        struct HookSpecificOutput: Encodable {
+            let hookEventName = "PreToolUse"
+            let permissionDecision = "allow"
+        }
+
+        var `continue` = true
+        var hookSpecificOutput = HookSpecificOutput()
     }
 
     public static func standardOutput(for response: BridgeResponse) throws -> Data? {
@@ -241,8 +263,10 @@ public enum CodexHookOutputEncoder {
             let data: Data
 
             switch directive {
+            case .allow:
+                data = try encoder.encode(AllowOutput())
             case let .deny(reason):
-                data = try encoder.encode(LegacyBlockOutput(reason: reason))
+                data = try encoder.encode(BlockOutput(reason: reason))
             }
 
             var line = data

--- a/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
+++ b/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
@@ -4,6 +4,11 @@ import OpenIslandCore
 @main
 struct OpenIslandHooksCLI {
     private static let interactiveClaudeHookTimeout: TimeInterval = 24 * 60 * 60
+    /// Must match the Codex hooks.json `timeout` we write for PreToolUse in
+    /// full-control mode. Keeping the client-side socket timeout a touch
+    /// below Codex's own kill threshold so a slow network read surfaces as a
+    /// clean fail-open instead of a sigkill mid-write.
+    private static let interactiveCodexHookTimeout: TimeInterval = 3500
 
     private enum HookSource: String {
         case codex
@@ -45,8 +50,14 @@ struct OpenIslandHooksCLI {
                     .decode(CodexHookPayload.self, from: input)
                     .withRuntimeContext(environment: ProcessInfo.processInfo.environment)
 
-                guard let response = try? client.send(.processCodexHook(payload)) else {
-                    logStderr("bridge unavailable for codex hook")
+                // PreToolUse blocks Codex on the user's approval decision;
+                // every other Codex event is a quick activity/status ping.
+                let timeout: TimeInterval = payload.hookEventName == .preToolUse
+                    ? Self.interactiveCodexHookTimeout
+                    : 45
+
+                guard let response = try? client.send(.processCodexHook(payload), timeout: timeout) else {
+                    logStderr("bridge unavailable for codex hook (\(payload.hookEventName.rawValue))")
                     return
                 }
 

--- a/Tests/OpenIslandCoreTests/CodexHookInstallerTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexHookInstallerTests.swift
@@ -1,0 +1,230 @@
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+/// Pins `CodexHookInstaller` behavior across the two install modes, since
+/// the event set and per-event timeouts it writes directly determine
+/// whether Codex will block on Open Island for PreToolUse approvals.
+struct CodexHookInstallerTests {
+    private static let hookCommand = "'/tmp/oi/OpenIslandHooks'"
+
+    // MARK: - Event set per mode
+
+    @Test
+    func notifyOnlyRegistersHistoricalEventsOnly() throws {
+        let mutation = try CodexHookInstaller.installHooksJSON(
+            existingData: nil,
+            hookCommand: Self.hookCommand,
+            mode: .notifyOnly
+        )
+
+        let hooks = try hooksObject(from: mutation)
+
+        #expect(Set(hooks.keys) == ["SessionStart", "UserPromptSubmit", "Stop"])
+        for entry in try managedEntries(in: hooks) {
+            #expect(entry["timeout"] as? Int == CodexHookInstaller.managedTimeout)
+        }
+    }
+
+    @Test
+    func fullControlAddsPreAndPostToolUse() throws {
+        let mutation = try CodexHookInstaller.installHooksJSON(
+            existingData: nil,
+            hookCommand: Self.hookCommand,
+            mode: .fullControl
+        )
+
+        let hooks = try hooksObject(from: mutation)
+
+        #expect(Set(hooks.keys) == [
+            "SessionStart", "UserPromptSubmit", "Stop",
+            "PreToolUse", "PostToolUse",
+        ])
+
+        let preToolUseEntry = try singleManagedEntry(in: hooks, event: "PreToolUse")
+        // PreToolUse blocks Codex on the user's approval decision; Codex
+        // sigkills the hook at this timeout, so 1h is intentional.
+        #expect(preToolUseEntry["timeout"] as? Int == CodexHookInstaller.managedPreToolUseTimeout)
+
+        let postToolUseEntry = try singleManagedEntry(in: hooks, event: "PostToolUse")
+        #expect(postToolUseEntry["timeout"] as? Int == CodexHookInstaller.managedTimeout)
+    }
+
+    // MARK: - Mode switching
+
+    @Test
+    func switchingFullControlToNotifyOnlyDropsPreAndPostToolUse() throws {
+        let initial = try CodexHookInstaller.installHooksJSON(
+            existingData: nil,
+            hookCommand: Self.hookCommand,
+            mode: .fullControl
+        )
+
+        let downgraded = try CodexHookInstaller.installHooksJSON(
+            existingData: initial.contents,
+            hookCommand: Self.hookCommand,
+            mode: .notifyOnly
+        )
+
+        let hooks = try hooksObject(from: downgraded)
+        #expect(Set(hooks.keys) == ["SessionStart", "UserPromptSubmit", "Stop"])
+    }
+
+    @Test
+    func switchingNotifyOnlyToFullControlAddsPreAndPostToolUse() throws {
+        let initial = try CodexHookInstaller.installHooksJSON(
+            existingData: nil,
+            hookCommand: Self.hookCommand,
+            mode: .notifyOnly
+        )
+
+        let upgraded = try CodexHookInstaller.installHooksJSON(
+            existingData: initial.contents,
+            hookCommand: Self.hookCommand,
+            mode: .fullControl
+        )
+
+        let hooks = try hooksObject(from: upgraded)
+        #expect(hooks["PreToolUse"] != nil)
+        #expect(hooks["PostToolUse"] != nil)
+        // SessionStart/etc must survive the upgrade with exactly one
+        // managed entry (not duplicated from the initial install).
+        for event in ["SessionStart", "UserPromptSubmit", "Stop"] {
+            let managed = try managedHooks(in: hooks, event: event, command: Self.hookCommand)
+            #expect(managed.count == 1)
+        }
+    }
+
+    @Test
+    func repeatedInstallAtSameModeIsIdempotent() throws {
+        let first = try CodexHookInstaller.installHooksJSON(
+            existingData: nil,
+            hookCommand: Self.hookCommand,
+            mode: .fullControl
+        )
+        let second = try CodexHookInstaller.installHooksJSON(
+            existingData: first.contents,
+            hookCommand: Self.hookCommand,
+            mode: .fullControl
+        )
+
+        #expect(first.contents == second.contents)
+        #expect(second.changed == false)
+    }
+
+    // MARK: - Uninstall covers all modes
+
+    @Test
+    func uninstallRemovesEntriesWrittenByFullControlEvenIfCurrentlyNotifyOnly() throws {
+        // Simulate a user that installed under fullControl, then we
+        // pretend the preference was rolled back to notifyOnly on disk
+        // (e.g., previous manifest lost). Uninstall must still clean
+        // PreToolUse/PostToolUse — the enumeration is mode-agnostic.
+        let installed = try CodexHookInstaller.installHooksJSON(
+            existingData: nil,
+            hookCommand: Self.hookCommand,
+            mode: .fullControl
+        )
+
+        let uninstalled = try CodexHookInstaller.uninstallHooksJSON(
+            existingData: installed.contents,
+            managedCommand: Self.hookCommand
+        )
+
+        // The whole hooks.json gets removed because nothing is left.
+        #expect(uninstalled.contents == nil)
+        #expect(uninstalled.hasRemainingHooks == false)
+    }
+
+    @Test
+    func uninstallPreservesUnrelatedHooks() throws {
+        let otherHook: [String: Any] = [
+            "hooks": [[
+                "type": "command",
+                "command": "/opt/other-tool/hook",
+                "timeout": 30,
+            ]]
+        ]
+        let seed: [String: Any] = [
+            "hooks": [
+                "PreToolUse": [otherHook],
+            ]
+        ]
+        let seedData = try JSONSerialization.data(withJSONObject: seed)
+
+        let installed = try CodexHookInstaller.installHooksJSON(
+            existingData: seedData,
+            hookCommand: Self.hookCommand,
+            mode: .fullControl
+        )
+
+        let uninstalled = try CodexHookInstaller.uninstallHooksJSON(
+            existingData: installed.contents,
+            managedCommand: Self.hookCommand
+        )
+
+        let hooks = try hooksObject(from: uninstalled)
+        // The other tool's PreToolUse entry must survive both install
+        // and uninstall.
+        #expect(hooks["PreToolUse"] != nil)
+    }
+
+    // MARK: - Manifest mode
+
+    @Test
+    func manifestDefaultsToNotifyOnlyWhenDecodingLegacyPayload() throws {
+        // A manifest serialized before this feature shipped has no
+        // `installMode` field. It must decode and report
+        // `.notifyOnly` via `effectiveInstallMode`.
+        let legacyJSON = """
+        {
+            "hookCommand": "'/tmp/oi/OpenIslandHooks'",
+            "enabledCodexHooksFeature": true,
+            "installedAt": "2026-01-01T00:00:00Z"
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let manifest = try decoder.decode(CodexHookInstallerManifest.self, from: legacyJSON)
+
+        #expect(manifest.installMode == nil)
+        #expect(manifest.effectiveInstallMode == .notifyOnly)
+    }
+
+    // MARK: - Helpers
+
+    private func hooksObject(from mutation: CodexHookFileMutation) throws -> [String: Any] {
+        let data = try #require(mutation.contents)
+        let root = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        return try #require(root?["hooks"] as? [String: Any])
+    }
+
+    private func managedEntries(in hooks: [String: Any]) throws -> [[String: Any]] {
+        var collected: [[String: Any]] = []
+        for (_, value) in hooks {
+            guard let groups = value as? [[String: Any]] else { continue }
+            for group in groups {
+                let inner = (group["hooks"] as? [[String: Any]]) ?? []
+                for entry in inner where (entry["command"] as? String) == Self.hookCommand {
+                    collected.append(entry)
+                }
+            }
+        }
+        return collected
+    }
+
+    private func managedHooks(in hooks: [String: Any], event: String, command: String) throws -> [[String: Any]] {
+        let groups = (hooks[event] as? [[String: Any]]) ?? []
+        return groups.flatMap { group -> [[String: Any]] in
+            let inner = (group["hooks"] as? [[String: Any]]) ?? []
+            return inner.filter { ($0["command"] as? String) == command }
+        }
+    }
+
+    private func singleManagedEntry(in hooks: [String: Any], event: String) throws -> [String: Any] {
+        let managed = try managedHooks(in: hooks, event: event, command: Self.hookCommand)
+        #expect(managed.count == 1)
+        return try #require(managed.first)
+    }
+}

--- a/Tests/OpenIslandCoreTests/CodexHookOutputEncoderTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexHookOutputEncoderTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+/// Pins the stdout shape of every `CodexHookDirective` branch because
+/// Codex parses the hook's stdout strictly — a misnamed field or wrong
+/// decision value silently reverts to default-continue, defeating the
+/// whole approval pipeline.
+struct CodexHookOutputEncoderTests {
+    @Test
+    func acknowledgedResponseProducesNoOutput() throws {
+        let output = try CodexHookOutputEncoder.standardOutput(for: .acknowledged)
+        #expect(output == nil)
+    }
+
+    @Test
+    func denyDirectiveProducesBlockEnvelope() throws {
+        let output = try CodexHookOutputEncoder.standardOutput(
+            for: .codexHookDirective(.deny(reason: "User denied"))
+        )
+        let payload = try decodedPayload(from: output)
+
+        #expect(payload["decision"] as? String == "block")
+        #expect(payload["reason"] as? String == "User denied")
+    }
+
+    @Test
+    func allowDirectiveProducesPermissionAllowEnvelope() throws {
+        // Codex currently rejects `decision:"approve"` on PreToolUse, so
+        // allow intentionally omits the top-level `decision` and relies
+        // on `continue:true` + `permissionDecision:"allow"` — the shape
+        // documented by Codex's bundled PreToolUse schema.
+        let output = try CodexHookOutputEncoder.standardOutput(
+            for: .codexHookDirective(.allow)
+        )
+        let payload = try decodedPayload(from: output)
+
+        #expect(payload["continue"] as? Bool == true)
+        #expect(payload["decision"] == nil)
+        let hookSpecific = try #require(payload["hookSpecificOutput"] as? [String: Any])
+        #expect(hookSpecific["hookEventName"] as? String == "PreToolUse")
+        #expect(hookSpecific["permissionDecision"] as? String == "allow")
+    }
+
+    @Test
+    func outputAlwaysEndsWithNewline() throws {
+        // Codex reads hook stdout line-by-line; a missing trailing
+        // newline has historically caused intermittent "no output"
+        // misreads for small payloads.
+        let output = try CodexHookOutputEncoder.standardOutput(
+            for: .codexHookDirective(.allow)
+        )
+        let data = try #require(output)
+        #expect(data.last == UInt8(ascii: "\n"))
+    }
+
+    // MARK: - Helpers
+
+    private func decodedPayload(from output: Data?) throws -> [String: Any] {
+        let data = try #require(output)
+        let object = try JSONSerialization.jsonObject(with: data)
+        return try #require(object as? [String: Any])
+    }
+}

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -503,7 +503,11 @@ struct SessionStateTests {
         let response = try await responseTask
 
         #expect(activityEvent.activityUpdate?.summary == "Permission approved. Codex continued the command.")
-        #expect(response == .acknowledged)
+        // Approved PreToolUse now returns an explicit allow directive so
+        // the hook writes a well-formed `{"continue":true,"hookSpecificOutput":
+        // {"permissionDecision":"allow"}}` envelope to Codex, instead of
+        // relying on Codex's default-continue behavior for empty stdout.
+        #expect(response == .codexHookDirective(.allow))
     }
 
     @Test


### PR DESCRIPTION
## Summary

Give users a choice between the historical quiet surface and a new **Full Control** mode that registers `PreToolUse` / `PostToolUse` hooks on Codex CLI, so shell commands surface approve/deny in the island (matching Claude Code).

- New `CodexHookInstallMode` (`.notifyOnly` / `.fullControl`), persisted to UserDefaults (`app.codexHookInstallMode`). Default is `.notifyOnly` — upgrading users see no behavior change until they opt in.
- `CodexHookInstaller` now takes a mode and writes `PreToolUse` with a 3600s timeout (hook blocks until the user answers); `PostToolUse` is fire-and-forget.
- `BridgeServer` already had Codex PreToolUse/PostToolUse handling wired against `pendingApprovals` — this PR flips the approved-resolution path from `.acknowledged` (relied on Codex default-continue) to an explicit `.codexHookDirective(.allow)` and teaches `CodexHookOutputEncoder` to emit the documented `{"continue":true,"hookSpecificOutput":{"permissionDecision":"allow"}}` envelope.
- `OpenIslandHooks` CLI uses a 3500s socket read timeout for Codex PreToolUse (just under Codex's kill threshold to fail open cleanly). Other Codex events keep the 45s default.
- Settings → CLI Hooks gets a segmented picker under Codex with localized descriptions (en / zh-Hans / zh-Hant). Switching the picker re-writes `hooks.json` immediately via `HookInstallationCoordinator.reapplyCodexHookMode`.
- Mode-agnostic uninstall: walks the superset of event names we might have written under any mode, so downgrading or uninstalling always cleans up `PreToolUse` / `PostToolUse` entries even if the current mode no longer lists them.

Commits are split for review: model → encoder → bridge → hooks CLI → AppModel → UI → tests.

## Test plan

- [x] `swift build` (all targets, release + debug)
- [x] `swift test` — all 218 existing + 12 new tests pass
  - `CodexHookInstallerTests`: event sets per mode, mode-switch cleanup, idempotent reinstall, uninstall preserves third-party entries, legacy manifest decodes to `.notifyOnly`
  - `CodexHookOutputEncoderTests`: allow / deny / acknowledged stdout shapes + trailing newline
  - Updated end-to-end PreToolUse resolve test to expect the explicit allow directive
- [ ] Manual: launch dev app, toggle the picker in Settings with Codex hooks installed, confirm `~/.codex/hooks.json` gets `PreToolUse` (timeout 3600) / `PostToolUse` entries on fullControl and drops them back on notifyOnly
- [ ] Manual: run `codex` CLI in fullControl mode, confirm a `ls` command surfaces an approval card in the notch and both Allow and Deny reach Codex correctly
- [ ] Manual: kill the app mid-approval, confirm the hook eventually exits cleanly (fail-open) instead of hanging Codex for a full hour

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Codex Integration settings with two operation modes: "Notify Only" displays events without intercepting command execution, while "Full Control" lets you approve or deny each command before it runs. Your preference is saved automatically.

* **Localization**
  * Added support for Simplified Chinese and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->