### PR TITLE
feat(ask-ui): support free text option "other"

### DIFF
--- a/Sources/OpenIslandApp/IslandDebugScenario.swift
+++ b/Sources/OpenIslandApp/IslandDebugScenario.swift
@@ -359,6 +359,7 @@ private enum DebugSessionFactory {
                             QuestionOption(label: "JWT tokens", description: "Stateless, scalable"),
                             QuestionOption(label: "Session cookies", description: "Traditional approach"),
                             QuestionOption(label: "OAuth 2.0", description: "Third-party auth"),
+                            QuestionOption(label: "Other", description: "", allowsFreeform: true),
                         ]
                     )
                 ]

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -151,6 +151,7 @@
 /* Island Panel - Question */
 "question.submit" = "Submit Answers";
 "question.answerNeeded" = "Answer needed";
+"question.otherPlaceholder" = "Type your answer…";
 
 /* Island Panel - Completion */
 "completion.done" = "Done";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -151,6 +151,7 @@
 /* Island Panel - Question */
 "question.submit" = "提交答案";
 "question.answerNeeded" = "需要回答";
+"question.otherPlaceholder" = "输入你的回答…";
 
 /* Island Panel - Completion */
 "completion.done" = "完成";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -150,6 +150,7 @@
 /* Island Panel - Question */
 "question.submit" = "提交答案";
 "question.answerNeeded" = "需要回答";
+"question.otherPlaceholder" = "輸入你的回答…";
 
 /* Island Panel - Completion */
 "completion.done" = "完成";

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1609,6 +1609,7 @@ private struct StructuredQuestionPromptView: View {
     let onAnswer: (QuestionPromptResponse) -> Void
 
     @State private var selections: [String: Set<String>] = [:]
+    @State private var freeformTexts: [String: String] = [:]
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -1672,44 +1673,74 @@ private struct StructuredQuestionPromptView: View {
 
     // MARK: - Option row (vertical, CLI-style)
 
-    /// Renders a single option as a selectable row with checkmark indicator, label, and optional description.
+    @ViewBuilder
     private func optionRow(_ option: QuestionOption, question: QuestionPromptItem) -> some View {
         let isSelected = selectedLabels(for: question).contains(option.label)
-        return Button {
-            toggle(option: option.label, for: question)
-        } label: {
-            HStack(spacing: 8) {
-                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(isSelected ? .yellow : .white.opacity(0.35))
+        let showsFreeform = option.allowsFreeform && isSelected
+        VStack(alignment: .leading, spacing: 0) {
+            Button {
+                toggle(option: option.label, for: question)
+            } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(isSelected ? .yellow : .white.opacity(0.35))
 
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(option.label)
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundStyle(.white.opacity(isSelected ? 1 : 0.78))
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(option.label)
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(.white.opacity(isSelected ? 1 : 0.78))
 
-                    if !option.description.isEmpty {
-                        Text(option.description)
-                            .font(.system(size: 10.5))
-                            .foregroundStyle(.white.opacity(0.4))
-                            .lineLimit(1)
+                        if !option.description.isEmpty {
+                            Text(option.description)
+                                .font(.system(size: 10.5))
+                                .foregroundStyle(.white.opacity(0.4))
+                                .lineLimit(1)
+                        }
                     }
-                }
 
-                Spacer(minLength: 0)
+                    Spacer(minLength: 0)
+                }
+                .contentShape(Rectangle())
+                .padding(.vertical, 5)
+                .padding(.horizontal, 10)
             }
-            .padding(.vertical, 5)
-            .padding(.horizontal, 10)
-            .background(
-                RoundedRectangle(cornerRadius: 10, style: .continuous)
-                    .fill(isSelected ? Color.yellow.opacity(0.10) : Color.white.opacity(0.04))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 10, style: .continuous)
-                    .strokeBorder(isSelected ? .yellow.opacity(0.25) : .clear)
-            )
+            .buttonStyle(.plain)
+
+            if showsFreeform {
+                Divider()
+                    .overlay(Color.white.opacity(0.08))
+                freeformField(for: option, question: question)
+            }
         }
-        .buttonStyle(.plain)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(isSelected ? Color.yellow.opacity(0.10) : Color.white.opacity(0.04))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .strokeBorder(isSelected ? .yellow.opacity(0.25) : .clear)
+        )
+    }
+
+    @ViewBuilder
+    private func freeformField(for option: QuestionOption, question: QuestionPromptItem) -> some View {
+        let key = freeformKey(for: question, option: option)
+        ReplyTextField(
+            placeholder: lang.t("question.otherPlaceholder"),
+            text: Binding(
+                get: { freeformTexts[key] ?? "" },
+                set: { freeformTexts[key] = $0 }
+            ),
+            onSubmit: {
+                if hasCompleteSelection {
+                    onAnswer(QuestionPromptResponse(answers: answerMap))
+                }
+            }
+        )
+        .frame(height: 22)
+        .padding(.vertical, 6)
+        .padding(.horizontal, 10)
     }
 
     // MARK: - Helpers
@@ -1737,20 +1768,58 @@ private struct StructuredQuestionPromptView: View {
 
     private var answerMap: [String: String] {
         Dictionary(uniqueKeysWithValues: structuredQuestions.compactMap { question in
-            let selected = selectedLabels(for: question)
-            guard !selected.isEmpty else {
+            let values = resolvedAnswers(for: question)
+            guard !values.isEmpty else {
                 return nil
             }
-            return (question.question, selected.sorted().joined(separator: ", "))
+            return (question.question, values.joined(separator: ", "))
         })
     }
 
     private var hasCompleteSelection: Bool {
-        structuredQuestions.allSatisfy { !selectedLabels(for: $0).isEmpty }
+        structuredQuestions.allSatisfy { question in
+            let selected = selectedLabels(for: question)
+            guard !selected.isEmpty else {
+                return false
+            }
+            // When a freeform option is selected, require non-empty text.
+            for option in question.options where option.allowsFreeform && selected.contains(option.label) {
+                if trimmedFreeform(for: question, option: option).isEmpty {
+                    return false
+                }
+            }
+            return true
+        }
     }
 
     private func selectedLabels(for question: QuestionPromptItem) -> Set<String> {
         selections[question.question] ?? []
+    }
+
+    private func resolvedAnswers(for question: QuestionPromptItem) -> [String] {
+        let selected = selectedLabels(for: question)
+        guard !selected.isEmpty else { return [] }
+
+        let optionOrder = question.options
+        var answers: [String] = []
+        for option in optionOrder where selected.contains(option.label) {
+            if option.allowsFreeform {
+                let text = trimmedFreeform(for: question, option: option)
+                answers.append(text.isEmpty ? option.label : text)
+            } else {
+                answers.append(option.label)
+            }
+        }
+        return answers
+    }
+
+    private func freeformKey(for question: QuestionPromptItem, option: QuestionOption) -> String {
+        "\(question.question)|\(option.label)"
+    }
+
+    private func trimmedFreeform(for question: QuestionPromptItem, option: QuestionOption) -> String {
+        (freeformTexts[freeformKey(for: question, option: option)] ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private func toggle(option: String, for question: QuestionPromptItem) {

--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -198,11 +198,19 @@ public struct QuestionOption: Equatable, Identifiable, Codable, Sendable {
     public var id: UUID
     public var label: String
     public var description: String
+    /// When true, the submitted answer is the user's typed text, not the label.
+    public var allowsFreeform: Bool
 
-    public init(id: UUID = UUID(), label: String, description: String = "") {
+    public init(
+        id: UUID = UUID(),
+        label: String,
+        description: String = "",
+        allowsFreeform: Bool = false
+    ) {
         self.id = id
         self.label = label
         self.description = description
+        self.allowsFreeform = allowsFreeform
     }
 }
 

--- a/Sources/OpenIslandCore/ClaudeHooks.swift
+++ b/Sources/OpenIslandCore/ClaudeHooks.swift
@@ -837,10 +837,16 @@ public extension ClaudeHookPayload {
                 return nil
             }
 
+            // CLIs add "Other" client-side and tell the model not to include one; mirror that here.
+            var resolvedOptions = options
+            resolvedOptions.append(
+                QuestionOption(label: "Other", description: "", allowsFreeform: true)
+            )
+
             return QuestionPromptItem(
                 question: questionText,
                 header: header,
-                options: options,
+                options: resolvedOptions,
                 multiSelect: questionObject["multiSelect"]?.boolValue ?? false
             )
         }

--- a/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
@@ -377,6 +377,34 @@ struct ClaudeHooksTests {
     }
 
     @Test
+    func questionPromptAlwaysAppendsOtherFreeformOption() throws {
+        let payload = ClaudeHookPayload(
+            cwd: "/tmp",
+            hookEventName: .preToolUse,
+            sessionID: "s1",
+            toolName: "AskUserQuestion",
+            toolInput: .object([
+                "questions": .array([
+                    .object([
+                        "question": .string("Pick one"),
+                        "header": .string("Pick"),
+                        "options": .array([
+                            option(label: "Production", description: ""),
+                            option(label: "Staging", description: ""),
+                        ]),
+                    ]),
+                ]),
+            ])
+        )
+
+        let prompt = try #require(payload.questionPrompt)
+        let options = try #require(prompt.questions.first?.options)
+        #expect(options.map(\.label) == ["Production", "Staging", "Other"])
+        #expect(options.last?.allowsFreeform == true)
+        #expect(options.dropLast().allSatisfy { !$0.allowsFreeform })
+    }
+
+    @Test
     func claudeDefaultJumpTargetForwardsWarpPaneUUID() {
         let payload = ClaudeHookPayload(
             cwd: "/tmp/demo",


### PR DESCRIPTION
## Context
Current ask-user-question UI doesn't support free-text input, which every agent CLI (Claude Code, Cursor, OpenCode, Qwen Code, Kimi CLI) supports natively by injecting an "Other" option client-side, this PR adds the "other" option with a free form input.

## Demo

https://github.com/user-attachments/assets/89023e3e-d6ea-425a-ab8d-7fbe9120cbee

## Changes
- Append an "Other" freeform option to every `AskUserQuestion` prompt, matching the behavior every CLI that ships this tool hard-codes client-side (Claude Code, Qwen Code, Kimi CLI, Cursor : all explicitly tell the model not to include one because "the system adds it automatically"; OpenCode strips its `custom` toggle from the model-facing schema for the same effect).
- Add `allowsFreeform: Bool` to `QuestionOption` to mark the synthesized row.
- Render the free-text field inline inside the same card as the "Other" row — no sub-card or indent offset.
- On submit, substitute the typed text for the label in the answer map so the agent receives the user's words, not the literal "Other".
- Disable the Submit button until the typed text is non-empty when "Other" is selected.
- Add `question.otherPlaceholder` localization (`en` / `zh-Hans` / `zh-Hant`).
- Parser test for the always-append behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Other" option with freeform text input to question prompts.
  * Implemented freeform text field for selected question options.
  * Added localization support for question prompts in English, Simplified Chinese, and Traditional Chinese.

* **Tests**
  * Added test for "Other" option inclusion in question prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->