### PR TITLE
chore: refresh contributors image cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Repository: Octane0411/open-vibe-island
 
 <a href="https://github.com/Octane0411/open-vibe-island/graphs/contributors">
   <!-- CONTRIBUTORS-IMG:START -->
-  <img src="https://contrib.rocks/image?repo=Octane0411/open-vibe-island&t=1775913499" />
+  <img src="https://contrib.rocks/image?repo=Octane0411/open-vibe-island&t=1776606651" />
   <!-- CONTRIBUTORS-IMG:END -->
 </a>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -220,7 +220,7 @@ Hooks **fail open**——如果 Open Island 没在运行，你的 agents 不受�
 
 <a href="https://github.com/Octane0411/open-vibe-island/graphs/contributors">
   <!-- CONTRIBUTORS-IMG:START -->
-  <img src="https://contrib.rocks/image?repo=Octane0411/open-vibe-island&t=1775913499" />
+  <img src="https://contrib.rocks/image?repo=Octane0411/open-vibe-island&t=1776606651" />
   <!-- CONTRIBUTORS-IMG:END -->
 </a>
 


### PR DESCRIPTION
## Summary
- Bump the `contrib.rocks` cache-bust timestamp on both README.md and README.zh-CN.md so the contributors image reflects the latest contributor list.

## Test plan
- [ ] Open README.md on GitHub and confirm the contributors image shows the current set of contributors.
- [ ] Same check on README.zh-CN.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed the contributors badge in README files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->