### PR TITLE
fix(claude): keep hook-managed sessions alive and suppress phantom synthetics when lsof transiently fails

### DIFF
--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -316,6 +316,28 @@ final class ProcessMonitoringCoordinator {
             claimedSessionIDs.insert(matched.id)
         }
 
+        // Pass 4: workspace (CWD) fallback. lsof can transiently fail to
+        // expose session ID / transcript path under load, and Pass 3's
+        // uniqueness check drops matches when multiple sessions share a
+        // workspace. Without a fallback, the hook-managed liveness timer
+        // in SessionState.markProcessLiveness would mark perfectly healthy
+        // sessions as ended after 2 polls and synthetic placeholders would
+        // take over. Keep any unclaimed tracked Claude session alive as
+        // long as at least one Claude process is running in its workspace;
+        // hooks remain authoritative for phase changes.
+        let claudeProcessCWDs: Set<String> = Set(
+            claudeProcesses.compactMap { normalizedPathForMatching($0.workingDirectory) }
+        )
+        if !claudeProcessCWDs.isEmpty {
+            for session in trackedClaudeSessions where !claimedSessionIDs.contains(session.id) {
+                guard let sessionCWD = normalizedPathForMatching(session.jumpTarget?.workingDirectory),
+                      claudeProcessCWDs.contains(sessionCWD) else {
+                    continue
+                }
+                aliveIDs.insert(session.id)
+            }
+        }
+
         // OpenCode sessions are hook-managed, but OpenCode does not expose a stable
         // session ID through process discovery. Match each active OpenCode process
         // to at most one tracked session.
@@ -638,6 +660,31 @@ final class ProcessMonitoringCoordinator {
 
             representedProcessKeys.insert(processKey)
             claimedSessionIDs.insert(matchedSession.id)
+        }
+
+        // Workspace fallback. When none of the above passes can pin a
+        // process to a specific tracked session (e.g. lsof didn't expose
+        // session ID or transcript path, or multiple sessions in the same
+        // workspace defeat Pass 3's uniqueness check), treat the process as
+        // "represented" whenever ANY unclaimed tracked Claude session lives
+        // in its workspace. This suppresses phantom synthetic rows that
+        // would otherwise replace the real hook-managed sessions while the
+        // liveness fallback and eviction fire in the same 2-second window.
+        let unclaimedSessionCWDs: Set<String> = Set(
+            trackedClaudeSessions
+                .filter { !claimedSessionIDs.contains($0.id) }
+                .compactMap { normalizedPathForMatching($0.jumpTarget?.workingDirectory) }
+        )
+        if !unclaimedSessionCWDs.isEmpty {
+            for process in activeProcesses {
+                let processKey = processIdentityKey(process)
+                guard !representedProcessKeys.contains(processKey),
+                      let processCWD = normalizedPathForMatching(process.workingDirectory),
+                      unclaimedSessionCWDs.contains(processCWD) else {
+                    continue
+                }
+                representedProcessKeys.insert(processKey)
+            }
         }
 
         return representedProcessKeys

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -743,6 +743,120 @@ struct AppModelSessionListTests {
         #expect(merged.map(\.id) == [existing.id])
     }
 
+    /// Regression test for the "session list collapses to synthetic placeholders" bug:
+    /// when multiple tracked hook-managed Claude sessions share a workspace and lsof
+    /// transiently fails to expose `sessionID` / `transcriptPath` for the corresponding
+    /// processes, Pass 1-3 of the matching logic can't uniquely pin down which process
+    /// owns which session. Without the workspace fallback, every process would be
+    /// treated as unrepresented, spawning one synthetic row per process (all stamped
+    /// with `now`, hence the "<1m" symptom) while the real sessions were evicted.
+    @Test
+    func mergedWithSyntheticClaudeSessionsDoesNotDuplicateWhenLsofCannotDisambiguateWorkspace() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let model = AppModel()
+
+        func trackedSession(id: String, tty: String) -> AgentSession {
+            var session = AgentSession(
+                id: id,
+                title: "Claude · osg-scp-mds",
+                tool: .claudeCode,
+                origin: .live,
+                attachmentState: .attached,
+                phase: .running,
+                summary: "Working",
+                updatedAt: now.addingTimeInterval(-600),
+                jumpTarget: JumpTarget(
+                    terminalApp: "Ghostty",
+                    workspaceName: "osg-scp-mds",
+                    paneTitle: "Claude \(id.prefix(8))",
+                    workingDirectory: "/Users/me/Personal/osg-scp-mds",
+                    terminalTTY: tty
+                ),
+                claudeMetadata: ClaudeSessionMetadata(
+                    transcriptPath: "/Users/me/.claude/projects/-Users-me-Personal-osg-scp-mds/\(id).jsonl",
+                    lastUserPrompt: "Real prompt preserved from hooks."
+                )
+            )
+            session.isHookManaged = true
+            session.isProcessAlive = true
+            return session
+        }
+
+        let tracked = [
+            trackedSession(id: "11111111-1111-1111-1111-111111111111", tty: "/dev/ttys010"),
+            trackedSession(id: "22222222-2222-2222-2222-222222222222", tty: "/dev/ttys011"),
+            trackedSession(id: "33333333-3333-3333-3333-333333333333", tty: "/dev/ttys012"),
+        ]
+
+        // Simulate lsof failing to expose sessionID and transcriptPath for any of
+        // the running Claude processes. TTYs differ but all share the workspace.
+        let activeProcesses: [ActiveProcessSnapshot] = [
+            .init(tool: .claudeCode, sessionID: nil, workingDirectory: "/Users/me/Personal/osg-scp-mds", terminalTTY: "/dev/ttys010", terminalApp: "Ghostty"),
+            .init(tool: .claudeCode, sessionID: nil, workingDirectory: "/Users/me/Personal/osg-scp-mds", terminalTTY: "/dev/ttys011", terminalApp: "Ghostty"),
+            .init(tool: .claudeCode, sessionID: nil, workingDirectory: "/Users/me/Personal/osg-scp-mds", terminalTTY: "/dev/ttys012", terminalApp: "Ghostty"),
+        ]
+
+        let merged = model.monitoring.mergedWithSyntheticClaudeSessions(
+            existingSessions: tracked,
+            activeProcesses: activeProcesses,
+            now: now
+        )
+
+        #expect(merged.count == tracked.count)
+        #expect(merged.allSatisfy { !$0.id.hasPrefix("claude-process:") })
+        #expect(Set(merged.map(\.id)) == Set(tracked.map(\.id)))
+    }
+
+    /// Regression test: hook-managed Claude sessions must stay alive while any Claude
+    /// process is running in the same workspace, even when lsof can't expose session
+    /// IDs or transcript paths. Otherwise `markProcessLiveness` would flip them to
+    /// `isSessionEnded` after two polls and `removeInvisibleSessions` would drop them.
+    @Test
+    func sessionIDsWithAliveProcessesKeepsHookManagedClaudeSessionsAliveByWorkspace() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let model = AppModel()
+
+        func hookSession(id: String, tty: String) -> AgentSession {
+            var session = AgentSession(
+                id: id,
+                title: "Claude · osg-scp-mds",
+                tool: .claudeCode,
+                origin: .live,
+                attachmentState: .attached,
+                phase: .running,
+                summary: "Working",
+                updatedAt: now.addingTimeInterval(-600),
+                jumpTarget: JumpTarget(
+                    terminalApp: "Ghostty",
+                    workspaceName: "osg-scp-mds",
+                    paneTitle: "Claude \(id.prefix(8))",
+                    workingDirectory: "/Users/me/Personal/osg-scp-mds",
+                    terminalTTY: tty
+                )
+            )
+            session.isHookManaged = true
+            return session
+        }
+
+        let sessions = [
+            hookSession(id: "11111111-1111-1111-1111-111111111111", tty: "/dev/ttys010"),
+            hookSession(id: "22222222-2222-2222-2222-222222222222", tty: "/dev/ttys011"),
+        ]
+        model.state = SessionState(sessions: sessions)
+
+        // lsof failed: sessionID / transcriptPath / even TTY are all missing.
+        // Only CWD remains — which is the realistic worst-case under load.
+        let activeProcesses: [ActiveProcessSnapshot] = [
+            .init(tool: .claudeCode, sessionID: nil, workingDirectory: "/Users/me/Personal/osg-scp-mds", terminalTTY: nil, terminalApp: "Ghostty"),
+            .init(tool: .claudeCode, sessionID: nil, workingDirectory: "/Users/me/Personal/osg-scp-mds", terminalTTY: nil, terminalApp: "Ghostty"),
+        ]
+
+        let aliveIDs = model.monitoring.sessionIDsWithAliveProcesses(activeProcesses: activeProcesses)
+
+        #expect(aliveIDs.contains("11111111-1111-1111-1111-111111111111"))
+        #expect(aliveIDs.contains("22222222-2222-2222-2222-222222222222"))
+    }
+
 
     /// Regression test: `measuredNotificationContentHeight` MUST be cleared when the
     /// surface changes to a different session, to avoid sizing the new card with stale


### PR DESCRIPTION
## Summary

Fixes a bug where the island's Claude session list would suddenly "collapse" — all populated sessions losing their task metadata, appearing as duplicated workspace-name-only rows, and every row stamped \"<1m\".

### Root cause

Every 2s `ProcessMonitoringCoordinator.reconcileSessionAttachments` tries to match running Claude processes to tracked hook-managed sessions via three passes:

1. `process.sessionID == session.id` (sessionID sourced from lsof / command line)
2. `process.transcriptPath == session.claudeMetadata.transcriptPath` (also lsof-sourced)
3. Unique TTY + CWD match

Both (1) and (2) depend on `lsof` returning within its 0.2s budget (`ActiveAgentProcessDiscovery.lsofCommandTimeout`). Under load lsof can return late or with partial output, dropping `sessionID` and `transcriptPath`. Pass 3 then has to carry the load, but its uniqueness check gives up as soon as multiple Claude sessions share a workspace (a common multi-terminal-on-same-repo setup).

The cascade:

1. `sessionIDsWithAliveProcesses` omits the real sessions.
2. `SessionState.markProcessLiveness` increments `processNotSeenCount`; after 2 polls it flips `isSessionEnded = true` and `removeInvisibleSessions` evicts the session.
3. `representedClaudeProcessKeys` leaves the process unrepresented, so `mergedWithSyntheticClaudeSessions` spawns a synthetic row with `updatedAt = .now`. Each subsequent tick refreshes `updatedAt` to now again — the \"<1m\" symptom.

### Fix

Add a workspace-scoped fallback pass in both `sessionIDsWithAliveProcesses` (Pass 4) and `representedClaudeProcessKeys`. When a tracked hook-managed Claude session shares a CWD with any running Claude process:

- Keep the session alive (don't tick toward `.isSessionEnded`).
- Treat the process as represented (don't spawn a phantom synthetic).

Hooks remain authoritative for phase changes; this fallback only prevents eviction / phantom rows during the matching blind-spots that happen when lsof stalls.

### Before / after

Before: user's island showed 7+ rows like:
- \`osg-scp-mds\` · Claude Code · Ghostty · <1m  (×4)
- \`osg-scp-projects\` · Claude Code · Ghostty · <1m  (×3)

All metadata (initial prompt, task, activity) gone; \"<1m\" refreshing every 2s.

After: matching transients don't evict sessions; the real hook-managed sessions stay on screen with their metadata and correct age badges.

## Test plan

- [x] `swift build` — passes
- [x] `swift test` — all 223 tests in 24 suites pass
- [x] New regression test `mergedWithSyntheticClaudeSessionsDoesNotDuplicateWhenLsofCannotDisambiguateWorkspace` — simulates lsof failing to expose sessionID/transcriptPath for multiple Claude processes in the same workspace; asserts no synthetics are spawned.
- [x] New regression test `sessionIDsWithAliveProcessesKeepsHookManagedClaudeSessionsAliveByWorkspace` — asserts hook-managed sessions stay alive when a process with matching CWD is running, even with no TTY / sessionID from lsof.
- [ ] Manual: run in dev app, open 3+ Claude sessions in the same repo, leave running for >10 min, confirm no collapse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session liveness tracking by adding workspace-based fallback matching. Sessions now remain active in more scenarios where standard identification methods are unavailable.

* **Tests**
  * Added regression tests for workspace-based session fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->