### PR TITLE
fix: narrow closed island on external displays

### DIFF
--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -869,9 +869,19 @@ final class NotchEventMonitors {
 // MARK: - NSScreen notch size helper
 
 extension NSScreen {
+    /// Simulated notch width used on non-notch (external) displays.
+    /// Sized close to a real MacBook notch (~200pt) so the closed island
+    /// doesn't feel disproportionately wide when the black rectangle is
+    /// fully visible (not hidden behind a physical notch).
+    static let externalDisplayNotchWidth: CGFloat = 190
+    static let externalDisplayNotchHeight: CGFloat = 38
+
     var notchSize: CGSize {
         guard safeAreaInsets.top > 0 else {
-            return CGSize(width: 224, height: 38)
+            return CGSize(
+                width: Self.externalDisplayNotchWidth,
+                height: Self.externalDisplayNotchHeight
+            )
         }
 
         let notchHeight = safeAreaInsets.top

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -336,7 +336,7 @@ struct IslandPanelView: View {
     // MARK: - Closed state
 
     private var closedNotchWidth: CGFloat {
-        (targetOverlayScreen ?? NSScreen.screens.first(where: { $0.safeAreaInsets.top > 0 }))?.notchSize.width ?? 224
+        (targetOverlayScreen ?? NSScreen.screens.first(where: { $0.safeAreaInsets.top > 0 }))?.notchSize.width ?? NSScreen.externalDisplayNotchWidth
     }
 
     private var closedNotchHeight: CGFloat {


### PR DESCRIPTION
## Summary
- Simulated notch width on non-notch (external) displays dropped from **224pt → 190pt** — closer to a real MacBook Pro notch so the closed island doesn't feel disproportionately wide when the black bar is fully visible (not tucked behind a physical notch).
- Extracted the fallback dimensions as named constants (`NSScreen.externalDisplayNotchWidth` / `externalDisplayNotchHeight`) so future tuning lives in one place.
- Built-in-notch code path is untouched — the change only affects screens where `safeAreaInsets.top == 0`.
- The central activity label added in #372 still has ~168pt available for truncated tool-call text.

## Test plan
- [x] `swift build` succeeds
- [x] `swift test --filter OverlayPanelControllerTests` — 11/11 pass
- [ ] Manual: drag Open Island to an external monitor, confirm the closed island looks narrower and the center tool-call label (when a session is active) still renders and truncates cleanly
- [ ] Manual: confirm built-in-notch Macs are visually unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved external display notch sizing consistency by standardizing dimensions across different screen configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->