### PR TITLE
refactor(claude): replace ps/lsof liveness polling with kernel PID exit monitoring

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1232,6 +1232,7 @@ final class AppModel {
                 case let .openCodeSessionMetadataUpdated(p): return p.sessionID
                 case let .cursorSessionMetadataUpdated(p): return p.sessionID
                 case let .actionableStateResolved(p): return p.sessionID
+                case let .claudeProcessExited(p): return p.sessionID
                 }
             }()
             let session = eventSessionID.flatMap { state.session(id: $0) }
@@ -1505,6 +1506,8 @@ final class AppModel {
             return payload.cursorMetadata.lastAssistantMessage ?? "Cursor session metadata updated."
         case let .actionableStateResolved(payload):
             return "Actionable state resolved for session \(payload.sessionID)."
+        case let .claudeProcessExited(payload):
+            return "Claude process exited for session \(payload.sessionID)."
         }
     }
 

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -457,7 +457,7 @@ final class AppModel {
     private var hasStarted = false
 
     @ObservationIgnored
-    private let bridgeServer = BridgeServer()
+    let bridgeServer = BridgeServer()
 
     @ObservationIgnored
     private var bridgeClient = LocalBridgeClient()
@@ -1320,6 +1320,8 @@ final class AppModel {
     private func applyStartupDiscoveryPayload(_ payload: SessionDiscoveryCoordinator.StartupDiscoveryPayload) {
         discovery.applyStartupDiscoveryPayload(payload)
 
+        rehydrateClaudePIDMonitorsForRestoredSessions()
+
         // Apply hooks binary URL and update the installed copy if the app ships a newer version.
         hooks.hooksBinaryURL = payload.hooksBinaryURL
         hooks.updateHooksBinaryIfNeeded()
@@ -1364,6 +1366,36 @@ final class AppModel {
         // Reconcile attachments and start monitoring (requires sessions to be loaded).
         monitoring.reconcileSessionAttachments()
         monitoring.startMonitoringIfNeeded()
+    }
+
+    /// Task 5 rehydration: reattach kernel PID monitors for Claude sessions whose
+    /// CLI process persisted across the app restart. If the PID is already dead,
+    /// apply a synthetic exit event directly through the reducer so the session
+    /// is marked Completed immediately (the bridge is the authoritative path for
+    /// live exits, but at rehydration time we may not have any subscribers yet).
+    func rehydrateClaudePIDMonitorsForRestoredSessions() {
+        for session in state.sessions {
+            guard session.tool == .claudeCode,
+                  session.isHookManaged,
+                  !session.isSessionEnded,
+                  let pid = session.claudeMetadata?.agentPID,
+                  pid > 0 else {
+                continue
+            }
+            if kill(pid, 0) == 0 {
+                bridgeServer.adoptClaudeSessionProcess(sessionID: session.id, pid: pid)
+            } else {
+                applyTrackedEvent(
+                    .claudeProcessExited(ClaudeProcessExited(
+                        sessionID: session.id,
+                        pid: pid,
+                        timestamp: .now
+                    )),
+                    updateLastActionMessage: false,
+                    ingress: .rollout
+                )
+            }
+        }
     }
 
 

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -252,6 +252,8 @@ final class ProcessMonitoringCoordinator {
             payload.sessionID
         case let .actionableStateResolved(payload):
             payload.sessionID
+        case let .claudeProcessExited(payload):
+            payload.sessionID
         }
     }
 

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -44,6 +44,11 @@ final class ProcessMonitoringCoordinator {
     @ObservationIgnored
     private var wasCodexAppRunning = false
 
+    // Freezes `updatedAt` on synthetic Claude rows at first-discovery time so
+    // the age badge reflects real age, not a "<1m" phantom refreshed every poll.
+    @ObservationIgnored
+    private var syntheticClaudeFirstSeen: [String: Date] = [:]
+
     private var state: SessionState {
         get { stateAccessor?() ?? SessionState() }
         set { stateUpdater?(newValue) }
@@ -519,11 +524,26 @@ final class ProcessMonitoringCoordinator {
         now: Date = .now
     ) -> [AgentSession] {
         let baseSessions = existingSessions.filter { !isSyntheticClaudeSession($0) }
+
+        // Any hook-managed Claude session authoritatively owns its workspace:
+        // even if this poll's snapshots miss the match, we must not synthesize
+        // a phantom sibling row for the same workspace.
+        let workspacesWithHookHistory: Set<String> = Set(
+            baseSessions
+                .filter { $0.tool == .claudeCode && $0.isHookManaged }
+                .compactMap { normalizedPathForMatching($0.jumpTarget?.workingDirectory) }
+        )
+
         let syntheticSessions = syntheticClaudeSessions(
             existingSessions: baseSessions,
             activeProcesses: activeProcesses,
+            workspacesWithHookHistory: workspacesWithHookHistory,
             now: now
         )
+
+        let activeClaudeProcesses = activeProcesses.filter { $0.tool == .claudeCode }
+        let liveIdentities = Set(activeClaudeProcesses.map { processIdentityKey($0) })
+        syntheticClaudeFirstSeen = syntheticClaudeFirstSeen.filter { liveIdentities.contains($0.key) }
 
         return baseSessions + syntheticSessions
     }
@@ -531,6 +551,7 @@ final class ProcessMonitoringCoordinator {
     private func syntheticClaudeSessions(
         existingSessions: [AgentSession],
         activeProcesses: [ActiveProcessSnapshot],
+        workspacesWithHookHistory: Set<String>,
         now: Date
     ) -> [AgentSession] {
         let activeClaudeProcesses = activeProcesses.filter { process in
@@ -547,6 +568,10 @@ final class ProcessMonitoringCoordinator {
 
         return activeClaudeProcesses
             .filter { !representedProcessKeys.contains(processIdentityKey($0)) }
+            .filter { process in
+                guard let cwd = normalizedPathForMatching(process.workingDirectory) else { return true }
+                return !workspacesWithHookHistory.contains(cwd)
+            }
             .sorted { processIdentityKey($0) < processIdentityKey($1) }
             .map { syntheticClaudeSession(for: $0, now: now) }
     }
@@ -560,6 +585,11 @@ final class ProcessMonitoringCoordinator {
         let terminalApp = supportedTerminalApp(for: process.terminalApp) ?? "Unknown"
         let identity = processIdentityKey(process)
 
+        if syntheticClaudeFirstSeen[identity] == nil {
+            syntheticClaudeFirstSeen[identity] = now
+        }
+        let firstSeen = syntheticClaudeFirstSeen[identity] ?? now
+
         var session = AgentSession(
             id: "\(syntheticClaudeSessionPrefix)\(identity)",
             title: "Claude · \(workspaceName)",
@@ -568,7 +598,7 @@ final class ProcessMonitoringCoordinator {
             attachmentState: .attached,
             phase: .completed,
             summary: "Claude session detected from \(terminalApp).",
-            updatedAt: now,
+            updatedAt: firstSeen,
             jumpTarget: JumpTarget(
                 terminalApp: terminalApp,
                 workspaceName: workspaceName,

--- a/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
+++ b/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
@@ -352,7 +352,8 @@ final class SessionDiscoveryCoordinator {
             agentID: discovered.agentID ?? existing.agentID,
             agentType: discovered.agentType ?? existing.agentType,
             worktreeBranch: discovered.worktreeBranch ?? existing.worktreeBranch,
-            activeSubagents: existing.activeSubagents.isEmpty ? discovered.activeSubagents : existing.activeSubagents
+            activeSubagents: existing.activeSubagents.isEmpty ? discovered.activeSubagents : existing.activeSubagents,
+            agentPID: discovered.agentPID ?? existing.agentPID
         )
         return merged.isEmpty ? nil : merged
     }

--- a/Sources/OpenIslandCore/AgentEvent.swift
+++ b/Sources/OpenIslandCore/AgentEvent.swift
@@ -238,6 +238,18 @@ public struct ActionableStateResolved: Equatable, Codable, Sendable {
     }
 }
 
+public struct ClaudeProcessExited: Equatable, Codable, Sendable {
+    public let sessionID: String
+    public let pid: Int32
+    public let timestamp: Date
+
+    public init(sessionID: String, pid: Int32, timestamp: Date) {
+        self.sessionID = sessionID
+        self.pid = pid
+        self.timestamp = timestamp
+    }
+}
+
 public enum AgentEvent: Equatable, Codable, Sendable {
     case sessionStarted(SessionStarted)
     case activityUpdated(SessionActivityUpdated)
@@ -251,6 +263,7 @@ public enum AgentEvent: Equatable, Codable, Sendable {
     case openCodeSessionMetadataUpdated(OpenCodeSessionMetadataUpdated)
     case cursorSessionMetadataUpdated(CursorSessionMetadataUpdated)
     case actionableStateResolved(ActionableStateResolved)
+    case claudeProcessExited(ClaudeProcessExited)
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -266,6 +279,7 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case openCodeSessionMetadataUpdated
         case cursorSessionMetadataUpdated
         case actionableStateResolved
+        case claudeProcessExited
     }
 
     private enum EventType: String, Codable {
@@ -281,6 +295,7 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case openCodeSessionMetadataUpdated
         case cursorSessionMetadataUpdated
         case actionableStateResolved
+        case claudeProcessExited = "claude_process_exited"
     }
 
     public init(from decoder: any Decoder) throws {
@@ -321,6 +336,10 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case .actionableStateResolved:
             self = .actionableStateResolved(
                 try container.decode(ActionableStateResolved.self, forKey: .actionableStateResolved)
+            )
+        case .claudeProcessExited:
+            self = .claudeProcessExited(
+                try container.decode(ClaudeProcessExited.self, forKey: .claudeProcessExited)
             )
         }
     }
@@ -365,6 +384,9 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case let .actionableStateResolved(payload):
             try container.encode(EventType.actionableStateResolved, forKey: .type)
             try container.encode(payload, forKey: .actionableStateResolved)
+        case let .claudeProcessExited(payload):
+            try container.encode(EventType.claudeProcessExited, forKey: .type)
+            try container.encode(payload, forKey: .claudeProcessExited)
         }
     }
 }

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -574,9 +574,11 @@ public final class BridgeServer: @unchecked Sendable {
         if let pid = payload.agentPID,
            pid > 0,
            payload.hookEventName != .sessionEnd {
-            claudePIDMonitor.track(sessionID: payload.sessionID, pid: pid) { [weak self] exit in
-                self?.handleClaudeProcessExit(sessionID: exit.sessionID, pid: exit.pid, at: exit.exitedAt)
-            }
+            claudePIDMonitor.track(
+                sessionID: payload.sessionID,
+                pid: pid,
+                onExit: makeClaudeExitHandler()
+            )
         }
 
         switch payload.hookEventName {
@@ -2461,6 +2463,31 @@ public final class BridgeServer: @unchecked Sendable {
                 timestamp: exitTime
             )))
         }
+    }
+
+    private func makeClaudeExitHandler() -> (ClaudePIDMonitor.ExitEvent) -> Void {
+        return { [weak self] exit in
+            self?.handleClaudeProcessExit(sessionID: exit.sessionID, pid: exit.pid, at: exit.exitedAt)
+        }
+    }
+
+    /// Reattaches a kernel PID monitor for a Claude session whose CLI process
+    /// persisted across an app restart. The restored session's persisted PID is
+    /// still alive; this call rehydrates exit notifications so the next kill
+    /// flows through the same `.claudeProcessExited` path as the live-hook path.
+    public func adoptClaudeSessionProcess(sessionID: String, pid: Int32) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.claudePIDMonitor.track(
+                sessionID: sessionID,
+                pid: pid,
+                onExit: self.makeClaudeExitHandler()
+            )
+        }
+    }
+
+    public func hasClaudeMonitorForSession(_ sessionID: String) -> Bool {
+        claudePIDMonitor.isTracking(sessionID: sessionID)
     }
 
     private func hasSession(id: String) -> Bool {

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -53,6 +53,7 @@ public final class BridgeServer: @unchecked Sendable {
     }
 
     private let socketURL: URL
+    private let claudePIDMonitor: ClaudePIDMonitor
     private let queue = DispatchQueue(label: "app.openisland.bridge.server")
     private let queueKey = DispatchSpecificKey<Void>()
 
@@ -75,9 +76,11 @@ public final class BridgeServer: @unchecked Sendable {
     private var localState = SessionState()
 
     public init(
-        socketURL: URL = BridgeSocketLocation.defaultURL
+        socketURL: URL = BridgeSocketLocation.defaultURL,
+        claudePIDMonitor: ClaudePIDMonitor = ClaudePIDMonitor()
     ) {
         self.socketURL = socketURL
+        self.claudePIDMonitor = claudePIDMonitor
         queue.setSpecific(key: queueKey, value: ())
     }
 
@@ -177,6 +180,7 @@ public final class BridgeServer: @unchecked Sendable {
         pendingClaudeToolContexts.removeAll()
         pendingOpenCodeInteractions.removeAll()
         pendingCursorInteractions.removeAll()
+        claudePIDMonitor.untrackAll()
 
         let activeConnections = Array(clients.values)
         activeConnections.forEach { $0.readSource.cancel() }
@@ -563,6 +567,18 @@ public final class BridgeServer: @unchecked Sendable {
         // subagents whose SubagentStop was never received.
         cleanUpStaleSubagents(forSession: payload.sessionID)
 
+        // Any parent-session Claude hook with a concrete PID proves the CLI
+        // process is currently alive. Attach/replace the kernel-level exit
+        // monitor so we can notice the process dying even if SessionEnd never
+        // fires (SIGKILL, crash, terminal closed without a clean exit).
+        if let pid = payload.agentPID,
+           pid > 0,
+           payload.hookEventName != .sessionEnd {
+            claudePIDMonitor.track(sessionID: payload.sessionID, pid: pid) { [weak self] exit in
+                self?.handleClaudeProcessExit(sessionID: exit.sessionID, pid: exit.pid, at: exit.exitedAt)
+            }
+        }
+
         switch payload.hookEventName {
         case .sessionStart:
             clearStaleClaudeInteractionIfNeeded(for: payload.sessionID)
@@ -936,6 +952,7 @@ public final class BridgeServer: @unchecked Sendable {
                     )
                 )
             )
+            claudePIDMonitor.untrack(sessionID: payload.sessionID)
             send(.response(.acknowledged), to: clientID)
         }
     }
@@ -2426,6 +2443,24 @@ public final class BridgeServer: @unchecked Sendable {
     private func emit(_ event: AgentEvent) {
         localState.apply(event)
         broadcast([.event(event)])
+    }
+
+    private func handleClaudeProcessExit(sessionID: String, pid: Int32, at exitTime: Date) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            // Guard against resume-flow races: if a newer monitor has already
+            // registered a different PID for this session, this exit callback
+            // is stale — ignore it rather than spuriously ending the session.
+            if let current = self.claudePIDMonitor.currentPID(for: sessionID), current != pid {
+                return
+            }
+            self.claudePIDMonitor.untrack(sessionID: sessionID)
+            self.emit(.claudeProcessExited(ClaudeProcessExited(
+                sessionID: sessionID,
+                pid: pid,
+                timestamp: exitTime
+            )))
+        }
     }
 
     private func hasSession(id: String) -> Bool {

--- a/Sources/OpenIslandCore/ClaudeHooks.swift
+++ b/Sources/OpenIslandCore/ClaudeHooks.swift
@@ -366,6 +366,7 @@ public struct ClaudeHookPayload: Equatable, Codable, Sendable {
     /// at hook runtime. Not sent over the wire by the hook script — populated
     /// in `withRuntimeContext` and serialized through the bridge.
     public var warpPaneUUID: String?
+    public var agentPID: Int32?
     /// Set to `true` by the Python hook client to indicate a remote (SSH) session.
     public var remote: Bool?
 
@@ -406,6 +407,7 @@ public struct ClaudeHookPayload: Equatable, Codable, Sendable {
         case terminalTTY = "terminal_tty"
         case terminalTitle = "terminal_title"
         case warpPaneUUID = "warp_pane_uuid"
+        case agentPID = "agent_pid"
         case remote
     }
 
@@ -439,6 +441,7 @@ public struct ClaudeHookPayload: Equatable, Codable, Sendable {
         terminalTTY: String? = nil,
         terminalTitle: String? = nil,
         warpPaneUUID: String? = nil,
+        agentPID: Int32? = nil,
         remote: Bool? = nil
     ) {
         self.cwd = cwd
@@ -470,6 +473,7 @@ public struct ClaudeHookPayload: Equatable, Codable, Sendable {
         self.terminalTTY = terminalTTY
         self.terminalTitle = terminalTitle
         self.warpPaneUUID = warpPaneUUID
+        self.agentPID = agentPID
         self.remote = remote
     }
 }
@@ -1025,6 +1029,15 @@ public extension ClaudeHookPayload {
             }
             if payload.terminalTitle == nil {
                 payload.terminalTitle = locator.title
+            }
+        }
+
+        if payload.agentPID == nil {
+            // Parent PID = the Claude CLI that spawned this hook. Captured here so the
+            // app can kernel-monitor its exit, rather than polling ps/lsof for liveness.
+            let pid = getppid()
+            if pid > 1 {
+                payload.agentPID = pid
             }
         }
 

--- a/Sources/OpenIslandCore/ClaudeHooks.swift
+++ b/Sources/OpenIslandCore/ClaudeHooks.swift
@@ -258,6 +258,7 @@ public struct ClaudeSessionMetadata: Equatable, Codable, Sendable {
     public var worktreeBranch: String?
     public var activeSubagents: [ClaudeSubagentInfo]
     public var activeTasks: [ClaudeTaskInfo]
+    public var agentPID: Int32?
 
     public init(
         transcriptPath: String? = nil,
@@ -273,7 +274,8 @@ public struct ClaudeSessionMetadata: Equatable, Codable, Sendable {
         agentType: String? = nil,
         worktreeBranch: String? = nil,
         activeSubagents: [ClaudeSubagentInfo] = [],
-        activeTasks: [ClaudeTaskInfo] = []
+        activeTasks: [ClaudeTaskInfo] = [],
+        agentPID: Int32? = nil
     ) {
         self.transcriptPath = transcriptPath
         self.initialUserPrompt = initialUserPrompt
@@ -289,6 +291,7 @@ public struct ClaudeSessionMetadata: Equatable, Codable, Sendable {
         self.worktreeBranch = worktreeBranch
         self.activeSubagents = activeSubagents
         self.activeTasks = activeTasks
+        self.agentPID = agentPID
     }
 
     public var isEmpty: Bool {
@@ -306,6 +309,7 @@ public struct ClaudeSessionMetadata: Equatable, Codable, Sendable {
             && worktreeBranch == nil
             && activeSubagents.isEmpty
             && activeTasks.isEmpty
+            && agentPID == nil
     }
 }
 
@@ -713,7 +717,8 @@ public extension ClaudeHookPayload {
             permissionMode: permissionMode,
             agentID: agentID,
             agentType: agentType,
-            worktreeBranch: worktreeBranch
+            worktreeBranch: worktreeBranch,
+            agentPID: agentPID
         )
     }
 

--- a/Sources/OpenIslandCore/ClaudePIDMonitor.swift
+++ b/Sources/OpenIslandCore/ClaudePIDMonitor.swift
@@ -1,0 +1,144 @@
+import Darwin
+import Foundation
+
+/// Kernel-level PID exit monitor for Claude sessions.
+///
+/// Wraps `DispatchSource.makeProcessSource(eventMask: .exit)` per tracked PID
+/// and exposes a small, session-keyed API. A short grace period absorbs
+/// `claude --resume`-style restarts where the old PID exits just before a
+/// new PID re-registers for the same session.
+public final class ClaudePIDMonitor: @unchecked Sendable {
+    public struct ExitEvent: Sendable {
+        public let sessionID: String
+        public let pid: Int32
+        public let exitedAt: Date
+
+        public init(sessionID: String, pid: Int32, exitedAt: Date) {
+            self.sessionID = sessionID
+            self.pid = pid
+            self.exitedAt = exitedAt
+        }
+    }
+
+    private final class MonitorRecord {
+        let pid: Int32
+        var source: DispatchSourceProcess?
+        var onExit: (ExitEvent) -> Void
+        var pendingGrace: DispatchWorkItem?
+
+        init(pid: Int32, source: DispatchSourceProcess?, onExit: @escaping (ExitEvent) -> Void) {
+            self.pid = pid
+            self.source = source
+            self.onExit = onExit
+            self.pendingGrace = nil
+        }
+    }
+
+    private let gracePeriod: TimeInterval
+    private let queue: DispatchQueue
+    private let stateQueue = DispatchQueue(label: "OpenIsland.ClaudePIDMonitor.state")
+    private var records: [String: MonitorRecord] = [:]
+
+    public init(gracePeriod: TimeInterval = 5.0, queue: DispatchQueue = .global(qos: .utility)) {
+        self.gracePeriod = gracePeriod
+        self.queue = queue
+    }
+
+    deinit {
+        // Cancel all sources and pending work so nothing fires into a released self.
+        for (_, record) in records {
+            record.pendingGrace?.cancel()
+            record.source?.cancel()
+        }
+        records.removeAll()
+    }
+
+    public func track(sessionID: String, pid: Int32, onExit: @escaping (ExitEvent) -> Void) {
+        performSync {
+            if let existing = self.records[sessionID] {
+                if existing.pid == pid {
+                    // Idempotent for same PID; keep existing monitor intact.
+                    return
+                }
+                existing.pendingGrace?.cancel()
+                existing.source?.cancel()
+                self.records.removeValue(forKey: sessionID)
+            }
+            self.installLocked(sessionID: sessionID, pid: pid, onExit: onExit)
+        }
+    }
+
+    public func untrack(sessionID: String) {
+        performSync {
+            guard let record = self.records.removeValue(forKey: sessionID) else { return }
+            record.pendingGrace?.cancel()
+            record.source?.cancel()
+        }
+    }
+
+    public func isTracking(sessionID: String) -> Bool {
+        performSync { self.records[sessionID] != nil }
+    }
+
+    public func isAlive(sessionID: String) -> Bool {
+        guard let pid = currentPID(for: sessionID) else { return false }
+        return kill(pid, 0) == 0
+    }
+
+    public func currentPID(for sessionID: String) -> Int32? {
+        performSync { self.records[sessionID]?.pid }
+    }
+
+    // MARK: - Private
+
+    private func performSync<T>(_ work: () -> T) -> T {
+        stateQueue.sync(execute: work)
+    }
+
+    /// Must be called on `stateQueue`.
+    private func installLocked(sessionID: String, pid: Int32, onExit: @escaping (ExitEvent) -> Void) {
+        if kill(pid, 0) != 0 && errno == ESRCH {
+            // PID is already dead; schedule a grace-delayed callback without a source.
+            let record = MonitorRecord(pid: pid, source: nil, onExit: onExit)
+            records[sessionID] = record
+            scheduleGraceLocked(sessionID: sessionID, record: record)
+            return
+        }
+
+        let source = DispatchSource.makeProcessSource(identifier: pid_t(pid), eventMask: .exit, queue: queue)
+        let record = MonitorRecord(pid: pid, source: source, onExit: onExit)
+        records[sessionID] = record
+
+        source.setEventHandler { [weak self] in
+            guard let self else { return }
+            self.performSync {
+                // Only schedule if this record is still the current one for the session.
+                guard let current = self.records[sessionID], current === record else { return }
+                self.scheduleGraceLocked(sessionID: sessionID, record: current)
+            }
+        }
+        source.resume()
+    }
+
+    /// Must be called on `stateQueue`.
+    private func scheduleGraceLocked(sessionID: String, record: MonitorRecord) {
+        record.pendingGrace?.cancel()
+        let pid = record.pid
+        let item = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            let callback: ((ExitEvent) -> Void)? = self.performSync {
+                guard let current = self.records[sessionID], current === record else { return nil }
+                current.source?.cancel()
+                self.records.removeValue(forKey: sessionID)
+                return current.onExit
+            }
+            callback?(ExitEvent(sessionID: sessionID, pid: pid, exitedAt: Date()))
+        }
+        record.pendingGrace = item
+        if gracePeriod <= 0 {
+            queue.async(execute: item)
+        } else {
+            queue.asyncAfter(deadline: .now() + gracePeriod, execute: item)
+        }
+    }
+}

--- a/Sources/OpenIslandCore/ClaudePIDMonitor.swift
+++ b/Sources/OpenIslandCore/ClaudePIDMonitor.swift
@@ -76,6 +76,16 @@ public final class ClaudePIDMonitor: @unchecked Sendable {
         }
     }
 
+    public func untrackAll() {
+        performSync {
+            for (_, record) in self.records {
+                record.pendingGrace?.cancel()
+                record.source?.cancel()
+            }
+            self.records.removeAll()
+        }
+    }
+
     public func isTracking(sessionID: String) -> Bool {
         performSync { self.records[sessionID] != nil }
     }

--- a/Sources/OpenIslandCore/ClaudeSessionRegistry.swift
+++ b/Sources/OpenIslandCore/ClaudeSessionRegistry.swift
@@ -10,6 +10,7 @@ public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
     public var updatedAt: Date
     public var jumpTarget: JumpTarget?
     public var claudeMetadata: ClaudeSessionMetadata?
+    public var agentPID: Int32?
 
     public init(
         sessionID: String,
@@ -20,7 +21,8 @@ public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
         phase: SessionPhase,
         updatedAt: Date,
         jumpTarget: JumpTarget? = nil,
-        claudeMetadata: ClaudeSessionMetadata? = nil
+        claudeMetadata: ClaudeSessionMetadata? = nil,
+        agentPID: Int32? = nil
     ) {
         self.sessionID = sessionID
         self.title = title
@@ -31,6 +33,7 @@ public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
         self.updatedAt = updatedAt
         self.jumpTarget = jumpTarget
         self.claudeMetadata = claudeMetadata
+        self.agentPID = agentPID
     }
 
     public init(session: AgentSession) {
@@ -43,12 +46,21 @@ public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
             phase: session.phase,
             updatedAt: session.updatedAt,
             jumpTarget: session.jumpTarget,
-            claudeMetadata: session.claudeMetadata
+            claudeMetadata: session.claudeMetadata,
+            agentPID: session.claudeMetadata?.agentPID
         )
     }
 
     public var session: AgentSession {
-        AgentSession(
+        var metadata = claudeMetadata
+        if let agentPID {
+            if metadata == nil {
+                metadata = ClaudeSessionMetadata(agentPID: agentPID)
+            } else if metadata?.agentPID == nil {
+                metadata?.agentPID = agentPID
+            }
+        }
+        return AgentSession(
             id: sessionID,
             title: title,
             tool: .claudeCode,
@@ -58,7 +70,7 @@ public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
             summary: summary,
             updatedAt: updatedAt,
             jumpTarget: jumpTarget,
-            claudeMetadata: claudeMetadata
+            claudeMetadata: metadata
         )
     }
 
@@ -78,6 +90,7 @@ public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
         case updatedAt
         case jumpTarget
         case claudeMetadata
+        case agentPID
     }
 
     public init(from decoder: any Decoder) throws {
@@ -91,6 +104,7 @@ public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
         updatedAt = try container.decode(Date.self, forKey: .updatedAt)
         jumpTarget = try container.decodeIfPresent(JumpTarget.self, forKey: .jumpTarget)
         claudeMetadata = try container.decodeIfPresent(ClaudeSessionMetadata.self, forKey: .claudeMetadata)
+        agentPID = try container.decodeIfPresent(Int32.self, forKey: .agentPID)
     }
 
     public func encode(to encoder: any Encoder) throws {
@@ -104,6 +118,7 @@ public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
         try container.encode(updatedAt, forKey: .updatedAt)
         try container.encodeIfPresent(jumpTarget, forKey: .jumpTarget)
         try container.encodeIfPresent(claudeMetadata, forKey: .claudeMetadata)
+        try container.encodeIfPresent(agentPID, forKey: .agentPID)
     }
 }
 

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -177,6 +177,16 @@ public struct SessionState: Equatable, Sendable {
             session.updatedAt = payload.timestamp
             upsert(session)
 
+        case let .claudeProcessExited(payload):
+            guard var session = sessionsByID[payload.sessionID] else { return }
+            guard !session.isSessionEnded else { return }
+            session.isSessionEnded = true
+            session.phase = .completed
+            session.isProcessAlive = false
+            session.updatedAt = payload.timestamp
+            session.processNotSeenCount = 0
+            upsert(session)
+
         case let .geminiSessionMetadataUpdated(payload):
             guard var session = sessionsByID[payload.sessionID] else {
                 return
@@ -375,6 +385,16 @@ public struct SessionState: Equatable, Sendable {
             // cleaned up.
             if session.isHookManaged {
                 if session.isSessionEnded {
+                    continue
+                }
+
+                if session.tool == .claudeCode {
+                    // Lifecycle is driven by hook events + ClaudePIDMonitor exit signals.
+                    // ps/lsof is unreliable under load and must not evict healthy sessions.
+                    if aliveSessionIDs.contains(id) {
+                        session.processNotSeenCount = 0
+                        upsert(session)
+                    }
                     continue
                 }
 

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -609,6 +609,82 @@ struct AppModelSessionListTests {
     }
 
     @Test
+    func restoringSessionWithAliveAgentPIDReattachesMonitor() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        process.arguments = ["10"]
+        try process.run()
+        defer {
+            if process.isRunning { process.terminate() }
+            process.waitUntilExit()
+        }
+
+        let pid = process.processIdentifier
+        #expect(pid > 0)
+
+        let model = AppModel()
+        var session = AgentSession(
+            id: "claude-rehydrate-alive",
+            title: "Claude · alive",
+            tool: .claudeCode,
+            origin: .live,
+            attachmentState: .stale,
+            phase: .running,
+            summary: "Restored",
+            updatedAt: Date(timeIntervalSince1970: 1_000),
+            claudeMetadata: ClaudeSessionMetadata(agentPID: pid)
+        )
+        session.isHookManaged = true
+        model.state = SessionState(sessions: [session])
+
+        model.rehydrateClaudePIDMonitorsForRestoredSessions()
+
+        // adoptClaudeSessionProcess hops onto the bridge's internal queue. Give
+        // the async track a moment to register before asserting.
+        let deadline = Date().addingTimeInterval(1.0)
+        while Date() < deadline,
+              !model.bridgeServer.hasClaudeMonitorForSession(session.id) {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        }
+
+        #expect(model.bridgeServer.hasClaudeMonitorForSession(session.id))
+    }
+
+    @Test
+    func restoringSessionWithDeadAgentPIDMarksSessionEnded() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        process.arguments = ["0"]
+        try process.run()
+        process.waitUntilExit()
+        let deadPID = process.processIdentifier
+        #expect(deadPID > 0)
+        #expect(kill(deadPID, 0) != 0)
+
+        let model = AppModel()
+        var session = AgentSession(
+            id: "claude-rehydrate-dead",
+            title: "Claude · dead",
+            tool: .claudeCode,
+            origin: .live,
+            attachmentState: .stale,
+            phase: .running,
+            summary: "Restored",
+            updatedAt: Date(timeIntervalSince1970: 1_000),
+            claudeMetadata: ClaudeSessionMetadata(agentPID: deadPID)
+        )
+        session.isHookManaged = true
+        model.state = SessionState(sessions: [session])
+
+        model.rehydrateClaudePIDMonitorsForRestoredSessions()
+
+        let updated = model.state.session(id: session.id)
+        #expect(updated?.isSessionEnded == true)
+        #expect(updated?.phase == .completed)
+        #expect(model.bridgeServer.hasClaudeMonitorForSession(session.id) == false)
+    }
+
+    @Test
     func mergedWithSyntheticClaudeSessionsAddsGhosttyClaudeProcessWhenNoTrackedSessionExists() {
         let now = Date(timeIntervalSince1970: 2_000)
         let model = AppModel()

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -778,6 +778,157 @@ struct AppModelSessionListTests {
     }
 
     @Test
+    func syntheticClaudeSessionUpdatedAtIsFrozenAtFirstDiscovery() {
+        let t0 = Date(timeIntervalSince1970: 10_000)
+        let model = AppModel()
+        let process: ActiveProcessSnapshot = .init(
+            tool: .claudeCode,
+            sessionID: nil,
+            workingDirectory: "/tmp/frozen-age",
+            terminalTTY: "/dev/ttys042",
+            terminalApp: "Ghostty"
+        )
+
+        let firstPass = model.monitoring.mergedWithSyntheticClaudeSessions(
+            existingSessions: [],
+            activeProcesses: [process],
+            now: t0
+        )
+
+        #expect(firstPass.count == 1)
+        #expect(firstPass.first?.updatedAt == t0)
+
+        let secondPass = model.monitoring.mergedWithSyntheticClaudeSessions(
+            existingSessions: [],
+            activeProcesses: [process],
+            now: t0.addingTimeInterval(300)
+        )
+
+        #expect(secondPass.count == 1)
+        #expect(secondPass.first?.updatedAt == t0)
+    }
+
+    @Test
+    func syntheticClaudeSessionEvictsFirstSeenWhenProcessDisappears() {
+        let t0 = Date(timeIntervalSince1970: 20_000)
+        let model = AppModel()
+        let process: ActiveProcessSnapshot = .init(
+            tool: .claudeCode,
+            sessionID: nil,
+            workingDirectory: "/tmp/evict-age",
+            terminalTTY: "/dev/ttys099",
+            terminalApp: "Ghostty"
+        )
+
+        let firstPass = model.monitoring.mergedWithSyntheticClaudeSessions(
+            existingSessions: [],
+            activeProcesses: [process],
+            now: t0
+        )
+        #expect(firstPass.first?.updatedAt == t0)
+
+        let emptyPass = model.monitoring.mergedWithSyntheticClaudeSessions(
+            existingSessions: [],
+            activeProcesses: [],
+            now: t0.addingTimeInterval(300)
+        )
+        #expect(emptyPass.isEmpty)
+
+        let reappearanceTime = t0.addingTimeInterval(600)
+        let thirdPass = model.monitoring.mergedWithSyntheticClaudeSessions(
+            existingSessions: [],
+            activeProcesses: [process],
+            now: reappearanceTime
+        )
+
+        #expect(thirdPass.count == 1)
+        #expect(thirdPass.first?.updatedAt == reappearanceTime)
+    }
+
+    @Test
+    func mergedWithSyntheticClaudeSessionsDoesNotCreateSyntheticWhenHookManagedSessionOwnsWorkspace() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let model = AppModel()
+        var hookManaged = AgentSession(
+            id: "abc-123",
+            title: "Claude · proj",
+            tool: .claudeCode,
+            origin: .live,
+            attachmentState: .stale,
+            phase: .running,
+            summary: "Running",
+            updatedAt: now,
+            jumpTarget: JumpTarget(
+                terminalApp: "Ghostty",
+                workspaceName: "proj",
+                paneTitle: "Claude abc-123",
+                workingDirectory: "/tmp/proj"
+            )
+        )
+        hookManaged.isHookManaged = true
+
+        let merged = model.monitoring.mergedWithSyntheticClaudeSessions(
+            existingSessions: [hookManaged],
+            activeProcesses: [
+                .init(
+                    tool: .claudeCode,
+                    sessionID: nil,
+                    workingDirectory: "/tmp/proj",
+                    terminalTTY: "/dev/ttys200",
+                    terminalApp: "Ghostty",
+                    transcriptPath: nil
+                ),
+            ],
+            now: now
+        )
+
+        #expect(merged.count == 1)
+        #expect(merged.first?.id == "abc-123")
+    }
+
+    @Test
+    func mergedWithSyntheticClaudeSessionsStillCreatesSyntheticForOrphanWorkspace() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let model = AppModel()
+        var hookManaged = AgentSession(
+            id: "abc-123",
+            title: "Claude · proj-A",
+            tool: .claudeCode,
+            origin: .live,
+            attachmentState: .stale,
+            phase: .running,
+            summary: "Running",
+            updatedAt: now,
+            jumpTarget: JumpTarget(
+                terminalApp: "Ghostty",
+                workspaceName: "proj-A",
+                paneTitle: "Claude abc-123",
+                workingDirectory: "/tmp/proj-A"
+            )
+        )
+        hookManaged.isHookManaged = true
+
+        let merged = model.monitoring.mergedWithSyntheticClaudeSessions(
+            existingSessions: [hookManaged],
+            activeProcesses: [
+                .init(
+                    tool: .claudeCode,
+                    sessionID: nil,
+                    workingDirectory: "/tmp/proj-B",
+                    terminalTTY: "/dev/ttys201",
+                    terminalApp: "Ghostty",
+                    transcriptPath: nil
+                ),
+            ],
+            now: now
+        )
+
+        #expect(merged.count == 2)
+        #expect(merged.contains { $0.id == "abc-123" })
+        #expect(merged.contains { $0.id.hasPrefix("claude-process:") })
+    }
+
+    @Test
     func mergedWithSyntheticClaudeSessionsSkipsSyntheticWhenStaleClaudeSessionMatchesActiveProcess() {
         let now = Date(timeIntervalSince1970: 2_000)
         let model = AppModel()

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -884,4 +884,117 @@ struct AppModelSessionListTests {
         let claudeSessions = model.state.sessions.filter { $0.tool == .claudeCode }
         #expect(claudeSessions.count == 2)
     }
+
+    @Test
+    func mergeKeepsEarlierAgentPIDWhenLaterIsNil() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let model = AppModel()
+        model.state = SessionState(
+            sessions: [
+                AgentSession(
+                    id: "claude-pid-session",
+                    title: "Claude · open-island",
+                    tool: .claudeCode,
+                    origin: .live,
+                    attachmentState: .stale,
+                    phase: .running,
+                    summary: "Running",
+                    updatedAt: now.addingTimeInterval(-30),
+                    jumpTarget: JumpTarget(
+                        terminalApp: "Ghostty",
+                        workspaceName: "open-island",
+                        paneTitle: "claude ~/open-island",
+                        workingDirectory: "/tmp/open-island"
+                    ),
+                    claudeMetadata: ClaudeSessionMetadata(
+                        transcriptPath: "/tmp/claude.jsonl",
+                        agentPID: 100
+                    )
+                ),
+            ]
+        )
+
+        let merged = model.discovery.mergeDiscoveredSessions([
+            AgentSession(
+                id: "claude-pid-session",
+                title: "Claude · open-island",
+                tool: .claudeCode,
+                origin: .live,
+                attachmentState: .stale,
+                phase: .running,
+                summary: "Running",
+                updatedAt: now,
+                jumpTarget: JumpTarget(
+                    terminalApp: "Ghostty",
+                    workspaceName: "open-island",
+                    paneTitle: "claude ~/open-island",
+                    workingDirectory: "/tmp/open-island"
+                ),
+                claudeMetadata: ClaudeSessionMetadata(
+                    transcriptPath: "/tmp/claude.jsonl",
+                    lastUserPrompt: "New prompt."
+                )
+            ),
+        ])
+
+        #expect(merged.count == 1)
+        #expect(merged.first?.claudeMetadata?.agentPID == 100)
+        #expect(merged.first?.claudeMetadata?.lastUserPrompt == "New prompt.")
+    }
+
+    @Test
+    func mergeAdoptsNewerAgentPIDWhenSpecified() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let model = AppModel()
+        model.state = SessionState(
+            sessions: [
+                AgentSession(
+                    id: "claude-pid-session",
+                    title: "Claude · open-island",
+                    tool: .claudeCode,
+                    origin: .live,
+                    attachmentState: .stale,
+                    phase: .running,
+                    summary: "Running",
+                    updatedAt: now.addingTimeInterval(-30),
+                    jumpTarget: JumpTarget(
+                        terminalApp: "Ghostty",
+                        workspaceName: "open-island",
+                        paneTitle: "claude ~/open-island",
+                        workingDirectory: "/tmp/open-island"
+                    ),
+                    claudeMetadata: ClaudeSessionMetadata(
+                        transcriptPath: "/tmp/claude.jsonl",
+                        agentPID: 100
+                    )
+                ),
+            ]
+        )
+
+        let merged = model.discovery.mergeDiscoveredSessions([
+            AgentSession(
+                id: "claude-pid-session",
+                title: "Claude · open-island",
+                tool: .claudeCode,
+                origin: .live,
+                attachmentState: .stale,
+                phase: .running,
+                summary: "Running",
+                updatedAt: now,
+                jumpTarget: JumpTarget(
+                    terminalApp: "Ghostty",
+                    workspaceName: "open-island",
+                    paneTitle: "claude ~/open-island",
+                    workingDirectory: "/tmp/open-island"
+                ),
+                claudeMetadata: ClaudeSessionMetadata(
+                    transcriptPath: "/tmp/claude.jsonl",
+                    agentPID: 200
+                )
+            ),
+        ])
+
+        #expect(merged.count == 1)
+        #expect(merged.first?.claudeMetadata?.agentPID == 200)
+    }
 }

--- a/Tests/OpenIslandAppTests/ClaudeSessionLifecycleIntegrationTests.swift
+++ b/Tests/OpenIslandAppTests/ClaudeSessionLifecycleIntegrationTests.swift
@@ -1,0 +1,225 @@
+import Darwin
+import Foundation
+import Testing
+@testable import OpenIslandApp
+import OpenIslandCore
+
+@MainActor
+struct ClaudeSessionLifecycleIntegrationTests {
+    @Test
+    func hookManagedClaudeSessionsSurviveEmptyProcessDiscoveryCycles() async throws {
+        var processes: [Process] = []
+        defer { processes.forEach { $0.ensureExited() } }
+
+        var fixtures: [SessionFixture] = []
+        let originalUpdatedAt = Date().addingTimeInterval(-600)
+
+        for index in 1...4 {
+            let process = try spawnSleep(duration: 30)
+            processes.append(process)
+            fixtures.append(
+                SessionFixture(
+                    id: "integration-session-\(index)",
+                    pid: process.processIdentifier,
+                    workspaceName: "integration-proj-\(index)",
+                    workingDirectory: "/tmp/integration-proj-\(index)",
+                    paneTitle: "claude-\(index)",
+                    summary: "session \(index) summary",
+                    initialUserPrompt: "session \(index) initial prompt",
+                    lastUserPrompt: "session \(index) latest",
+                    updatedAt: originalUpdatedAt
+                )
+            )
+        }
+
+        let model = AppModel()
+        model.state = SessionState(sessions: fixtures.map { $0.makeSession() })
+
+        for fixture in fixtures {
+            model.bridgeServer.adoptClaudeSessionProcess(sessionID: fixture.id, pid: fixture.pid)
+        }
+
+        for fixture in fixtures {
+            #expect(
+                waitForCondition { model.bridgeServer.hasClaudeMonitorForSession(fixture.id) },
+                "Monitor should be tracking \(fixture.id) after adoption"
+            )
+        }
+
+        for _ in 0..<10 {
+            model.monitoring.reconcileSessionAttachments(activeProcesses: [])
+        }
+
+        for fixture in fixtures {
+            let restored = model.state.session(id: fixture.id)
+            #expect(restored != nil)
+            #expect(restored?.phase == .running)
+            #expect(restored?.isSessionEnded == false)
+            #expect(restored?.claudeMetadata?.initialUserPrompt == fixture.initialUserPrompt)
+            #expect(restored?.claudeMetadata?.lastUserPrompt == fixture.lastUserPrompt)
+            #expect(restored?.claudeMetadata?.agentPID == fixture.pid)
+            if let updated = restored?.updatedAt {
+                #expect(abs(updated.timeIntervalSince(originalUpdatedAt)) < 0.01)
+            }
+        }
+    }
+
+    @Test
+    func killingOneClaudeProcessFlipsOnlyThatSessionToCompleted() async throws {
+        var processes: [Process] = []
+        defer { processes.forEach { $0.ensureExited() } }
+
+        var fixtures: [SessionFixture] = []
+        let originalUpdatedAt = Date().addingTimeInterval(-600)
+
+        for index in 1...4 {
+            let process = try spawnSleep(duration: 30)
+            processes.append(process)
+            fixtures.append(
+                SessionFixture(
+                    id: "kill-session-\(index)",
+                    pid: process.processIdentifier,
+                    workspaceName: "kill-proj-\(index)",
+                    workingDirectory: "/tmp/kill-proj-\(index)",
+                    paneTitle: "claude-\(index)",
+                    summary: "session \(index) summary",
+                    initialUserPrompt: "session \(index) initial prompt",
+                    lastUserPrompt: "session \(index) latest",
+                    updatedAt: originalUpdatedAt
+                )
+            )
+        }
+
+        let model = AppModel()
+        model.state = SessionState(sessions: fixtures.map { $0.makeSession() })
+
+        for fixture in fixtures {
+            model.bridgeServer.adoptClaudeSessionProcess(sessionID: fixture.id, pid: fixture.pid)
+        }
+
+        for fixture in fixtures {
+            #expect(
+                waitForCondition { model.bridgeServer.hasClaudeMonitorForSession(fixture.id) },
+                "Monitor should be tracking \(fixture.id) after adoption"
+            )
+        }
+
+        let targetIndex = 1
+        let target = fixtures[targetIndex]
+        let targetProcess = processes[targetIndex]
+
+        targetProcess.terminate()
+        targetProcess.waitUntilExit()
+
+        // AppModel's BridgeServer is constructed with the default 5s grace;
+        // wait for the kernel exit + grace period to elapse and the server's
+        // internal handler to untrack the monitor.
+        #expect(
+            waitForCondition(timeout: 12.0) {
+                model.bridgeServer.hasClaudeMonitorForSession(target.id) == false
+            },
+            "Monitor for killed session should untrack after grace period"
+        )
+
+        // AppModel's bridge observer only connects when startApp(startBridge: true)
+        // runs; this isolated test has no listener on the server's emit, so
+        // drive the reducer directly with the same event the bridge would have
+        // emitted. Using .rollout ingress avoids the attachment/liveness side
+        // effects that the bridge ingress path applies (attached/processAlive),
+        // which would otherwise fight the reducer's isProcessAlive = false.
+        model.applyTrackedEvent(
+            .claudeProcessExited(ClaudeProcessExited(
+                sessionID: target.id,
+                pid: target.pid,
+                timestamp: .now
+            )),
+            updateLastActionMessage: false,
+            ingress: .rollout
+        )
+
+        let killed = model.state.session(id: target.id)
+        #expect(killed?.phase == .completed)
+        #expect(killed?.isSessionEnded == true)
+        #expect(killed?.isProcessAlive == false)
+
+        for (index, fixture) in fixtures.enumerated() where index != targetIndex {
+            let survivor = model.state.session(id: fixture.id)
+            #expect(survivor?.phase == .running)
+            #expect(survivor?.isSessionEnded == false)
+            #expect(model.bridgeServer.hasClaudeMonitorForSession(fixture.id) == true)
+        }
+
+        #expect(model.bridgeServer.hasClaudeMonitorForSession(target.id) == false)
+    }
+}
+
+// MARK: - Helpers
+
+private struct SessionFixture {
+    let id: String
+    let pid: Int32
+    let workspaceName: String
+    let workingDirectory: String
+    let paneTitle: String
+    let summary: String
+    let initialUserPrompt: String
+    let lastUserPrompt: String
+    let updatedAt: Date
+
+    func makeSession() -> AgentSession {
+        var session = AgentSession(
+            id: id,
+            title: "Claude · \(workspaceName)",
+            tool: .claudeCode,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: summary,
+            updatedAt: updatedAt,
+            jumpTarget: JumpTarget(
+                terminalApp: "Ghostty",
+                workspaceName: workspaceName,
+                paneTitle: paneTitle,
+                workingDirectory: workingDirectory
+            ),
+            claudeMetadata: ClaudeSessionMetadata(
+                initialUserPrompt: initialUserPrompt,
+                lastUserPrompt: lastUserPrompt,
+                agentPID: pid
+            )
+        )
+        session.isHookManaged = true
+        session.isProcessAlive = true
+        return session
+    }
+}
+
+private func spawnSleep(duration: Double) throws -> Process {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/sleep")
+    process.arguments = [String(duration)]
+    try process.run()
+    return process
+}
+
+private extension Process {
+    func ensureExited() {
+        if isRunning {
+            terminate()
+            waitUntilExit()
+        }
+    }
+}
+
+@MainActor
+private func waitForCondition(
+    timeout: TimeInterval = 4.0,
+    _ check: () -> Bool
+) -> Bool {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+        if check() { return true }
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+    }
+    return check()
+}

--- a/Tests/OpenIslandCoreTests/BridgeServerPIDMonitorTests.swift
+++ b/Tests/OpenIslandCoreTests/BridgeServerPIDMonitorTests.swift
@@ -1,0 +1,265 @@
+import Darwin
+import Dispatch
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+struct BridgeServerPIDMonitorTests {
+    @Test
+    func sessionStartWithAgentPIDRegistersMonitor() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let monitor = ClaudePIDMonitor(gracePeriod: 0)
+        let server = BridgeServer(socketURL: socketURL, claudePIDMonitor: monitor)
+        try server.start()
+        defer { server.stop() }
+
+        let process = try spawnSleep(duration: 10)
+        defer { process.ensureExited() }
+
+        let payload = ClaudeHookPayload(
+            cwd: "/tmp/demo",
+            hookEventName: .sessionStart,
+            sessionID: "claude-pid-1",
+            agentPID: process.processIdentifier
+        )
+
+        let response = try await sendOnBackgroundQueue(.processClaudeHook(payload), socketURL: socketURL)
+        #expect(response == .acknowledged)
+
+        #expect(monitor.isTracking(sessionID: "claude-pid-1") == true)
+        #expect(monitor.currentPID(for: "claude-pid-1") == process.processIdentifier)
+    }
+
+    @Test
+    func sessionStartWithoutAgentPIDDoesNotRegisterMonitor() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let monitor = ClaudePIDMonitor(gracePeriod: 0)
+        let server = BridgeServer(socketURL: socketURL, claudePIDMonitor: monitor)
+        try server.start()
+        defer { server.stop() }
+
+        let payload = ClaudeHookPayload(
+            cwd: "/tmp/demo",
+            hookEventName: .sessionStart,
+            sessionID: "claude-pid-legacy"
+        )
+
+        let response = try await sendOnBackgroundQueue(.processClaudeHook(payload), socketURL: socketURL)
+        #expect(response == .acknowledged)
+
+        #expect(monitor.isTracking(sessionID: "claude-pid-legacy") == false)
+    }
+
+    @Test
+    func sessionEndUntracksMonitor() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let monitor = ClaudePIDMonitor(gracePeriod: 0)
+        let server = BridgeServer(socketURL: socketURL, claudePIDMonitor: monitor)
+        try server.start()
+        defer { server.stop() }
+
+        let process = try spawnSleep(duration: 10)
+        defer { process.ensureExited() }
+
+        let startPayload = ClaudeHookPayload(
+            cwd: "/tmp/demo",
+            hookEventName: .sessionStart,
+            sessionID: "claude-pid-end",
+            agentPID: process.processIdentifier
+        )
+        _ = try await sendOnBackgroundQueue(.processClaudeHook(startPayload), socketURL: socketURL)
+        #expect(monitor.isTracking(sessionID: "claude-pid-end") == true)
+
+        let endPayload = ClaudeHookPayload(
+            cwd: "/tmp/demo",
+            hookEventName: .sessionEnd,
+            sessionID: "claude-pid-end",
+            agentPID: process.processIdentifier
+        )
+        let endResponse = try await sendOnBackgroundQueue(.processClaudeHook(endPayload), socketURL: socketURL)
+        #expect(endResponse == .acknowledged)
+
+        #expect(monitor.isTracking(sessionID: "claude-pid-end") == false)
+    }
+
+    @Test
+    func kernelExitEmitsClaudeProcessExited() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let monitor = ClaudePIDMonitor(gracePeriod: 0)
+        let server = BridgeServer(socketURL: socketURL, claudePIDMonitor: monitor)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        // Long enough to register the hook first, short enough to exit during the test.
+        let process = try spawnSleep(duration: 0.5)
+        let pid = process.processIdentifier
+
+        let payload = ClaudeHookPayload(
+            cwd: "/tmp/demo",
+            hookEventName: .sessionStart,
+            sessionID: "claude-pid-exit",
+            agentPID: pid
+        )
+        _ = try await sendOnBackgroundQueue(.processClaudeHook(payload), socketURL: socketURL)
+        #expect(monitor.isTracking(sessionID: "claude-pid-exit") == true)
+
+        var iterator = stream.makeAsyncIterator()
+        let exitEvent = try await nextMatchingEvent(from: &iterator, maxEvents: 12) { event in
+            if case .claudeProcessExited = event { return true }
+            return false
+        }
+
+        if case let .claudeProcessExited(info) = exitEvent {
+            #expect(info.sessionID == "claude-pid-exit")
+            #expect(info.pid == pid)
+        } else {
+            Issue.record("Expected a claudeProcessExited event")
+        }
+
+        #expect(monitor.isTracking(sessionID: "claude-pid-exit") == false)
+
+        process.ensureExited()
+    }
+
+    @Test
+    func subagentHookDoesNotRegisterMonitor() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let monitor = ClaudePIDMonitor(gracePeriod: 0)
+        let server = BridgeServer(socketURL: socketURL, claudePIDMonitor: monitor)
+        try server.start()
+        defer { server.stop() }
+
+        let process = try spawnSleep(duration: 10)
+        defer { process.ensureExited() }
+
+        let payload = ClaudeHookPayload(
+            cwd: "/tmp/demo",
+            hookEventName: .userPromptSubmit,
+            sessionID: "claude-pid-subagent",
+            agentID: "subagent-1",
+            agentPID: process.processIdentifier
+        )
+
+        _ = try await sendOnBackgroundQueue(.processClaudeHook(payload), socketURL: socketURL)
+
+        #expect(monitor.isTracking(sessionID: "claude-pid-subagent") == false)
+    }
+
+    @Test
+    func resumeFlowReplacesMonitor() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let monitor = ClaudePIDMonitor(gracePeriod: 0)
+        let server = BridgeServer(socketURL: socketURL, claudePIDMonitor: monitor)
+        try server.start()
+        defer { server.stop() }
+
+        let first = try spawnSleep(duration: 10)
+        let firstPID = first.processIdentifier
+        let second = try spawnSleep(duration: 10)
+        let secondPID = second.processIdentifier
+        defer {
+            first.ensureExited()
+            second.ensureExited()
+        }
+
+        let startPayload = ClaudeHookPayload(
+            cwd: "/tmp/demo",
+            hookEventName: .sessionStart,
+            sessionID: "claude-pid-resume",
+            agentPID: firstPID
+        )
+        _ = try await sendOnBackgroundQueue(.processClaudeHook(startPayload), socketURL: socketURL)
+        #expect(monitor.currentPID(for: "claude-pid-resume") == firstPID)
+
+        let resumePayload = ClaudeHookPayload(
+            cwd: "/tmp/demo",
+            hookEventName: .userPromptSubmit,
+            sessionID: "claude-pid-resume",
+            agentPID: secondPID
+        )
+        _ = try await sendOnBackgroundQueue(.processClaudeHook(resumePayload), socketURL: socketURL)
+        #expect(monitor.currentPID(for: "claude-pid-resume") == secondPID)
+
+        // Kill the first (now-stale) PID. Its DispatchSource fired inside the
+        // monitor was cancelled when the second track() replaced the record,
+        // so no handleClaudeProcessExit should occur for firstPID. Even if
+        // the cancellation races, the bridge's race guard drops stale exits
+        // whose pid != currentPID. Assert the monitor remains anchored to
+        // the new PID after any in-flight exit has had a chance to land.
+        first.terminate()
+        first.waitUntilExit()
+
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        #expect(monitor.isTracking(sessionID: "claude-pid-resume") == true)
+        #expect(monitor.currentPID(for: "claude-pid-resume") == secondPID)
+    }
+}
+
+// MARK: - Helpers
+
+private enum BridgeServerPIDMonitorTestError: Error {
+    case streamEnded
+    case noMatchingEvent
+}
+
+private func nextEvent(
+    from iterator: inout AsyncThrowingStream<AgentEvent, Error>.AsyncIterator
+) async throws -> AgentEvent {
+    guard let event = try await iterator.next() else {
+        throw BridgeServerPIDMonitorTestError.streamEnded
+    }
+    return event
+}
+
+private func nextMatchingEvent(
+    from iterator: inout AsyncThrowingStream<AgentEvent, Error>.AsyncIterator,
+    maxEvents: Int,
+    predicate: (AgentEvent) -> Bool
+) async throws -> AgentEvent {
+    for _ in 0..<maxEvents {
+        let event = try await nextEvent(from: &iterator)
+        if predicate(event) {
+            return event
+        }
+    }
+    throw BridgeServerPIDMonitorTestError.noMatchingEvent
+}
+
+private func sendOnBackgroundQueue(
+    _ command: BridgeCommand,
+    socketURL: URL
+) async throws -> BridgeResponse? {
+    try await withCheckedThrowingContinuation { continuation in
+        DispatchQueue.global().async {
+            do {
+                let response = try BridgeCommandClient(socketURL: socketURL).send(command)
+                continuation.resume(returning: response)
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+}
+
+private func spawnSleep(duration: Double) throws -> Process {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/sleep")
+    process.arguments = [String(duration)]
+    try process.run()
+    return process
+}
+
+private extension Process {
+    func ensureExited() {
+        if isRunning {
+            terminate()
+            waitUntilExit()
+        }
+    }
+}

--- a/Tests/OpenIslandCoreTests/ClaudeHookPayloadPIDTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeHookPayloadPIDTests.swift
@@ -1,0 +1,76 @@
+import Darwin
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+struct ClaudeHookPayloadPIDTests {
+    @Test
+    func agentPIDRoundTripsThroughJSON() throws {
+        let payload = ClaudeHookPayload(
+            cwd: "/tmp/demo",
+            hookEventName: .sessionStart,
+            sessionID: "s1",
+            agentPID: 12_345
+        )
+
+        let encoded = try JSONEncoder().encode(payload)
+        let object = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        #expect(object?["agent_pid"] as? Int == 12_345)
+
+        let decoded = try JSONDecoder().decode(ClaudeHookPayload.self, from: encoded)
+        #expect(decoded.agentPID == 12_345)
+    }
+
+    @Test
+    func legacyPayloadWithoutAgentPIDDecodesAsNil() throws {
+        let json = """
+        {
+            "cwd": "/tmp/demo",
+            "hook_event_name": "SessionStart",
+            "session_id": "legacy-1",
+            "source": "startup"
+        }
+        """
+        let data = Data(json.utf8)
+
+        let decoded = try JSONDecoder().decode(ClaudeHookPayload.self, from: data)
+        #expect(decoded.agentPID == nil)
+        #expect(decoded.sessionID == "legacy-1")
+        #expect(decoded.hookEventName == .sessionStart)
+    }
+
+    @Test
+    func withRuntimeContextPopulatesAgentPIDFromGetppid() {
+        let payload = ClaudeHookPayload(
+            cwd: "/tmp/demo",
+            hookEventName: .sessionStart,
+            sessionID: "s1"
+        ).withRuntimeContext(
+            environment: [:],
+            currentTTYProvider: { nil },
+            terminalLocatorProvider: { _ in (sessionID: nil, tty: nil, title: nil) },
+            warpPaneResolver: { _ in nil }
+        )
+
+        let pid = try? #require(payload.agentPID)
+        #expect((pid ?? 0) > 1)
+        #expect(payload.agentPID == getppid())
+    }
+
+    @Test
+    func withRuntimeContextDoesNotOverrideExistingAgentPID() {
+        let payload = ClaudeHookPayload(
+            cwd: "/tmp/demo",
+            hookEventName: .sessionStart,
+            sessionID: "s1",
+            agentPID: 999
+        ).withRuntimeContext(
+            environment: [:],
+            currentTTYProvider: { nil },
+            terminalLocatorProvider: { _ in (sessionID: nil, tty: nil, title: nil) },
+            warpPaneResolver: { _ in nil }
+        )
+
+        #expect(payload.agentPID == 999)
+    }
+}

--- a/Tests/OpenIslandCoreTests/ClaudePIDMonitorTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudePIDMonitorTests.swift
@@ -1,0 +1,230 @@
+import Darwin
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+struct ClaudePIDMonitorTests {
+    @Test
+    func tracksLiveProcessAndFiresExitCallback() throws {
+        let monitor = ClaudePIDMonitor(gracePeriod: 0)
+        let process = try spawnSleep(duration: 0.3)
+        let pid = process.processIdentifier
+
+        let semaphore = DispatchSemaphore(value: 0)
+        let captured = CapturedExit()
+
+        monitor.track(sessionID: "s1", pid: pid) { event in
+            captured.store(event)
+            semaphore.signal()
+        }
+
+        let result = semaphore.wait(timeout: .now() + .seconds(3))
+        #expect(result == .success)
+        #expect(captured.event?.sessionID == "s1")
+        #expect(captured.event?.pid == pid)
+
+        process.ensureExited()
+    }
+
+    @Test
+    func untrackCancelsCallback() throws {
+        let monitor = ClaudePIDMonitor(gracePeriod: 0)
+        let process = try spawnSleep(duration: 0.2)
+        let pid = process.processIdentifier
+
+        let counter = CallCounter()
+        monitor.track(sessionID: "s1", pid: pid) { _ in
+            counter.increment()
+        }
+        monitor.untrack(sessionID: "s1")
+
+        #expect(monitor.isTracking(sessionID: "s1") == false)
+
+        // Wait well past the process lifetime to be sure no late callback slipped through.
+        Thread.sleep(forTimeInterval: 2.0)
+        #expect(counter.value == 0)
+
+        process.ensureExited()
+    }
+
+    @Test
+    func retrackWithDifferentPIDDuringGraceCancelsFirstExit() throws {
+        let monitor = ClaudePIDMonitor(gracePeriod: 1.0)
+        let first = try spawnSleep(duration: 0.2)
+        let firstPID = first.processIdentifier
+
+        let counter = CallCounter()
+        monitor.track(sessionID: "s1", pid: firstPID) { _ in
+            counter.increment()
+        }
+
+        // Wait for the first process to actually exit (grace is now ticking).
+        first.waitUntilExit()
+        Thread.sleep(forTimeInterval: 0.2)
+
+        let second = try spawnSleep(duration: 10)
+        let secondPID = second.processIdentifier
+        monitor.track(sessionID: "s1", pid: secondPID) { _ in
+            counter.increment()
+        }
+
+        // Wait past when the first grace would have fired (1.0s).
+        Thread.sleep(forTimeInterval: 2.5)
+        #expect(counter.value == 0)
+        #expect(monitor.currentPID(for: "s1") == secondPID)
+
+        monitor.untrack(sessionID: "s1")
+        second.terminate()
+        second.waitUntilExit()
+    }
+
+    @Test
+    func retrackWithSamePIDIsIdempotent() throws {
+        let monitor = ClaudePIDMonitor(gracePeriod: 0)
+        let process = try spawnSleep(duration: 10)
+        let pid = process.processIdentifier
+
+        let counter = CallCounter()
+        let semaphore = DispatchSemaphore(value: 0)
+
+        monitor.track(sessionID: "s1", pid: pid) { _ in
+            counter.increment()
+            semaphore.signal()
+        }
+        #expect(monitor.currentPID(for: "s1") == pid)
+
+        // Re-track with the same PID; must not replace the existing monitor.
+        monitor.track(sessionID: "s1", pid: pid) { _ in
+            counter.increment()
+            semaphore.signal()
+        }
+        #expect(monitor.isTracking(sessionID: "s1") == true)
+        #expect(monitor.currentPID(for: "s1") == pid)
+
+        process.terminate()
+
+        let result = semaphore.wait(timeout: .now() + .seconds(3))
+        #expect(result == .success)
+
+        // Give any spurious extra callback a chance to land.
+        Thread.sleep(forTimeInterval: 0.5)
+        #expect(counter.value == 1)
+
+        process.ensureExited()
+    }
+
+    @Test
+    func alreadyDeadPIDFiresExitCallback() throws {
+        let monitor = ClaudePIDMonitor(gracePeriod: 0)
+        let process = try spawnSleep(duration: 0.05)
+        let pid = process.processIdentifier
+        process.waitUntilExit()
+        // Extra safety — make sure the kernel has reaped the PID.
+        Thread.sleep(forTimeInterval: 0.1)
+
+        let semaphore = DispatchSemaphore(value: 0)
+        let captured = CapturedExit()
+
+        monitor.track(sessionID: "s1", pid: pid) { event in
+            captured.store(event)
+            semaphore.signal()
+        }
+
+        let result = semaphore.wait(timeout: .now() + .seconds(3))
+        #expect(result == .success)
+        #expect(captured.event?.sessionID == "s1")
+        #expect(captured.event?.pid == pid)
+    }
+
+    @Test
+    func isAliveReflectsProcessLiveness() throws {
+        let monitor = ClaudePIDMonitor(gracePeriod: 5.0)
+        let process = try spawnSleep(duration: 10)
+        let pid = process.processIdentifier
+
+        monitor.track(sessionID: "s1", pid: pid) { _ in }
+        #expect(monitor.isAlive(sessionID: "s1") == true)
+        #expect(monitor.isAlive(sessionID: "nope") == false)
+
+        process.terminate()
+        process.waitUntilExit()
+
+        let deadline = Date().addingTimeInterval(2.0)
+        while Date() < deadline {
+            if !monitor.isAlive(sessionID: "s1") { break }
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        #expect(monitor.isAlive(sessionID: "s1") == false)
+
+        monitor.untrack(sessionID: "s1")
+    }
+
+    @Test
+    func deinitCancelsEverythingCleanly() throws {
+        let process = try spawnSleep(duration: 10)
+        let pid = process.processIdentifier
+
+        do {
+            let monitor = ClaudePIDMonitor(gracePeriod: 0)
+            monitor.track(sessionID: "s1", pid: pid) { _ in
+                // If this fires after the monitor is gone, we want to know.
+                Issue.record("onExit must not fire after monitor is deallocated")
+            }
+            #expect(monitor.isTracking(sessionID: "s1") == true)
+        }
+
+        // Monitor is gone. Kill the process; if deinit didn't cancel, this would crash.
+        process.terminate()
+        process.waitUntilExit()
+        Thread.sleep(forTimeInterval: 0.3)
+    }
+
+    // MARK: - Helpers
+
+    private func spawnSleep(duration: Double) throws -> Process {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        process.arguments = [String(duration)]
+        try process.run()
+        return process
+    }
+}
+
+private final class CapturedExit: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _event: ClaudePIDMonitor.ExitEvent?
+
+    var event: ClaudePIDMonitor.ExitEvent? {
+        lock.lock(); defer { lock.unlock() }
+        return _event
+    }
+
+    func store(_ event: ClaudePIDMonitor.ExitEvent) {
+        lock.lock(); defer { lock.unlock() }
+        _event = event
+    }
+}
+
+private final class CallCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var value: Int {
+        lock.lock(); defer { lock.unlock() }
+        return count
+    }
+
+    func increment() {
+        lock.lock(); defer { lock.unlock() }
+        count += 1
+    }
+}
+
+private extension Process {
+    func ensureExited() {
+        if isRunning {
+            terminate()
+            waitUntilExit()
+        }
+    }
+}

--- a/Tests/OpenIslandCoreTests/ClaudePIDMonitorTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudePIDMonitorTests.swift
@@ -160,6 +160,36 @@ struct ClaudePIDMonitorTests {
     }
 
     @Test
+    func untrackAllCancelsEveryPendingCallback() throws {
+        let monitor = ClaudePIDMonitor(gracePeriod: 0)
+        let first = try spawnSleep(duration: 0.2)
+        let second = try spawnSleep(duration: 0.2)
+
+        let counter = CallCounter()
+        monitor.track(sessionID: "s1", pid: first.processIdentifier) { _ in
+            counter.increment()
+        }
+        monitor.track(sessionID: "s2", pid: second.processIdentifier) { _ in
+            counter.increment()
+        }
+
+        #expect(monitor.isTracking(sessionID: "s1") == true)
+        #expect(monitor.isTracking(sessionID: "s2") == true)
+
+        monitor.untrackAll()
+
+        #expect(monitor.isTracking(sessionID: "s1") == false)
+        #expect(monitor.isTracking(sessionID: "s2") == false)
+
+        // Let both subprocesses exit; any surviving dispatch source would fire now.
+        Thread.sleep(forTimeInterval: 1.0)
+        #expect(counter.value == 0)
+
+        first.ensureExited()
+        second.ensureExited()
+    }
+
+    @Test
     func deinitCancelsEverythingCleanly() throws {
         let process = try spawnSleep(duration: 10)
         let pid = process.processIdentifier

--- a/Tests/OpenIslandCoreTests/ClaudeSessionMetadataPIDTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeSessionMetadataPIDTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+struct ClaudeSessionMetadataPIDTests {
+    @Test
+    func claudeSessionMetadataCarriesAgentPIDThroughCodec() throws {
+        let metadata = ClaudeSessionMetadata(
+            transcriptPath: "/tmp/claude.jsonl",
+            agentPID: 4_242
+        )
+
+        let encoded = try JSONEncoder().encode(metadata)
+        let decoded = try JSONDecoder().decode(ClaudeSessionMetadata.self, from: encoded)
+
+        #expect(decoded.agentPID == 4_242)
+        #expect(decoded.transcriptPath == "/tmp/claude.jsonl")
+    }
+
+    @Test
+    func claudeSessionMetadataWithOnlyAgentPIDIsNotEmpty() {
+        let metadata = ClaudeSessionMetadata(agentPID: 42)
+
+        #expect(metadata.isEmpty == false)
+    }
+
+    @Test
+    func claudeSessionMetadataEmptyIsTrueWhenAllNil() {
+        let metadata = ClaudeSessionMetadata()
+
+        #expect(metadata.isEmpty == true)
+    }
+
+    @Test
+    func defaultClaudeMetadataIncludesAgentPIDFromPayload() {
+        let payload = ClaudeHookPayload(
+            cwd: "/tmp/demo",
+            hookEventName: .sessionStart,
+            sessionID: "s1",
+            agentPID: 777
+        )
+
+        let metadata = payload.defaultClaudeMetadata
+
+        #expect(metadata.agentPID == 777)
+    }
+}

--- a/Tests/OpenIslandCoreTests/ClaudeSessionRegistryTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeSessionRegistryTests.swift
@@ -52,6 +52,89 @@ struct ClaudeSessionRegistryTests {
     }
 
     @Test
+    func recordRoundTripsWithAgentPID() throws {
+        let record = ClaudeTrackedSessionRecord(
+            sessionID: "claude-session-pid",
+            title: "Claude · pid",
+            summary: "",
+            phase: .running,
+            updatedAt: Date(timeIntervalSince1970: 1_500),
+            agentPID: 9876
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(record)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(ClaudeTrackedSessionRecord.self, from: data)
+
+        #expect(decoded.agentPID == 9876)
+        #expect(decoded == record)
+    }
+
+    @Test
+    func recordDecodesLegacyJSONWithoutAgentPIDAsNil() throws {
+        let legacyJSON = """
+        {
+            "sessionID": "legacy",
+            "title": "Legacy",
+            "attachmentState": "stale",
+            "summary": "",
+            "phase": "completed",
+            "updatedAt": "2026-01-01T00:00:00Z"
+        }
+        """
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(
+            ClaudeTrackedSessionRecord.self,
+            from: Data(legacyJSON.utf8)
+        )
+
+        #expect(decoded.agentPID == nil)
+    }
+
+    @Test
+    func initFromSessionPullsAgentPIDFromClaudeMetadata() {
+        let session = AgentSession(
+            id: "claude-session-from-session",
+            title: "Claude",
+            tool: .claudeCode,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "",
+            updatedAt: Date(timeIntervalSince1970: 1_000),
+            claudeMetadata: ClaudeSessionMetadata(agentPID: 4321)
+        )
+
+        let record = ClaudeTrackedSessionRecord(session: session)
+
+        #expect(record.agentPID == 4321)
+    }
+
+    @Test
+    func restorableSessionPutsAgentPIDBackOnMetadata() {
+        let record = ClaudeTrackedSessionRecord(
+            sessionID: "claude-session-restore",
+            title: "Claude",
+            summary: "",
+            phase: .running,
+            updatedAt: Date(timeIntervalSince1970: 1_000),
+            claudeMetadata: ClaudeSessionMetadata(transcriptPath: "/tmp/claude.jsonl"),
+            agentPID: 4321
+        )
+
+        let restored = record.restorableSession
+
+        #expect(restored.claudeMetadata?.agentPID == 4321)
+        #expect(restored.claudeMetadata?.transcriptPath == "/tmp/claude.jsonl")
+    }
+
+    @Test
     func claudeTrackedSessionRecordRestoresAsStale() {
         let record = ClaudeTrackedSessionRecord(
             sessionID: "claude-session-1",

--- a/Tests/OpenIslandCoreTests/SessionStateClaudeExitTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateClaudeExitTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+struct SessionStateClaudeExitTests {
+    private func hookManagedClaudeSession(
+        id: String = "claude-session",
+        phase: SessionPhase = .running,
+        updatedAt: Date
+    ) -> AgentSession {
+        var session = AgentSession(
+            id: id,
+            title: "Claude · repo",
+            tool: .claudeCode,
+            origin: .live,
+            attachmentState: .attached,
+            phase: phase,
+            summary: "Working",
+            updatedAt: updatedAt
+        )
+        session.isHookManaged = true
+        session.isSessionEnded = false
+        session.isProcessAlive = true
+        session.processNotSeenCount = 0
+        return session
+    }
+
+    private func hookManagedOpenCodeSession(
+        id: String = "opencode-session",
+        updatedAt: Date
+    ) -> AgentSession {
+        var session = AgentSession(
+            id: id,
+            title: "OpenCode · repo",
+            tool: .openCode,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Working",
+            updatedAt: updatedAt
+        )
+        session.isHookManaged = true
+        session.isSessionEnded = false
+        session.isProcessAlive = true
+        session.processNotSeenCount = 0
+        return session
+    }
+
+    @Test
+    func claudeProcessExitedFlipsSessionToCompleted() {
+        let startedAt = Date(timeIntervalSince1970: 10_000)
+        var state = SessionState(sessions: [
+            hookManagedClaudeSession(updatedAt: startedAt)
+        ])
+
+        let exitedAt = startedAt.addingTimeInterval(30)
+        state.apply(
+            .claudeProcessExited(
+                ClaudeProcessExited(
+                    sessionID: "claude-session",
+                    pid: 4242,
+                    timestamp: exitedAt
+                )
+            )
+        )
+
+        let session = state.session(id: "claude-session")
+        #expect(session?.phase == .completed)
+        #expect(session?.isSessionEnded == true)
+        #expect(session?.isProcessAlive == false)
+        #expect(session?.processNotSeenCount == 0)
+        #expect(session?.updatedAt == exitedAt)
+    }
+
+    @Test
+    func claudeProcessExitedIsNoOpWhenSessionAlreadyEnded() {
+        let startedAt = Date(timeIntervalSince1970: 11_000)
+        var session = hookManagedClaudeSession(phase: .completed, updatedAt: startedAt)
+        session.isSessionEnded = true
+        var state = SessionState(sessions: [session])
+
+        let before = state.session(id: "claude-session")
+
+        state.apply(
+            .claudeProcessExited(
+                ClaudeProcessExited(
+                    sessionID: "claude-session",
+                    pid: 4242,
+                    timestamp: startedAt.addingTimeInterval(60)
+                )
+            )
+        )
+
+        let after = state.session(id: "claude-session")
+        #expect(before == after)
+    }
+
+    @Test
+    func claudeProcessExitedIsNoOpWhenSessionUnknown() {
+        var state = SessionState()
+
+        state.apply(
+            .claudeProcessExited(
+                ClaudeProcessExited(
+                    sessionID: "missing",
+                    pid: 1,
+                    timestamp: Date(timeIntervalSince1970: 12_000)
+                )
+            )
+        )
+
+        #expect(state.sessions.isEmpty)
+    }
+
+    @Test
+    func claudeProcessExitedRoundTripsThroughCodable() throws {
+        let event = AgentEvent.claudeProcessExited(
+            ClaudeProcessExited(
+                sessionID: "claude-session",
+                pid: 9876,
+                timestamp: Date(timeIntervalSince1970: 13_000)
+            )
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(event)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(AgentEvent.self, from: data)
+
+        #expect(decoded == event)
+    }
+
+    @Test
+    func markProcessLivenessDoesNotEvictHookManagedClaudeSession() {
+        let startedAt = Date(timeIntervalSince1970: 14_000)
+        var state = SessionState(sessions: [
+            hookManagedClaudeSession(id: "claude-session", updatedAt: startedAt),
+            hookManagedOpenCodeSession(id: "opencode-session", updatedAt: startedAt)
+        ])
+
+        for _ in 0..<10 {
+            _ = state.markProcessLiveness(aliveSessionIDs: [])
+        }
+
+        let claude = state.session(id: "claude-session")
+        #expect(claude?.isSessionEnded == false)
+        #expect(claude?.phase == .running)
+
+        let openCode = state.session(id: "opencode-session")
+        #expect(openCode?.isSessionEnded == true)
+        #expect(openCode?.phase == .completed)
+    }
+}

--- a/docs/exec-plans/active/2026-04-19-claude-kernel-pid-monitor.md
+++ b/docs/exec-plans/active/2026-04-19-claude-kernel-pid-monitor.md
@@ -1,6 +1,6 @@
 # Claude Lifecycle: Replace ps/lsof Polling with Kernel PID Exit Monitoring
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+**Status:** Active. Task steps use `- [ ]` checkboxes — update them in place as work lands.
 
 **Goal:** Stop using `ps`/`lsof` polling as an authoritative signal for hook-managed Claude Code session liveness. Replace it with `DispatchSource.makeProcessSource(eventMask: .exit)` anchored to the Claude CLI PID that each hook brings in. Hook events + kernel exit notifications become the only source of truth for live-session lifecycle. Process polling is retained **only** for cold-start discovery of orphan Claude processes that have no hook history.
 

--- a/docs/superpowers/plans/2026-04-19-claude-kernel-pid-monitor.md
+++ b/docs/superpowers/plans/2026-04-19-claude-kernel-pid-monitor.md
@@ -1,0 +1,512 @@
+# Claude Lifecycle: Replace ps/lsof Polling with Kernel PID Exit Monitoring
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop using `ps`/`lsof` polling as an authoritative signal for hook-managed Claude Code session liveness. Replace it with `DispatchSource.makeProcessSource(eventMask: .exit)` anchored to the Claude CLI PID that each hook brings in. Hook events + kernel exit notifications become the only source of truth for live-session lifecycle. Process polling is retained **only** for cold-start discovery of orphan Claude processes that have no hook history.
+
+**Tech Stack:** Swift 6.2, AppKit, Foundation (`Process`, `DispatchSource`, Unix sockets), Observation framework.
+
+**Context / why this is needed:**
+
+The current architecture fails in a very concrete way users have hit in production (see PR #375 for the symptom): when `lsof` transiently returns late or with partial output, `ActiveAgentProcessDiscovery.claudeSnapshot` produces snapshots missing `sessionID` and `transcriptPath`. `ProcessMonitoringCoordinator.reconcileSessionAttachments`'s three-pass matching can't pin those processes to their tracked hook-managed sessions (Pass 3's uniqueness check also gives up when multiple Claude sessions share a workspace). The downstream effects cascade:
+
+1. `sessionIDsWithAliveProcesses` omits real sessions.
+2. `SessionState.markProcessLiveness` ticks `processNotSeenCount` and after 2 polls (4 seconds) flips hook-managed sessions to `isSessionEnded = true`. `removeInvisibleSessions` then evicts them.
+3. `mergedWithSyntheticClaudeSessions` spawns one synthetic row per unrepresented process, each with `updatedAt = .now`; every subsequent tick refreshes `updatedAt` to now again — hence the "<1m" phantom rows users reported.
+
+The architectural root cause is **double source of truth**: hook events are the authoritative lifecycle signal (they come from Claude itself), but `ps`/`lsof`-driven `markProcessLiveness` is allowed to override them. A less reliable signal is permitted to kill entries that the more reliable signal still considers live.
+
+Prior-art note: other macOS implementations in this space draw the same line — sessions with an active kernel-level PID monitor trust only explicit Stop/SessionEnd hooks or kernel exit events, never time- or poll-based inference; sessions without a PID (hook-only) fall back to looser time thresholds. We are adopting the same discipline.
+
+---
+
+## Target Architecture
+
+```
+┌──────────────────────┐    stdin    ┌────────────────────┐  envelope  ┌──────────────────┐
+│ Claude CLI (long-    ├────────────►│ OpenIslandHooks    ├───────────►│ BridgeServer     │
+│ running process PID) │             │ (short-lived CLI)  │            │                  │
+└──────────▲───────────┘             │ reads getppid()    │            │  on sessionStart │
+           │                         │ → payload.agentPID │            │  → PIDMonitor    │
+           │                         └────────────────────┘            │    .track(pid)   │
+           │                                                           │                  │
+           │  kernel DispatchSource.makeProcessSource(.exit, pid)      │                  │
+           └───────────────────────────────────────────────────────────┤ on .exit         │
+                                                                       │  → 5s grace      │
+                                                                       │  → dismissSession│
+                                                                       └──────────────────┘
+```
+
+**Invariants after this refactor:**
+
+- **Live hook-managed Claude session** = `isHookManaged == true` AND `ClaudePIDMonitor` holds a live monitor for its PID, OR the session has never had a PID (legacy hooks / remote SSH). No `ps`/`lsof` polling for these.
+- **`SessionState.markProcessLiveness` no longer flips `isSessionEnded = true` for hook-managed Claude sessions.** The reducer path for `isSessionEnded` is either (a) explicit `SessionEnd` hook event, (b) `ClaudePIDMonitor` reports exit + 5s grace elapsed without re-attachment, or (c) cold-start discovery sweep during app launch determines the PID is gone and hook history is stale (> 24h).
+- **Synthetic Claude sessions only exist for cold-start discovery** (orphan process seen at launch that never emits a hook). They never overwrite hook-managed sessions, and their `updatedAt` is frozen at first-discovery time — not refreshed on each poll.
+- **`ps`/`lsof` is used exclusively for**: (i) cold-start orphan discovery, (ii) workspace/jumpTarget enrichment (terminal app, TTY, tmux), (iii) OpenCode/Cursor/Kimi/Gemini whose hooks don't carry a stable PID path yet. It does **not** decide Claude liveness.
+
+---
+
+## Scope & Non-Goals
+
+**In scope (this plan):**
+- Claude Code hook sessions and every Claude-format hook variant that already shares `ClaudeHookPayload` (qoder, qwen, factory, droid, codebuddy, kimi — they all go through the same wire format).
+- Removal of the `processNotSeenCount` eviction path for hook-managed Claude sessions.
+- Synthetic Claude session isolation (frozen `updatedAt`, creation gated by absence of hook history for the workspace).
+
+**Out of scope (separate future work):**
+- Codex session lifecycle (the rollout watcher + Codex.app liveness already works differently; touching it here enlarges blast radius).
+- OpenCode, Cursor, Gemini — they don't currently hit this bug and their hook payloads don't carry a PID path; migrating them is a follow-up.
+- Reverting PR #375's CWD fallback in `ProcessMonitoringCoordinator`. **PR #375 will be closed without merging** in favour of this refactor, because the fallback is no longer needed once polling no longer evicts sessions.
+
+**Backwards compat stance:**
+- Old `OpenIslandHooks` binaries (installed by previous app versions, not re-installed) will continue to send payloads without `agentPID`. The bridge must handle missing `agentPID` gracefully: fall back to hook-only liveness (no PID monitor, session stays alive until explicit `SessionEnd` hook or 30-minute absence timeout). No forced re-install; users get improved behaviour automatically when hooks are refreshed (or the app proactively reinstalls on version bump — existing flow).
+
+---
+
+## Concrete Touch Points
+
+| File | Change |
+| --- | --- |
+| `Sources/OpenIslandCore/ClaudeHooks.swift` | Add `agentPID: Int32?` to `ClaudeHookPayload` + CodingKey. Populate in `withRuntimeContext` via `getppid()`. |
+| `Sources/OpenIslandHooks/OpenIslandHooksCLI.swift` | No code change required — already calls `withRuntimeContext`. Verify path. |
+| `Sources/OpenIslandCore/ClaudePIDMonitor.swift` | **New file.** Wraps `DispatchSource.makeProcessSource(eventMask: .exit)`. Owns a `[sessionID: MonitorRecord]` dictionary. Public API: `track(sessionID:pid:onExit:)`, `untrack(sessionID:)`, `isTracking(sessionID:)`, `isAlive(sessionID:)` (via `kill(pid, 0)` sanity check). |
+| `Sources/OpenIslandCore/BridgeServer.swift` | In `handleClaudeHook` for `.sessionStart` / `.userPromptSubmit` / `.preToolUse`, if `payload.agentPID` is non-nil and no monitor yet for that sessionID, call `claudePIDMonitor.track(sessionID:pid:onExit:)`. On `.sessionEnd` (explicit), `untrack`. The `onExit` callback posts a new `AgentEvent.claudeProcessExited(sessionID:)` to the reducer after a 5s grace period unless re-attached. |
+| `Sources/OpenIslandCore/AgentEvent.swift` | Add `.claudeProcessExited(ClaudeProcessExited)` case with sessionID + timestamp. |
+| `Sources/OpenIslandCore/SessionState.swift` | Add reducer branch for `.claudeProcessExited`: set `isSessionEnded = true`, `phase = .completed`. In `markProcessLiveness`, **remove** the `processNotSeenCount >= 2 → isSessionEnded` path for `session.isHookManaged && session.tool == .claudeCode`. Leave it for other hook-managed tools (OpenCode, Cursor, etc.) until they're migrated. |
+| `Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift` | Drop the synthetic-session creation for workspaces that have any tracked hook-managed Claude session (regardless of matching success). Freeze synthetic `updatedAt` at first-discovery time (store in a `[identityKey: Date]` first-seen map). Remove PR #375's CWD fallback in `representedClaudeProcessKeys` / `sessionIDsWithAliveProcesses` once the hook-managed eviction path is gone — it becomes redundant. |
+| `Sources/OpenIslandApp/AppModel.swift` | Wire `claudePIDMonitor` ownership; hand it to `BridgeServer` at init. On cold-start discovery apply, for each restored session that has a recorded PID in metadata, attempt to rehydrate the monitor (and if `kill(pid, 0)` fails, mark session as ended immediately — the process died while the app was off). |
+| `Sources/OpenIslandCore/ClaudeSessionRegistry.swift` / `ClaudeTrackedSessionRecord` | Persist `agentPID: Int32?` alongside transcriptPath so we can rehydrate the PID monitor on startup. |
+| `Tests/OpenIslandCoreTests/ClaudePIDMonitorTests.swift` | **New.** Unit-test track/untrack, exit callback, grace period, kill(0) sanity check. Use dummy `sleep` subprocesses to get deterministic PIDs. |
+| `Tests/OpenIslandCoreTests/BridgeServerTests.swift` | Add: sessionStart with agentPID registers a monitor; explicit sessionEnd unregisters; simulated process exit triggers `.claudeProcessExited` after grace. |
+| `Tests/OpenIslandAppTests/AppModelSessionListTests.swift` | Add: hook-managed Claude session whose process is clearly "not seen by ps" (empty `activeProcesses`) stays alive — no eviction. Remove / rewrite the PR #375 regression tests that assumed `ps`-based aliveness was the driver. |
+
+---
+
+### Task 1: Add `agentPID` to `ClaudeHookPayload`
+
+**Files:**
+- Modify: `Sources/OpenIslandCore/ClaudeHooks.swift`
+
+- [ ] **Step 1: Add the property, CodingKey, and init parameter**
+
+  - Declare `public var agentPID: Int32?` alongside the existing runtime-context fields (`terminalApp`, `terminalSessionID`, etc.).
+  - Add `case agentPID = "agent_pid"` to `CodingKeys`.
+  - Extend the main `init(...)` to accept `agentPID: Int32? = nil`.
+  - **Why `Int32`:** macOS `pid_t` is `Int32`. Using `Int32` avoids platform-size surprises when serialized.
+
+- [ ] **Step 2: Populate in `withRuntimeContext`**
+
+  - In the existing `func withRuntimeContext(environment:)` path, after the Warp pane resolution block, add:
+    ```swift
+    if payload.agentPID == nil {
+        payload.agentPID = getppid()
+    }
+    ```
+  - `getppid()` from Darwin returns the parent PID of the current process (`OpenIslandHooks` binary), which is the Claude CLI that spawned the hook. This is the PID we want to monitor.
+  - **Do NOT** populate from environment — stdin-invoked hooks don't reliably inherit any PID-identifying env var, and CLAUDE_* envs aren't stable contract.
+
+- [ ] **Step 3: Unit tests**
+
+  - In `Tests/OpenIslandCoreTests/ClaudeHookPayloadTests.swift` (or nearest existing sibling): verify round-trip codec with `agent_pid: 12345`, verify absence is tolerated, verify `withRuntimeContext` populates a positive value when called from the test process.
+
+- [ ] **Step 4: Verify**
+
+  - [ ] `swift build` succeeds.
+  - [ ] New codec tests pass.
+  - [ ] Existing Claude hook tests still pass.
+
+---
+
+### Task 2: Create `ClaudePIDMonitor`
+
+**Files:**
+- Create: `Sources/OpenIslandCore/ClaudePIDMonitor.swift`
+- Create: `Tests/OpenIslandCoreTests/ClaudePIDMonitorTests.swift`
+
+- [ ] **Step 1: Implement the monitor**
+
+  Minimal public surface:
+
+  ```swift
+  public final class ClaudePIDMonitor: @unchecked Sendable {
+      public struct ExitEvent: Sendable {
+          public let sessionID: String
+          public let pid: Int32
+          public let exitedAt: Date
+      }
+
+      public init(gracePeriod: TimeInterval = 5.0, queue: DispatchQueue = .global(qos: .utility))
+
+      /// Begins watching `pid`. If already tracking `sessionID` with a different
+      /// PID, the previous monitor is cancelled and replaced. If the PID is
+      /// already dead at track time, `onExit` fires synchronously on `queue`.
+      public func track(sessionID: String, pid: Int32, onExit: @escaping (ExitEvent) -> Void)
+
+      /// Stops watching and cancels any pending grace timer.
+      public func untrack(sessionID: String)
+
+      /// Returns true while a monitor is registered.
+      public func isTracking(sessionID: String) -> Bool
+
+      /// Returns true if the last-known PID for this session passes `kill(pid, 0)`.
+      public func isAlive(sessionID: String) -> Bool
+  }
+  ```
+
+  Internals:
+
+  - `DispatchSource.makeProcessSource(identifier: pid_t(pid), eventMask: .exit, queue: queue)` per tracked PID.
+  - On exit event: start a `DispatchWorkItem` on `queue` with `gracePeriod` delay. If `untrack` is called before it fires (new monitor re-attached during grace), the pending work item is cancelled. If it fires, invoke `onExit`.
+  - **Why the 5s grace:** covers `claude --resume`-style restarts and agent self-update flows where the old PID exits but a new PID is about to register for the same sessionID. Without grace, we'd briefly flip the session to ended and then re-create it, which churns the UI.
+  - Internal state (`[sessionID: MonitorRecord]`) synchronized on a dedicated serial queue to keep `track`/`untrack`/exit-callback races deterministic.
+
+- [ ] **Step 2: Unit tests**
+
+  - Track a short-lived `/bin/sleep 0.2` subprocess; assert `onExit` fires within `0.2 + gracePeriod + slack` seconds with correct `sessionID`.
+  - Track a long-lived `/bin/sleep 10` subprocess; assert `isAlive` is true. Call `untrack`; assert no callback fires even after we kill the process externally.
+  - Track, then within the grace window call `track` again with a new PID for the same sessionID; assert exit callback never fires for the first PID.
+  - Track a PID that's already dead (spawn then wait); assert `onExit` fires exactly once on the monitor's queue.
+  - Test with `gracePeriod: 0` for determinism in CI.
+
+- [ ] **Step 3: Verify**
+
+  - [ ] `swift test --filter ClaudePIDMonitorTests` all green.
+  - [ ] No leaked `DispatchSource`s (instruments check or ref-count assertion in teardown).
+
+---
+
+### Task 3: Add `claudeProcessExited` event to `AgentEvent`
+
+**Files:**
+- Modify: `Sources/OpenIslandCore/AgentEvent.swift`
+- Modify: `Sources/OpenIslandCore/SessionState.swift`
+
+- [ ] **Step 1: Event case**
+
+  Add to `AgentEvent`:
+
+  ```swift
+  case claudeProcessExited(ClaudeProcessExited)
+
+  public struct ClaudeProcessExited: Equatable, Codable, Sendable {
+      public let sessionID: String
+      public let pid: Int32
+      public let timestamp: Date
+  }
+  ```
+
+  Wire format: serialize as a new envelope type `claude_process_exited`. **Not** emitted by hooks — only by the in-app `ClaudePIDMonitor` via `BridgeServer.emit`.
+
+- [ ] **Step 2: Reducer branch**
+
+  In `SessionState.apply(_:)`:
+
+  ```swift
+  case let .claudeProcessExited(payload):
+      guard var session = sessionsByID[payload.sessionID] else { return }
+      // If hook explicitly ended this session already, don't re-process.
+      guard !session.isSessionEnded else { return }
+      session.isSessionEnded = true
+      session.phase = .completed
+      session.updatedAt = payload.timestamp
+      session.isProcessAlive = false
+      upsert(session)
+  ```
+
+  Update the exhaustive-switch sites that reference `AgentEvent` cases (there are several `switch event { ... }` blocks in `AppModel.swift`, `BridgeServer.swift`, and `ProcessMonitoringCoordinator.swift`'s `sessionID(for:)`). Add the new case everywhere.
+
+- [ ] **Step 3: Remove ps-based eviction for hook-managed Claude sessions**
+
+  In `SessionState.markProcessLiveness`, locate the hook-managed branch:
+
+  ```swift
+  if session.isHookManaged {
+      if session.isSessionEnded { continue }
+      ...
+      if aliveSessionIDs.contains(id) {
+          session.processNotSeenCount = 0
+      } else {
+          session.processNotSeenCount += 1
+          if session.processNotSeenCount >= 2 {
+              session.isSessionEnded = true
+              session.phase = .completed
+              changed.insert(id)
+          }
+      }
+      upsert(session)
+      continue
+  }
+  ```
+
+  Change to: for `session.tool == .claudeCode`, never mutate `processNotSeenCount`, never set `isSessionEnded` based on `aliveSessionIDs`. Still reset `processNotSeenCount = 0` when `aliveSessionIDs.contains(id)` (cheap, defensive). Leave the branch intact for `.openCode`, `.cursor`, `.kimiCLI`, `.qoder` etc. — their migrations come later.
+
+  Add a `SessionState` unit test: hook-managed Claude session + `markProcessLiveness(aliveSessionIDs: [])` called 10 times → session remains non-ended.
+
+- [ ] **Step 4: Verify**
+
+  - [ ] `swift build` succeeds (all exhaustive switches updated).
+  - [ ] New reducer test + updated `markProcessLiveness` test pass.
+
+---
+
+### Task 4: Bridge integration — track / untrack / emit
+
+**Files:**
+- Modify: `Sources/OpenIslandCore/BridgeServer.swift`
+- Modify: `Tests/OpenIslandCoreTests/BridgeServerTests.swift` (or create if absent)
+
+- [ ] **Step 1: Own the monitor**
+
+  Add a private `let claudePIDMonitor: ClaudePIDMonitor` to `BridgeServer`. Accept it through `init` with a default `ClaudePIDMonitor()` so tests can inject mocks. Pass an `onExit` closure that, in turn, calls `self.handleClaudeProcessExit(sessionID: pid:)` serialized on the bridge's internal queue.
+
+- [ ] **Step 2: Track on hook events that prove liveness**
+
+  In `handleClaudeHook`, after the subagent filter and before the event emit, add:
+
+  ```swift
+  if let pid = payload.agentPID,
+     pid > 0,
+     payload.agentID == nil,              // parent session only
+     payload.hookEventName != .sessionEnd // handled below
+  {
+      claudePIDMonitor.track(sessionID: payload.sessionID, pid: pid) { [weak self] exit in
+          self?.handleClaudeProcessExit(sessionID: exit.sessionID, pid: exit.pid, at: exit.exitedAt)
+      }
+  }
+  ```
+
+  Rationale: any hook event from the parent session with a valid PID re-confirms liveness and lets us re-bind if a previous monitor was lost. `track` is idempotent for the same PID.
+
+- [ ] **Step 3: Untrack on explicit `.sessionEnd`**
+
+  In the `.sessionEnd` branch, immediately after emitting `.sessionCompleted(isSessionEnd: true)`, call `claudePIDMonitor.untrack(sessionID: payload.sessionID)`. The explicit hook is authoritative; the monitor's grace period would add useless latency.
+
+- [ ] **Step 4: `handleClaudeProcessExit`**
+
+  ```swift
+  private func handleClaudeProcessExit(sessionID: String, pid: Int32, at exitTime: Date) {
+      // If a later hook re-attached a different PID (resume flow), ignore.
+      if let current = claudePIDMonitor.currentPID(for: sessionID), current != pid {
+          return
+      }
+      claudePIDMonitor.untrack(sessionID: sessionID)
+      emit(.claudeProcessExited(.init(sessionID: sessionID, pid: pid, timestamp: exitTime)))
+  }
+  ```
+
+  (Requires a `currentPID(for:)` accessor on `ClaudePIDMonitor`.)
+
+- [ ] **Step 5: Tests**
+
+  - sessionStart with `agentPID = <running pid>` → `isTracking(sessionID)` becomes true.
+  - sessionEnd → `isTracking(sessionID)` becomes false.
+  - Simulated process exit → after grace, `.claudeProcessExited` is visible in the bridge's local state; reducer flips session to `.completed / isSessionEnded`.
+  - sessionStart with `agentPID = nil` (legacy hook) → no monitor registered; no crash; existing hook flow unaffected.
+
+- [ ] **Step 6: Verify**
+
+  - [ ] `swift test --filter BridgeServerTests` all green.
+
+---
+
+### Task 5: Persist PID for cross-launch rehydration
+
+**Files:**
+- Modify: `Sources/OpenIslandCore/ClaudeSessionRegistry.swift` (and the record type)
+- Modify: `Sources/OpenIslandApp/AppModel.swift` / `SessionDiscoveryCoordinator.swift`
+
+- [ ] **Step 1: Record field**
+
+  Add `public var agentPID: Int32?` to `ClaudeTrackedSessionRecord`. Codec via `Codable` default. Old records without the field decode to `nil` — don't break the JSON schema.
+
+- [ ] **Step 2: Populate on persist**
+
+  Wherever `ClaudeTrackedSessionRecord(session:)` is constructed (see `SessionDiscoveryCoordinator.scheduleClaudeSessionPersistence`), pull the agentPID from the session's `claudeMetadata` (Task 6 will add a stash there) or from the bridge's `claudePIDMonitor.currentPID(for:)`.
+
+- [ ] **Step 3: Rehydrate on startup**
+
+  In `applyStartupDiscoveryPayload`, for each restored Claude session:
+
+  - If the record has `agentPID`, call `kill(pid, 0)`:
+    - Success → re-track via `BridgeServer.claudePIDMonitor.track`.
+    - Failure (`errno == ESRCH`) → emit `.claudeProcessExited` immediately; the process died while the app was off, the session is stale.
+  - If the record has no `agentPID` (legacy), do nothing special — the session stays in its restored `.completed` phase and will age out normally.
+
+- [ ] **Step 4: Tests**
+
+  - Record codec round-trip with and without `agentPID`.
+  - Startup rehydration: a record whose PID is dead → session becomes `isSessionEnded` synchronously.
+
+- [ ] **Step 5: Verify**
+
+  - [ ] `swift test --filter ClaudeSessionRegistryTests` + startup tests green.
+
+---
+
+### Task 6: Stash agentPID on the session itself
+
+**Files:**
+- Modify: `Sources/OpenIslandCore/AgentSession.swift` (or `ClaudeSessionMetadata`)
+
+- [ ] **Step 1: Where to put it**
+
+  Prefer `ClaudeSessionMetadata.agentPID: Int32?` rather than a top-level `AgentSession` field — keeps the core model tool-agnostic. Update `ClaudeSessionMetadata.isEmpty` to not treat a solitary `agentPID` as "empty" (we'd lose it on merge otherwise — see `SessionDiscoveryCoordinator.mergeClaudeMetadata`).
+
+- [ ] **Step 2: Write-through on hook events**
+
+  In `BridgeServer.handleClaudeHook`, when we have `payload.agentPID`, emit an additional `.claudeSessionMetadataUpdated` piggybacking the PID alongside existing fields, OR simpler: stash it in the `sessionStarted` event payload's initial `claudeMetadata`. Pick whichever keeps diffs small — the former is safer because multiple hook paths need to populate it.
+
+- [ ] **Step 3: Tests**
+
+  - `SessionState.apply(.sessionStarted)` with `claudeMetadata.agentPID = 1234` produces a session whose metadata carries the PID.
+  - Merge test: a later `.claudeSessionMetadataUpdated` event without PID doesn't blow away an earlier PID (merge preserves).
+
+---
+
+### Task 7: Synthetic Claude session isolation
+
+**Files:**
+- Modify: `Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift`
+
+- [ ] **Step 1: Freeze synthetic `updatedAt`**
+
+  Introduce `private var syntheticClaudeFirstSeen: [String: Date] = [:]` on the coordinator, keyed by `processIdentityKey`. In `syntheticClaudeSession(for:now:)`, look up first-seen; if absent, record `now`; use the stored value as `updatedAt`. Evict entries whose identity key no longer appears in active processes (keeps the map bounded).
+
+  **Why:** stops the "<1m" refresh phantom. A synthetic that's been around for 20 minutes should read "20m".
+
+- [ ] **Step 2: Don't synthesize in workspaces with hook history**
+
+  `mergedWithSyntheticClaudeSessions` currently filters `baseSessions = existingSessions.filter { !isSyntheticClaudeSession($0) }` and unconditionally produces synthetics for unmatched processes. Add a gate:
+
+  ```swift
+  let workspacesWithHookHistory: Set<String> = Set(
+      baseSessions
+          .filter { $0.tool == .claudeCode && $0.isHookManaged }
+          .compactMap { normalizedPathForMatching($0.jumpTarget?.workingDirectory) }
+  )
+  ```
+
+  In the synthetic-building loop, skip any process whose normalized CWD is in `workspacesWithHookHistory`. The real hook-managed session for that workspace is authoritative, even if we can't pin this specific process to it.
+
+- [ ] **Step 3: Remove PR #375's CWD fallback from `representedClaudeProcessKeys` and `sessionIDsWithAliveProcesses`**
+
+  Once Task 3 removes the `ps`-based eviction path for hook-managed Claude sessions, the workspace fallback from PR #375 becomes dead weight. Delete those two Pass-4 blocks.
+
+- [ ] **Step 4: Tests**
+
+  - Synthetic session created at t0, reconciled at t0+5s: `updatedAt == t0` (frozen).
+  - Hook-managed session exists for workspace `/tmp/proj`; a Claude process with identical CWD and no hook match appears — `mergedWithSyntheticClaudeSessions` produces **no synthetic** (it's the same logical session, just temporarily unmatched).
+  - Orphan Claude process in workspace `/tmp/other` with no hook session anywhere — synthetic **is** created (cold-start discovery still works).
+  - Remove / rewrite the PR #375 regression tests (they asserted the now-removed fallback).
+
+---
+
+### Task 8: Integration test — simulate the original bug
+
+**Files:**
+- Create: `Tests/OpenIslandAppTests/ClaudeSessionLifecycleIntegrationTests.swift`
+
+- [ ] **Step 1: End-to-end regression**
+
+  1. Boot `AppModel` with test-injectable `ActiveAgentProcessDiscovery` and `ClaudePIDMonitor`.
+  2. Simulate 4 Claude hook `sessionStart` events, each with `agentPID` pointing to real `/bin/sleep 30` subprocesses in the same fake CWD.
+  3. Simulate 4 `userPromptSubmit` hooks with realistic `initialUserPrompt` text.
+  4. Have the injected `ActiveAgentProcessDiscovery` return `[]` for 10 reconcile cycles (simulate total lsof failure).
+  5. Assert: all 4 sessions remain alive and their metadata is intact. `spotlightHeadlineText` still shows `"workspace · <prompt>"`, not bare `workspace`. `spotlightAgeBadge` doesn't regress to `"<1m"`.
+  6. Kill one of the `sleep` subprocesses externally. Wait `5s + slack`. Assert: that specific session flips to `isSessionEnded`, others remain alive.
+
+- [ ] **Step 2: Verify**
+
+  - [ ] `swift test --filter ClaudeSessionLifecycleIntegrationTests` green on CI.
+
+---
+
+### Task 9: Manual verification in dev app
+
+- [ ] **Step 1: Refresh hooks**
+
+  - `zsh scripts/setup-dev-signing.sh` (one-time, if not done).
+  - `zsh scripts/launch-dev-app.sh`.
+  - Open Settings → reinstall Claude hooks so the new `OpenIslandHooks` binary is in place.
+
+- [ ] **Step 2: Reproduce original scenario**
+
+  - Open 3+ Ghostty tabs, each `cd` into the same repo, start `claude` in each.
+  - Induce load that would previously trigger the collapse: run a `find / -name ...` in another terminal to contend I/O, or `stress-ng --io 4 --timeout 60s` if installed.
+  - Keep sessions active for 10 minutes with intermittent prompts.
+  - Assert: no row ever collapses to bare workspace name + "<1m"; task metadata remains; age badges read the true age.
+
+- [ ] **Step 3: Kill-path check**
+
+  - In one tab, `kill -9` the claude process. Within ~5s, that specific session on the island should flip to Completed. Others stay untouched.
+
+- [ ] **Step 4: Resume path check**
+
+  - In a tab where you killed Claude, immediately run `claude --resume <prior-session-id>`. The old session should re-activate (new PID adopted, same sessionID) — no duplicate row should appear.
+
+---
+
+### Task 10: Close PR #375 and cut the new PR
+
+- [ ] **Step 1: Close #375 with a comment**
+
+  Explain that the fallback patch is superseded by this refactor and paste a link to the new PR.
+
+- [ ] **Step 2: Open new PR from this branch**
+
+  - Target: `main`.
+  - Title: `refactor(claude): replace ps/lsof liveness polling with kernel PID exit monitoring`.
+  - Body: link to this plan document, summarize the architectural shift, include the integration-test evidence.
+
+---
+
+## Testing Strategy
+
+| Layer | Tool | What it covers |
+| --- | --- | --- |
+| Unit — codec | `ClaudeHookPayloadTests` | `agentPID` round-trips; legacy payloads decode. |
+| Unit — monitor | `ClaudePIDMonitorTests` | track/untrack, grace, already-dead PID, PID reuse during grace. |
+| Unit — reducer | `SessionStateTests` | `.claudeProcessExited` flips the session; `markProcessLiveness` does NOT touch hook-managed Claude sessions. |
+| Unit — bridge | `BridgeServerTests` | sessionStart→track, sessionEnd→untrack, kernel exit→event emission, legacy-no-PID path. |
+| Unit — persistence | `ClaudeSessionRegistryTests` | record round-trip with PID, rehydration on dead PID. |
+| Unit — app | updated `AppModelSessionListTests` | synthetic `updatedAt` frozen; no synthetic in hook-history workspaces. |
+| Integration | `ClaudeSessionLifecycleIntegrationTests` | 4-session collapse scenario reproduced and **not** reproducible on the new code. |
+| Manual | dev-app smoke | realistic multi-terminal session for ≥10 minutes; kill and resume paths. |
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Mitigation |
+| --- | --- | --- |
+| Legacy `OpenIslandHooks` binary without `agentPID` leaves sessions without monitors → they never get a clean end. | Medium for users who don't re-install. | Fall back to hook-only liveness (no ps polling). Add a 30-minute "no activity" safety timeout for hook-managed Claude sessions as a last-resort zombie cleaner (much looser than current 4s). Nudge reinstallation via existing health-check UI. |
+| `DispatchSource` process source missing an exit event (macOS has known sporadic misses). | Low but non-zero. | Periodic (60s) self-check: for each tracked sessionID, `kill(pid, 0)`; if `ESRCH`, synthesize the exit manually. |
+| `getppid()` returning non-Claude PID — e.g., `claude` was invoked via `npm exec` or a wrapper shell. | Medium. | `withRuntimeContext` walks parents briefly (up to 4 levels) looking for an executable whose name matches Claude CLI patterns (`/\bclaude$/`, `/.local/bin/claude$/`). If found, use that PID; otherwise fall back to `getppid()`. Add a test for `npm exec claude` wrapping. |
+| Test flakiness due to timing-sensitive grace period. | Medium. | `ClaudePIDMonitor(gracePeriod: 0)` in unit tests; only integration test uses non-zero grace and widens tolerance. |
+| Session ID collision across restarts (user runs `claude --resume same-id` in a different terminal). | Low. | `track` replaces the previous monitor for the same sessionID (explicit contract). Test covers this path. |
+| Removing `processNotSeenCount` path for Claude leaves OpenCode/Cursor etc. with divergent behaviour. | Inherent — this is only Claude's migration. | Scope doc (above) is explicit; follow-up plan covers other tools. |
+
+---
+
+## Phases & Rollout
+
+| Phase | Tasks | Gating |
+| --- | --- | --- |
+| 1. Foundation | 1, 2, 3 | All unit tests green. |
+| 2. Integration | 4, 5, 6 | Bridge + persistence tests green. |
+| 3. UI isolation | 7 | Synthetic tests green. |
+| 4. Verification | 8, 9 | Integration test + manual smoke clean. |
+| 5. Release | 10 | PR open, reviewed, merged. |
+
+Phases 1-4 can all land in one PR (this is a coherent refactor) unless review asks to split. Phase 5 is PR lifecycle bookkeeping.
+
+---
+
+## Success Criteria
+
+- `ActiveAgentProcessDiscovery` returning `[]` for an arbitrary number of reconcile cycles does **not** evict hook-managed Claude sessions.
+- `kill -9 <claude-pid>` flips the specific session to Completed within `grace_period + 1s`.
+- Synthetic rows (when present at all) show a true age, not "<1m".
+- Integration test `ClaudeSessionLifecycleIntegrationTests` passes on CI.
+- Manual 10-minute multi-session smoke on the dev app shows no collapse.
+- No regression in OpenCode / Cursor / Gemini session handling (their code paths are unchanged).


### PR DESCRIPTION
## Summary

Replaces `ps`/`lsof` polling as the authoritative liveness signal for hook-managed Claude sessions with a kernel-level `DispatchSource` process-exit monitor anchored to the Claude CLI's PID. Fixes the "session list collapses to duplicated placeholder rows all stamped `<1m`" bug reported in production, without the workspace-fallback patch from #375.

Plan: [`docs/exec-plans/active/2026-04-19-claude-kernel-pid-monitor.md`](./docs/exec-plans/active/2026-04-19-claude-kernel-pid-monitor.md) — read this first; every commit on the branch corresponds to one task in the plan.

## Root cause (one-line recap)

Two lifecycle sources of truth competed for hook-managed Claude sessions: authoritative hook events vs. `ps`/`lsof` polling. Under load the 0.2s lsof timeout dropped `sessionID`/`transcriptPath`, the 3-pass matching lost those processes, and after 4s `markProcessLiveness` evicted healthy sessions; `mergedWithSyntheticClaudeSessions` then spawned placeholder rows whose `updatedAt` was refreshed to `.now` every tick (the `<1m` phantom).

## Architecture delta

Before → after:

- `agent_pid` now carried on `ClaudeHookPayload` (CLI reads `getppid()`).
- `ClaudePIDMonitor` wraps `DispatchSource.makeProcessSource(eventMask: .exit)` per tracked PID. 5s grace window absorbs `claude --resume`-style PID rotations.
- `BridgeServer` drives the monitor from every parent-session hook; explicit `.sessionEnd` untracks; kernel exit → `.claudeProcessExited` event.
- `SessionState.markProcessLiveness` **no longer evicts hook-managed Claude sessions** based on `ps`/`lsof`. OpenCode/Cursor/Kimi paths unchanged.
- `ClaudeTrackedSessionRecord` persists `agentPID`; `AppModel.rehydrateClaudePIDMonitorsForRestoredSessions()` reattaches monitors at launch (or immediately marks the session ended if the PID is already dead).
- Synthetic Claude sessions: `updatedAt` frozen at first-discovery, and suppressed entirely in workspaces owned by a hook-managed session.

`ps`/`lsof` retained only for cold-start orphan discovery + jumpTarget enrichment. Never again authoritative for Claude liveness.

## Commits (10)

| # | Commit | Task |
|---|---|---|
| 1 | `f0d2a45` docs: plan | — |
| 2 | `58a3372` docs: move plan to exec-plans/active | — |
| 3 | `9c84d7f` feat(claude-hooks): carry agent_pid on the hook envelope | T1 |
| 4 | `07a8fbf` feat(core): add ClaudePIDMonitor for kernel-level process-exit tracking | T2 |
| 5 | `0c42443` feat(core): claudeProcessExited event + stop ps eviction | T3 |
| 6 | `693790f` feat(bridge): drive ClaudePIDMonitor from hook events | T4 |
| 7 | `22909a9` feat(core): stash agentPID on ClaudeSessionMetadata | T6 |
| 8 | `a9987cf` feat(core): persist agentPID across restarts and rehydrate on launch | T5 |
| 9 | `ffe25bf` refactor(process-monitor): freeze synthetic updatedAt + defer by workspace | T7 |
| 10 | `596f96d` test(app): end-to-end integration tests for Claude session lifecycle | T8 |

## Backwards compatibility

Old `OpenIslandHooks` binaries without `agent_pid` decode the new field as `nil`. Sessions without a monitor continue to rely on hook events alone; the 30-minute zombie safety net in the plan is deferred unless field evidence requires it. Existing health-check UI nudges users whose hooks are outdated.

## Scope discipline

Only Claude-format hooks (Claude Code + qoder/qwen/factory/droid/codebuddy/kimi — same wire format). OpenCode / Cursor / Gemini / Codex untouched; their migrations are separate plans.

## Relationship to #375

#375 patched the symptom with a workspace-scoped fallback in `ProcessMonitoringCoordinator`. This PR removes the need for that fallback entirely by cutting the `ps`-based eviction path. **#375 will be closed without merging** once this lands.

## Test results

`swift test` — **262 tests in 29 suites, all green**. Zero pre-existing tests were modified; all new behaviour is covered by new tests.

New test modules:
- `ClaudeHookPayloadPIDTests` — codec + `withRuntimeContext` enrichment.
- `ClaudePIDMonitorTests` — 8 cases: live-exit, untrack, retrack during grace, same-PID idempotency, already-dead PID, `isAlive` transitions, `untrackAll`, deinit cleanup.
- `BridgeServerPIDMonitorTests` — 6 cases via real Unix socket: start-registers, no-PID-skips, end-untracks, kernel-exit-emits, subagent-filter, resume-replaces.
- `SessionStateClaudeExitTests` — reducer branch + "10 consecutive empty polls don't evict Claude but still evict OpenCode" invariant.
- `ClaudeSessionMetadataPIDTests` + 2 new tests in `AppModelSessionListTests` — metadata codec / isEmpty / merge direction.
- `ClaudeSessionRegistryTests` — 4 new cases: codec round-trip, legacy decode, init-from-session, restorableSession.
- `ClaudeSessionLifecycleIntegrationTests` — **2 end-to-end tests**: 10 empty reconcile cycles don't collapse 4 live sessions (original bug repro); killing one PID flips only that session to Completed.

Synthetic-session tests in `AppModelSessionListTests` — 4 new cases (frozen `updatedAt`, first-seen re-registration, workspace-gate suppression, orphan-workspace still synthesizes).

## Manual verification (Task 9 — reserved for @Octane0411)

Please smoke before merging:

- [ ] `zsh scripts/setup-dev-signing.sh` (one-time if not done)
- [ ] `zsh scripts/launch-dev-app.sh` → Settings → reinstall Claude hooks so the new `OpenIslandHooks` binary is deployed
- [ ] Open 3+ Ghostty tabs in the same repo, `claude` in each, let sessions run for ≥10 minutes with intermittent prompts while another terminal runs heavy I/O (`find /` / `stress-ng --io 4 --timeout 60s`). Assert no collapse: metadata stays, age badges read true age.
- [ ] In one tab, `kill -9 <claude-pid>`. Within ~5s (grace period) the island should flip that specific row to Completed; others stay.
- [ ] In a killed tab, `claude --resume <session-id>`. The row should re-activate under the new PID — no duplicate row.
- [ ] Restart the app with Claude still running in a tab. After launch, the session should remain live and its kernel monitor should be reattached (check `Settings → Diagnostics` if such a readout exists, or just kill the PID afterwards and verify the flip still works).

Once smoke passes, `gh pr close 375` and merge this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)