### PR TITLE
fix: prevent late Claude hooks from rebounding completed sessions to running

### DIFF
--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -733,7 +733,7 @@ public final class BridgeServer: @unchecked Sendable {
                     SessionActivityUpdated(
                         sessionID: payload.sessionID,
                         summary: summary,
-                        phase: .running,
+                        phase: claudeIntermediatePhase(for: payload.sessionID),
                         timestamp: .now
                     )
                 )
@@ -752,7 +752,9 @@ public final class BridgeServer: @unchecked Sendable {
                     SessionActivityUpdated(
                         sessionID: payload.sessionID,
                         summary: payload.error ?? "Claude tool failed.",
-                        phase: payload.isInterrupt == true ? .completed : .running,
+                        phase: payload.isInterrupt == true
+                            ? .completed
+                            : claudeIntermediatePhase(for: payload.sessionID),
                         timestamp: .now
                     )
                 )
@@ -868,7 +870,7 @@ public final class BridgeServer: @unchecked Sendable {
                     SessionActivityUpdated(
                         sessionID: payload.sessionID,
                         summary: summary,
-                        phase: .running,
+                        phase: claudeIntermediatePhase(for: payload.sessionID),
                         timestamp: .now
                     )
                 )
@@ -892,7 +894,7 @@ public final class BridgeServer: @unchecked Sendable {
                     SessionActivityUpdated(
                         sessionID: payload.sessionID,
                         summary: summary,
-                        phase: .running,
+                        phase: claudeIntermediatePhase(for: payload.sessionID),
                         timestamp: .now
                     )
                 )
@@ -909,7 +911,7 @@ public final class BridgeServer: @unchecked Sendable {
                     SessionActivityUpdated(
                         sessionID: payload.sessionID,
                         summary: "Claude is compacting the conversation.",
-                        phase: .running,
+                        phase: claudeIntermediatePhase(for: payload.sessionID),
                         timestamp: .now
                     )
                 )
@@ -1736,6 +1738,18 @@ public final class BridgeServer: @unchecked Sendable {
                 )
             )
         )
+    }
+
+    /// Phase to use for "intermediate" Claude hook events (postToolUse,
+    /// subagentStart/Stop, preCompact, ...) that semantically mean "Claude is
+    /// still working".  These events can legitimately arrive after the
+    /// authoritative `Stop` hook — `subagentStop` is emitted from a child
+    /// process whose IPC ordering relative to the parent is not guaranteed,
+    /// and a delayed `postToolUse` can race the same way.  Without this guard
+    /// a late event would flip an already-`.completed` session back to
+    /// `.running` and leave it stuck.
+    private func claudeIntermediatePhase(for sessionID: String) -> SessionPhase {
+        localState.session(id: sessionID)?.phase == .completed ? .completed : .running
     }
 
     private func ensureSessionExists(for payload: CodexHookPayload) {

--- a/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
@@ -408,6 +408,85 @@ struct ClaudeHooksTests {
         #expect(payload.defaultJumpTarget.warpPaneUUID == "DEADBEEFDEADBEEFDEADBEEFDEADBEEF")
     }
 
+    /// Regression: a `subagentStop` (and other "intermediate" hook events)
+    /// arriving after the parent's `Stop` must not flip the session from
+    /// `.completed` back to `.running`.  Subagents run in their own process,
+    /// so their hook delivery can race the parent's `Stop` hook; without the
+    /// guard the island would show "Running" forever even though Claude is
+    /// idle.
+    @Test
+    func lateSubagentStopDoesNotResurrectCompletedClaudeSession() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let sessionID = "claude-session-late-subagent"
+        let cwd = "/tmp/worktree-late"
+
+        let promptPayload = ClaudeHookPayload(
+            cwd: cwd,
+            hookEventName: .userPromptSubmit,
+            sessionID: sessionID,
+            prompt: "do the thing"
+        )
+        let stopPayload = ClaudeHookPayload(
+            cwd: cwd,
+            hookEventName: .stop,
+            sessionID: sessionID,
+            lastAssistantMessage: "done"
+        )
+        let lateSubagentStopPayload = ClaudeHookPayload(
+            cwd: cwd,
+            hookEventName: .subagentStop,
+            sessionID: sessionID,
+            agentType: "general-purpose"
+        )
+        let latePostToolUsePayload = ClaudeHookPayload(
+            cwd: cwd,
+            hookEventName: .postToolUse,
+            sessionID: sessionID,
+            toolName: "Bash"
+        )
+
+        let client = BridgeCommandClient(socketURL: socketURL)
+        _ = try client.send(.processClaudeHook(promptPayload))
+        _ = try client.send(.processClaudeHook(stopPayload))
+        _ = try client.send(.processClaudeHook(lateSubagentStopPayload))
+        _ = try client.send(.processClaudeHook(latePostToolUsePayload))
+
+        var iterator = stream.makeAsyncIterator()
+        var sawCompletion = false
+        var lastActivityPhase: SessionPhase?
+        for _ in 0..<24 {
+            let event = try await nextEvent(from: &iterator)
+            switch event {
+            case let .sessionCompleted(payload) where payload.sessionID == sessionID:
+                sawCompletion = true
+            case let .activityUpdated(payload) where payload.sessionID == sessionID:
+                if sawCompletion {
+                    lastActivityPhase = payload.phase
+                }
+            default:
+                break
+            }
+            if sawCompletion, lastActivityPhase != nil {
+                break
+            }
+        }
+
+        #expect(sawCompletion, "Stop hook should produce a sessionCompleted event")
+        #expect(
+            lastActivityPhase == .completed,
+            "Late subagentStop / postToolUse must not downgrade a completed session back to .running"
+        )
+    }
+
     @Test
     func claudeWithRuntimeContextSkipsWarpResolverForNonWarpTerminal() {
         var resolverCalls = 0


### PR DESCRIPTION
## Summary
- The Claude hook handler unconditionally emitted `activityUpdated(phase: .running)` for `postToolUse`, `postToolUseFailure`, `subagentStart`, `subagentStop`, and `preCompact`. Because `subagentStop` is delivered from the subagent's own process, its IPC ordering relative to the parent's `Stop` hook is **not** guaranteed; a late event would flip the session from `.completed` back to `.running` and the island would show "Running" indefinitely while Claude was actually idle.
- Mirror the existing `notification` handler pattern: introduce `claudeIntermediatePhase(for:)` which returns `.completed` when the session is already completed, otherwise `.running`. Apply to the five intermediate events. `userPromptSubmit` / `preToolUse` keep `.running` (legitimate "new turn" signals from the parent).
- Add a regression test (`lateSubagentStopDoesNotResurrectCompletedClaudeSession`) that fires `Stop` then a late `subagentStop` + `postToolUse` and asserts the activity phase stays `.completed`.

## Test plan
- [x] `swift build`
- [x] `swift test --filter ClaudeHooksTests` — 14/14 pass (incl. new regression test)
- [x] `swift test --filter "SessionStateTests|BridgeServerJumpTargetMergeTests"` — all pass
- [ ] Manual: long-running Claude turn with subagents, observe island returns to "Completed" after Stop and stays there

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where session state could be incorrectly reverted to "running" when intermediate events arrived out of order, ensuring proper session state integrity.

* **Tests**
  * Added regression test to verify event-ordering robustness and session state tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->