### PR TITLE
feat: surface active tool call in closed island on external displays

### DIFF
--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -209,6 +209,17 @@ struct IslandPanelView: View {
             || targetOverlayScreen?.safeAreaInsets.top ?? 0 > 0
     }
 
+    /// True when the closed island sits on an external (non-notched) display.
+    /// The central black rectangle is otherwise aligned with the physical
+    /// notch, so center content is only useful here.
+    private var isExternalDisplayPlacement: Bool {
+        if let mode = model.overlayPlacementDiagnostics?.mode {
+            return mode == .topBar
+        }
+        // Fallback when diagnostics haven't been populated yet.
+        return (targetOverlayScreen?.safeAreaInsets.top ?? 0) == 0
+    }
+
     private var openedHeaderButtonsWidth: CGFloat {
         (Self.headerControlButtonSize * 2) + Self.headerControlSpacing
     }
@@ -374,6 +385,13 @@ struct IslandPanelView: View {
                     Rectangle()
                         .fill(Color.black)
                         .frame(width: closedNotchWidth - NotchShape.closedTopRadius + (isPopping ? 18 : 0))
+                        .overlay(
+                            CentralActivityLabel(
+                                toolName: closedSpotlightSession?.currentToolName,
+                                preview: closedSpotlightSession?.currentCommandPreviewText,
+                                isVisible: isExternalDisplayPlacement && hasClosedPresence
+                            )
+                        )
                 }
 
                 if hasClosedPresence {
@@ -1901,6 +1919,109 @@ private struct ClosedCountBadge: View {
             .padding(.horizontal, 8)
             .padding(.vertical, 2)
             .background(Color(red: 0.14, green: 0.14, blue: 0.15), in: Capsule())
+    }
+}
+
+// MARK: - Central activity overlay (external-display only)
+
+/// Renders the focus session's current tool call inside the central black
+/// rectangle of the closed island. The notch on built-in displays physically
+/// covers this area, so we gate rendering on `placementMode == .topBar`.
+///
+/// State machine: while a tool is active the label tracks it live. When the
+/// tool clears (PostToolUse fires or metadata drops the field), the last
+/// value lingers for `fadeDelay` then disappears.
+private struct CentralActivityLabel: View {
+    let toolName: String?
+    let preview: String?
+    let isVisible: Bool
+
+    @State private var displayed: DisplayedActivity?
+
+    private static let fadeDelay: Duration = .seconds(2)
+
+    struct DisplayedActivity: Equatable {
+        var tool: String
+        var preview: String?
+    }
+
+    var body: some View {
+        Group {
+            if isVisible, let displayed {
+                HStack(spacing: 4) {
+                    Image(systemName: Self.icon(for: displayed.tool))
+                        .font(.system(size: 9, weight: .semibold))
+                    Text(Self.label(for: displayed))
+                        .font(.system(size: 10, weight: .semibold))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+                .foregroundStyle(.white.opacity(0.85))
+                .padding(.horizontal, 8)
+                .transition(.opacity.combined(with: .scale(scale: 0.96)))
+            }
+        }
+        .animation(.easeOut(duration: 0.22), value: displayed)
+        .onChange(of: trackingKey, initial: true) { _, _ in
+            sync()
+        }
+        .task(id: clearTaskID) {
+            guard toolName == nil, displayed != nil else { return }
+            do {
+                try await Task.sleep(for: Self.fadeDelay)
+                displayed = nil
+            } catch {
+                // cancelled — a new tool arrived, let sync() handle it
+            }
+        }
+    }
+
+    /// Composite key so `.onChange` fires on either tool or preview change.
+    private var trackingKey: String {
+        "\(toolName ?? "")|\(preview ?? "")"
+    }
+
+    /// Key used to (re)start the clear timer. Changes whenever we transition
+    /// between active/idle so `.task(id:)` cancels and restarts cleanly.
+    private var clearTaskID: String {
+        toolName == nil ? "clearing-\(displayed?.tool ?? "")" : "active-\(toolName ?? "")"
+    }
+
+    private func sync() {
+        if let toolName, !toolName.isEmpty {
+            displayed = DisplayedActivity(tool: toolName, preview: preview)
+        }
+    }
+
+    private static func label(for activity: DisplayedActivity) -> String {
+        if let preview = activity.preview?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !preview.isEmpty {
+            return "\(activity.tool) · \(preview)"
+        }
+        return activity.tool
+    }
+
+    private static func icon(for tool: String) -> String {
+        let lower = tool.lowercased()
+        if lower.contains("grep") || lower.contains("search") || lower.contains("glob") {
+            return "magnifyingglass"
+        }
+        if lower.contains("edit") || lower.contains("write") {
+            return "pencil"
+        }
+        if lower.contains("bash") || lower.contains("shell") || lower.contains("exec") || lower.contains("run") {
+            return "terminal"
+        }
+        if lower.contains("read") {
+            return "doc.text"
+        }
+        if lower.contains("web") || lower.contains("fetch") {
+            return "globe"
+        }
+        if lower.contains("task") || lower.contains("agent") || lower.contains("subagent") {
+            return "sparkles"
+        }
+        return "wrench.and.screwdriver"
     }
 }
 


### PR DESCRIPTION
## Summary

Use the central black area of the closed island — which is physically hidden by the notch on built-in displays but sits as an opaque strip on external displays — to show the focus session's current tool call. External-display users get the same peripheral awareness of what the agent is doing that notched-display users already get from the moving "contents grow out of the notch" illusion.

Example: when Claude Code is running \`Bash\`, the closed island on an external display shows \`◨ Bash · swift test\` in the middle; on a MacBook with a notch the view is byte-for-byte unchanged.

## Why not show it everywhere?

Because on a notched Mac the central rectangle is under the physical notch cutout — putting content there shows nothing. The asymmetry isn't a feature gap, it's a honest use of the two screens' different geometries.

## Implementation

- New \`CentralActivityLabel\` view rendered as an \`.overlay\` on the existing \`Rectangle().fill(Color.black)\` at \`IslandPanelView.swift\` — no layout math touched, so the notch path is completely unaffected.
- Visibility gated on \`overlayPlacementDiagnostics?.mode == .topBar\`; falls back to \`safeAreaInsets.top == 0\` during cold start before diagnostics populate.
- Reuses existing \`AgentSession.currentToolName\` and \`AgentSession.currentCommandPreviewText\` (which already aggregate across Claude Code, Codex, OpenCode, Cursor), so every supported agent benefits without extra plumbing.
- Follows the existing \`closedSpotlightSession\` priority: when multiple sessions are active, we show the one the closed chrome is already highlighting.
- 2s fade-out after \`currentToolName\` clears (PostToolUse). This prevents flicker between back-to-back tool calls while still clearing promptly when the agent goes idle.
- Icons mapped by tool-name keyword: \`grep/search/glob → magnifyingglass\`, \`edit/write → pencil\`, \`bash/shell/exec/run → terminal\`, \`read → doc.text\`, \`web/fetch → globe\`, \`task/agent/subagent → sparkles\`, default → \`wrench.and.screwdriver\`.

## Scope

v1 intentionally narrow:
- No tool-argument filtering / masking (direct display is the desired behavior per product discussion — the preview field is already truncated upstream).
- No scrolling history — just current tool with fade.
- No multi-session rotation.

## Test plan

- [x] \`swift build\` passes (45s).
- [x] \`swift test\` — 221 tests in 24 suites all pass.
- [ ] Manual: external display — trigger Grep / Edit / Bash from Claude Code, confirm the center shows the tool call and fades out ~2s after it ends.
- [ ] Manual: built-in notch — trigger the same tool calls, confirm the center remains empty (view is still mounted but \`isVisible\` is false).
- [ ] Manual: multi-session — two concurrent Claude Code sessions, confirm only the spotlight one's tool is shown.
- [ ] Manual: long file path — trigger \`Edit\` on a ~120-char path, confirm \`.truncationMode(.tail)\` kicks in and text stays inside the central rectangle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added visual activity indicator on external displays, showing the currently active tool with its icon, label, and optional preview
* Indicator includes smooth fade animations and automatically updates when switching tools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->