### PR TITLE
feat: support Codex PermissionRequest approvals

### DIFF
--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -13,6 +13,7 @@ public final class BridgeServer: @unchecked Sendable {
 
     private struct PendingApproval {
         let clientID: UUID
+        let hookEventName: CodexHookEventName
     }
 
     private struct PendingClaudeToolContext {
@@ -506,7 +507,39 @@ public final class BridgeServer: @unchecked Sendable {
             emit(approvalEvent)
 
             pendingApprovals[payload.sessionID] = PendingApproval(
-                clientID: clientID
+                clientID: clientID,
+                hookEventName: .preToolUse
+            )
+
+        case .permissionRequest:
+            ensureSessionExists(for: payload)
+            synchronizeJumpTarget(for: payload)
+            synchronizeCodexMetadata(for: payload)
+
+            let command = payload.commandPreview ?? "Bash command"
+            let summary = payload.toolInput?.description ?? "Codex wants to run a shell command."
+
+            emit(
+                .permissionRequested(
+                    PermissionRequested(
+                        sessionID: payload.sessionID,
+                        request: PermissionRequest(
+                            title: "Run Bash command",
+                            summary: summary,
+                            affectedPath: payload.commandText ?? command,
+                            primaryActionTitle: "Allow",
+                            secondaryActionTitle: "Deny",
+                            toolName: payload.toolName,
+                            toolUseID: payload.toolUseID
+                        ),
+                        timestamp: .now
+                    )
+                )
+            )
+
+            pendingApprovals[payload.sessionID] = PendingApproval(
+                clientID: clientID,
+                hookEventName: .permissionRequest
             )
 
         case .postToolUse:
@@ -1975,7 +2008,7 @@ public final class BridgeServer: @unchecked Sendable {
         switch hookEventName {
         case .userPromptSubmit, .postToolUse, .stop:
             return nil
-        case .sessionStart, .preToolUse:
+        case .sessionStart, .preToolUse, .permissionRequest:
             return existing
         }
     }
@@ -2247,7 +2280,7 @@ public final class BridgeServer: @unchecked Sendable {
         switch hookEventName {
         case .userPromptSubmit, .postToolUse, .stop:
             return nil
-        case .sessionStart, .preToolUse:
+        case .sessionStart, .preToolUse, .permissionRequest:
             return existing
         }
     }
@@ -2257,11 +2290,22 @@ public final class BridgeServer: @unchecked Sendable {
             return
         }
 
+        let denyReason = "Permission denied in Open Island."
         let response: BridgeResponse
-        if approved {
-            response = .acknowledged
-        } else {
-            response = .codexHookDirective(.deny(reason: "Permission denied in Open Island."))
+        switch pendingApproval.hookEventName {
+        case .preToolUse:
+            // Legacy PreToolUse approvals continue by returning no directive.
+            response = approved
+                ? .acknowledged
+                : .codexHookDirective(.deny(reason: denyReason))
+        case .permissionRequest:
+            response = approved
+                ? .codexHookDirective(.permissionRequest(.allow))
+                : .codexHookDirective(.permissionRequest(.deny(message: denyReason)))
+        case .sessionStart, .userPromptSubmit, .postToolUse, .stop:
+            response = approved
+                ? .acknowledged
+                : .codexHookDirective(.deny(reason: denyReason))
         }
 
         send(.response(response), to: pendingApproval.clientID)

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -2303,9 +2303,10 @@ public final class BridgeServer: @unchecked Sendable {
                 ? .codexHookDirective(.permissionRequest(.allow))
                 : .codexHookDirective(.permissionRequest(.deny(message: denyReason)))
         case .sessionStart, .userPromptSubmit, .postToolUse, .stop:
-            response = approved
-                ? .acknowledged
-                : .codexHookDirective(.deny(reason: denyReason))
+            assertionFailure("Unexpected pending approval event: \(pendingApproval.hookEventName.rawValue)")
+            // This branch should be unreachable because only PreToolUse/PermissionRequest register approvals.
+            // Fail open with acknowledged so Codex never receives a mismatched directive payload.
+            response = .acknowledged
         }
 
         send(.response(response), to: pendingApproval.clientID)

--- a/Sources/OpenIslandCore/CodexHookInstaller.swift
+++ b/Sources/OpenIslandCore/CodexHookInstaller.swift
@@ -59,6 +59,8 @@ public enum CodexHookInstaller {
     public static let managedStatusMessage = "Managed by Open Island"
     public static let legacyManagedStatusMessage = "Managed by Vibe Island"
     public static let managedTimeout = 45
+    // Intentionally above OpenIslandHooksCLI.interactiveCodexHookTimeout (3500) so the CLI can
+    // fail open first instead of waiting for the full Codex-managed window.
     public static let managedInteractiveTimeout = 3600
 
     // Keep the managed Codex install low-noise while still surfacing approval prompts.

--- a/Sources/OpenIslandCore/CodexHookInstaller.swift
+++ b/Sources/OpenIslandCore/CodexHookInstaller.swift
@@ -59,14 +59,15 @@ public enum CodexHookInstaller {
     public static let managedStatusMessage = "Managed by Open Island"
     public static let legacyManagedStatusMessage = "Managed by Vibe Island"
     public static let managedTimeout = 45
+    public static let managedInteractiveTimeout = 3600
 
-    // Keep the managed Codex install aligned with the original app's low-noise footprint.
-    // The bridge still understands richer hook events, but we do not install them by default
-    // because per-command Bash hooks produce a large amount of terminal log spam.
-    private static let eventSpecs: [(name: String, matcher: String?)] = [
-        ("SessionStart", "startup|resume"),
-        ("UserPromptSubmit", nil),
-        ("Stop", nil),
+    // Keep the managed Codex install low-noise while still surfacing approval prompts.
+    // PermissionRequest hooks are interactive, so they get a long timeout.
+    private static let eventSpecs: [(name: String, matcher: String?, timeout: Int)] = [
+        ("SessionStart", "startup|resume", managedTimeout),
+        ("UserPromptSubmit", nil, managedTimeout),
+        ("PermissionRequest", nil, managedInteractiveTimeout),
+        ("Stop", nil, managedTimeout),
     ]
 
     public static func hookCommand(for binaryPath: String) -> String {
@@ -93,7 +94,11 @@ public enum CodexHookInstaller {
         for spec in eventSpecs {
             let existingGroups = hooksObject[spec.name] as? [Any] ?? []
             let cleanedGroups = sanitizeForInstall(groups: existingGroups, replacingCommand: hookCommand)
-            hooksObject[spec.name] = cleanedGroups + [managedGroup(matcher: spec.matcher, hookCommand: hookCommand)]
+            hooksObject[spec.name] = cleanedGroups + [managedGroup(
+                matcher: spec.matcher,
+                hookCommand: hookCommand,
+                timeout: spec.timeout
+            )]
         }
 
         rootObject["hooks"] = hooksObject
@@ -292,12 +297,12 @@ public enum CodexHookInstaller {
         }
     }
 
-    private static func managedGroup(matcher: String?, hookCommand: String) -> [String: Any] {
+    private static func managedGroup(matcher: String?, hookCommand: String, timeout: Int) -> [String: Any] {
         var group: [String: Any] = [
             "hooks": [[
                 "type": "command",
                 "command": hookCommand,
-                "timeout": managedTimeout,
+                "timeout": timeout,
             ]]
         ]
 

--- a/Sources/OpenIslandCore/CodexHooks.swift
+++ b/Sources/OpenIslandCore/CodexHooks.swift
@@ -282,7 +282,7 @@ public enum CodexHookOutputEncoder {
 
     private struct PermissionRequestOutput: Encodable {
         struct HookSpecificOutput: Encodable {
-            let hookEventName = CodexHookEventName.permissionRequest.rawValue
+            let hookEventName: String = CodexHookEventName.permissionRequest.rawValue
             let decision: CodexPermissionRequestDecision
         }
 

--- a/Sources/OpenIslandCore/CodexHooks.swift
+++ b/Sources/OpenIslandCore/CodexHooks.swift
@@ -3,6 +3,7 @@ import Foundation
 public enum CodexHookEventName: String, Codable, Sendable {
     case sessionStart = "SessionStart"
     case preToolUse = "PreToolUse"
+    case permissionRequest = "PermissionRequest"
     case postToolUse = "PostToolUse"
     case userPromptSubmit = "UserPromptSubmit"
     case stop = "Stop"
@@ -20,9 +21,11 @@ public enum CodexPermissionMode: String, Codable, Sendable {
 
 public struct CodexHookToolInput: Equatable, Codable, Sendable {
     public var command: String
+    public var description: String?
 
-    public init(command: String) {
+    public init(command: String, description: String? = nil) {
         self.command = command
+        self.description = description
     }
 }
 
@@ -191,16 +194,58 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
     }
 }
 
+public enum CodexPermissionRequestDecision: Equatable, Codable, Sendable {
+    case allow
+    case deny(message: String?)
+
+    private enum CodingKeys: String, CodingKey {
+        case behavior
+        case message
+    }
+
+    private enum Behavior: String, Codable {
+        case allow
+        case deny
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let behavior = try container.decode(Behavior.self, forKey: .behavior)
+
+        switch behavior {
+        case .allow:
+            self = .allow
+        case .deny:
+            self = .deny(message: try container.decodeIfPresent(String.self, forKey: .message))
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        switch self {
+        case .allow:
+            try container.encode(Behavior.allow, forKey: .behavior)
+        case let .deny(message):
+            try container.encode(Behavior.deny, forKey: .behavior)
+            try container.encodeIfPresent(message, forKey: .message)
+        }
+    }
+}
+
 public enum CodexHookDirective: Equatable, Codable, Sendable {
     case deny(reason: String)
+    case permissionRequest(CodexPermissionRequestDecision)
 
     private enum CodingKeys: String, CodingKey {
         case type
         case reason
+        case decision
     }
 
     private enum DirectiveType: String, Codable {
         case deny
+        case permissionRequest
     }
 
     public init(from decoder: any Decoder) throws {
@@ -210,6 +255,8 @@ public enum CodexHookDirective: Equatable, Codable, Sendable {
         switch type {
         case .deny:
             self = .deny(reason: try container.decode(String.self, forKey: .reason))
+        case .permissionRequest:
+            self = .permissionRequest(try container.decode(CodexPermissionRequestDecision.self, forKey: .decision))
         }
     }
 
@@ -220,6 +267,9 @@ public enum CodexHookDirective: Equatable, Codable, Sendable {
         case let .deny(reason):
             try container.encode(DirectiveType.deny, forKey: .type)
             try container.encode(reason, forKey: .reason)
+        case let .permissionRequest(decision):
+            try container.encode(DirectiveType.permissionRequest, forKey: .type)
+            try container.encode(decision, forKey: .decision)
         }
     }
 }
@@ -228,6 +278,21 @@ public enum CodexHookOutputEncoder {
     private struct LegacyBlockOutput: Codable {
         var decision = "block"
         var reason: String
+    }
+
+    private struct PermissionRequestOutput: Encodable {
+        struct HookSpecificOutput: Encodable {
+            let hookEventName = CodexHookEventName.permissionRequest.rawValue
+            let decision: CodexPermissionRequestDecision
+        }
+
+        var continue_ = true
+        var hookSpecificOutput: HookSpecificOutput
+
+        private enum CodingKeys: String, CodingKey {
+            case continue_ = "continue"
+            case hookSpecificOutput
+        }
     }
 
     public static func standardOutput(for response: BridgeResponse) throws -> Data? {
@@ -243,6 +308,12 @@ public enum CodexHookOutputEncoder {
             switch directive {
             case let .deny(reason):
                 data = try encoder.encode(LegacyBlockOutput(reason: reason))
+            case let .permissionRequest(decision):
+                data = try encoder.encode(
+                    PermissionRequestOutput(
+                        hookSpecificOutput: PermissionRequestOutput.HookSpecificOutput(decision: decision)
+                    )
+                )
             }
 
             var line = data
@@ -307,6 +378,8 @@ public extension CodexHookPayload {
             return "Started Codex session in \(workspaceName)."
         case .preToolUse:
             return "Codex is preparing a Bash command in \(workspaceName)."
+        case .permissionRequest:
+            return "Codex is waiting for permission approval in \(workspaceName)."
         case .postToolUse:
             return "Codex reported a Bash result in \(workspaceName)."
         case .userPromptSubmit:

--- a/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
+++ b/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
@@ -4,6 +4,8 @@ import OpenIslandCore
 @main
 struct OpenIslandHooksCLI {
     private static let interactiveClaudeHookTimeout: TimeInterval = 24 * 60 * 60
+    // Keep this slightly below CodexHookInstaller.managedInteractiveTimeout (3600).
+    // This lets the CLI fail open before Codex reaches its full managed timeout window.
     private static let interactiveCodexHookTimeout: TimeInterval = 3500
 
     private enum HookSource: String {

--- a/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
+++ b/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
@@ -4,6 +4,7 @@ import OpenIslandCore
 @main
 struct OpenIslandHooksCLI {
     private static let interactiveClaudeHookTimeout: TimeInterval = 24 * 60 * 60
+    private static let interactiveCodexHookTimeout: TimeInterval = 3500
 
     private enum HookSource: String {
         case codex
@@ -46,8 +47,16 @@ struct OpenIslandHooksCLI {
                     .decode(CodexHookPayload.self, from: input)
                     .withRuntimeContext(environment: ProcessInfo.processInfo.environment)
 
-                guard let response = try? client.send(.processCodexHook(payload)) else {
-                    logStderr("bridge unavailable for codex hook")
+                let timeout: TimeInterval
+                switch payload.hookEventName {
+                case .permissionRequest:
+                    timeout = Self.interactiveCodexHookTimeout
+                case .sessionStart, .preToolUse, .postToolUse, .userPromptSubmit, .stop:
+                    timeout = 45
+                }
+
+                guard let response = try? client.send(.processCodexHook(payload), timeout: timeout) else {
+                    logStderr("bridge unavailable for codex hook (\(payload.hookEventName.rawValue))")
                     return
                 }
 

--- a/Tests/OpenIslandCoreTests/CodexHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexHooksTests.swift
@@ -4,6 +4,50 @@ import Testing
 
 struct CodexHooksTests {
     @Test
+    func codexPermissionRequestOutputEncodesAllowDecision() throws {
+        let output = try #require(
+            try CodexHookOutputEncoder.standardOutput(
+                for: .codexHookDirective(.permissionRequest(.allow))
+            )
+        )
+
+        let object = try jsonObject(from: output)
+        #expect(object["continue"] as? Bool == true)
+
+        let hookSpecificOutput = object["hookSpecificOutput"] as? [String: Any]
+        #expect(hookSpecificOutput?["hookEventName"] as? String == "PermissionRequest")
+        let decision = hookSpecificOutput?["decision"] as? [String: Any]
+        #expect(decision?["behavior"] as? String == "allow")
+    }
+
+    @Test
+    func codexPermissionRequestOutputEncodesDenyDecision() throws {
+        let output = try #require(
+            try CodexHookOutputEncoder.standardOutput(
+                for: .codexHookDirective(.permissionRequest(.deny(message: "Denied by policy")))
+            )
+        )
+
+        let object = try jsonObject(from: output)
+        let hookSpecificOutput = object["hookSpecificOutput"] as? [String: Any]
+        let decision = hookSpecificOutput?["decision"] as? [String: Any]
+        #expect(decision?["behavior"] as? String == "deny")
+        #expect(decision?["message"] as? String == "Denied by policy")
+    }
+
+    @Test
+    func codexLegacyDenyOutputRemainsBlockShape() throws {
+        let output = try #require(
+            try CodexHookOutputEncoder.standardOutput(
+                for: .codexHookDirective(.deny(reason: "nope"))
+            )
+        )
+        let object = try jsonObject(from: output)
+        #expect(object["decision"] as? String == "block")
+        #expect(object["reason"] as? String == "nope")
+    }
+
+    @Test
     func codexDefaultJumpTargetForwardsWarpPaneUUID() {
         var payload = CodexHookPayload(
             cwd: "/tmp/demo",
@@ -86,4 +130,9 @@ struct CodexHooksTests {
         #expect(payload.warpPaneUUID == nil)
     }
 
+    private func jsonObject(from data: Data?) throws -> [String: Any] {
+        let data = try #require(data)
+        let object = try JSONSerialization.jsonObject(with: data, options: [])
+        return try #require(object as? [String: Any])
+    }
 }

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -507,6 +507,87 @@ struct SessionStateTests {
     }
 
     @Test
+    func codexPermissionRequestReturnsAllowDirectiveAfterApproval() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let payload = CodexHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .permissionRequest,
+            model: "gpt-5-codex",
+            permissionMode: .default,
+            sessionID: "codex-session-permission-allow",
+            transcriptPath: nil,
+            turnID: "turn-1",
+            toolName: "Bash",
+            toolInput: CodexHookToolInput(command: "curl https://example.com", description: "network-access example.com")
+        )
+
+        async let responseTask = sendOnGCDThread(.processCodexHook(payload), socketURL: socketURL)
+
+        var iterator = stream.makeAsyncIterator()
+        let startedEvent = try await nextEvent(from: &iterator)
+        let permissionEvent = try await nextEvent(from: &iterator)
+
+        #expect(startedEvent.isSessionStarted)
+        #expect(permissionEvent.isPermissionRequested)
+
+        try await observer.send(.resolvePermission(sessionID: "codex-session-permission-allow", resolution: .allowOnce()))
+
+        let activityEvent = try await nextEvent(from: &iterator)
+        let response = try await responseTask
+
+        #expect(activityEvent.activityUpdate?.summary == "Permission approved. Codex continued the command.")
+        #expect(response == .codexHookDirective(.permissionRequest(.allow)))
+    }
+
+    @Test
+    func codexPermissionRequestReturnsDenyDirectiveAfterRejection() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let payload = CodexHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .permissionRequest,
+            model: "gpt-5-codex",
+            permissionMode: .default,
+            sessionID: "codex-session-permission-deny",
+            transcriptPath: nil,
+            turnID: "turn-1",
+            toolName: "Bash",
+            toolInput: CodexHookToolInput(command: "rm -rf /tmp/demo")
+        )
+
+        async let responseTask = sendOnGCDThread(.processCodexHook(payload), socketURL: socketURL)
+
+        var iterator = stream.makeAsyncIterator()
+        let startedEvent = try await nextEvent(from: &iterator)
+        let permissionEvent = try await nextEvent(from: &iterator)
+
+        #expect(startedEvent.isSessionStarted)
+        #expect(permissionEvent.isPermissionRequested)
+
+        try await observer.send(.resolvePermission(sessionID: "codex-session-permission-deny", resolution: .deny()))
+
+        let response = try await responseTask
+        #expect(response == .codexHookDirective(.permissionRequest(.deny(message: "Permission denied in Open Island."))))
+    }
+
+    @Test
     func codexHookUpdatesJumpTargetWhenLaterHooksLearnMoreAboutTheTerminal() async throws {
         let socketURL = BridgeSocketLocation.uniqueTestURL()
         let server = BridgeServer(socketURL: socketURL)
@@ -699,6 +780,13 @@ struct SessionStateTests {
 
         let sessionStartGroups = hooks?["SessionStart"] as? [[String: Any]]
         #expect(sessionStartGroups?.contains(where: { $0["matcher"] as? String == "startup|resume" }) == true)
+        let permissionGroups = hooks?["PermissionRequest"] as? [[String: Any]]
+        #expect(permissionGroups?.isEmpty == false)
+        let managedPermissionHook = permissionGroups?
+            .compactMap { $0["hooks"] as? [[String: Any]] }
+            .flatMap { $0 }
+            .first(where: { $0["command"] as? String == "'/tmp/OpenIslandHooks'" })
+        #expect(managedPermissionHook?["timeout"] as? Int == CodexHookInstaller.managedInteractiveTimeout)
         #expect(hooks?["PreToolUse"] == nil)
         #expect(hooks?["PostToolUse"] == nil)
     }

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -457,7 +457,9 @@ struct SessionStateTests {
 
         try await observer.send(.resolvePermission(sessionID: "codex-session-1", resolution: .deny()))
 
+        let completionEvent = try await nextEvent(from: &iterator)
         let response = try await responseTask
+        #expect(completionEvent.sessionCompleted?.summary == "Permission denied in Open Island.")
         #expect(response == .codexHookDirective(.deny(reason: "Permission denied in Open Island.")))
     }
 
@@ -583,7 +585,9 @@ struct SessionStateTests {
 
         try await observer.send(.resolvePermission(sessionID: "codex-session-permission-deny", resolution: .deny()))
 
+        let completionEvent = try await nextEvent(from: &iterator)
         let response = try await responseTask
+        #expect(completionEvent.sessionCompleted?.summary == "Permission denied in Open Island.")
         #expect(response == .codexHookDirective(.permissionRequest(.deny(message: "Permission denied in Open Island."))))
     }
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -37,6 +37,7 @@ Agent
 |---|---|---|
 | `SessionStart` | Session starts or resumes (`source: "resume"` on resume) | `prompt`, `source` |
 | `PreToolUse` | Before a shell command executes | `tool_name`, `tool_input.command`, `turn_id`, `tool_use_id` |
+| `PermissionRequest` | Codex requests user approval before running a tool action | `tool_name`, `tool_input.command`, `tool_input.description`, `turn_id`, `tool_use_id` |
 | `PostToolUse` | After a shell command completes | `tool_name`, `tool_input`, `tool_response`, `turn_id` |
 | `UserPromptSubmit` | User submits a new prompt | `prompt` |
 | `Stop` | A turn completes | `last_assistant_message`, `stop_hook_active` |
@@ -59,20 +60,58 @@ Agent
 | `tool_name` | `toolName` | Tool name (e.g. `shell`) |
 | `tool_use_id` | `toolUseID` | Tool-use call ID |
 | `tool_input` | `toolInput` | Tool input (contains `command`) |
+| `tool_input.description` | `toolInput.description` | Human-readable approval summary for `PermissionRequest` |
 | `tool_response` | `toolResponse` | Tool output (JSON) |
 | `prompt` | `prompt` | User prompt text |
 | `last_assistant_message` | `lastAssistantMessage` | Last assistant message |
 | `stop_hook_active` | `stopHookActive` | Whether the stop hook is active |
 
-### Directive response (PreToolUse only)
+### Directive responses
 
-The app can block a command by writing this to stdout:
+#### PreToolUse (legacy block shape)
+
+OpenIsland can block a command by writing this to stdout:
 
 ```json
 {"decision": "block", "reason": "Blocked by Open Island"}
 ```
 
-All other events require no stdout response.
+#### PermissionRequest
+
+For `PermissionRequest`, OpenIsland writes a Codex decision payload to stdout.
+
+Allow:
+
+```json
+{
+  "continue": true,
+  "hookSpecificOutput": {
+    "hookEventName": "PermissionRequest",
+    "decision": {
+      "behavior": "allow"
+    }
+  }
+}
+```
+
+Deny:
+
+```json
+{
+  "continue": true,
+  "hookSpecificOutput": {
+    "hookEventName": "PermissionRequest",
+    "decision": {
+      "behavior": "deny",
+      "message": "Permission denied in Open Island."
+    }
+  }
+}
+```
+
+When multiple matching hooks return decisions, Codex treats `deny` as higher priority than `allow`.
+
+All other Codex events require no stdout response.
 
 ---
 
@@ -255,7 +294,8 @@ Setting `interrupt: true` terminates the current agent turn immediately.
 
 | Source | Event | Timeout |
 |---|---|---|
-| Codex | All events | Bridge default |
+| Codex | `PermissionRequest` | **3500 seconds** in `OpenIslandHooks` (managed hook entry uses **3600 seconds**) |
+| Codex | All other events | **45 seconds** |
 | Claude Code | `PermissionRequest` | **24 hours** (awaits human approval) |
 | Claude Code | All other events | **45 seconds** |
 | Gemini CLI | All events | Bridge default |


### PR DESCRIPTION
## Summary
- add first-class support for Codex `PermissionRequest` hook events in the Codex hook event/payload model
- add `tool_input.description` support so permission prompts can surface richer summaries
- handle Codex `PermissionRequest` approvals in `BridgeServer` and return Codex-compliant allow/deny directives
- keep legacy `PreToolUse` approval behavior unchanged for backward compatibility
- install/manage Codex `PermissionRequest` hooks with an interactive timeout in `CodexHookInstaller`
- add Codex CLI timeout handling for `PermissionRequest` and document the intentional CLI-vs-installer timeout gap
- harden `resolvePendingApproval` for unreachable event types with `assertionFailure` and fail-open fallback
- expand tests for Codex permission flows and directive encoding (including deny completion event assertions)

## Testing
- `swift test --filter CodexHooksTests --filter SessionStateTests`
- result: 34 tests passed

## Compatibility
- Validated with Codex CLI v0.122.0 (PermissionRequest event observed).
- Older Codex versions that do not emit PermissionRequest continue to use the legacy PreToolUse approval path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PermissionRequest hook event for interactive permission flows.
  * Tool requests may include an optional description.
  * Configurable per-event timeouts with a longer interactive timeout for permission requests.
  * Permission responses now return explicit allow or deny directives, with optional denial messages.

* **Behavior Changes**
  * Metadata and session state for permission requests are preserved across related events.

* **Tests**
  * Added tests validating permission request encoding and end-to-end approval/denial flows.

* **Documentation**
  * Docs updated with PermissionRequest payloads, directive shapes, and timeout policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
