### PR TITLE
feat: add Hermes Agent status integration

### DIFF
--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -128,6 +128,23 @@ struct ActiveAgentProcessDiscovery {
                     terminalTTY: process.terminalTTY,
                     terminalApp: terminalApp(for: process, processesByPID: processesByPID)
                 ))
+                continue
+            }
+
+            if isHermesProcess(command: process.command) {
+                let claimKey = "hermes:\(process.pid)"
+                guard claimedKeys.insert(claimKey).inserted else {
+                    continue
+                }
+
+                let lsofOutput = lsofOutput(pid: process.pid)
+                snapshots.append(ProcessSnapshot(
+                    tool: .hermes,
+                    sessionID: nil,
+                    workingDirectory: lsofOutput.flatMap(workingDirectory(from:)),
+                    terminalTTY: process.terminalTTY,
+                    terminalApp: terminalApp(for: process, processesByPID: processesByPID)
+                ))
             }
         }
 
@@ -532,6 +549,37 @@ struct ActiveAgentProcessDiscovery {
             || lowered.contains("/bin/gemini")
             || lowered.contains("/google/gemini-cli")
             || lowered.contains("/@google/gemini-cli")
+    }
+
+    /// Matches Hermes CLI processes (`hermes` / `python -m hermes_cli.main`).
+    /// Excludes `hermes gateway`, which runs Hermes as a background daemon
+    /// rather than as an interactive coding agent in a terminal.
+    private func isHermesProcess(command: String) -> Bool {
+        let lowered = command.lowercased()
+        let tokens = lowered.split(separator: " ", omittingEmptySubsequences: true).map(String.init)
+        guard let firstToken = tokens.first else {
+            return false
+        }
+
+        let matchesHermesBinary = firstToken == "hermes"
+            || firstToken.hasSuffix("/hermes")
+            || lowered.contains("/bin/hermes")
+
+        let matchesHermesModule = lowered.contains("hermes_cli.main")
+            || lowered.contains("hermes_cli/main")
+            || lowered.contains("-m hermes_cli")
+
+        guard matchesHermesBinary || matchesHermesModule else {
+            return false
+        }
+
+        // Exclude gateway/daemon invocations: `hermes gateway ...` or
+        // `python -m hermes_cli.main gateway ...`.
+        if tokens.dropFirst().contains("gateway") {
+            return false
+        }
+
+        return true
     }
 
     /// Returns `true` when the given `ps` command string belongs to a Claude Code process.

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1179,6 +1179,7 @@ final class AppModel {
                 case let .geminiSessionMetadataUpdated(p): return p.sessionID
                 case let .openCodeSessionMetadataUpdated(p): return p.sessionID
                 case let .cursorSessionMetadataUpdated(p): return p.sessionID
+                case let .hermesSessionMetadataUpdated(p): return p.sessionID
                 case let .actionableStateResolved(p): return p.sessionID
                 }
             }()
@@ -1439,6 +1440,12 @@ final class AppModel {
             }
 
             return payload.cursorMetadata.lastAssistantMessage ?? "Cursor session metadata updated."
+        case let .hermesSessionMetadataUpdated(payload):
+            if let currentTool = payload.hermesMetadata.currentTool {
+                return "Hermes is running \(currentTool)."
+            }
+
+            return payload.hermesMetadata.lastAssistantMessage ?? "Hermes session metadata updated."
         case let .actionableStateResolved(payload):
             return "Actionable state resolved for session \(payload.sessionID)."
         }

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -250,6 +250,8 @@ final class ProcessMonitoringCoordinator {
             payload.sessionID
         case let .cursorSessionMetadataUpdated(payload):
             payload.sessionID
+        case let .hermesSessionMetadataUpdated(payload):
+            payload.sessionID
         case let .actionableStateResolved(payload):
             payload.sessionID
         }
@@ -906,6 +908,8 @@ final class ProcessMonitoringCoordinator {
             return "CodeBuddy \(session.id.prefix(8))"
         case .cursor:
             return "Cursor \(session.id.prefix(8))"
+        case .hermes:
+            return "Hermes \(session.id.prefix(8))"
         }
     }
 }

--- a/Sources/OpenIslandCore/AgentEvent.swift
+++ b/Sources/OpenIslandCore/AgentEvent.swift
@@ -14,6 +14,7 @@ public struct SessionStarted: Equatable, Codable, Sendable {
     public var geminiMetadata: GeminiSessionMetadata?
     public var openCodeMetadata: OpenCodeSessionMetadata?
     public var cursorMetadata: CursorSessionMetadata?
+    public var hermesMetadata: HermesSessionMetadata?
     public var isRemote: Bool
 
     public init(
@@ -30,6 +31,7 @@ public struct SessionStarted: Equatable, Codable, Sendable {
         geminiMetadata: GeminiSessionMetadata? = nil,
         openCodeMetadata: OpenCodeSessionMetadata? = nil,
         cursorMetadata: CursorSessionMetadata? = nil,
+        hermesMetadata: HermesSessionMetadata? = nil,
         isRemote: Bool = false
     ) {
         self.sessionID = sessionID
@@ -45,6 +47,7 @@ public struct SessionStarted: Equatable, Codable, Sendable {
         self.geminiMetadata = geminiMetadata
         self.openCodeMetadata = openCodeMetadata
         self.cursorMetadata = cursorMetadata
+        self.hermesMetadata = hermesMetadata
         self.isRemote = isRemote
     }
 }
@@ -222,6 +225,22 @@ public struct CursorSessionMetadataUpdated: Equatable, Codable, Sendable {
     }
 }
 
+public struct HermesSessionMetadataUpdated: Equatable, Codable, Sendable {
+    public var sessionID: String
+    public var hermesMetadata: HermesSessionMetadata
+    public var timestamp: Date
+
+    public init(
+        sessionID: String,
+        hermesMetadata: HermesSessionMetadata,
+        timestamp: Date
+    ) {
+        self.sessionID = sessionID
+        self.hermesMetadata = hermesMetadata
+        self.timestamp = timestamp
+    }
+}
+
 public struct ActionableStateResolved: Equatable, Codable, Sendable {
     public var sessionID: String
     public var summary: String
@@ -250,6 +269,7 @@ public enum AgentEvent: Equatable, Codable, Sendable {
     case geminiSessionMetadataUpdated(GeminiSessionMetadataUpdated)
     case openCodeSessionMetadataUpdated(OpenCodeSessionMetadataUpdated)
     case cursorSessionMetadataUpdated(CursorSessionMetadataUpdated)
+    case hermesSessionMetadataUpdated(HermesSessionMetadataUpdated)
     case actionableStateResolved(ActionableStateResolved)
 
     private enum CodingKeys: String, CodingKey {
@@ -265,6 +285,7 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case geminiSessionMetadataUpdated
         case openCodeSessionMetadataUpdated
         case cursorSessionMetadataUpdated
+        case hermesSessionMetadataUpdated
         case actionableStateResolved
     }
 
@@ -280,6 +301,7 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case geminiSessionMetadataUpdated
         case openCodeSessionMetadataUpdated
         case cursorSessionMetadataUpdated
+        case hermesSessionMetadataUpdated
         case actionableStateResolved
     }
 
@@ -317,6 +339,10 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case .cursorSessionMetadataUpdated:
             self = .cursorSessionMetadataUpdated(
                 try container.decode(CursorSessionMetadataUpdated.self, forKey: .cursorSessionMetadataUpdated)
+            )
+        case .hermesSessionMetadataUpdated:
+            self = .hermesSessionMetadataUpdated(
+                try container.decode(HermesSessionMetadataUpdated.self, forKey: .hermesSessionMetadataUpdated)
             )
         case .actionableStateResolved:
             self = .actionableStateResolved(
@@ -362,6 +388,9 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case let .cursorSessionMetadataUpdated(payload):
             try container.encode(EventType.cursorSessionMetadataUpdated, forKey: .type)
             try container.encode(payload, forKey: .cursorSessionMetadataUpdated)
+        case let .hermesSessionMetadataUpdated(payload):
+            try container.encode(EventType.hermesSessionMetadataUpdated, forKey: .type)
+            try container.encode(payload, forKey: .hermesSessionMetadataUpdated)
         case let .actionableStateResolved(payload):
             try container.encode(EventType.actionableStateResolved, forKey: .type)
             try container.encode(payload, forKey: .actionableStateResolved)

--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -10,6 +10,7 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
     case factory
     case codebuddy
     case cursor
+    case hermes
 
     public var displayName: String {
         switch self {
@@ -31,6 +32,8 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
             "CodeBuddy"
         case .cursor:
             "Cursor"
+        case .hermes:
+            "Hermes"
         }
     }
 
@@ -54,6 +57,8 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
             "CODEBUDDY"
         case .cursor:
             "CURSOR"
+        case .hermes:
+            "HERMES"
         }
     }
 
@@ -334,6 +339,7 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
     public var geminiMetadata: GeminiSessionMetadata?
     public var openCodeMetadata: OpenCodeSessionMetadata?
     public var cursorMetadata: CursorSessionMetadata?
+    public var hermesMetadata: HermesSessionMetadata?
 
     /// Whether this session originates from a remote (SSH) connection.
     public var isRemote: Bool = false
@@ -378,7 +384,8 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
         claudeMetadata: ClaudeSessionMetadata? = nil,
         geminiMetadata: GeminiSessionMetadata? = nil,
         openCodeMetadata: OpenCodeSessionMetadata? = nil,
-        cursorMetadata: CursorSessionMetadata? = nil
+        cursorMetadata: CursorSessionMetadata? = nil,
+        hermesMetadata: HermesSessionMetadata? = nil
     ) {
         self.id = id
         self.title = title
@@ -396,6 +403,7 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
         self.geminiMetadata = geminiMetadata
         self.openCodeMetadata = openCodeMetadata
         self.cursorMetadata = cursorMetadata
+        self.hermesMetadata = hermesMetadata
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -415,6 +423,7 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
         case geminiMetadata
         case openCodeMetadata
         case cursorMetadata
+        case hermesMetadata
     }
 
     public init(from decoder: any Decoder) throws {
@@ -435,6 +444,7 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
         geminiMetadata = try container.decodeIfPresent(GeminiSessionMetadata.self, forKey: .geminiMetadata)
         openCodeMetadata = try container.decodeIfPresent(OpenCodeSessionMetadata.self, forKey: .openCodeMetadata)
         cursorMetadata = try container.decodeIfPresent(CursorSessionMetadata.self, forKey: .cursorMetadata)
+        hermesMetadata = try container.decodeIfPresent(HermesSessionMetadata.self, forKey: .hermesMetadata)
     }
 
     public func encode(to encoder: any Encoder) throws {
@@ -455,6 +465,7 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
         try container.encodeIfPresent(geminiMetadata, forKey: .geminiMetadata)
         try container.encodeIfPresent(openCodeMetadata, forKey: .openCodeMetadata)
         try container.encodeIfPresent(cursorMetadata, forKey: .cursorMetadata)
+        try container.encodeIfPresent(hermesMetadata, forKey: .hermesMetadata)
     }
 }
 
@@ -464,7 +475,7 @@ public extension AgentSession {
     }
 
     var isTrackedLiveSession: Bool {
-        !isDemoSession && (tool == .codex || tool == .claudeCode || tool == .geminiCLI || tool == .openCode || tool == .qoder || tool == .qwenCode || tool == .factory || tool == .codebuddy || tool == .cursor)
+        !isDemoSession && (tool == .codex || tool == .claudeCode || tool == .geminiCLI || tool == .openCode || tool == .qoder || tool == .qwenCode || tool == .factory || tool == .codebuddy || tool == .cursor || tool == .hermes)
     }
 
     var isTrackedLiveCodexSession: Bool {
@@ -491,11 +502,11 @@ public extension AgentSession {
     }
 
     var currentToolName: String? {
-        codexMetadata?.currentTool ?? claudeMetadata?.currentTool ?? openCodeMetadata?.currentTool ?? cursorMetadata?.currentTool
+        codexMetadata?.currentTool ?? claudeMetadata?.currentTool ?? openCodeMetadata?.currentTool ?? cursorMetadata?.currentTool ?? hermesMetadata?.currentTool
     }
 
     var lastAssistantMessageText: String? {
-        codexMetadata?.lastAssistantMessage ?? claudeMetadata?.lastAssistantMessage ?? geminiMetadata?.lastAssistantMessage ?? openCodeMetadata?.lastAssistantMessage ?? cursorMetadata?.lastAssistantMessage
+        codexMetadata?.lastAssistantMessage ?? claudeMetadata?.lastAssistantMessage ?? geminiMetadata?.lastAssistantMessage ?? openCodeMetadata?.lastAssistantMessage ?? cursorMetadata?.lastAssistantMessage ?? hermesMetadata?.lastAssistantMessage
     }
 
     var completionAssistantMessageText: String? {
@@ -517,15 +528,15 @@ public extension AgentSession {
     }
 
     var latestUserPromptText: String? {
-        codexMetadata?.lastUserPrompt ?? claudeMetadata?.lastUserPrompt ?? geminiMetadata?.lastUserPrompt ?? openCodeMetadata?.lastUserPrompt ?? cursorMetadata?.lastUserPrompt
+        codexMetadata?.lastUserPrompt ?? claudeMetadata?.lastUserPrompt ?? geminiMetadata?.lastUserPrompt ?? openCodeMetadata?.lastUserPrompt ?? cursorMetadata?.lastUserPrompt ?? hermesMetadata?.lastUserPrompt
     }
 
     var initialUserPromptText: String? {
-        codexMetadata?.initialUserPrompt ?? claudeMetadata?.initialUserPrompt ?? geminiMetadata?.initialUserPrompt ?? openCodeMetadata?.initialUserPrompt ?? cursorMetadata?.initialUserPrompt
+        codexMetadata?.initialUserPrompt ?? claudeMetadata?.initialUserPrompt ?? geminiMetadata?.initialUserPrompt ?? openCodeMetadata?.initialUserPrompt ?? cursorMetadata?.initialUserPrompt ?? hermesMetadata?.initialUserPrompt
     }
 
     var currentCommandPreviewText: String? {
-        codexMetadata?.currentCommandPreview ?? claudeMetadata?.currentToolInputPreview ?? openCodeMetadata?.currentToolInputPreview ?? cursorMetadata?.currentToolInputPreview
+        codexMetadata?.currentCommandPreview ?? claudeMetadata?.currentToolInputPreview ?? openCodeMetadata?.currentToolInputPreview ?? cursorMetadata?.currentToolInputPreview ?? hermesMetadata?.currentToolInputPreview
     }
 }
 

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -434,6 +434,9 @@ public final class BridgeServer: @unchecked Sendable {
 
         case let .processGeminiHook(payload):
             handleGeminiHook(payload, from: clientID)
+
+        case let .processHermesHook(payload):
+            handleHermesHook(payload, from: clientID)
         }
     }
 
@@ -1383,6 +1386,157 @@ public final class BridgeServer: @unchecked Sendable {
                 GeminiSessionMetadataUpdated(
                     sessionID: payload.sessionID,
                     geminiMetadata: merged,
+                    timestamp: .now
+                )
+            )
+        )
+    }
+
+    private func handleHermesHook(_ payload: HermesHookPayload, from clientID: UUID) {
+        switch payload.hookEventName {
+        case .sessionStart:
+            emit(
+                .sessionStarted(
+                    SessionStarted(
+                        sessionID: payload.sessionID,
+                        title: payload.sessionTitle,
+                        tool: .hermes,
+                        origin: .live,
+                        initialPhase: .running,
+                        summary: payload.implicitSummary,
+                        timestamp: .now,
+                        jumpTarget: payload.defaultJumpTarget,
+                        hermesMetadata: payload.defaultHermesMetadata.isEmpty ? nil : payload.defaultHermesMetadata
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .preToolCall:
+            ensureHermesSessionExists(for: payload)
+            synchronizeHermesJumpTarget(for: payload)
+            synchronizeHermesMetadata(for: payload, clearToolState: false)
+            emit(
+                .activityUpdated(
+                    SessionActivityUpdated(
+                        sessionID: payload.sessionID,
+                        summary: payload.implicitSummary,
+                        phase: .running,
+                        timestamp: .now
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .postToolCall:
+            ensureHermesSessionExists(for: payload)
+            synchronizeHermesJumpTarget(for: payload)
+            synchronizeHermesMetadata(for: payload, clearToolState: true)
+            emit(
+                .activityUpdated(
+                    SessionActivityUpdated(
+                        sessionID: payload.sessionID,
+                        summary: payload.implicitSummary,
+                        phase: .running,
+                        timestamp: .now
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .sessionEnd:
+            ensureHermesSessionExists(for: payload)
+            synchronizeHermesJumpTarget(for: payload)
+            synchronizeHermesMetadata(for: payload, clearToolState: true)
+            emit(
+                .sessionCompleted(
+                    SessionCompleted(
+                        sessionID: payload.sessionID,
+                        summary: payload.implicitSummary,
+                        timestamp: .now,
+                        isInterrupt: payload.interrupted == true ? true : nil,
+                        isSessionEnd: true
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+        }
+    }
+
+    private func ensureHermesSessionExists(for payload: HermesHookPayload) {
+        guard !hasSession(id: payload.sessionID) else {
+            return
+        }
+
+        emit(
+            .sessionStarted(
+                SessionStarted(
+                    sessionID: payload.sessionID,
+                    title: payload.sessionTitle,
+                    tool: .hermes,
+                    origin: .live,
+                    initialPhase: .running,
+                    summary: payload.implicitSummary,
+                    timestamp: .now,
+                    jumpTarget: payload.defaultJumpTarget,
+                    hermesMetadata: payload.defaultHermesMetadata.isEmpty ? nil : payload.defaultHermesMetadata
+                )
+            )
+        )
+    }
+
+    private func synchronizeHermesJumpTarget(for payload: HermesHookPayload) {
+        guard let existingSession = localState.session(id: payload.sessionID) else {
+            return
+        }
+
+        let jumpTarget = Self.mergeJumpTargetPreservingExistingResolvedFields(
+            incoming: payload.defaultJumpTarget,
+            existing: existingSession.jumpTarget
+        )
+
+        guard existingSession.jumpTarget != jumpTarget else {
+            return
+        }
+
+        emit(
+            .jumpTargetUpdated(
+                JumpTargetUpdated(
+                    sessionID: payload.sessionID,
+                    jumpTarget: jumpTarget,
+                    timestamp: .now
+                )
+            )
+        )
+    }
+
+    private func synchronizeHermesMetadata(for payload: HermesHookPayload, clearToolState: Bool) {
+        guard let existingSession = localState.session(id: payload.sessionID) else {
+            return
+        }
+
+        let update = payload.defaultHermesMetadata
+        let existing = existingSession.hermesMetadata
+
+        let merged = HermesSessionMetadata(
+            initialUserPrompt: existing?.initialUserPrompt ?? update.initialUserPrompt,
+            lastUserPrompt: update.lastUserPrompt ?? existing?.lastUserPrompt,
+            lastAssistantMessage: update.lastAssistantMessage ?? existing?.lastAssistantMessage,
+            currentTool: clearToolState ? nil : (update.currentTool ?? existing?.currentTool),
+            currentToolInputPreview: clearToolState ? nil : (update.currentToolInputPreview ?? existing?.currentToolInputPreview),
+            model: update.model ?? existing?.model,
+            cwd: update.cwd ?? existing?.cwd
+        )
+
+        guard existing != merged else {
+            return
+        }
+
+        emit(
+            .hermesSessionMetadataUpdated(
+                HermesSessionMetadataUpdated(
+                    sessionID: payload.sessionID,
+                    hermesMetadata: merged,
                     timestamp: .now
                 )
             )

--- a/Sources/OpenIslandCore/BridgeTransport.swift
+++ b/Sources/OpenIslandCore/BridgeTransport.swift
@@ -89,6 +89,7 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
     case processOpenCodeHook(OpenCodeHookPayload)
     case processCursorHook(CursorHookPayload)
     case processGeminiHook(GeminiHookPayload)
+    case processHermesHook(HermesHookPayload)
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -102,6 +103,7 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
         case openCodeHook
         case cursorHook
         case geminiHook
+        case hermesHook
     }
 
     private enum CommandType: String, Codable {
@@ -114,6 +116,7 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
         case processOpenCodeHook
         case processCursorHook
         case processGeminiHook
+        case processHermesHook
     }
 
     public init(from decoder: any Decoder) throws {
@@ -148,6 +151,8 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
             self = .processCursorHook(try container.decode(CursorHookPayload.self, forKey: .cursorHook))
         case .processGeminiHook:
             self = .processGeminiHook(try container.decode(GeminiHookPayload.self, forKey: .geminiHook))
+        case .processHermesHook:
+            self = .processHermesHook(try container.decode(HermesHookPayload.self, forKey: .hermesHook))
         }
     }
 
@@ -185,6 +190,9 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
         case let .processGeminiHook(payload):
             try container.encode(CommandType.processGeminiHook, forKey: .type)
             try container.encode(payload, forKey: .geminiHook)
+        case let .processHermesHook(payload):
+            try container.encode(CommandType.processHermesHook, forKey: .type)
+            try container.encode(payload, forKey: .hermesHook)
         }
     }
 }

--- a/Sources/OpenIslandCore/HermesHookInstallationManager.swift
+++ b/Sources/OpenIslandCore/HermesHookInstallationManager.swift
@@ -1,0 +1,180 @@
+import Foundation
+
+public struct HermesHookInstallationStatus: Equatable, Sendable {
+    public var hermesDirectory: URL
+    public var pluginDirectory: URL
+    public var pluginYAMLURL: URL
+    public var pluginInitURL: URL
+    public var manifestURL: URL
+    public var hooksBinaryURL: URL?
+    public var managedHooksPresent: Bool
+    public var hasForeignPluginDirectory: Bool
+    public var manifest: HermesHookInstallerManifest?
+
+    public init(
+        hermesDirectory: URL,
+        pluginDirectory: URL,
+        pluginYAMLURL: URL,
+        pluginInitURL: URL,
+        manifestURL: URL,
+        hooksBinaryURL: URL?,
+        managedHooksPresent: Bool,
+        hasForeignPluginDirectory: Bool,
+        manifest: HermesHookInstallerManifest?
+    ) {
+        self.hermesDirectory = hermesDirectory
+        self.pluginDirectory = pluginDirectory
+        self.pluginYAMLURL = pluginYAMLURL
+        self.pluginInitURL = pluginInitURL
+        self.manifestURL = manifestURL
+        self.hooksBinaryURL = hooksBinaryURL
+        self.managedHooksPresent = managedHooksPresent
+        self.hasForeignPluginDirectory = hasForeignPluginDirectory
+        self.manifest = manifest
+    }
+}
+
+public final class HermesHookInstallationManager: @unchecked Sendable {
+    public let hermesDirectory: URL
+    public let pluginDirectory: URL
+    public let managedHooksBinaryURL: URL
+    private let fileManager: FileManager
+
+    public init(
+        hermesDirectory: URL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".hermes", isDirectory: true),
+        managedHooksBinaryURL: URL = ManagedHooksBinary.defaultURL(),
+        fileManager: FileManager = .default
+    ) {
+        self.hermesDirectory = hermesDirectory
+        self.pluginDirectory = hermesDirectory
+            .appendingPathComponent("plugins", isDirectory: true)
+            .appendingPathComponent(HermesHookInstaller.pluginDirectoryName, isDirectory: true)
+        self.managedHooksBinaryURL = managedHooksBinaryURL.standardizedFileURL
+        self.fileManager = fileManager
+    }
+
+    public func status(hooksBinaryURL: URL? = nil) throws -> HermesHookInstallationStatus {
+        let pluginYAMLURL = pluginDirectory.appendingPathComponent("plugin.yaml")
+        let pluginInitURL = pluginDirectory.appendingPathComponent("__init__.py")
+        let manifestURL = pluginDirectory.appendingPathComponent(HermesHookInstallerManifest.fileName)
+        let resolvedBinaryURL = resolvedHooksBinaryURL(explicitURL: hooksBinaryURL)
+        let manifest = try loadManifest(at: manifestURL)
+
+        let pluginDirectoryExists = fileManager.fileExists(atPath: pluginDirectory.path)
+        let yamlData = try? Data(contentsOf: pluginYAMLURL)
+        let isManaged = HermesHookInstaller.isManagedPlugin(pluginYAMLData: yamlData)
+        let managedHooksPresent = pluginDirectoryExists
+            && isManaged
+            && fileManager.fileExists(atPath: pluginInitURL.path)
+        let hasForeignPluginDirectory = pluginDirectoryExists && !isManaged
+
+        return HermesHookInstallationStatus(
+            hermesDirectory: hermesDirectory,
+            pluginDirectory: pluginDirectory,
+            pluginYAMLURL: pluginYAMLURL,
+            pluginInitURL: pluginInitURL,
+            manifestURL: manifestURL,
+            hooksBinaryURL: resolvedBinaryURL,
+            managedHooksPresent: managedHooksPresent,
+            hasForeignPluginDirectory: hasForeignPluginDirectory,
+            manifest: manifest
+        )
+    }
+
+    @discardableResult
+    public func install(hooksBinaryURL: URL) throws -> HermesHookInstallationStatus {
+        try fileManager.createDirectory(at: pluginDirectory, withIntermediateDirectories: true)
+
+        let installedBinaryURL = try ManagedHooksBinary.install(
+            from: hooksBinaryURL,
+            to: managedHooksBinaryURL,
+            fileManager: fileManager
+        )
+
+        let pluginYAMLURL = pluginDirectory.appendingPathComponent("plugin.yaml")
+        let pluginInitURL = pluginDirectory.appendingPathComponent("__init__.py")
+        let manifestURL = pluginDirectory.appendingPathComponent(HermesHookInstallerManifest.fileName)
+
+        // If a foreign plugin lives at this path, refuse to clobber it. The
+        // caller can clean it up manually or pass a different directory.
+        if fileManager.fileExists(atPath: pluginYAMLURL.path) {
+            let yamlData = try? Data(contentsOf: pluginYAMLURL)
+            if !HermesHookInstaller.isManagedPlugin(pluginYAMLData: yamlData) {
+                throw HermesHookInstallationError.foreignPluginAtPath(pluginDirectory.path)
+            }
+        }
+
+        let assets = HermesHookInstaller.renderPluginAssets(hookBinaryPath: installedBinaryURL.path)
+
+        try assets.pluginYAML.write(to: pluginYAMLURL, options: .atomic)
+        try assets.pluginInit.write(to: pluginInitURL, options: .atomic)
+
+        let manifest = HermesHookInstallerManifest(hookBinaryPath: installedBinaryURL.path)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(manifest).write(to: manifestURL, options: .atomic)
+
+        return try status(hooksBinaryURL: installedBinaryURL)
+    }
+
+    @discardableResult
+    public func uninstall() throws -> HermesHookInstallationStatus {
+        let pluginYAMLURL = pluginDirectory.appendingPathComponent("plugin.yaml")
+
+        guard fileManager.fileExists(atPath: pluginDirectory.path) else {
+            return try status()
+        }
+
+        let yamlData = try? Data(contentsOf: pluginYAMLURL)
+        guard HermesHookInstaller.isManagedPlugin(pluginYAMLData: yamlData) else {
+            // Do not touch a user-authored plugin at the same path.
+            return try status()
+        }
+
+        try fileManager.removeItem(at: pluginDirectory)
+
+        // Also remove the containing `plugins` directory only when it is empty,
+        // to avoid leaving our breadcrumbs behind in user `.hermes` trees.
+        let pluginsRoot = pluginDirectory.deletingLastPathComponent()
+        if fileManager.fileExists(atPath: pluginsRoot.path),
+           let contents = try? fileManager.contentsOfDirectory(at: pluginsRoot, includingPropertiesForKeys: nil),
+           contents.isEmpty {
+            try? fileManager.removeItem(at: pluginsRoot)
+        }
+
+        return try status()
+    }
+
+    private func loadManifest(at url: URL) throws -> HermesHookInstallerManifest? {
+        guard fileManager.fileExists(atPath: url.path) else { return nil }
+
+        let data = try Data(contentsOf: url)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(HermesHookInstallerManifest.self, from: data)
+    }
+
+    private func resolvedHooksBinaryURL(explicitURL: URL?) -> URL? {
+        if let explicitURL {
+            return explicitURL.standardizedFileURL
+        }
+
+        guard fileManager.isExecutableFile(atPath: managedHooksBinaryURL.path) else {
+            return nil
+        }
+
+        return managedHooksBinaryURL
+    }
+}
+
+public enum HermesHookInstallationError: Error, LocalizedError {
+    case foreignPluginAtPath(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .foreignPluginAtPath(path):
+            return "A non-Open-Island plugin already exists at \(path). Remove it manually or use a different plugin directory before installing."
+        }
+    }
+}

--- a/Sources/OpenIslandCore/HermesHookInstaller.swift
+++ b/Sources/OpenIslandCore/HermesHookInstaller.swift
@@ -1,0 +1,208 @@
+import Foundation
+
+public struct HermesHookInstallerManifest: Equatable, Codable, Sendable {
+    public static let fileName = "open-island-hermes-install.json"
+
+    public var hookBinaryPath: String
+    public var pluginVersion: String
+    public var installedAt: Date
+
+    public init(
+        hookBinaryPath: String,
+        pluginVersion: String = HermesHookInstaller.pluginVersion,
+        installedAt: Date = .now
+    ) {
+        self.hookBinaryPath = hookBinaryPath
+        self.pluginVersion = pluginVersion
+        self.installedAt = installedAt
+    }
+}
+
+public struct HermesPluginAssets: Equatable, Sendable {
+    public var pluginYAML: Data
+    public var pluginInit: Data
+
+    public init(pluginYAML: Data, pluginInit: Data) {
+        self.pluginYAML = pluginYAML
+        self.pluginInit = pluginInit
+    }
+}
+
+public enum HermesHookInstaller {
+    public static let pluginVersion = "1.0.0"
+    public static let pluginDirectoryName = "open-island"
+    public static let managedMarker = "open_island_managed: true"
+
+    public static func renderPluginAssets(hookBinaryPath: String) -> HermesPluginAssets {
+        HermesPluginAssets(
+            pluginYAML: Data(pluginYAML().utf8),
+            pluginInit: Data(pluginInitPython(hookBinaryPath: hookBinaryPath).utf8)
+        )
+    }
+
+    public static func isManagedPlugin(pluginYAMLData: Data?) -> Bool {
+        guard let data = pluginYAMLData,
+              let text = String(data: data, encoding: .utf8) else {
+            return false
+        }
+
+        return text.contains(managedMarker)
+    }
+
+    public static func pluginYAML() -> String {
+        """
+        # Managed by Open Island. Do not edit by hand.
+        # Removing the marker below will cause `OpenIslandSetup uninstallHermes` to
+        # leave this plugin directory in place.
+        open_island_managed: true
+        name: open-island
+        version: \(pluginVersion)
+        description: >
+          Forwards Hermes Agent hook events to the local Open Island bridge.
+          Observer-only: never blocks tool calls.
+        """
+    }
+
+    public static func pluginInitPython(hookBinaryPath: String) -> String {
+        """
+        # Managed by Open Island. Do not edit by hand.
+        \"\"\"Open Island bridge plugin for Hermes Agent.
+
+        Forwards Hermes hook events (``on_session_start``, ``pre_tool_call``,
+        ``post_tool_call``, ``on_session_end``) to the local Open Island bridge
+        via the OpenIslandHooks binary over stdin. Failures are swallowed so the
+        Hermes CLI keeps running when the island app is not available.
+        \"\"\"
+
+        from __future__ import annotations
+
+        import json
+        import os
+        import subprocess
+        from typing import Any, Mapping
+
+        HOOK_BINARY = \(pythonQuote(hookBinaryPath))
+
+
+        def _send(payload: Mapping[str, Any]) -> None:
+            try:
+                data = json.dumps(payload, default=str).encode(\"utf-8\")
+            except Exception:
+                return
+
+            try:
+                process = subprocess.Popen(
+                    [HOOK_BINARY, \"--source\", \"hermes\"],
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    close_fds=True,
+                )
+            except Exception:
+                return
+
+            try:
+                process.stdin.write(data)
+            except Exception:
+                pass
+            finally:
+                try:
+                    process.stdin.close()
+                except Exception:
+                    pass
+
+
+        def _coerce(value: Any) -> Any:
+            if isinstance(value, (str, int, float, bool)) or value is None:
+                return value
+            if isinstance(value, Mapping):
+                return {str(k): _coerce(v) for k, v in value.items()}
+            if isinstance(value, (list, tuple, set)):
+                return [_coerce(v) for v in value]
+            return str(value)
+
+
+        def _base_payload(event_name: str, ctx: Any) -> dict[str, Any]:
+            session_id = getattr(ctx, \"session_id\", None) or getattr(ctx, \"sessionID\", None)
+            payload: dict[str, Any] = {
+                \"hook_event_name\": event_name,
+                \"session_id\": str(session_id) if session_id is not None else \"\",
+                \"cwd\": os.getcwd(),
+                \"pid\": os.getpid(),
+                \"platform\": \"cli\",
+            }
+
+            model = getattr(ctx, \"model\", None)
+            if model:
+                payload[\"model\"] = str(model)
+
+            return payload
+
+
+        def _on_session_start(ctx: Any = None, **kwargs: Any) -> None:
+            payload = _base_payload(\"session_start\", ctx)
+            _send(payload)
+
+
+        def _pre_tool_call(ctx: Any = None, tool_name: Any = None, tool_args: Any = None, tool_call_id: Any = None, **kwargs: Any) -> None:
+            payload = _base_payload(\"pre_tool_call\", ctx)
+            if tool_name is not None:
+                payload[\"tool_name\"] = str(tool_name)
+            if tool_args is not None:
+                payload[\"tool_args\"] = _coerce(tool_args)
+            if tool_call_id is not None:
+                payload[\"tool_call_id\"] = str(tool_call_id)
+            _send(payload)
+            return None
+
+
+        def _post_tool_call(ctx: Any = None, tool_name: Any = None, tool_args: Any = None, tool_call_id: Any = None, result: Any = None, **kwargs: Any) -> None:
+            payload = _base_payload(\"post_tool_call\", ctx)
+            if tool_name is not None:
+                payload[\"tool_name\"] = str(tool_name)
+            if tool_call_id is not None:
+                payload[\"tool_call_id\"] = str(tool_call_id)
+            _send(payload)
+
+
+        def _on_session_end(ctx: Any = None, completed: Any = None, interrupted: Any = None, **kwargs: Any) -> None:
+            payload = _base_payload(\"session_end\", ctx)
+            if completed is not None:
+                payload[\"completed\"] = bool(completed)
+            if interrupted is not None:
+                payload[\"interrupted\"] = bool(interrupted)
+            _send(payload)
+
+
+        def register(ctx: Any) -> None:
+            \"\"\"Hermes plugin entry point.
+
+            Hermes looks up a ``register`` callable on the plugin module and passes
+            its own plugin context. The context exposes ``register_hook(name, fn)``.
+            \"\"\"
+
+            for event_name, callback in (
+                (\"on_session_start\", _on_session_start),
+                (\"pre_tool_call\", _pre_tool_call),
+                (\"post_tool_call\", _post_tool_call),
+                (\"on_session_end\", _on_session_end),
+            ):
+                register_hook = getattr(ctx, \"register_hook\", None)
+                if register_hook is None:
+                    return
+                try:
+                    register_hook(event_name, callback)
+                except Exception:
+                    # Never propagate: the Hermes CLI must keep running even if
+                    # the bridge plugin fails to register a single callback.
+                    continue
+        """
+    }
+
+    private static func pythonQuote(_ string: String) -> String {
+        let escaped = string
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        return "\"\(escaped)\""
+    }
+}

--- a/Sources/OpenIslandCore/HermesHooks.swift
+++ b/Sources/OpenIslandCore/HermesHooks.swift
@@ -1,0 +1,321 @@
+import Foundation
+
+public enum HermesHookEventName: String, Codable, Sendable {
+    case sessionStart = "session_start"
+    case preToolCall = "pre_tool_call"
+    case postToolCall = "post_tool_call"
+    case sessionEnd = "session_end"
+}
+
+public struct HermesHookPayload: Equatable, Codable, Sendable {
+    public var hookEventName: HermesHookEventName
+    public var sessionID: String
+    public var cwd: String
+    public var pid: Int?
+    public var model: String?
+    public var platform: String?
+    public var toolName: String?
+    public var toolArgs: CodexHookJSONValue?
+    public var toolCallID: String?
+    public var taskID: String?
+    public var completed: Bool?
+    public var interrupted: Bool?
+    public var terminalApp: String?
+    public var terminalSessionID: String?
+    public var terminalTTY: String?
+    public var terminalTitle: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case hookEventName = "hook_event_name"
+        case sessionID = "session_id"
+        case cwd
+        case pid
+        case model
+        case platform
+        case toolName = "tool_name"
+        case toolArgs = "tool_args"
+        case toolCallID = "tool_call_id"
+        case taskID = "task_id"
+        case completed
+        case interrupted
+        case terminalApp = "terminal_app"
+        case terminalSessionID = "terminal_session_id"
+        case terminalTTY = "terminal_tty"
+        case terminalTitle = "terminal_title"
+    }
+
+    public init(
+        hookEventName: HermesHookEventName,
+        sessionID: String,
+        cwd: String,
+        pid: Int? = nil,
+        model: String? = nil,
+        platform: String? = nil,
+        toolName: String? = nil,
+        toolArgs: CodexHookJSONValue? = nil,
+        toolCallID: String? = nil,
+        taskID: String? = nil,
+        completed: Bool? = nil,
+        interrupted: Bool? = nil,
+        terminalApp: String? = nil,
+        terminalSessionID: String? = nil,
+        terminalTTY: String? = nil,
+        terminalTitle: String? = nil
+    ) {
+        self.hookEventName = hookEventName
+        self.sessionID = sessionID
+        self.cwd = cwd
+        self.pid = pid
+        self.model = model
+        self.platform = platform
+        self.toolName = toolName
+        self.toolArgs = toolArgs
+        self.toolCallID = toolCallID
+        self.taskID = taskID
+        self.completed = completed
+        self.interrupted = interrupted
+        self.terminalApp = terminalApp
+        self.terminalSessionID = terminalSessionID
+        self.terminalTTY = terminalTTY
+        self.terminalTitle = terminalTitle
+    }
+}
+
+public struct HermesSessionMetadata: Equatable, Codable, Sendable {
+    public var initialUserPrompt: String?
+    public var lastUserPrompt: String?
+    public var lastAssistantMessage: String?
+    public var currentTool: String?
+    public var currentToolInputPreview: String?
+    public var model: String?
+    public var cwd: String?
+
+    public init(
+        initialUserPrompt: String? = nil,
+        lastUserPrompt: String? = nil,
+        lastAssistantMessage: String? = nil,
+        currentTool: String? = nil,
+        currentToolInputPreview: String? = nil,
+        model: String? = nil,
+        cwd: String? = nil
+    ) {
+        self.initialUserPrompt = initialUserPrompt
+        self.lastUserPrompt = lastUserPrompt
+        self.lastAssistantMessage = lastAssistantMessage
+        self.currentTool = currentTool
+        self.currentToolInputPreview = currentToolInputPreview
+        self.model = model
+        self.cwd = cwd
+    }
+
+    public var isEmpty: Bool {
+        initialUserPrompt == nil
+            && lastUserPrompt == nil
+            && lastAssistantMessage == nil
+            && currentTool == nil
+            && currentToolInputPreview == nil
+            && model == nil
+            && cwd == nil
+    }
+}
+
+public extension HermesHookPayload {
+    var workspaceName: String {
+        WorkspaceNameResolver.workspaceName(for: cwd)
+    }
+
+    var sessionTitle: String {
+        "Hermes · \(workspaceName)"
+    }
+
+    var defaultJumpTarget: JumpTarget {
+        JumpTarget(
+            terminalApp: terminalApp ?? "Terminal",
+            workspaceName: workspaceName,
+            paneTitle: terminalTitle ?? "Hermes \(sessionID.prefix(8))",
+            workingDirectory: cwd,
+            terminalSessionID: terminalSessionID,
+            terminalTTY: terminalTTY
+        )
+    }
+
+    var defaultHermesMetadata: HermesSessionMetadata {
+        HermesSessionMetadata(
+            currentTool: toolName,
+            currentToolInputPreview: toolArgsPreview,
+            model: model,
+            cwd: cwd
+        )
+    }
+
+    var implicitSummary: String {
+        switch hookEventName {
+        case .sessionStart:
+            return "Started Hermes session in \(workspaceName)."
+        case .preToolCall:
+            return "Hermes is preparing \(toolName ?? "a tool") in \(workspaceName)."
+        case .postToolCall:
+            return "Hermes finished \(toolName ?? "a tool") in \(workspaceName)."
+        case .sessionEnd:
+            if interrupted == true {
+                return "Hermes session interrupted in \(workspaceName)."
+            }
+            return "Hermes session ended in \(workspaceName)."
+        }
+    }
+
+    var toolArgsPreview: String? {
+        guard let toolArgs else {
+            return nil
+        }
+
+        return clipped(renderToolArgs(toolArgs), limit: 160)
+    }
+
+    func withRuntimeContext(environment: [String: String]) -> HermesHookPayload {
+        var payload = self
+
+        if payload.terminalApp == nil {
+            payload.terminalApp = Self.inferTerminalApp(from: environment)
+        }
+
+        if payload.terminalTTY == nil {
+            payload.terminalTTY = Self.currentTTY()
+        }
+
+        if payload.terminalSessionID == nil {
+            if let sessionID = environment["ITERM_SESSION_ID"] {
+                payload.terminalSessionID = sessionID
+            } else if let sessionID = environment["TERM_SESSION_ID"] {
+                payload.terminalSessionID = sessionID
+            }
+        }
+
+        return payload
+    }
+
+    private func clipped(_ value: String?, limit: Int = 110) -> String? {
+        guard let value else {
+            return nil
+        }
+
+        let collapsed = value
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\t", with: " ")
+            .split(separator: " ", omittingEmptySubsequences: true)
+            .joined(separator: " ")
+
+        guard !collapsed.isEmpty else {
+            return nil
+        }
+
+        guard collapsed.count > limit else {
+            return collapsed
+        }
+
+        let endIndex = collapsed.index(collapsed.startIndex, offsetBy: limit - 1)
+        return "\(collapsed[..<endIndex])…"
+    }
+
+    private func renderToolArgs(_ value: CodexHookJSONValue) -> String {
+        switch value {
+        case let .string(text):
+            return text
+        case let .number(number):
+            return String(number)
+        case let .boolean(flag):
+            return flag ? "true" : "false"
+        case .null:
+            return "null"
+        case let .array(items):
+            let rendered = items.map(renderToolArgs(_:)).joined(separator: ", ")
+            return "[\(rendered)]"
+        case let .object(object):
+            let rendered = object
+                .keys
+                .sorted()
+                .map { key in
+                    let value = object[key].map(renderToolArgs(_:)) ?? "null"
+                    return "\(key)=\(value)"
+                }
+                .joined(separator: " ")
+            return rendered
+        }
+    }
+
+    private static func inferTerminalApp(from environment: [String: String]) -> String? {
+        if environment["ITERM_SESSION_ID"] != nil || environment["LC_TERMINAL"] == "iTerm2" {
+            return "iTerm"
+        }
+
+        if environment["CMUX_WORKSPACE_ID"] != nil || environment["CMUX_SOCKET_PATH"] != nil {
+            return "cmux"
+        }
+
+        if environment["ZELLIJ"] != nil {
+            return "Zellij"
+        }
+
+        if environment["GHOSTTY_RESOURCES_DIR"] != nil {
+            return "Ghostty"
+        }
+
+        if environment["WARP_IS_LOCAL_SHELL_SESSION"] != nil {
+            return "Warp"
+        }
+
+        let termProgram = environment["TERM_PROGRAM"]?.lowercased()
+        switch termProgram {
+        case .some("apple_terminal"):
+            return "Terminal"
+        case .some("iterm.app"), .some("iterm2"):
+            return "iTerm"
+        case let value? where value.contains("ghostty"):
+            return "Ghostty"
+        case let value? where value.contains("warp"):
+            return "Warp"
+        case let value? where value.contains("wezterm"):
+            return "WezTerm"
+        case .some("kaku"):
+            return "Kaku"
+        case .some("vscode"):
+            return "VS Code"
+        case .some("vscode-insiders"):
+            return "VS Code Insiders"
+        case .some("windsurf"):
+            return "Windsurf"
+        case .some("trae"):
+            return "Trae"
+        default:
+            break
+        }
+
+        return nil
+    }
+
+    private static func currentTTY() -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/tty")
+        let outputPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return nil
+        }
+
+        let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        guard !data.isEmpty,
+              let output = String(data: data, encoding: .utf8)?
+              .trimmingCharacters(in: .whitespacesAndNewlines),
+              !output.isEmpty,
+              !output.contains("not a tty") else {
+            return nil
+        }
+
+        return output
+    }
+}

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -70,7 +70,8 @@ public struct SessionState: Equatable, Sendable {
                 claudeMetadata: payload.claudeMetadata?.isEmpty == true ? nil : payload.claudeMetadata,
                 geminiMetadata: payload.geminiMetadata?.isEmpty == true ? nil : payload.geminiMetadata,
                 openCodeMetadata: payload.openCodeMetadata?.isEmpty == true ? nil : payload.openCodeMetadata,
-                cursorMetadata: payload.cursorMetadata?.isEmpty == true ? nil : payload.cursorMetadata
+                cursorMetadata: payload.cursorMetadata?.isEmpty == true ? nil : payload.cursorMetadata,
+                hermesMetadata: payload.hermesMetadata?.isEmpty == true ? nil : payload.hermesMetadata
             )
             session.isRemote = payload.isRemote
             session.isHookManaged = payload.origin == .live
@@ -201,6 +202,15 @@ public struct SessionState: Equatable, Sendable {
             }
 
             session.cursorMetadata = payload.cursorMetadata.isEmpty ? nil : payload.cursorMetadata
+            session.updatedAt = payload.timestamp
+            upsert(session)
+
+        case let .hermesSessionMetadataUpdated(payload):
+            guard var session = sessionsByID[payload.sessionID] else {
+                return
+            }
+
+            session.hermesMetadata = payload.hermesMetadata.isEmpty ? nil : payload.hermesMetadata
             session.updatedAt = payload.timestamp
             upsert(session)
 

--- a/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
+++ b/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
@@ -15,12 +15,13 @@ struct OpenIslandHooksCLI {
         case codebuddy
         case cursor
         case gemini
+        case hermes
 
         var isClaudeFormat: Bool {
             switch self {
             case .claude, .qoder, .qwen, .factory, .droid, .codebuddy:
                 return true
-            case .codex, .cursor, .gemini:
+            case .codex, .cursor, .gemini, .hermes:
                 return false
             }
         }
@@ -94,6 +95,12 @@ struct OpenIslandHooksCLI {
                     .withRuntimeContext(environment: ProcessInfo.processInfo.environment)
 
                 _ = try? client.send(.processGeminiHook(payload), timeout: 45)
+            case .hermes:
+                let payload = try decoder
+                    .decode(HermesHookPayload.self, from: input)
+                    .withRuntimeContext(environment: ProcessInfo.processInfo.environment)
+
+                _ = try? client.send(.processHermesHook(payload), timeout: 45)
             }
         } catch {
             // Hooks should fail open so the CLI continues working even if the bridge is unavailable.

--- a/Sources/OpenIslandSetup/OpenIslandSetupCLI.swift
+++ b/Sources/OpenIslandSetup/OpenIslandSetupCLI.swift
@@ -25,11 +25,15 @@ private struct SetupCommand {
         case installClaude
         case uninstallClaude
         case statusClaude
+        case installHermes
+        case uninstallHermes
+        case statusHermes
     }
 
     let action: Action
     let codexDirectory: URL
     let claudeDirectory: URL
+    let hermesDirectory: URL
     let hooksBinary: URL?
 
     init(arguments: [String]) throws {
@@ -43,6 +47,7 @@ private struct SetupCommand {
         var hooksBinary: URL?
         var codexDirectory = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".codex", isDirectory: true)
         var claudeDirectory = ClaudeConfigDirectory.resolved()
+        var hermesDirectory = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".hermes", isDirectory: true)
 
         var index = 1
         while index < arguments.count {
@@ -68,6 +73,13 @@ private struct SetupCommand {
                 }
                 claudeDirectory = URL(fileURLWithPath: arguments[index]).standardizedFileURL
 
+            case "--hermes-dir":
+                index += 1
+                guard index < arguments.count else {
+                    throw SetupError.missingValue("--hermes-dir")
+                }
+                hermesDirectory = URL(fileURLWithPath: arguments[index]).standardizedFileURL
+
             default:
                 throw SetupError.unexpectedArgument(arguments[index])
             }
@@ -75,12 +87,13 @@ private struct SetupCommand {
             index += 1
         }
 
-        if (action == .install || action == .installClaude), hooksBinary == nil {
+        if action == .install || action == .installClaude || action == .installHermes, hooksBinary == nil {
             hooksBinary = HooksBinaryLocator.locate()
         }
 
         self.codexDirectory = codexDirectory
         self.claudeDirectory = claudeDirectory
+        self.hermesDirectory = hermesDirectory
         self.hooksBinary = hooksBinary
     }
 
@@ -98,6 +111,12 @@ private struct SetupCommand {
             try uninstallClaude()
         case .statusClaude:
             try statusClaude()
+        case .installHermes:
+            try installHermes()
+        case .uninstallHermes:
+            try uninstallHermes()
+        case .statusHermes:
+            try statusHermes()
         }
     }
 
@@ -192,6 +211,53 @@ private struct SetupCommand {
             print("Manifest: missing")
         }
     }
+
+    private func installHermes() throws {
+        guard let hooksBinary else {
+            throw SetupError.usage
+        }
+
+        let manager = HermesHookInstallationManager(hermesDirectory: hermesDirectory)
+        let status = try manager.install(hooksBinaryURL: hooksBinary)
+
+        print("Installed Open Island Hermes plugin.")
+        print("Hermes dir: \(status.hermesDirectory.path)")
+        print("Plugin dir: \(status.pluginDirectory.path)")
+        print("Hooks binary: \(hooksBinary.path)")
+    }
+
+    private func uninstallHermes() throws {
+        let manager = HermesHookInstallationManager(hermesDirectory: hermesDirectory)
+        let status = try manager.uninstall()
+
+        print("Removed Open Island Hermes plugin.")
+        print("Hermes dir: \(status.hermesDirectory.path)")
+        if status.hasForeignPluginDirectory {
+            print("Preserved non-Open-Island plugin at \(status.pluginDirectory.path).")
+        }
+    }
+
+    private func statusHermes() throws {
+        let manager = HermesHookInstallationManager(hermesDirectory: hermesDirectory)
+        let status = try manager.status(hooksBinaryURL: hooksBinary)
+
+        print("Hermes dir: \(status.hermesDirectory.path)")
+        print("Plugin dir: \(status.pluginDirectory.path)")
+        print("Managed plugin present: \(status.managedHooksPresent ? "yes" : "no")")
+        if status.hasForeignPluginDirectory {
+            print("Foreign plugin at plugin dir: yes")
+        }
+        if let hooksBinary = status.hooksBinaryURL {
+            print("Hooks binary: \(hooksBinary.path)")
+        }
+        if let manifest = status.manifest {
+            print("Manifest: present")
+            print("Plugin version: \(manifest.pluginVersion)")
+            print("Hook binary path: \(manifest.hookBinaryPath)")
+        } else {
+            print("Manifest: missing")
+        }
+    }
 }
 
 private enum SetupError: Error, LocalizedError {
@@ -210,6 +276,9 @@ private enum SetupError: Error, LocalizedError {
               swift run OpenIslandSetup installClaude [--hooks-binary /abs/path/to/OpenIslandHooks] [--claude-dir /abs/path/to/.claude]
               swift run OpenIslandSetup uninstallClaude [--claude-dir /abs/path/to/.claude]
               swift run OpenIslandSetup statusClaude [--hooks-binary /abs/path/to/OpenIslandHooks] [--claude-dir /abs/path/to/.claude]
+              swift run OpenIslandSetup installHermes [--hooks-binary /abs/path/to/OpenIslandHooks] [--hermes-dir /abs/path/to/.hermes]
+              swift run OpenIslandSetup uninstallHermes [--hermes-dir /abs/path/to/.hermes]
+              swift run OpenIslandSetup statusHermes [--hooks-binary /abs/path/to/OpenIslandHooks] [--hermes-dir /abs/path/to/.hermes]
             """
         case let .missingValue(flag):
             "Missing value for \(flag)"

--- a/Tests/OpenIslandCoreTests/HermesHookInstallerTests.swift
+++ b/Tests/OpenIslandCoreTests/HermesHookInstallerTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+struct HermesHookInstallerTests {
+    @Test
+    func pluginYAMLContainsManagedMarker() {
+        let yaml = HermesHookInstaller.pluginYAML()
+        #expect(yaml.contains(HermesHookInstaller.managedMarker))
+        #expect(yaml.contains("name: open-island"))
+    }
+
+    @Test
+    func pluginInitShellsOutToHookBinaryWithHermesSource() {
+        let python = HermesHookInstaller.pluginInitPython(hookBinaryPath: "/usr/local/bin/OpenIslandHooks")
+        #expect(python.contains("\"/usr/local/bin/OpenIslandHooks\""))
+        #expect(python.contains("--source"))
+        #expect(python.contains("\"hermes\""))
+        #expect(python.contains("def register(ctx"))
+        #expect(python.contains("on_session_start"))
+        #expect(python.contains("pre_tool_call"))
+        #expect(python.contains("post_tool_call"))
+        #expect(python.contains("on_session_end"))
+    }
+
+    @Test
+    func isManagedPluginRecognizesMarker() {
+        let managed = Data(HermesHookInstaller.pluginYAML().utf8)
+        #expect(HermesHookInstaller.isManagedPlugin(pluginYAMLData: managed))
+
+        let foreign = Data("name: some-other-plugin\n".utf8)
+        #expect(!HermesHookInstaller.isManagedPlugin(pluginYAMLData: foreign))
+
+        #expect(!HermesHookInstaller.isManagedPlugin(pluginYAMLData: nil))
+    }
+
+    @Test
+    func installCreatesPluginFilesAndManifest() throws {
+        let (hermesDir, hookBinaryURL) = try makeTempHermesEnvironment()
+        defer { try? FileManager.default.removeItem(at: hermesDir.deletingLastPathComponent()) }
+
+        let managedBinaryURL = hermesDir
+            .appendingPathComponent("managed-bin")
+            .appendingPathComponent("OpenIslandHooks")
+        let manager = HermesHookInstallationManager(
+            hermesDirectory: hermesDir,
+            managedHooksBinaryURL: managedBinaryURL
+        )
+
+        let status = try manager.install(hooksBinaryURL: hookBinaryURL)
+
+        #expect(status.managedHooksPresent)
+        #expect(FileManager.default.fileExists(atPath: status.pluginYAMLURL.path))
+        #expect(FileManager.default.fileExists(atPath: status.pluginInitURL.path))
+        #expect(FileManager.default.fileExists(atPath: status.manifestURL.path))
+
+        let manifest = try #require(status.manifest)
+        #expect(manifest.hookBinaryPath == managedBinaryURL.standardizedFileURL.path)
+
+        let yamlContents = try String(contentsOf: status.pluginYAMLURL)
+        #expect(yamlContents.contains(HermesHookInstaller.managedMarker))
+    }
+
+    @Test
+    func installIsIdempotent() throws {
+        let (hermesDir, hookBinaryURL) = try makeTempHermesEnvironment()
+        defer { try? FileManager.default.removeItem(at: hermesDir.deletingLastPathComponent()) }
+
+        let managedBinaryURL = hermesDir
+            .appendingPathComponent("managed-bin")
+            .appendingPathComponent("OpenIslandHooks")
+        let manager = HermesHookInstallationManager(
+            hermesDirectory: hermesDir,
+            managedHooksBinaryURL: managedBinaryURL
+        )
+
+        _ = try manager.install(hooksBinaryURL: hookBinaryURL)
+        let rerun = try manager.install(hooksBinaryURL: hookBinaryURL)
+
+        #expect(rerun.managedHooksPresent)
+        #expect(rerun.manifest != nil)
+    }
+
+    @Test
+    func uninstallRemovesManagedPluginOnly() throws {
+        let (hermesDir, hookBinaryURL) = try makeTempHermesEnvironment()
+        defer { try? FileManager.default.removeItem(at: hermesDir.deletingLastPathComponent()) }
+
+        let managedBinaryURL = hermesDir
+            .appendingPathComponent("managed-bin")
+            .appendingPathComponent("OpenIslandHooks")
+        let manager = HermesHookInstallationManager(
+            hermesDirectory: hermesDir,
+            managedHooksBinaryURL: managedBinaryURL
+        )
+
+        _ = try manager.install(hooksBinaryURL: hookBinaryURL)
+        let afterUninstall = try manager.uninstall()
+
+        #expect(!afterUninstall.managedHooksPresent)
+        #expect(!FileManager.default.fileExists(atPath: afterUninstall.pluginDirectory.path))
+    }
+
+    @Test
+    func uninstallSkipsForeignPluginDirectory() throws {
+        let (hermesDir, hookBinaryURL) = try makeTempHermesEnvironment()
+        defer { try? FileManager.default.removeItem(at: hermesDir.deletingLastPathComponent()) }
+        _ = hookBinaryURL
+
+        let managedBinaryURL = hermesDir
+            .appendingPathComponent("managed-bin")
+            .appendingPathComponent("OpenIslandHooks")
+        let manager = HermesHookInstallationManager(
+            hermesDirectory: hermesDir,
+            managedHooksBinaryURL: managedBinaryURL
+        )
+
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(at: manager.pluginDirectory, withIntermediateDirectories: true)
+        let foreignYAML = manager.pluginDirectory.appendingPathComponent("plugin.yaml")
+        try Data("name: user-plugin\nversion: 0.1.0\n".utf8).write(to: foreignYAML)
+
+        let status = try manager.uninstall()
+
+        #expect(!status.managedHooksPresent)
+        #expect(status.hasForeignPluginDirectory)
+        #expect(fileManager.fileExists(atPath: foreignYAML.path))
+    }
+
+    @Test
+    func installRefusesToClobberForeignPluginDirectory() throws {
+        let (hermesDir, hookBinaryURL) = try makeTempHermesEnvironment()
+        defer { try? FileManager.default.removeItem(at: hermesDir.deletingLastPathComponent()) }
+
+        let managedBinaryURL = hermesDir
+            .appendingPathComponent("managed-bin")
+            .appendingPathComponent("OpenIslandHooks")
+        let manager = HermesHookInstallationManager(
+            hermesDirectory: hermesDir,
+            managedHooksBinaryURL: managedBinaryURL
+        )
+
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(at: manager.pluginDirectory, withIntermediateDirectories: true)
+        let foreignYAML = manager.pluginDirectory.appendingPathComponent("plugin.yaml")
+        try Data("name: user-plugin\nversion: 0.1.0\n".utf8).write(to: foreignYAML)
+
+        #expect(throws: HermesHookInstallationError.self) {
+            _ = try manager.install(hooksBinaryURL: hookBinaryURL)
+        }
+    }
+
+    private func makeTempHermesEnvironment() throws -> (hermesDir: URL, hookBinaryURL: URL) {
+        let fileManager = FileManager.default
+        let baseDir = fileManager.temporaryDirectory
+            .appendingPathComponent("open-island-hermes-tests-\(UUID().uuidString)", isDirectory: true)
+        let hermesDir = baseDir.appendingPathComponent(".hermes", isDirectory: true)
+        let binaryDir = baseDir.appendingPathComponent("bin", isDirectory: true)
+        try fileManager.createDirectory(at: hermesDir, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: binaryDir, withIntermediateDirectories: true)
+
+        let hookBinaryURL = binaryDir.appendingPathComponent("OpenIslandHooks")
+        try Data("#!/bin/sh\nexit 0\n".utf8).write(to: hookBinaryURL)
+        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: hookBinaryURL.path)
+
+        return (hermesDir, hookBinaryURL)
+    }
+}

--- a/Tests/OpenIslandCoreTests/HermesHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/HermesHooksTests.swift
@@ -1,0 +1,233 @@
+import Dispatch
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+struct HermesHooksTests {
+    @Test
+    func hermesHookPayloadRoundTripsEachEventName() throws {
+        let payloads: [HermesHookPayload] = [
+            HermesHookPayload(
+                hookEventName: .sessionStart,
+                sessionID: "hermes-session-a",
+                cwd: "/tmp/project",
+                model: "claude-opus-4-7",
+                platform: "cli"
+            ),
+            HermesHookPayload(
+                hookEventName: .preToolCall,
+                sessionID: "hermes-session-a",
+                cwd: "/tmp/project",
+                toolName: "read_file",
+                toolArgs: .object([
+                    "path": .string("/tmp/project/README.md"),
+                    "limit": .number(200)
+                ]),
+                toolCallID: "call-1"
+            ),
+            HermesHookPayload(
+                hookEventName: .postToolCall,
+                sessionID: "hermes-session-a",
+                cwd: "/tmp/project",
+                toolName: "read_file",
+                toolCallID: "call-1"
+            ),
+            HermesHookPayload(
+                hookEventName: .sessionEnd,
+                sessionID: "hermes-session-a",
+                cwd: "/tmp/project",
+                completed: true,
+                interrupted: false
+            ),
+        ]
+
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        for payload in payloads {
+            let data = try encoder.encode(payload)
+            let decoded = try decoder.decode(HermesHookPayload.self, from: data)
+            #expect(decoded == payload)
+        }
+    }
+
+    @Test
+    func hermesHookPayloadDecodesFromSnakeCaseJSON() throws {
+        let json = """
+        {
+          "hook_event_name": "pre_tool_call",
+          "session_id": "hermes-session-b",
+          "cwd": "/Users/me/project",
+          "pid": 4321,
+          "platform": "cli",
+          "tool_name": "run_shell",
+          "tool_args": {"command": "ls -la"},
+          "tool_call_id": "tc-7"
+        }
+        """.data(using: .utf8)!
+
+        let payload = try JSONDecoder().decode(HermesHookPayload.self, from: json)
+
+        #expect(payload.hookEventName == .preToolCall)
+        #expect(payload.sessionID == "hermes-session-b")
+        #expect(payload.cwd == "/Users/me/project")
+        #expect(payload.toolName == "run_shell")
+        #expect(payload.toolCallID == "tc-7")
+        #expect(payload.toolArgsPreview?.contains("command") == true)
+    }
+
+    @Test
+    func defaultHermesMetadataCapturesToolState() {
+        let payload = HermesHookPayload(
+            hookEventName: .preToolCall,
+            sessionID: "hermes-session-c",
+            cwd: "/tmp/repo",
+            model: "claude-opus-4-7",
+            toolName: "run_shell",
+            toolArgs: .object(["command": .string("npm install")])
+        )
+
+        let metadata = payload.defaultHermesMetadata
+        #expect(metadata.currentTool == "run_shell")
+        #expect(metadata.currentToolInputPreview?.contains("npm install") == true)
+        #expect(metadata.model == "claude-opus-4-7")
+        #expect(metadata.cwd == "/tmp/repo")
+    }
+
+    @Test
+    func hermesSessionLifecycleProducesStartAndCompleteEvents() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let startPayload = HermesHookPayload(
+            hookEventName: .sessionStart,
+            sessionID: "hermes-session-lifecycle",
+            cwd: "/tmp/project"
+        )
+        let endPayload = HermesHookPayload(
+            hookEventName: .sessionEnd,
+            sessionID: "hermes-session-lifecycle",
+            cwd: "/tmp/project",
+            completed: true
+        )
+
+        _ = try BridgeCommandClient(socketURL: socketURL).send(.processHermesHook(startPayload))
+        _ = try BridgeCommandClient(socketURL: socketURL).send(.processHermesHook(endPayload))
+
+        var iterator = stream.makeAsyncIterator()
+        let startEvent = try await nextMatchingHermesEvent(from: &iterator, maxEvents: 8) { event in
+            if case .sessionStarted = event { return true }
+            return false
+        }
+        guard case let .sessionStarted(startedPayload) = startEvent else {
+            Issue.record("Expected a Hermes sessionStarted event")
+            return
+        }
+        #expect(startedPayload.sessionID == "hermes-session-lifecycle")
+        #expect(startedPayload.tool == .hermes)
+        #expect(startedPayload.initialPhase == .running)
+
+        let completionEvent = try await nextMatchingHermesEvent(from: &iterator, maxEvents: 8) { event in
+            if case .sessionCompleted = event { return true }
+            return false
+        }
+        guard case let .sessionCompleted(completedPayload) = completionEvent else {
+            Issue.record("Expected a Hermes sessionCompleted event")
+            return
+        }
+        #expect(completedPayload.sessionID == "hermes-session-lifecycle")
+        #expect(completedPayload.isSessionEnd == true)
+    }
+
+    @Test
+    func hermesPreAndPostToolCallsUpdateMetadata() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let sessionID = "hermes-session-tool"
+        let startPayload = HermesHookPayload(
+            hookEventName: .sessionStart,
+            sessionID: sessionID,
+            cwd: "/tmp/project"
+        )
+        let prePayload = HermesHookPayload(
+            hookEventName: .preToolCall,
+            sessionID: sessionID,
+            cwd: "/tmp/project",
+            toolName: "run_shell",
+            toolArgs: .object(["command": .string("ls -la")])
+        )
+        let postPayload = HermesHookPayload(
+            hookEventName: .postToolCall,
+            sessionID: sessionID,
+            cwd: "/tmp/project",
+            toolName: "run_shell"
+        )
+
+        let client = BridgeCommandClient(socketURL: socketURL)
+        _ = try client.send(.processHermesHook(startPayload))
+        _ = try client.send(.processHermesHook(prePayload))
+        _ = try client.send(.processHermesHook(postPayload))
+
+        var iterator = stream.makeAsyncIterator()
+
+        let preMetadataEvent = try await nextMatchingHermesEvent(from: &iterator, maxEvents: 12) { event in
+            if case let .hermesSessionMetadataUpdated(payload) = event,
+               payload.hermesMetadata.currentTool == "run_shell" {
+                return true
+            }
+            return false
+        }
+        guard case let .hermesSessionMetadataUpdated(preMetadata) = preMetadataEvent else {
+            Issue.record("Expected a Hermes metadata update from pre_tool_call")
+            return
+        }
+        #expect(preMetadata.hermesMetadata.currentToolInputPreview?.contains("ls -la") == true)
+
+        let postMetadataEvent = try await nextMatchingHermesEvent(from: &iterator, maxEvents: 12) { event in
+            if case let .hermesSessionMetadataUpdated(payload) = event,
+               payload.hermesMetadata.currentTool == nil {
+                return true
+            }
+            return false
+        }
+        guard case let .hermesSessionMetadataUpdated(postMetadata) = postMetadataEvent else {
+            Issue.record("Expected a Hermes metadata update from post_tool_call")
+            return
+        }
+        #expect(postMetadata.hermesMetadata.currentTool == nil)
+        #expect(postMetadata.hermesMetadata.currentToolInputPreview == nil)
+    }
+}
+
+private func nextMatchingHermesEvent(
+    from iterator: inout AsyncThrowingStream<AgentEvent, Error>.AsyncIterator,
+    maxEvents: Int = 8,
+    predicate: (AgentEvent) -> Bool
+) async throws -> AgentEvent {
+    for _ in 0..<maxEvents {
+        guard let event = try await iterator.next() else {
+            break
+        }
+        if predicate(event) {
+            return event
+        }
+    }
+
+    Issue.record("Expected matching event within \(maxEvents) events")
+    throw CancellationError()
+}


### PR DESCRIPTION
## Summary

- Surface Hermes CLI (Nous Research) sessions in the notch with the same lifecycle fidelity as Codex/Gemini (session start/end, current tool, last assistant message).
- Managed Python plugin at `~/.hermes/plugins/open-island/` shells out to `OpenIslandHooks --source hermes` on each callback; transport reuses the existing bridge socket end-to-end.
- Observer-only in v1: `pre_tool_call` is fire-and-forget (no blocking permission UI). Gateway/daemon mode is explicitly out of scope — process discovery skips `hermes gateway`.

## Changes

- Core: `.hermes` added to `AgentTool`; `HermesSessionMetadata`, `HermesHookPayload`, `HermesHookEventName`, and `BridgeCommand.processHermesHook` wired through reducer + event model.
- Bridge: `BridgeServer.handleHermesHook` maps `session_start`/`pre_tool_call`/`post_tool_call`/`session_end` to existing `sessionStarted`/`activityUpdated`/`sessionCompleted` events.
- Installer: `HermesHookInstaller` + `HermesHookInstallationManager` use an `open_island_managed: true` marker so uninstall/install never clobber a user-authored plugin at the same path.
- CLIs: `OpenIslandHooks` gains `--source hermes`; `OpenIslandSetup` gains `installHermes` / `uninstallHermes` / `statusHermes`.
- Discovery: `ActiveAgentProcessDiscovery` matches the `hermes` CLI and explicitly excludes `hermes gateway`.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 219 tests pass (incl. new `HermesHooksTests` and `HermesHookInstallerTests`)
- [ ] Manual: `swift run OpenIslandSetup installHermes` creates the plugin files idempotently; a foreign plugin at the same path is preserved
- [ ] Manual: run `hermes` in a terminal with OpenIslandApp active — session card appears on first prompt, current-tool updates during `pre_tool_call`, clears on `post_tool_call`, transitions to Completed on `/quit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection and monitoring of Hermes CLI processes in running terminal sessions
  * Added real-time Hermes agent session metadata tracking with status updates
  * Added plugin installation and management tools for Hermes integration
  
* **Tests**
  * Added comprehensive test coverage for Hermes plugin management and session events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->