### PR TITLE
fix(opencode): overhaul process discovery and session liveness tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ build/
 
 # Swift Package Manager
 .build/
+.swiftpm/
 Packages/
 Package.resolved
 
@@ -24,3 +25,4 @@ output/
 *.log
 *.tmp
 .worktrees/
+.air/

--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -100,17 +100,55 @@ struct ActiveAgentProcessDiscovery {
             }
 
             if isOpenCodeProcess(command: process.command) {
-                let claimKey = "opencode:\(process.pid)"
+                let lsofOutput = lsofOutput(pid: process.pid)
+                let cwd = lsofOutput.flatMap(workingDirectory(from:))
+
+                // Deduplicate by TTY and working directory instead of PID.
+                // Wrappers like `npm exec` and their child `node` process share the same TTY and CWD.
+                // Treat a missing cwd as a wildcard for the TTY to match existing claims, but let concrete cwd overwrite wildcard.
+                let ttyId = process.terminalTTY ?? process.pid
+                
+                if cwd == nil {
+                    // Only insert wildcard if no concrete claim exists for this TTY.
+                    if claimedKeys.contains(where: { $0.hasPrefix("opencode:\(ttyId):") && $0 != "opencode:\(ttyId):" }) {
+                        continue
+                    }
+                } else {
+                    // Concrete CWD: remove any existing wildcard claim for this TTY before claiming.
+                    if claimedKeys.remove("opencode:\(ttyId):") != nil {
+                        // Also remove the orphaned snapshot that was previously appended.
+                        snapshots.removeAll {
+                            $0.tool == .openCode && $0.terminalTTY == process.terminalTTY && $0.workingDirectory == nil
+                        }
+                    }
+                }
+
+                let claimKey = "opencode:\(ttyId):\(cwd ?? "")"
                 guard claimedKeys.insert(claimKey).inserted else {
                     continue
                 }
 
-                snapshots.append(ProcessSnapshot(
+                var snapshot = ProcessSnapshot(
                     tool: .openCode,
                     sessionID: nil,
-                    workingDirectory: nil,
-                    terminalTTY: process.terminalTTY
-                ))
+                    workingDirectory: cwd,
+                    terminalTTY: process.terminalTTY,
+                    terminalApp: terminalApp(for: process, processesByPID: processesByPID)
+                )
+
+                if snapshot.terminalApp == nil, let agentTTY = process.terminalTTY {
+                    if let (tmuxTarget, hostTerminalApp, socketPath) = resolveTmuxInfo(
+                        agentTTY: agentTTY,
+                        processes: processesByPID.values.map { $0 },
+                        processesByPID: processesByPID
+                    ) {
+                        snapshot.terminalApp = hostTerminalApp
+                        snapshot.tmuxTarget = tmuxTarget
+                        snapshot.tmuxSocketPath = socketPath
+                    }
+                }
+
+                snapshots.append(snapshot)
                 continue
             }
 
@@ -517,8 +555,70 @@ struct ActiveAgentProcessDiscovery {
 
     private func isOpenCodeProcess(command: String) -> Bool {
         let lowered = command.lowercased()
-        return lowered.contains("/opencode-ai/") || lowered.contains("/opencode")
-            || lowered.contains("/.opencode")
+
+        guard let firstToken = lowered.split(separator: " ").first.map(String.init) else {
+            return false
+        }
+
+        // Fast path: explicitly launched as opencode or opencode-ai
+        if firstToken == "opencode"
+            || firstToken == "opencode-ai"
+            || firstToken.hasSuffix("/opencode")
+            || firstToken.hasSuffix("/opencode-ai")
+        {
+            return true
+        }
+
+        guard lowered.contains("opencode") else {
+            return false
+        }
+
+        // Wrappers: npx, npm exec, yarn, pnpm dlx, bunx
+        let isPackageRunner = firstToken == "npx" || firstToken.hasSuffix("/npx")
+            || firstToken == "pnpx" || firstToken.hasSuffix("/pnpx")
+            || firstToken == "bunx" || firstToken.hasSuffix("/bunx")
+            || ((firstToken == "npm" || firstToken.hasSuffix("/npm")) && (lowered.contains(" exec ") || lowered.contains(" run ")))
+            || ((firstToken == "pnpm" || firstToken.hasSuffix("/pnpm")) && (lowered.contains(" dlx ") || lowered.contains(" exec ") || lowered.contains(" run ")))
+            || firstToken == "yarn" || firstToken.hasSuffix("/yarn")
+
+        if isPackageRunner {
+            let tokens = lowered.split(separator: " ")
+            let packageIndex = tokens.firstIndex { token in
+                if token.hasPrefix("@opencode-ai/") {
+                    return true
+                }
+                let baseToken = token.hasPrefix("@") ? String(token) : (token.split(separator: "@").first.map(String.init) ?? String(token))
+                return baseToken == "opencode" || baseToken == "opencode-ai"
+            }
+            
+            if let packageIndex = packageIndex {
+                let installLike: Set<Substring> = ["install", "i", "add", "remove", "rm", "uninstall", "update", "upgrade", "up", "unlink"]
+                let isInstallCommand = tokens[..<packageIndex].contains(where: { installLike.contains($0) })
+                if !isInstallCommand {
+                    return true
+                }
+            }
+        }
+
+        // Node / Bun executing the specific CLI script
+        let isNode = firstToken == "node" || firstToken.hasSuffix("/node") || firstToken == "bun" || firstToken.hasSuffix("/bun")
+        if isNode && (
+            lowered.contains("/opencode-ai/")
+            || lowered.contains("/@opencode-ai/")
+            || lowered.contains("/node_modules/opencode/")
+            || lowered.contains("/node_modules/opencode-ai/")
+            || lowered.contains("/node_modules/@opencode-ai/")
+            || lowered.hasSuffix("/.bin/opencode")
+            || lowered.contains("/.bin/opencode ")
+            || lowered.hasSuffix("/.bin/opencode-ai")
+            || lowered.contains("/.bin/opencode-ai ")
+            || lowered.hasSuffix("/.bin/@opencode-ai")
+            || lowered.contains("/.bin/@opencode-ai ")
+        ) {
+            return true
+        }
+
+        return false
     }
 
     private func isGeminiProcess(command: String) -> Bool {

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -552,6 +552,7 @@ final class AppModel {
         monitoring.onPersistenceNeeded = { [weak self] in
             self?.discovery.scheduleCodexSessionPersistence()
             self?.discovery.scheduleClaudeSessionPersistence()
+            self?.discovery.scheduleOpenCodeSessionPersistence()
             self?.discovery.scheduleCursorSessionPersistence()
         }
         monitoring.onCodexAppRunningChanged = { [weak self] isRunning in
@@ -1162,6 +1163,7 @@ final class AppModel {
         refreshOverlayPlacementIfVisible()
         discovery.scheduleCodexSessionPersistence()
         discovery.scheduleClaudeSessionPersistence()
+        discovery.scheduleOpenCodeSessionPersistence()
         discovery.scheduleCursorSessionPersistence()
 
         // Push relevant events to the Watch/iPhone via the relay

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -415,28 +415,35 @@ final class HookInstallationCoordinator {
 
     // MARK: - Health check & auto-repair
 
-    var claudeHealthReport: HookHealthReport?
     var codexHealthReport: HookHealthReport?
+    var claudeHealthReport: HookHealthReport?
+    var openCodeHealthReport: HookHealthReport?
+    var cursorHealthReport: HookHealthReport?
+    var geminiHealthReport: HookHealthReport?
 
-    /// Runs health checks for both Claude and Codex hooks.
+
+    /// Runs health checks for Claude, Codex and OpenCode hooks.
     func runHealthChecks() {
         Task { @MainActor [weak self] in
             guard let self else { return }
 
             let binaryURL = self.hooksBinaryURL
-            let (claudeReport, codexReport) = await Task.detached(priority: .utility) {
+            let (claudeReport, codexReport, openCodeReport) = await Task.detached(priority: .utility) {
                 let claude = HookHealthCheck.checkClaude(hooksBinaryURL: binaryURL)
                 let codex = HookHealthCheck.checkCodex(hooksBinaryURL: binaryURL)
-                return (claude, codex)
+                let openCode = HookHealthCheck.checkOpenCode()
+                return (claude, codex, openCode)
             }.value
 
             self.claudeHealthReport = claudeReport
             self.codexHealthReport = codexReport
+            self.openCodeHealthReport = openCodeReport
 
-            if !claudeReport.isHealthy || !codexReport.isHealthy {
-                let claudeIssueCount = claudeReport.issues.count
-                let codexIssueCount = codexReport.issues.count
-                self.onStatusMessage?("Hook health check: \(claudeIssueCount) Claude issue(s), \(codexIssueCount) Codex issue(s).")
+            if !claudeReport.isHealthy || !codexReport.isHealthy || !openCodeReport.isHealthy {
+                let claudeIssueCount = claudeReport.errors.count
+                let codexIssueCount = codexReport.errors.count
+                let openCodeIssueCount = openCodeReport.errors.count
+                self.onStatusMessage?("Hook health check: \(claudeIssueCount) Claude, \(codexIssueCount) Codex, \(openCodeIssueCount) OpenCode issue(s).")
             }
         }
     }
@@ -449,14 +456,16 @@ final class HookInstallationCoordinator {
 
         // Re-run health checks first
         let binaryURL = hooksBinaryURL
-        let (claudeReport, codexReport) = await Task.detached(priority: .utility) {
+        let (claudeReport, codexReport, openCodeReport) = await Task.detached(priority: .utility) {
             let claude = HookHealthCheck.checkClaude(hooksBinaryURL: binaryURL)
             let codex = HookHealthCheck.checkCodex(hooksBinaryURL: binaryURL)
-            return (claude, codex)
+            let openCode = HookHealthCheck.checkOpenCode()
+            return (claude, codex, openCode)
         }.value
 
         claudeHealthReport = claudeReport
         codexHealthReport = codexReport
+        openCodeHealthReport = openCodeReport
 
         // Repair Claude hooks if there are repairable issues
         if !claudeReport.repairableIssues.isEmpty, hooksBinaryURL != nil {
@@ -472,22 +481,31 @@ final class HookInstallationCoordinator {
             repaired = true
         }
 
+        // Repair OpenCode plugin if there are repairable issues
+        if !openCodeReport.repairableIssues.isEmpty {
+            onStatusMessage?("Repairing OpenCode plugin: \(openCodeReport.repairableIssues.map(\.description).joined(separator: "; "))")
+            installOpenCodePlugin()
+            repaired = true
+        }
+
         // Refresh health reports after repair
         if repaired {
             try? await Task.sleep(for: .milliseconds(500))
-            let (updatedClaude, updatedCodex) = await Task.detached(priority: .utility) {
+            let (updatedClaude, updatedCodex, updatedOpenCode) = await Task.detached(priority: .utility) {
                 let claude = HookHealthCheck.checkClaude(hooksBinaryURL: binaryURL)
                 let codex = HookHealthCheck.checkCodex(hooksBinaryURL: binaryURL)
-                return (claude, codex)
+                let openCode = HookHealthCheck.checkOpenCode()
+                return (claude, codex, openCode)
             }.value
             claudeHealthReport = updatedClaude
             codexHealthReport = updatedCodex
+            openCodeHealthReport = updatedOpenCode
 
-            if updatedClaude.isHealthy && updatedCodex.isHealthy {
+            if updatedClaude.isHealthy && updatedCodex.isHealthy && updatedOpenCode.isHealthy {
                 onStatusMessage?("Hook repair completed successfully.")
             } else {
-                let remaining = updatedClaude.errors.count + updatedCodex.errors.count
-                onStatusMessage?("Hook repair completed with \(remaining) remaining issue(s) that need manual attention.")
+                let remaining = updatedClaude.errors.count + updatedCodex.errors.count + updatedOpenCode.errors.count
+                onStatusMessage?("Hook repair finished with \(remaining) remaining issue(s).")
             }
         }
 

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -316,12 +316,37 @@ final class ProcessMonitoringCoordinator {
             claimedSessionIDs.insert(matched.id)
         }
 
-        // OpenCode sessions: the JS plugin runs inside the OpenCode process.
-        // We can't match by session ID (plugin doesn't expose it to ps), so
-        // keep all OpenCode sessions alive as long as any OpenCode process exists.
-        let hasOpenCodeProcess = activeProcesses.contains { $0.tool == .openCode }
-        if hasOpenCodeProcess {
-            for session in sessions where session.tool == .openCode && !session.isDemoSession {
+        // OpenCode sessions are hook-managed, but OpenCode does not expose a stable
+        // session ID through process discovery. Match each active OpenCode process
+        // to at most one tracked session.
+        let openCodeProcesses = activeProcesses.filter { $0.tool == .openCode }
+        // Do not filter by `isHookManaged` here because restored sessions drop that flag.
+        let trackedOpenCodeSessions = sessions.filter { $0.tool == .openCode && !$0.isDemoSession }
+        var claimedOpenCodeSessionIDs: Set<String> = []
+        var hasUnmatchedOpenCodeProcess = false
+
+        for process in openCodeProcesses {
+            let matchResult = uniqueTrackedOpenCodeSession(
+                for: process,
+                sessions: trackedOpenCodeSessions,
+                claimedSessionIDs: claimedOpenCodeSessionIDs
+            )
+            switch matchResult {
+            case .matched(let matched):
+                aliveIDs.insert(matched.id)
+                claimedOpenCodeSessionIDs.insert(matched.id)
+            case .ambiguous:
+                hasUnmatchedOpenCodeProcess = true
+            case .rejectedConflict:
+                break
+            }
+        }
+
+        // Fallback: If there are active OpenCode processes that we couldn't uniquely
+        // match, keep all remaining unclaimed OpenCode sessions alive to prevent
+        // incorrectly marking them as ended.
+        if hasUnmatchedOpenCodeProcess {
+            for session in trackedOpenCodeSessions where !claimedOpenCodeSessionIDs.contains(session.id) {
                 aliveIDs.insert(session.id)
             }
         }
@@ -365,6 +390,63 @@ final class ProcessMonitoringCoordinator {
         }
 
         return aliveIDs
+    }
+
+    private enum OpenCodeMatchResult {
+        case matched(AgentSession)
+        case ambiguous
+        case rejectedConflict
+    }
+
+    private func uniqueTrackedOpenCodeSession(
+        for process: ActiveProcessSnapshot,
+        sessions: [AgentSession],
+        claimedSessionIDs: Set<String>
+    ) -> OpenCodeMatchResult {
+        let unclaimedSessions = sessions.filter { !claimedSessionIDs.contains($0.id) }
+        guard !unclaimedSessions.isEmpty else {
+            return .ambiguous
+        }
+
+        if let terminalTTY = normalizedTTYForMatching(process.terminalTTY) {
+            let candidates = unclaimedSessions.filter {
+                normalizedTTYForMatching($0.jumpTarget?.terminalTTY) == terminalTTY
+            }
+            if candidates.count == 1 {
+                let candidate = candidates[0]
+                if let processCWD = normalizedPathForMatching(process.workingDirectory),
+                   let sessionCWD = normalizedPathForMatching(candidate.jumpTarget?.workingDirectory),
+                   processCWD != sessionCWD {
+                    // TTY matched, but CWD explicitly differs (e.g., terminal tab was reused in another directory).
+                    return .rejectedConflict
+                }
+                return .matched(candidate)
+            }
+            if !candidates.isEmpty {
+                if let processCWD = normalizedPathForMatching(process.workingDirectory) {
+                    let cwdCandidates = candidates.filter {
+                        normalizedPathForMatching($0.jumpTarget?.workingDirectory) == processCWD
+                    }
+                    if cwdCandidates.count == 1 {
+                        return .matched(cwdCandidates[0])
+                    }
+                }
+                return .ambiguous
+            }
+        }
+
+        if let processCWD = normalizedPathForMatching(process.workingDirectory) {
+            let workspaceMatches = unclaimedSessions.filter {
+                normalizedPathForMatching($0.jumpTarget?.workingDirectory) == processCWD
+            }
+            if workspaceMatches.count == 1 {
+                return .matched(workspaceMatches[0])
+            }
+        }
+
+        // We require at least a positive match on TTY or CWD.
+        // Do not blindly link the process just because only one session remains.
+        return .ambiguous
     }
 
     private func uniqueTrackedGeminiSession(

--- a/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
+++ b/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
@@ -12,6 +12,8 @@ final class SessionDiscoveryCoordinator {
         var codexRecordsNeedPrune: Bool
         var claudeRecords: [ClaudeTrackedSessionRecord]
         var claudeRecordsNeedPrune: Bool
+        var openCodeRecords: [OpenCodeTrackedSessionRecord]
+        var openCodeRecordsNeedPrune: Bool
         var cursorRecords: [CursorTrackedSessionRecord]
         var cursorRecordsNeedPrune: Bool
         var discoveredCodexRecords: [CodexTrackedSessionRecord]
@@ -41,6 +43,9 @@ final class SessionDiscoveryCoordinator {
     private let claudeSessionRegistry = ClaudeSessionRegistry()
 
     @ObservationIgnored
+    private let openCodeSessionRegistry = OpenCodeSessionRegistry()
+
+    @ObservationIgnored
     private let cursorSessionRegistry = CursorSessionRegistry()
 
     @ObservationIgnored
@@ -57,6 +62,9 @@ final class SessionDiscoveryCoordinator {
 
     @ObservationIgnored
     private var claudeSessionPersistenceTask: Task<Void, Never>?
+
+    @ObservationIgnored
+    private var openCodeSessionPersistenceTask: Task<Void, Never>?
 
     @ObservationIgnored
     private var cursorSessionPersistenceTask: Task<Void, Never>?
@@ -81,6 +89,9 @@ final class SessionDiscoveryCoordinator {
         let allClaude = (try? claudeSessionRegistry.load()) ?? []
         let claudeRecords = allClaude.filter { $0.updatedAt >= cutoff && $0.shouldRestoreToLiveState }
 
+        let allOpenCode = (try? openCodeSessionRegistry.load()) ?? []
+        let openCodeRecords = allOpenCode.filter { $0.updatedAt >= cutoff }
+
         let allCursor = (try? cursorSessionRegistry.load()) ?? []
         let cursorRecords = allCursor.filter { $0.updatedAt >= cutoff && $0.shouldRestoreToLiveState }
 
@@ -92,6 +103,8 @@ final class SessionDiscoveryCoordinator {
             codexRecordsNeedPrune: codexRecords != allCodex,
             claudeRecords: claudeRecords,
             claudeRecordsNeedPrune: claudeRecords != allClaude,
+            openCodeRecords: openCodeRecords,
+            openCodeRecordsNeedPrune: openCodeRecords != allOpenCode,
             cursorRecords: cursorRecords,
             cursorRecordsNeedPrune: cursorRecords != allCursor,
             discoveredCodexRecords: discoveredCodex,
@@ -112,6 +125,9 @@ final class SessionDiscoveryCoordinator {
         if payload.claudeRecordsNeedPrune {
             try? claudeSessionRegistry.save(payload.claudeRecords)
         }
+        if payload.openCodeRecordsNeedPrune {
+            try? openCodeSessionRegistry.save(payload.openCodeRecords)
+        }
         if payload.cursorRecordsNeedPrune {
             try? cursorSessionRegistry.save(payload.cursorRecords)
         }
@@ -127,6 +143,13 @@ final class SessionDiscoveryCoordinator {
             let restoredSessions = payload.claudeRecords.map(\.restorableSession)
             state = SessionState(sessions: mergeDiscoveredSessions(restoredSessions))
             onStatusMessage?("Restored \(payload.claudeRecords.count) recent Claude session(s) from local registry.")
+        }
+
+        // Restore persisted OpenCode sessions.
+        if !payload.openCodeRecords.isEmpty {
+            let restoredSessions = payload.openCodeRecords.map(\.restorableSession)
+            state = SessionState(sessions: mergeDiscoveredSessions(restoredSessions))
+            onStatusMessage?("Restored \(payload.openCodeRecords.count) recent OpenCode session(s) from local registry.")
         }
 
         // Restore persisted Cursor sessions.
@@ -206,6 +229,7 @@ final class SessionDiscoveryCoordinator {
         merged.jumpTarget = existing.jumpTarget ?? discovered.jumpTarget
         merged.codexMetadata = mergeCodexMetadata(existing.codexMetadata, discovered.codexMetadata)
         merged.claudeMetadata = mergeClaudeMetadata(existing.claudeMetadata, discovered.claudeMetadata)
+        merged.openCodeMetadata = mergeOpenCodeMetadata(existing.openCodeMetadata, discovered.openCodeMetadata)
         merged.cursorMetadata = mergeCursorMetadata(existing.cursorMetadata, discovered.cursorMetadata)
         // Once a session is identified as a Codex.app session by any source
         // (hook or rediscovery), preserve that flag so liveness uses the
@@ -213,6 +237,29 @@ final class SessionDiscoveryCoordinator {
         merged.isCodexAppSession = existing.isCodexAppSession || discovered.isCodexAppSession
 
         return merged
+    }
+
+    private func mergeOpenCodeMetadata(
+        _ existing: OpenCodeSessionMetadata?,
+        _ discovered: OpenCodeSessionMetadata?
+    ) -> OpenCodeSessionMetadata? {
+        guard let existing else {
+            return discovered?.isEmpty == true ? nil : discovered
+        }
+
+        guard let discovered else {
+            return existing.isEmpty ? nil : existing
+        }
+
+        let merged = OpenCodeSessionMetadata(
+            initialUserPrompt: existing.initialUserPrompt ?? discovered.initialUserPrompt ?? discovered.lastUserPrompt,
+            lastUserPrompt: discovered.lastUserPrompt ?? existing.lastUserPrompt,
+            lastAssistantMessage: discovered.lastAssistantMessage ?? existing.lastAssistantMessage,
+            currentTool: discovered.currentTool ?? existing.currentTool,
+            currentToolInputPreview: discovered.currentToolInputPreview ?? existing.currentToolInputPreview,
+            model: discovered.model ?? existing.model
+        )
+        return merged.isEmpty ? nil : merged
     }
 
     private func mergeCursorMetadata(
@@ -430,6 +477,24 @@ final class SessionDiscoveryCoordinator {
         let registry = claudeSessionRegistry
 
         claudeSessionPersistenceTask = Task.detached(priority: .utility) {
+            try? await Task.sleep(for: .milliseconds(250))
+            try? registry.save(records)
+        }
+    }
+
+    func scheduleOpenCodeSessionPersistence() {
+        openCodeSessionPersistenceTask?.cancel()
+
+        let records = state.sessions
+            .filter {
+                $0.tool == .openCode
+                    && $0.isTrackedLiveSession
+                    && $0.updatedAt >= Date.now.addingTimeInterval(-86_400)
+            }
+            .map(OpenCodeTrackedSessionRecord.init(session:))
+        let registry = openCodeSessionRegistry
+
+        openCodeSessionPersistenceTask = Task.detached(priority: .utility) {
             try? await Task.sleep(for: .milliseconds(250))
             try? registry.save(records)
         }

--- a/Sources/OpenIslandCore/HookHealthCheck.swift
+++ b/Sources/OpenIslandCore/HookHealthCheck.swift
@@ -22,6 +22,8 @@ public struct HookHealthReport: Equatable, Sendable {
         case otherHooksDetected(names: [String])
         /// The manifest file is missing even though hooks appear installed.
         case manifestMissing(expectedPath: String)
+        /// The OpenCode plugin file is missing even though it should be installed.
+        case pluginMissing(expectedPath: String)
 
         public var description: String {
             switch self {
@@ -37,6 +39,8 @@ public struct HookHealthReport: Equatable, Sendable {
                 "Other hooks coexist: \(names.joined(separator: ", "))"
             case .manifestMissing(let expectedPath):
                 "Installation manifest missing: \(expectedPath)"
+            case .pluginMissing(let expectedPath):
+                "OpenCode plugin file is missing: \(expectedPath)"
             }
         }
 
@@ -51,7 +55,7 @@ public struct HookHealthReport: Equatable, Sendable {
 
         public var isAutoRepairable: Bool {
             switch self {
-            case .staleCommandPath, .binaryNotExecutable, .manifestMissing:
+            case .staleCommandPath, .binaryNotExecutable, .manifestMissing, .pluginMissing:
                 true
             default:
                 false
@@ -224,6 +228,31 @@ public enum HookHealthCheck {
             issues: issues,
             binaryPath: resolvedBinaryPath,
             configPath: hooksPath
+        )
+    }
+
+    /// Check OpenCode plugin health.
+    public static func checkOpenCode(
+        opencodeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".config/opencode", isDirectory: true),
+        fileManager: FileManager = .default
+    ) -> HookHealthReport {
+        var issues: [HookHealthReport.Issue] = []
+        let pluginsDir = opencodeDirectory.appendingPathComponent("plugins", isDirectory: true)
+        let pluginFileURL = pluginsDir.appendingPathComponent("open-island.js")
+
+        if !fileManager.fileExists(atPath: pluginFileURL.path) {
+            // Only report as an issue if the plugins directory itself exists,
+            // implying OpenCode is likely installed and intended to be used.
+            if fileManager.fileExists(atPath: opencodeDirectory.path) {
+                issues.append(.pluginMissing(expectedPath: pluginFileURL.path))
+            }
+        }
+
+        return HookHealthReport(
+            agent: "opencode",
+            issues: issues,
+            binaryPath: nil,
+            configPath: pluginFileURL.path
         )
     }
 

--- a/Sources/OpenIslandCore/OpenCodeSessionRegistry.swift
+++ b/Sources/OpenIslandCore/OpenCodeSessionRegistry.swift
@@ -1,0 +1,152 @@
+import Foundation
+
+public struct OpenCodeTrackedSessionRecord: Equatable, Codable, Sendable {
+    public var sessionID: String
+    public var title: String
+    public var origin: SessionOrigin?
+    public var attachmentState: SessionAttachmentState
+    public var summary: String
+    public var phase: SessionPhase
+    public var updatedAt: Date
+    public var jumpTarget: JumpTarget?
+    public var openCodeMetadata: OpenCodeSessionMetadata?
+
+    public init(
+        sessionID: String,
+        title: String,
+        origin: SessionOrigin? = nil,
+        attachmentState: SessionAttachmentState = .stale,
+        summary: String,
+        phase: SessionPhase,
+        updatedAt: Date,
+        jumpTarget: JumpTarget? = nil,
+        openCodeMetadata: OpenCodeSessionMetadata? = nil
+    ) {
+        self.sessionID = sessionID
+        self.title = title
+        self.origin = origin
+        self.attachmentState = attachmentState
+        self.summary = summary
+        self.phase = phase
+        self.updatedAt = updatedAt
+        self.jumpTarget = jumpTarget
+        self.openCodeMetadata = openCodeMetadata
+    }
+
+    public init(session: AgentSession) {
+        self.init(
+            sessionID: session.id,
+            title: session.title,
+            origin: session.origin,
+            attachmentState: session.attachmentState,
+            summary: session.summary,
+            phase: session.phase,
+            updatedAt: session.updatedAt,
+            jumpTarget: session.jumpTarget,
+            openCodeMetadata: session.openCodeMetadata
+        )
+    }
+
+    public var session: AgentSession {
+        AgentSession(
+            id: sessionID,
+            title: title,
+            tool: .openCode,
+            origin: origin,
+            attachmentState: attachmentState,
+            phase: phase,
+            summary: summary,
+            updatedAt: updatedAt,
+            jumpTarget: jumpTarget,
+            openCodeMetadata: openCodeMetadata
+        )
+    }
+
+    public var restorableSession: AgentSession {
+        var session = session
+        session.attachmentState = .stale
+        return session
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionID
+        case title
+        case origin
+        case attachmentState
+        case summary
+        case phase
+        case updatedAt
+        case jumpTarget
+        case openCodeMetadata
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        sessionID = try container.decode(String.self, forKey: .sessionID)
+        title = try container.decode(String.self, forKey: .title)
+        origin = try container.decodeIfPresent(SessionOrigin.self, forKey: .origin)
+        attachmentState = try container.decodeIfPresent(SessionAttachmentState.self, forKey: .attachmentState) ?? .stale
+        summary = try container.decode(String.self, forKey: .summary)
+        phase = try container.decode(SessionPhase.self, forKey: .phase)
+        updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+        jumpTarget = try container.decodeIfPresent(JumpTarget.self, forKey: .jumpTarget)
+        openCodeMetadata = try container.decodeIfPresent(OpenCodeSessionMetadata.self, forKey: .openCodeMetadata)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(sessionID, forKey: .sessionID)
+        try container.encode(title, forKey: .title)
+        try container.encodeIfPresent(origin, forKey: .origin)
+        try container.encode(attachmentState, forKey: .attachmentState)
+        try container.encode(summary, forKey: .summary)
+        try container.encode(phase, forKey: .phase)
+        try container.encode(updatedAt, forKey: .updatedAt)
+        try container.encodeIfPresent(jumpTarget, forKey: .jumpTarget)
+        try container.encodeIfPresent(openCodeMetadata, forKey: .openCodeMetadata)
+    }
+}
+
+public final class OpenCodeSessionRegistry: @unchecked Sendable {
+    public let fileURL: URL
+    private let fileManager: FileManager
+
+    public static var defaultDirectoryURL: URL {
+        CodexSessionStore.defaultDirectoryURL
+    }
+
+    public static var defaultFileURL: URL {
+        defaultDirectoryURL.appendingPathComponent("opencode-session-registry.json")
+    }
+
+    public init(
+        fileURL: URL = OpenCodeSessionRegistry.defaultFileURL,
+        fileManager: FileManager = .default
+    ) {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+    }
+
+    public func load() throws -> [OpenCodeTrackedSessionRecord] {
+        guard fileManager.fileExists(atPath: fileURL.path) else {
+            return []
+        }
+
+        let data = try Data(contentsOf: fileURL)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode([OpenCodeTrackedSessionRecord].self, from: data)
+    }
+
+    public func save(_ records: [OpenCodeTrackedSessionRecord]) throws {
+        let directoryURL = fileURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        let data = try encoder.encode(records)
+        try data.write(to: fileURL, options: .atomic)
+    }
+}

--- a/Tests/OpenIslandCoreTests/OpenCodeSessionRegistryTests.swift
+++ b/Tests/OpenIslandCoreTests/OpenCodeSessionRegistryTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+import OpenIslandCore
+
+final class OpenCodeSessionRegistryTests: XCTestCase {
+    var tempFileURL: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempFileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("json")
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempFileURL)
+        super.tearDown()
+    }
+
+    func testSaveAndLoad() throws {
+        let registry = OpenCodeSessionRegistry(fileURL: tempFileURL)
+        let records = [
+            OpenCodeTrackedSessionRecord(
+                sessionID: "opencode-1",
+                title: "Test Session",
+                origin: .live,
+                attachmentState: .attached,
+                summary: "Testing OpenCode persistence",
+                phase: .running,
+                updatedAt: Date(),
+                openCodeMetadata: OpenCodeSessionMetadata(
+                    initialUserPrompt: "Hello",
+                    model: "gpt-4"
+                )
+            )
+        ]
+
+        try registry.save(records)
+        let loaded = try registry.load()
+
+        XCTAssertEqual(loaded.count, 1)
+        XCTAssertEqual(loaded[0].sessionID, "opencode-1")
+        XCTAssertEqual(loaded[0].openCodeMetadata?.initialUserPrompt, "Hello")
+    }
+
+    func testLoadEmpty() throws {
+        let registry = OpenCodeSessionRegistry(fileURL: tempFileURL)
+        let loaded = try registry.load()
+        XCTAssertEqual(loaded.count, 0)
+    }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,10 @@ This index is the repository map for humans and coding agents. Read these files 
 - [docs/exec-plans/README.md](./exec-plans/README.md) for the active and completed execution-plan convention
 - [docs/references/README.md](./references/README.md) for pinned reference material and external behavior baselines
 
+## Superpowers Plans
+
+- [docs/superpowers/plans/2026-04-18-opencode-stability.md](./superpowers/plans/2026-04-18-opencode-stability.md) for the OpenCode stability implementation plan
+
 ## Runtime And Product Notes
 
 - [docs/notch-surface-model.md](./notch-surface-model.md) for the island surface routing model and debug harness intent

--- a/docs/superpowers/plans/2026-04-18-opencode-stability.md
+++ b/docs/superpowers/plans/2026-04-18-opencode-stability.md
@@ -1,0 +1,319 @@
+# OpenCode Stability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make OpenCode support as stable as Claude Code by adding session persistence, startup discovery, and refined liveness detection.
+
+**Architecture:** Implement `OpenCodeSessionRegistry` for persistence, integrate it into `SessionDiscoveryCoordinator` for startup recovery, and update `ProcessMonitoringCoordinator` to handle OpenCode sessions more robustly.
+
+**Tech Stack:** Swift, Observation framework, JSON persistence.
+
+---
+
+### Task 1: Create OpenCodeSessionRegistry
+
+**Files:**
+- Create: `Sources/OpenIslandCore/OpenCodeSessionRegistry.swift`
+
+- [ ] **Step 1: Implement OpenCodeTrackedSessionRecord and OpenCodeSessionRegistry**
+
+```swift
+import Foundation
+
+public struct OpenCodeTrackedSessionRecord: Equatable, Codable, Sendable {
+    public var sessionID: String
+    public var title: String
+    public var origin: SessionOrigin?
+    public var attachmentState: SessionAttachmentState
+    public var summary: String
+    public var phase: SessionPhase
+    public var updatedAt: Date
+    public var jumpTarget: JumpTarget?
+    public var openCodeMetadata: OpenCodeSessionMetadata?
+
+    public init(
+        sessionID: String,
+        title: String,
+        origin: SessionOrigin? = nil,
+        attachmentState: SessionAttachmentState = .stale,
+        summary: String,
+        phase: SessionPhase,
+        updatedAt: Date,
+        jumpTarget: JumpTarget? = nil,
+        openCodeMetadata: OpenCodeSessionMetadata? = nil
+    ) {
+        self.sessionID = sessionID
+        self.title = title
+        self.origin = origin
+        self.attachmentState = attachmentState
+        self.summary = summary
+        self.phase = phase
+        self.updatedAt = updatedAt
+        self.jumpTarget = jumpTarget
+        self.openCodeMetadata = openCodeMetadata
+    }
+
+    public init(session: AgentSession) {
+        self.init(
+            sessionID: session.id,
+            title: session.title,
+            origin: session.origin,
+            attachmentState: session.attachmentState,
+            summary: session.summary,
+            phase: session.phase,
+            updatedAt: session.updatedAt,
+            jumpTarget: session.jumpTarget,
+            openCodeMetadata: session.openCodeMetadata
+        )
+    }
+
+    public var session: AgentSession {
+        AgentSession(
+            id: sessionID,
+            title: title,
+            tool: .openCode,
+            origin: origin,
+            attachmentState: attachmentState,
+            phase: phase,
+            summary: summary,
+            updatedAt: updatedAt,
+            jumpTarget: jumpTarget,
+            openCodeMetadata: openCodeMetadata
+        )
+    }
+
+    public var restorableSession: AgentSession {
+        var session = session
+        session.attachmentState = .stale
+        return session
+    }
+}
+
+public final class OpenCodeSessionRegistry: @unchecked Sendable {
+    public let fileURL: URL
+    private let fileManager: FileManager
+
+    public static var defaultDirectoryURL: URL {
+        CodexSessionStore.defaultDirectoryURL
+    }
+
+    public static var defaultFileURL: URL {
+        defaultDirectoryURL.appendingPathComponent("opencode-session-registry.json")
+    }
+
+    public init(
+        fileURL: URL = OpenCodeSessionRegistry.defaultFileURL,
+        fileManager: FileManager = .default
+    ) {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+    }
+
+    public func load() throws -> [OpenCodeTrackedSessionRecord] {
+        guard fileManager.fileExists(atPath: fileURL.path) else {
+            return []
+        }
+
+        let data = try Data(contentsOf: fileURL)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode([OpenCodeTrackedSessionRecord].self, from: data)
+    }
+
+    public func save(_ records: [OpenCodeTrackedSessionRecord]) throws {
+        let directoryURL = fileURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        let data = try encoder.encode(records)
+        try data.write(to: fileURL, options: .atomic)
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add Sources/OpenIslandCore/OpenCodeSessionRegistry.swift
+git commit -m "feat: add OpenCodeSessionRegistry for session persistence"
+```
+
+---
+
+### Task 2: Integrate into SessionDiscoveryCoordinator
+
+**Files:**
+- Modify: `Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift`
+
+- [ ] **Step 1: Add OpenCode fields to StartupDiscoveryPayload**
+
+```swift
+    struct StartupDiscoveryPayload: Sendable {
+        // ...
+        var openCodeRecords: [OpenCodeTrackedSessionRecord]
+        var openCodeRecordsNeedPrune: Bool
+        // ...
+    }
+```
+
+- [ ] **Step 2: Initialize OpenCodeSessionRegistry and add persistence task**
+
+```swift
+    @ObservationIgnored
+    private let openCodeSessionRegistry = OpenCodeSessionRegistry()
+
+    @ObservationIgnored
+    private var openCodeSessionPersistenceTask: Task<Void, Never>?
+```
+
+- [ ] **Step 3: Update loadStartupDiscoveryPayload to load OpenCode records**
+
+```swift
+    nonisolated func loadStartupDiscoveryPayload() -> StartupDiscoveryPayload {
+        // ...
+        let allOpenCode = (try? openCodeSessionRegistry.load()) ?? []
+        let openCodeRecords = allOpenCode.filter { $0.updatedAt >= cutoff }
+        // ...
+        return StartupDiscoveryPayload(
+            // ...
+            openCodeRecords: openCodeRecords,
+            openCodeRecordsNeedPrune: openCodeRecords != allOpenCode,
+            // ...
+        )
+    }
+```
+
+- [ ] **Step 4: Update applyStartupDiscoveryPayload to restore OpenCode sessions**
+
+```swift
+    func applyStartupDiscoveryPayload(_ payload: StartupDiscoveryPayload) {
+        // ...
+        if payload.openCodeRecordsNeedPrune {
+            try? openCodeSessionRegistry.save(payload.openCodeRecords)
+        }
+
+        // Restore persisted OpenCode sessions.
+        if !payload.openCodeRecords.isEmpty {
+            let restoredSessions = payload.openCodeRecords.map(\.restorableSession)
+            state = SessionState(sessions: mergeDiscoveredSessions(restoredSessions))
+            onStatusMessage?("Restored \(payload.openCodeRecords.count) recent OpenCode session(s) from local registry.")
+        }
+        // ...
+    }
+```
+
+- [ ] **Step 5: Add scheduleOpenCodeSessionPersistence method**
+
+```swift
+    func scheduleOpenCodeSessionPersistence() {
+        openCodeSessionPersistenceTask?.cancel()
+
+        let records = state.sessions
+            .filter {
+                $0.tool == .openCode
+                    && $0.isTrackedLiveSession
+                    && $0.updatedAt >= Date.now.addingTimeInterval(-86_400)
+            }
+            .map(OpenCodeTrackedSessionRecord.init(session:))
+        let registry = openCodeSessionRegistry
+
+        openCodeSessionPersistenceTask = Task.detached(priority: .utility) {
+            try? await Task.sleep(for: .milliseconds(250))
+            try? registry.save(records)
+        }
+    }
+```
+
+- [ ] **Step 6: Update merge method to handle OpenCode metadata**
+
+```swift
+    private func merge(discovered: AgentSession, into existing: AgentSession) -> AgentSession {
+        // ...
+        merged.openCodeMetadata = mergeOpenCodeMetadata(existing.openCodeMetadata, discovered.openCodeMetadata)
+        // ...
+    }
+
+    private func mergeOpenCodeMetadata(
+        _ existing: OpenCodeSessionMetadata?,
+        _ discovered: OpenCodeSessionMetadata?
+    ) -> OpenCodeSessionMetadata? {
+        guard let existing else {
+            return discovered?.isEmpty == true ? nil : discovered
+        }
+
+        guard let discovered else {
+            return existing.isEmpty ? nil : existing
+        }
+
+        let merged = OpenCodeSessionMetadata(
+            initialUserPrompt: existing.initialUserPrompt ?? discovered.initialUserPrompt ?? discovered.lastUserPrompt,
+            lastUserPrompt: discovered.lastUserPrompt ?? existing.lastUserPrompt,
+            lastAssistantMessage: discovered.lastAssistantMessage ?? existing.lastAssistantMessage,
+            currentTool: discovered.currentTool ?? existing.currentTool,
+            currentToolInputPreview: discovered.currentToolInputPreview ?? existing.currentToolInputPreview,
+            model: discovered.model ?? existing.model
+        )
+        return merged.isEmpty ? nil : merged
+    }
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
+git commit -m "feat: integrate OpenCode session persistence into SessionDiscoveryCoordinator"
+```
+
+---
+
+### Task 3: Update AppModel and ProcessMonitoringCoordinator
+
+**Files:**
+- Modify: `Sources/OpenIslandApp/AppModel.swift`
+- Modify: `Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift`
+
+- [ ] **Step 1: Call scheduleOpenCodeSessionPersistence in AppModel**
+
+In `AppModel.handleBridgeCommand`, specifically in `processOpenCodeHook` case, call `discovery.scheduleOpenCodeSessionPersistence()`.
+
+- [ ] **Step 2: Update ProcessMonitoringCoordinator to trigger persistence on reconciliation**
+
+Ensure `onPersistenceNeeded?()` is called when OpenCode sessions change.
+
+- [ ] **Step 3: Refine liveness detection in ProcessMonitoringCoordinator**
+
+Actually, OpenCode is already managed by hooks (`SessionStart`, `SessionEnd`). We should mark it as `isHookManaged = true`.
+
+Modify `AppModel.swift` in `handleOpenCodeHook`:
+```swift
+    private func handleOpenCodeHook(_ payload: OpenCodeHookPayload) {
+        // ...
+        var session = sessions.first { $0.id == payload.sessionID } ?? AgentSession(...)
+        session.isHookManaged = true
+        // ...
+    }
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/OpenIslandApp/AppModel.swift Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+git commit -m "feat: mark OpenCode sessions as hook-managed and trigger persistence"
+```
+
+---
+
+### Task 4: Verification
+
+- [ ] **Step 1: Verify OpenCode sessions are saved and restored**
+1. Start OpenCode session (via script or real usage).
+2. Check `~/Library/Application Support/open-island/opencode-session-registry.json`.
+3. Restart Open Island.
+4. Verify session is restored in the UI.
+
+- [ ] **Step 2: Verify metadata merging**
+1. Trigger multiple updates for the same OpenCode session.
+2. Verify metadata is merged correctly in `AgentSession`.


### PR DESCRIPTION
- Refine `isOpenCodeProcess` to parse argv tokens instead of relying on broad substring matches, preventing unrelated processes (e.g., `vim ~/.opencode/...`) from keeping sessions alive.
- Add robust support for package runners (`npx`, `npm exec`, `yarn`, `pnpm dlx`) executing the `opencode` CLI.
- Deduplicate process snapshots by TTY and working directory rather than PID. This ensures that a package runner and its child Node process don't produce duplicate snapshots.
- Overhaul OpenCode session liveness in `ProcessMonitoringCoordinator` by uniquely matching active processes to tracked sessions via their TTY and normalized working directories.
- Eliminate the previous fallback that blindly marked all OpenCode sessions alive if any OpenCode process existed.
- Prevent claiming a session when the TTY matches but the working directory explicitly differs (e.g., terminal tab was reused for a different workspace).
- Fallback to keeping remaining unclaimed sessions alive only if there are active OpenCode processes that couldn't be uniquely matched, preventing accidental session termination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate OpenCode process detection, including launches via package runners and explicit CLI/node invocations.
  * Consistent capture of process working directories in snapshots for improved context.
  * Reduced duplicate snapshots by deduplicating based on terminal and working directory information.
  * Populate terminal application info and resolve tmux-derived details on snapshots when available.
  * Refined per-process session liveness matching to avoid incorrectly ending or duplicating OpenCode sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->