### PR TITLE
fix(notification): auto-expand ask-user ui with vertical options

### DIFF
--- a/Sources/OpenIslandApp/IslandDebugScenario.swift
+++ b/Sources/OpenIslandApp/IslandDebugScenario.swift
@@ -350,8 +350,18 @@ private enum DebugSessionFactory {
             summary: "这个提醒态需要自动收起吗？",
             updatedAt: now.addingTimeInterval(-18),
             questionPrompt: QuestionPrompt(
-                title: "这个提醒态需要自动收起吗？",
-                options: ["10 秒", "鼠标离开收起", "都要"]
+                title: "Which authentication method should we use?",
+                questions: [
+                    QuestionPromptItem(
+                        question: "Which authentication method should we use?",
+                        header: "Auth",
+                        options: [
+                            QuestionOption(label: "JWT tokens", description: "Stateless, scalable"),
+                            QuestionOption(label: "Session cookies", description: "Traditional approach"),
+                            QuestionOption(label: "OAuth 2.0", description: "Third-party auth"),
+                        ]
+                    )
+                ]
             ),
             jumpTarget: JumpTarget(
                 terminalApp: "Ghostty",

--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -24,7 +24,8 @@ final class OverlayPanelController {
     // Approval card: header row (~72) + actionableBody padding (16*2 + 14 bottom) + body content (~186)
     // Bumped to 310 to ensure the estimated panel height is never smaller than the actual rendered card.
     private static let approvalCardHeight: CGFloat = 310
-    private static let questionCardHeight: CGFloat = 110
+    private static let questionCardBaseHeight: CGFloat = 110
+    private static let questionCardMaxHeight: CGFloat = 420
     // Completion card chrome breakdown (everything except the scrollable text):
     // openedContent vertical padding: 24, card container padding: 28,
     // card VStack spacing: 14, card header (title+prompt): ~50,
@@ -626,8 +627,34 @@ final class OverlayPanelController {
         return headerHeight + 1 + markdownHeight + replyInputHeight
     }
 
+    /// Estimates the question card height based on prompt content (question count,
+    /// option count per question, and whether the prompt title is shown).
     private func questionCardHeight(for prompt: QuestionPrompt?) -> CGFloat {
-        Self.questionCardHeight
+        guard let prompt, !prompt.questions.isEmpty else {
+            return Self.questionCardBaseHeight
+        }
+
+        // Card chrome: outer padding + submit button ≈ 90pt.
+        // When the prompt title is suppressed (single question whose title
+        // matches the question text), reduce chrome by ~20pt.
+        let titleSuppressed = prompt.questions.count == 1
+            && prompt.title == prompt.questions.first?.question
+        let chromeHeight: CGFloat = titleSuppressed ? 70 : 90
+        var contentHeight: CGFloat = 0
+
+        for question in prompt.questions {
+            if prompt.questions.count > 1 {
+                contentHeight += 16 // header
+            }
+            contentHeight += 20 // question text
+            contentHeight += CGFloat(question.options.count) * 30 // option rows
+        }
+
+        // Inter-question spacing (only between questions, not after the last).
+        contentHeight += CGFloat(max(0, prompt.questions.count - 1)) * 10
+
+        let estimated = chromeHeight + contentHeight
+        return min(Self.questionCardMaxHeight, max(Self.questionCardBaseHeight, estimated))
     }
 
     private func completionCardHeight(for model: AppModel) -> CGFloat {

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1593,7 +1593,7 @@ private struct StructuredQuestionPromptView: View {
     @State private var selections: [String: Set<String>] = [:]
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 10) {
             if showsPromptTitle {
                 Text(promptTitle)
                     .font(.system(size: 13, weight: .semibold))
@@ -1601,55 +1601,20 @@ private struct StructuredQuestionPromptView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            if structuredQuestions.isEmpty {
-                HStack(spacing: 10) {
-                    ForEach(prompt?.options.prefix(3) ?? [], id: \.self) { option in
-                        Button(option) {
-                            onAnswer(QuestionPromptResponse(answer: option))
-                        }
-                        .buttonStyle(IslandWideButtonStyle(kind: .secondary))
-                    }
+            VStack(alignment: .leading, spacing: 10) {
+                ForEach(structuredQuestions, id: \.question) { question in
+                    questionRow(question)
                 }
-            } else {
-                ScrollView(.vertical, showsIndicators: false) {
-                    VStack(alignment: .leading, spacing: 12) {
-                        ForEach(structuredQuestions, id: \.question) { question in
-                            VStack(alignment: .leading, spacing: 8) {
-                                Text(question.header)
-                                    .font(.system(size: 10.5, weight: .bold))
-                                    .foregroundStyle(.white.opacity(0.5))
 
-                                Text(question.question)
-                                    .font(.system(size: 12.5, weight: .medium))
-                                    .foregroundStyle(.white.opacity(0.88))
-                                    .fixedSize(horizontal: false, vertical: true)
-
-                                HStack(spacing: 8) {
-                                    ForEach(question.options.prefix(4), id: \.label) { option in
-                                        Button(option.label) {
-                                            toggle(option: option.label, for: question)
-                                        }
-                                        .buttonStyle(
-                                            IslandWideButtonStyle(
-                                                kind: selectedLabels(for: question).contains(option.label) ? .primary : .secondary
-                                            )
-                                        )
-                                    }
-                                }
-                            }
-                        }
-
-                        Button(lang.t("question.submit")) {
-                            onAnswer(QuestionPromptResponse(answers: answerMap))
-                        }
-                        .buttonStyle(IslandWideButtonStyle(kind: .primary))
-                        .disabled(!hasCompleteSelection)
-                    }
+                Button(lang.t("question.submit")) {
+                    onAnswer(QuestionPromptResponse(answers: answerMap))
                 }
+                .buttonStyle(IslandWideButtonStyle(kind: .primary))
+                .disabled(!hasCompleteSelection)
             }
         }
         .padding(.horizontal, 14)
-        .padding(.vertical, 12)
+        .padding(.vertical, 10)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: 18, style: .continuous)
@@ -1660,6 +1625,76 @@ private struct StructuredQuestionPromptView: View {
                 .strokeBorder(.white.opacity(0.06))
         )
     }
+
+    // MARK: - Per-question row
+
+    /// Renders a single question with its header, text, and vertical option list.
+    @ViewBuilder
+    private func questionRow(_ question: QuestionPromptItem) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if structuredQuestions.count > 1 {
+                Text(question.header)
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(.white.opacity(0.5))
+            }
+
+            Text(question.question)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.white.opacity(0.88))
+                .fixedSize(horizontal: false, vertical: true)
+
+            // Vertical option list
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(question.options) { option in
+                    optionRow(option, question: question)
+                }
+            }
+        }
+    }
+
+    // MARK: - Option row (vertical, CLI-style)
+
+    /// Renders a single option as a selectable row with checkmark indicator, label, and optional description.
+    private func optionRow(_ option: QuestionOption, question: QuestionPromptItem) -> some View {
+        let isSelected = selectedLabels(for: question).contains(option.label)
+        return Button {
+            toggle(option: option.label, for: question)
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(isSelected ? .yellow : .white.opacity(0.35))
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(option.label)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.white.opacity(isSelected ? 1 : 0.78))
+
+                    if !option.description.isEmpty {
+                        Text(option.description)
+                            .font(.system(size: 10.5))
+                            .foregroundStyle(.white.opacity(0.4))
+                            .lineLimit(1)
+                    }
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(.vertical, 5)
+            .padding(.horizontal, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(isSelected ? Color.yellow.opacity(0.10) : Color.white.opacity(0.04))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .strokeBorder(isSelected ? .yellow.opacity(0.25) : .clear)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Helpers
 
     private var structuredQuestions: [QuestionPromptItem] {
         prompt?.questions ?? []
@@ -1688,7 +1723,6 @@ private struct StructuredQuestionPromptView: View {
             guard !selected.isEmpty else {
                 return nil
             }
-
             return (question.question, selected.sorted().joined(separator: ", "))
         })
     }

--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -193,11 +193,14 @@ public struct PermissionRequest: Equatable, Identifiable, Codable, Sendable {
     }
 }
 
-public struct QuestionOption: Equatable, Codable, Sendable {
+/// A single selectable option within a structured question prompt.
+public struct QuestionOption: Equatable, Identifiable, Codable, Sendable {
+    public var id: UUID
     public var label: String
     public var description: String
 
-    public init(label: String, description: String = "") {
+    public init(id: UUID = UUID(), label: String, description: String = "") {
+        self.id = id
         self.label = label
         self.description = description
     }


### PR DESCRIPTION
## Context

When a CLI (e.g: Claude code) uses the ask-user-question tool and a hook is fired and detected by Open Vibe Island a notification pops up with the different options, unfortunately it's currently not very convenient to use as it requires scrolling down etc

## Implementation
This PR redesigns question UI from horizontal to vertical layout with dynamic card height sizing.

### Changes
•  Replace horizontal button row + `ScrollView` with vertical option list (each row shows label + description with a radio-style checkmark indicator)
•  Make question card height dynamic based on prompt content (number of options) instead of a fixed 110pt
•  Update debug scenario to use a structured question with option descriptions

## Demo

### Before
https://github.com/user-attachments/assets/fa0372c5-ca2e-41b7-8a92-ccb14b98b18c



### After
https://github.com/user-attachments/assets/3c16a4b9-70a5-4a83-b2c8-8ff2477285b5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prompts can present multiple structured questions with per-option descriptions for clearer choices.

* **UI Improvements**
  * Redesigned vertical option list with checkmark indicators and improved submit placement.
  * Dynamic panel height estimation adapts to content for more consistent sizing.
  * Reduced spacing and refined visual presentation for question layouts.

* **Behavior**
  * More reliable option selection and identity handling for consistent interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->