### PR TITLE
ci: refresh contributors image cache on each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,6 +239,34 @@ jobs:
           EOF
           )"
 
+      - name: Refresh contributors image cache via PR
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          timestamp="$(date +%s)"
+          branch="chore/contributors-v${{ steps.version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin main
+          git checkout -f -b "$branch" origin/main
+          for file in README.md README.zh-CN.md; do
+            sed -i '' "s|contrib.rocks/image?repo=Octane0411/open-vibe-island&t=[0-9]*|contrib.rocks/image?repo=Octane0411/open-vibe-island\&t=${timestamp}|g" "$file"
+          done
+          if git diff --quiet; then
+            echo "No contributors timestamp changes detected, skipping."
+            exit 0
+          fi
+          git add README.md README.zh-CN.md
+          git commit -m "chore: refresh contributors image cache for v${{ steps.version.outputs.version }}"
+          git push --force origin "$branch"
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "chore: refresh contributors image cache for v${{ steps.version.outputs.version }}" \
+            --body "Automated contrib.rocks cache-bust from release workflow."
+          gh pr merge "$branch" --merge --admin --delete-branch
+
       - name: Cleanup keychain
         if: always()
         run: |


### PR DESCRIPTION
## Summary
- Add an independent, unconditional step to `release.yml` that bumps the `contrib.rocks` cache-bust timestamp in both READMEs on every `v*` tag.
- Uses the same "create branch → `gh pr merge --admin`" pattern the appcast step already uses to bypass branch protection on `main`.
- `continue-on-error: true` so a failure here never blocks a release.

## Why
Manually bumping the timestamp (most recently #373, #279) is easy to forget. Since we always want the contributors image to reflect the latest contributors after a release, it's a natural spot to automate.

## Test plan
- [ ] Next `v*` tag push triggers a second auto-PR titled `chore: refresh contributors image cache for vX.Y.Z` and it self-merges.
- [ ] `README.md` and `README.zh-CN.md` on `main` show an updated `&t=<timestamp>` afterward.
- [ ] Failing this step does not fail the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated refresh of contributor image cache in the release workflow to ensure up-to-date contributor information is displayed in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->