### PR TITLE
feat: add CatPaw IDE support via hook integration

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -130,6 +130,11 @@ final class AppModel {
     var kimiHookStatus: KimiHookInstallationStatus? { hooks.kimiHookStatus }
     var kimiHookStatusTitle: String { hooks.kimiHookStatusTitle }
     var kimiHookStatusSummary: String { hooks.kimiHookStatusSummary }
+    var catPawHooksInstalled: Bool { hooks.catPawHooksInstalled }
+    var isCatPawHookSetupBusy: Bool { hooks.isCatPawHookSetupBusy }
+    var catPawHookStatus: CatPawHookInstallationStatus? { hooks.catPawHookStatus }
+    var catPawHookStatusTitle: String { hooks.catPawHookStatusTitle }
+    var catPawHookStatusSummary: String { hooks.catPawHookStatusSummary }
     var codexHookStatusTitle: String { hooks.codexHookStatusTitle }
     var codexHookStatusSummary: String { hooks.codexHookStatusSummary }
 
@@ -156,6 +161,7 @@ final class AppModel {
             || hooks.openCodePluginInstalled
             || hooks.geminiHooksInstalled
             || hooks.kimiHooksInstalled
+            || hooks.catPawHooksInstalled
     }
     func refreshCodexHookStatus() { hooks.refreshCodexHookStatus() }
     func refreshClaudeHookStatus() { hooks.refreshClaudeHookStatus() }
@@ -186,6 +192,9 @@ final class AppModel {
     func refreshKimiHookStatus() { hooks.refreshKimiHookStatus() }
     func installKimiHooks() { hooks.installKimiHooks() }
     func uninstallKimiHooks() { hooks.uninstallKimiHooks() }
+    func refreshCatPawHookStatus() { hooks.refreshCatPawHookStatus() }
+    func installCatPawHooks() { hooks.installCatPawHooks() }
+    func uninstallCatPawHooks() { hooks.uninstallCatPawHooks() }
     func installClaudeUsageBridge() { hooks.installClaudeUsageBridge() }
     func uninstallClaudeUsageBridge() { hooks.uninstallClaudeUsageBridge() }
     func updateClaudeConfigDirectory(to newDirectory: URL?) { hooks.updateClaudeConfigDirectory(to: newDirectory) }

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -22,6 +22,7 @@ final class HookInstallationCoordinator {
     var cursorHookStatus: CursorHookInstallationStatus?
     var geminiHookStatus: GeminiHookInstallationStatus?
     var kimiHookStatus: KimiHookInstallationStatus?
+    var catPawHookStatus: CatPawHookInstallationStatus?
     var claudeStatusLineStatus: ClaudeStatusLineInstallationStatus?
     var claudeUsageSnapshot: ClaudeUsageSnapshot?
     var codexUsageSnapshot: CodexUsageSnapshot?
@@ -36,6 +37,7 @@ final class HookInstallationCoordinator {
     var isCursorHookSetupBusy = false
     var isGeminiHookSetupBusy = false
     var isKimiHookSetupBusy = false
+    var isCatPawHookSetupBusy = false
     var isClaudeUsageSetupBusy = false
 
     @ObservationIgnored
@@ -84,6 +86,9 @@ final class HookInstallationCoordinator {
 
     @ObservationIgnored
     private let kimiHookInstallationManager = KimiHookInstallationManager()
+
+    @ObservationIgnored
+    private let catPawHookInstallationManager = CatPawHookInstallationManager()
 
     /// Computed so it always reflects the latest `ClaudeConfigDirectory` setting.
     private var claudeStatusLineInstallationManager: ClaudeStatusLineInstallationManager {
@@ -143,6 +148,10 @@ final class HookInstallationCoordinator {
 
     var kimiHooksInstalled: Bool {
         kimiHookStatus?.managedHooksPresent == true
+    }
+
+    var catPawHooksInstalled: Bool {
+        catPawHookStatus?.managedHooksPresent == true
     }
 
     var claudeUsageInstalled: Bool {
@@ -378,6 +387,34 @@ final class HookInstallationCoordinator {
         return "no managed Kimi hooks"
     }
 
+    var catPawHookStatusTitle: String {
+        if catPawHooksInstalled {
+            return "CatPaw hooks installed"
+        }
+
+        if hooksBinaryURL == nil {
+            return "Hook binary not found"
+        }
+
+        return "CatPaw hooks not installed"
+    }
+
+    var catPawHookStatusSummary: String {
+        guard catPawHookStatus != nil else {
+            return "Reading ~/.catpaw/settings.json."
+        }
+
+        if catPawHooksInstalled {
+            return "managed hooks present"
+        }
+
+        if hooksBinaryURL == nil {
+            return "Build OpenIslandHooks before installing."
+        }
+
+        return "no managed CatPaw hooks"
+    }
+
     var codexHookStatusTitle: String {
         if codexHooksInstalled {
             return "Codex hooks installed"
@@ -450,6 +487,7 @@ final class HookInstallationCoordinator {
                     self.refreshCodexHookStatus()
                     self.refreshClaudeHookStatus()
                     self.refreshCursorHookStatus()
+                    self.refreshCatPawHookStatus()
                 }
             } catch {
                 self.onStatusMessage?("Failed to update hooks binary: \(error.localizedDescription)")
@@ -689,6 +727,16 @@ final class HookInstallationCoordinator {
                     self.onStatusMessage?("Failed to read Kimi hook status: \(error.localizedDescription)")
                 }
             }
+
+            group.addTask { @MainActor [weak self] in
+                guard let self else { return }
+                do {
+                    let status = try self.catPawHookInstallationManager.status(hooksBinaryURL: self.hooksBinaryURL)
+                    self.catPawHookStatus = status
+                } catch {
+                    self.onStatusMessage?("Failed to read CatPaw hook status: \(error.localizedDescription)")
+                }
+            }
         }
     }
 
@@ -740,6 +788,19 @@ final class HookInstallationCoordinator {
                 self.kimiHookStatus = status
             } catch {
                 self.onStatusMessage?("Failed to read Kimi hook status: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    func refreshCatPawHookStatus() {
+        Task { [weak self] in
+            guard let self else { return }
+
+            do {
+                let status = try self.catPawHookInstallationManager.status(hooksBinaryURL: self.hooksBinaryURL)
+                self.catPawHookStatus = status
+            } catch {
+                self.onStatusMessage?("Failed to read CatPaw hook status: \(error.localizedDescription)")
             }
         }
     }
@@ -814,6 +875,7 @@ final class HookInstallationCoordinator {
         case .openCode: return !openCodePluginInstalled
         case .gemini: return !geminiHooksInstalled
         case .kimi: return !kimiHooksInstalled
+        case .catPaw: return !catPawHooksInstalled
         case .claudeUsageBridge: return !claudeUsageInstalled
         }
     }
@@ -838,6 +900,7 @@ final class HookInstallationCoordinator {
             case .openCode: return openCodePluginInstalled
             case .gemini: return geminiHooksInstalled
             case .kimi: return kimiHooksInstalled
+            case .catPaw: return catPawHooksInstalled
             case .claudeUsageBridge: return claudeUsageInstalled
             }
         }
@@ -1045,6 +1108,23 @@ final class HookInstallationCoordinator {
 
     func uninstallKimiHooks() {
         updateKimiHooks(userMessage: "Removing Kimi hooks.", intent: .uninstalled) { manager in
+            try manager.uninstall()
+        }
+    }
+
+    func installCatPawHooks() {
+        guard let hooksBinaryURL else {
+            onStatusMessage?("Could not find a local OpenIslandHooks binary. Build the package first.")
+            return
+        }
+
+        updateCatPawHooks(userMessage: "Installing CatPaw hooks.", intent: .installed) { manager in
+            try manager.install(hooksBinaryURL: hooksBinaryURL)
+        }
+    }
+
+    func uninstallCatPawHooks() {
+        updateCatPawHooks(userMessage: "Removing CatPaw hooks.", intent: .uninstalled) { manager in
             try manager.uninstall()
         }
     }
@@ -1257,6 +1337,34 @@ final class HookInstallationCoordinator {
                 }
             } catch {
                 self.onStatusMessage?("Kimi hook update failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func updateCatPawHooks(
+        userMessage: String,
+        intent: AgentHookIntent,
+        operation: @escaping (CatPawHookInstallationManager) throws -> CatPawHookInstallationStatus
+    ) {
+        isCatPawHookSetupBusy = true
+        onStatusMessage?(userMessage)
+
+        Task { [weak self] in
+            guard let self else { return }
+
+            defer { self.isCatPawHookSetupBusy = false }
+
+            do {
+                let status = try operation(self.catPawHookInstallationManager)
+                self.catPawHookStatus = status
+                self.intentStore.setIntent(intent, for: .catPaw)
+                if status.managedHooksPresent {
+                    self.onStatusMessage?("CatPaw hooks are installed and ready.")
+                } else {
+                    self.onStatusMessage?("CatPaw hooks are not installed.")
+                }
+            } catch {
+                self.onStatusMessage?("CatPaw hook update failed: \(error.localizedDescription)")
             }
         }
     }

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -417,6 +417,7 @@ struct SetupSettingsPane: View {
     @State private var confirmingUninstallCursor = false
     @State private var confirmingUninstallGemini = false
     @State private var confirmingUninstallKimi = false
+    @State private var confirmingUninstallCatPaw = false
     @State private var confirmingUninstallClaudeUsage = false
 
     private var lang: LanguageManager { model.lang }
@@ -601,6 +602,23 @@ struct SetupSettingsPane: View {
                 } message: {
                     Text("This will remove Open Island hooks from ~/.kimi/config.toml.")
                 }
+
+                hookRow(
+                    name: "CatPaw",
+                    installed: model.catPawHooksInstalled,
+                    busy: model.isCatPawHookSetupBusy,
+                    configLocationURL: model.catPawHookStatus?.settingsURL,
+                    installAction: { model.installCatPawHooks() },
+                    uninstallAction: { confirmingUninstallCatPaw = true }
+                )
+                .alert(lang.t("settings.general.uninstallConfirmTitle"), isPresented: $confirmingUninstallCatPaw) {
+                    Button(lang.t("settings.general.uninstallConfirmAction"), role: .destructive) {
+                        model.uninstallCatPawHooks()
+                    }
+                    Button(lang.t("settings.general.cancel"), role: .cancel) {}
+                } message: {
+                    Text("This will remove Open Island hooks from ~/.catpaw/settings.json.")
+                }
             }
 
             Section {
@@ -678,6 +696,7 @@ struct SetupSettingsPane: View {
                     if !model.cursorHooksInstalled { model.installCursorHooks() }
                     if !model.geminiHooksInstalled { model.installGeminiHooks() }
                     if !model.kimiHooksInstalled { model.installKimiHooks() }
+                    if !model.catPawHooksInstalled { model.installCatPawHooks() }
                     if !model.claudeUsageInstalled { model.installClaudeUsageBridge() }
                 }
                 .disabled(model.hooksBinaryURL == nil || allReady)
@@ -739,7 +758,8 @@ struct SetupSettingsPane: View {
     private var allReady: Bool {
         model.claudeHooksInstalled && model.codexHooksInstalled && model.openCodePluginInstalled
             && model.qoderHooksInstalled && model.qwenCodeHooksInstalled && model.factoryHooksInstalled && model.codebuddyHooksInstalled
-            && model.cursorHooksInstalled && model.geminiHooksInstalled && model.kimiHooksInstalled && model.claudeUsageInstalled
+            && model.cursorHooksInstalled && model.geminiHooksInstalled && model.kimiHooksInstalled && model.catPawHooksInstalled
+            && model.claudeUsageInstalled
     }
 
     @ViewBuilder

--- a/Sources/OpenIslandCore/AgentEvent.swift
+++ b/Sources/OpenIslandCore/AgentEvent.swift
@@ -14,6 +14,7 @@ public struct SessionStarted: Equatable, Codable, Sendable {
     public var geminiMetadata: GeminiSessionMetadata?
     public var openCodeMetadata: OpenCodeSessionMetadata?
     public var cursorMetadata: CursorSessionMetadata?
+    public var catPawMetadata: CatPawSessionMetadata?
     public var isRemote: Bool
 
     public init(
@@ -30,6 +31,7 @@ public struct SessionStarted: Equatable, Codable, Sendable {
         geminiMetadata: GeminiSessionMetadata? = nil,
         openCodeMetadata: OpenCodeSessionMetadata? = nil,
         cursorMetadata: CursorSessionMetadata? = nil,
+        catPawMetadata: CatPawSessionMetadata? = nil,
         isRemote: Bool = false
     ) {
         self.sessionID = sessionID
@@ -45,6 +47,7 @@ public struct SessionStarted: Equatable, Codable, Sendable {
         self.geminiMetadata = geminiMetadata
         self.openCodeMetadata = openCodeMetadata
         self.cursorMetadata = cursorMetadata
+        self.catPawMetadata = catPawMetadata
         self.isRemote = isRemote
     }
 }
@@ -222,6 +225,22 @@ public struct CursorSessionMetadataUpdated: Equatable, Codable, Sendable {
     }
 }
 
+public struct CatPawSessionMetadataUpdated: Equatable, Codable, Sendable {
+    public var sessionID: String
+    public var catPawMetadata: CatPawSessionMetadata
+    public var timestamp: Date
+
+    public init(
+        sessionID: String,
+        catPawMetadata: CatPawSessionMetadata,
+        timestamp: Date
+    ) {
+        self.sessionID = sessionID
+        self.catPawMetadata = catPawMetadata
+        self.timestamp = timestamp
+    }
+}
+
 public struct ActionableStateResolved: Equatable, Codable, Sendable {
     public var sessionID: String
     public var summary: String
@@ -250,6 +269,7 @@ public enum AgentEvent: Equatable, Codable, Sendable {
     case geminiSessionMetadataUpdated(GeminiSessionMetadataUpdated)
     case openCodeSessionMetadataUpdated(OpenCodeSessionMetadataUpdated)
     case cursorSessionMetadataUpdated(CursorSessionMetadataUpdated)
+    case catPawSessionMetadataUpdated(CatPawSessionMetadataUpdated)
     case actionableStateResolved(ActionableStateResolved)
 
     private enum CodingKeys: String, CodingKey {
@@ -265,6 +285,7 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case geminiSessionMetadataUpdated
         case openCodeSessionMetadataUpdated
         case cursorSessionMetadataUpdated
+        case catPawSessionMetadataUpdated
         case actionableStateResolved
     }
 
@@ -280,6 +301,7 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case geminiSessionMetadataUpdated
         case openCodeSessionMetadataUpdated
         case cursorSessionMetadataUpdated
+        case catPawSessionMetadataUpdated
         case actionableStateResolved
     }
 
@@ -317,6 +339,10 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case .cursorSessionMetadataUpdated:
             self = .cursorSessionMetadataUpdated(
                 try container.decode(CursorSessionMetadataUpdated.self, forKey: .cursorSessionMetadataUpdated)
+            )
+        case .catPawSessionMetadataUpdated:
+            self = .catPawSessionMetadataUpdated(
+                try container.decode(CatPawSessionMetadataUpdated.self, forKey: .catPawSessionMetadataUpdated)
             )
         case .actionableStateResolved:
             self = .actionableStateResolved(
@@ -362,6 +388,9 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case let .cursorSessionMetadataUpdated(payload):
             try container.encode(EventType.cursorSessionMetadataUpdated, forKey: .type)
             try container.encode(payload, forKey: .cursorSessionMetadataUpdated)
+        case let .catPawSessionMetadataUpdated(payload):
+            try container.encode(EventType.catPawSessionMetadataUpdated, forKey: .type)
+            try container.encode(payload, forKey: .catPawSessionMetadataUpdated)
         case let .actionableStateResolved(payload):
             try container.encode(EventType.actionableStateResolved, forKey: .type)
             try container.encode(payload, forKey: .actionableStateResolved)

--- a/Sources/OpenIslandCore/AgentHookIntent.swift
+++ b/Sources/OpenIslandCore/AgentHookIntent.swift
@@ -27,5 +27,6 @@ public enum AgentIdentifier: String, Codable, Sendable, CaseIterable {
     case openCode
     case gemini
     case kimi
+    case catPaw
     case claudeUsageBridge
 }

--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -11,6 +11,7 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
     case codebuddy
     case cursor
     case kimiCLI
+    case catPaw
 
     public var displayName: String {
         switch self {
@@ -34,6 +35,8 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
             "Cursor"
         case .kimiCLI:
             "Kimi CLI"
+        case .catPaw:
+            "CatPaw"
         }
     }
 
@@ -59,12 +62,14 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
             "CURSOR"
         case .kimiCLI:
             "KIMI"
+        case .catPaw:
+            "CATPAW"
         }
     }
 
     public var isClaudeCodeFork: Bool {
         switch self {
-        case .claudeCode, .qoder, .qwenCode, .factory, .codebuddy, .kimiCLI:
+        case .claudeCode, .qoder, .qwenCode, .factory, .codebuddy, .kimiCLI, .catPaw:
             true
         default:
             false
@@ -350,6 +355,7 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
     public var geminiMetadata: GeminiSessionMetadata?
     public var openCodeMetadata: OpenCodeSessionMetadata?
     public var cursorMetadata: CursorSessionMetadata?
+    public var catPawMetadata: CatPawSessionMetadata?
 
     /// Whether this session originates from a remote (SSH) connection.
     public var isRemote: Bool = false
@@ -394,7 +400,8 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
         claudeMetadata: ClaudeSessionMetadata? = nil,
         geminiMetadata: GeminiSessionMetadata? = nil,
         openCodeMetadata: OpenCodeSessionMetadata? = nil,
-        cursorMetadata: CursorSessionMetadata? = nil
+        cursorMetadata: CursorSessionMetadata? = nil,
+        catPawMetadata: CatPawSessionMetadata? = nil
     ) {
         self.id = id
         self.title = title
@@ -412,6 +419,7 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
         self.geminiMetadata = geminiMetadata
         self.openCodeMetadata = openCodeMetadata
         self.cursorMetadata = cursorMetadata
+        self.catPawMetadata = catPawMetadata
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -431,6 +439,7 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
         case geminiMetadata
         case openCodeMetadata
         case cursorMetadata
+        case catPawMetadata
     }
 
     public init(from decoder: any Decoder) throws {
@@ -451,6 +460,7 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
         geminiMetadata = try container.decodeIfPresent(GeminiSessionMetadata.self, forKey: .geminiMetadata)
         openCodeMetadata = try container.decodeIfPresent(OpenCodeSessionMetadata.self, forKey: .openCodeMetadata)
         cursorMetadata = try container.decodeIfPresent(CursorSessionMetadata.self, forKey: .cursorMetadata)
+        catPawMetadata = try container.decodeIfPresent(CatPawSessionMetadata.self, forKey: .catPawMetadata)
     }
 
     public func encode(to encoder: any Encoder) throws {
@@ -471,6 +481,7 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
         try container.encodeIfPresent(geminiMetadata, forKey: .geminiMetadata)
         try container.encodeIfPresent(openCodeMetadata, forKey: .openCodeMetadata)
         try container.encodeIfPresent(cursorMetadata, forKey: .cursorMetadata)
+        try container.encodeIfPresent(catPawMetadata, forKey: .catPawMetadata)
     }
 }
 
@@ -480,7 +491,7 @@ public extension AgentSession {
     }
 
     var isTrackedLiveSession: Bool {
-        !isDemoSession && (tool == .codex || tool == .claudeCode || tool == .geminiCLI || tool == .openCode || tool == .qoder || tool == .qwenCode || tool == .factory || tool == .codebuddy || tool == .cursor || tool == .kimiCLI)
+        !isDemoSession && (tool == .codex || tool == .claudeCode || tool == .geminiCLI || tool == .openCode || tool == .qoder || tool == .qwenCode || tool == .factory || tool == .codebuddy || tool == .cursor || tool == .kimiCLI || tool == .catPaw)
     }
 
     var isTrackedLiveCodexSession: Bool {
@@ -507,11 +518,11 @@ public extension AgentSession {
     }
 
     var currentToolName: String? {
-        codexMetadata?.currentTool ?? claudeMetadata?.currentTool ?? openCodeMetadata?.currentTool ?? cursorMetadata?.currentTool
+        codexMetadata?.currentTool ?? claudeMetadata?.currentTool ?? openCodeMetadata?.currentTool ?? cursorMetadata?.currentTool ?? catPawMetadata?.currentTool
     }
 
     var lastAssistantMessageText: String? {
-        codexMetadata?.lastAssistantMessage ?? claudeMetadata?.lastAssistantMessage ?? geminiMetadata?.lastAssistantMessage ?? openCodeMetadata?.lastAssistantMessage ?? cursorMetadata?.lastAssistantMessage
+        codexMetadata?.lastAssistantMessage ?? claudeMetadata?.lastAssistantMessage ?? geminiMetadata?.lastAssistantMessage ?? openCodeMetadata?.lastAssistantMessage ?? cursorMetadata?.lastAssistantMessage ?? catPawMetadata?.lastAssistantMessage
     }
 
     var completionAssistantMessageText: String? {
@@ -529,7 +540,7 @@ public extension AgentSession {
     }
 
     var trackingTranscriptPath: String? {
-        codexMetadata?.transcriptPath ?? claudeMetadata?.transcriptPath ?? geminiMetadata?.transcriptPath
+        codexMetadata?.transcriptPath ?? claudeMetadata?.transcriptPath ?? geminiMetadata?.transcriptPath ?? catPawMetadata?.transcriptPath
     }
 
     var latestUserPromptText: String? {

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -566,18 +566,20 @@ public final class BridgeServer: @unchecked Sendable {
         switch payload.hookEventName {
         case .sessionStart:
             clearStaleClaudeInteractionIfNeeded(for: payload.sessionID)
+            let isCatPaw = payload.resolvedAgentTool == .catPaw
             emit(
                 .sessionStarted(
                     SessionStarted(
                         sessionID: payload.sessionID,
-                        title: payload.sessionTitle,
+                        title: isCatPaw ? payload.catPawSessionTitle : payload.sessionTitle,
                         tool: payload.resolvedAgentTool,
                         origin: .live,
                         initialPhase: .completed,
                         summary: payload.implicitStartSummary,
                         timestamp: .now,
                         jumpTarget: payload.defaultJumpTarget,
-                        claudeMetadata: payload.defaultClaudeMetadata.isEmpty ? nil : payload.defaultClaudeMetadata,
+                        claudeMetadata: isCatPaw ? nil : (payload.defaultClaudeMetadata.isEmpty ? nil : payload.defaultClaudeMetadata),
+                        catPawMetadata: isCatPaw ? (payload.defaultCatPawMetadata.isEmpty ? nil : payload.defaultCatPawMetadata) : nil,
                         isRemote: payload.remote == true
                     )
                 )
@@ -1824,18 +1826,20 @@ public final class BridgeServer: @unchecked Sendable {
             return
         }
 
+        let isCatPaw = payload.resolvedAgentTool == .catPaw
         emit(
             .sessionStarted(
                 SessionStarted(
                     sessionID: payload.sessionID,
-                    title: payload.sessionTitle,
+                    title: isCatPaw ? payload.catPawSessionTitle : payload.sessionTitle,
                     tool: payload.resolvedAgentTool,
                     origin: .live,
                     initialPhase: .completed,
                     summary: payload.implicitStartSummary,
                     timestamp: .now,
                     jumpTarget: payload.defaultJumpTarget,
-                    claudeMetadata: payload.defaultClaudeMetadata.isEmpty ? nil : payload.defaultClaudeMetadata,
+                    claudeMetadata: isCatPaw ? nil : (payload.defaultClaudeMetadata.isEmpty ? nil : payload.defaultClaudeMetadata),
+                    catPawMetadata: isCatPaw ? (payload.defaultCatPawMetadata.isEmpty ? nil : payload.defaultCatPawMetadata) : nil,
                     isRemote: payload.remote == true
                 )
             )
@@ -1912,6 +1916,12 @@ public final class BridgeServer: @unchecked Sendable {
     }
 
     private func synchronizeClaudeMetadata(for payload: ClaudeHookPayload) {
+        // CatPaw sessions use catPawMetadata instead of claudeMetadata.
+        if payload.resolvedAgentTool == .catPaw {
+            synchronizeCatPawMetadata(for: payload)
+            return
+        }
+
         guard let existingSession = localState.session(id: payload.sessionID) else {
             return
         }
@@ -1934,6 +1944,42 @@ public final class BridgeServer: @unchecked Sendable {
                 ClaudeSessionMetadataUpdated(
                     sessionID: payload.sessionID,
                     claudeMetadata: mergedMetadata,
+                    timestamp: .now
+                )
+            )
+        )
+    }
+
+    private func synchronizeCatPawMetadata(for payload: ClaudeHookPayload) {
+        guard let existingSession = localState.session(id: payload.sessionID) else {
+            return
+        }
+
+        let incoming = payload.defaultCatPawMetadata
+        let existing = existingSession.catPawMetadata
+        let merged = CatPawSessionMetadata(
+            transcriptPath: incoming.transcriptPath ?? existing?.transcriptPath,
+            initialUserPrompt: existing?.initialUserPrompt ?? incoming.initialUserPrompt ?? incoming.lastUserPrompt,
+            lastUserPrompt: incoming.lastUserPrompt ?? existing?.lastUserPrompt,
+            lastAssistantMessage: incoming.lastAssistantMessage ?? existing?.lastAssistantMessage,
+            currentTool: incoming.currentTool,
+            currentToolInputPreview: incoming.currentToolInputPreview,
+            model: incoming.model ?? existing?.model
+        )
+
+        guard !merged.isEmpty else {
+            return
+        }
+
+        guard existingSession.catPawMetadata != merged else {
+            return
+        }
+
+        emit(
+            .catPawSessionMetadataUpdated(
+                CatPawSessionMetadataUpdated(
+                    sessionID: payload.sessionID,
+                    catPawMetadata: merged,
                     timestamp: .now
                 )
             )

--- a/Sources/OpenIslandCore/CatPawHookInstallationManager.swift
+++ b/Sources/OpenIslandCore/CatPawHookInstallationManager.swift
@@ -1,0 +1,165 @@
+import Foundation
+
+public struct CatPawHookInstallationStatus: Equatable, Sendable {
+    public var catPawDirectory: URL
+    public var settingsURL: URL
+    public var manifestURL: URL
+    public var hooksBinaryURL: URL?
+    public var managedHooksPresent: Bool
+    public var manifest: CatPawHookInstallerManifest?
+
+    public init(
+        catPawDirectory: URL,
+        settingsURL: URL,
+        manifestURL: URL,
+        hooksBinaryURL: URL?,
+        managedHooksPresent: Bool,
+        manifest: CatPawHookInstallerManifest?
+    ) {
+        self.catPawDirectory = catPawDirectory
+        self.settingsURL = settingsURL
+        self.manifestURL = manifestURL
+        self.hooksBinaryURL = hooksBinaryURL
+        self.managedHooksPresent = managedHooksPresent
+        self.manifest = manifest
+    }
+}
+
+/// Manages installation of Open Island hooks into CatPaw's settings.json.
+///
+/// CatPaw stores its configuration under `~/.catpaw/` with a `settings.json` file
+/// that uses the same hook format as Claude Code.
+public final class CatPawHookInstallationManager: @unchecked Sendable {
+    public let catPawDirectory: URL
+    public let managedHooksBinaryURL: URL
+    private let fileManager: FileManager
+
+    public init(
+        catPawDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".catpaw", isDirectory: true),
+        managedHooksBinaryURL: URL = ManagedHooksBinary.defaultURL(),
+        fileManager: FileManager = .default
+    ) {
+        self.catPawDirectory = catPawDirectory
+        self.managedHooksBinaryURL = managedHooksBinaryURL.standardizedFileURL
+        self.fileManager = fileManager
+    }
+
+    public func status(hooksBinaryURL: URL? = nil) throws -> CatPawHookInstallationStatus {
+        let settingsURL = catPawDirectory.appendingPathComponent("settings.json")
+        let manifestURL = catPawDirectory.appendingPathComponent(CatPawHookInstallerManifest.fileName)
+        let resolvedBinaryURL = resolvedHooksBinaryURL(explicitURL: hooksBinaryURL)
+
+        let settingsData = try? Data(contentsOf: settingsURL)
+        let manifest = try loadManifest(at: manifestURL)
+        let managedCommand = manifest?.hookCommand
+            ?? resolvedBinaryURL.map { CatPawHookInstaller.hookCommand(for: $0.path) }
+        let uninstallMutation = try CatPawHookInstaller.uninstallSettingsJSON(
+            existingData: settingsData,
+            managedCommand: managedCommand
+        )
+
+        return CatPawHookInstallationStatus(
+            catPawDirectory: catPawDirectory,
+            settingsURL: settingsURL,
+            manifestURL: manifestURL,
+            hooksBinaryURL: resolvedBinaryURL,
+            managedHooksPresent: uninstallMutation.managedHooksPresent,
+            manifest: manifest
+        )
+    }
+
+    @discardableResult
+    public func install(hooksBinaryURL: URL) throws -> CatPawHookInstallationStatus {
+        try fileManager.createDirectory(at: catPawDirectory, withIntermediateDirectories: true)
+
+        let settingsURL = catPawDirectory.appendingPathComponent("settings.json")
+        let manifestURL = catPawDirectory.appendingPathComponent(CatPawHookInstallerManifest.fileName)
+        let existingSettings = try? Data(contentsOf: settingsURL)
+        let installedBinaryURL = try ManagedHooksBinary.install(
+            from: hooksBinaryURL,
+            to: managedHooksBinaryURL,
+            fileManager: fileManager
+        )
+        let command = CatPawHookInstaller.hookCommand(for: installedBinaryURL.path)
+        let mutation = try CatPawHookInstaller.installSettingsJSON(
+            existingData: existingSettings,
+            hookCommand: command
+        )
+
+        if mutation.changed, fileManager.fileExists(atPath: settingsURL.path) {
+            try backupFile(at: settingsURL)
+        }
+
+        if let contents = mutation.contents {
+            try contents.write(to: settingsURL, options: .atomic)
+        }
+
+        let manifest = CatPawHookInstallerManifest(hookCommand: command)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(manifest).write(to: manifestURL, options: .atomic)
+
+        return try status(hooksBinaryURL: installedBinaryURL)
+    }
+
+    @discardableResult
+    public func uninstall() throws -> CatPawHookInstallationStatus {
+        let settingsURL = catPawDirectory.appendingPathComponent("settings.json")
+        let manifestURL = catPawDirectory.appendingPathComponent(CatPawHookInstallerManifest.fileName)
+        let manifest = try loadManifest(at: manifestURL)
+        let existingSettings = try? Data(contentsOf: settingsURL)
+        let mutation = try CatPawHookInstaller.uninstallSettingsJSON(
+            existingData: existingSettings,
+            managedCommand: manifest?.hookCommand
+        )
+
+        if mutation.changed, fileManager.fileExists(atPath: settingsURL.path) {
+            try backupFile(at: settingsURL)
+        }
+
+        if let contents = mutation.contents {
+            try contents.write(to: settingsURL, options: .atomic)
+        } else if fileManager.fileExists(atPath: settingsURL.path) {
+            try fileManager.removeItem(at: settingsURL)
+        }
+
+        if fileManager.fileExists(atPath: manifestURL.path) {
+            try fileManager.removeItem(at: manifestURL)
+        }
+
+        return try status()
+    }
+
+    // MARK: - Private helpers
+
+    private func loadManifest(at url: URL) throws -> CatPawHookInstallerManifest? {
+        guard fileManager.fileExists(atPath: url.path) else { return nil }
+
+        let data = try Data(contentsOf: url)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(CatPawHookInstallerManifest.self, from: data)
+    }
+
+    private func resolvedHooksBinaryURL(explicitURL: URL?) -> URL? {
+        if let explicitURL { return explicitURL.standardizedFileURL }
+        guard fileManager.isExecutableFile(atPath: managedHooksBinaryURL.path) else { return nil }
+        return managedHooksBinaryURL
+    }
+
+    private func backupFile(at url: URL) throws {
+        guard fileManager.fileExists(atPath: url.path) else { return }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let timestamp = formatter.string(from: .now).replacingOccurrences(of: ":", with: "-")
+        let backupURL = url.appendingPathExtension("backup.\(timestamp)")
+        if fileManager.fileExists(atPath: backupURL.path) {
+            try fileManager.removeItem(at: backupURL)
+        }
+        try fileManager.copyItem(at: url, to: backupURL)
+    }
+}
+

--- a/Sources/OpenIslandCore/CatPawHookInstaller.swift
+++ b/Sources/OpenIslandCore/CatPawHookInstaller.swift
@@ -1,0 +1,250 @@
+import Foundation
+
+// CatPaw uses the same hook format as Claude Code (settings.json with a "hooks" object),
+// but stores its configuration under ~/.catpaw/ instead of ~/.claude/.
+
+public struct CatPawHookInstallerManifest: Equatable, Codable, Sendable {
+    public static let fileName = "open-island-catpaw-hooks-install.json"
+
+    public var hookCommand: String
+    public var installedAt: Date
+
+    public init(hookCommand: String, installedAt: Date = .now) {
+        self.hookCommand = hookCommand
+        self.installedAt = installedAt
+    }
+}
+
+public struct CatPawHookFileMutation: Equatable, Sendable {
+    public var contents: Data?
+    public var changed: Bool
+    public var managedHooksPresent: Bool
+
+    public init(contents: Data?, changed: Bool, managedHooksPresent: Bool) {
+        self.contents = contents
+        self.changed = changed
+        self.managedHooksPresent = managedHooksPresent
+    }
+}
+
+public enum CatPawHookInstallerError: Error, LocalizedError {
+    case invalidSettingsJSON
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidSettingsJSON:
+            "The existing CatPaw settings.json is not valid JSON."
+        }
+    }
+}
+
+/// Installs and uninstalls Open Island hooks into CatPaw's settings.json.
+///
+/// CatPaw uses the identical hook format as Claude Code (settings.json with a
+/// "hooks" key), but stores configuration under ~/.catpaw/ instead of ~/.claude/.
+/// The hook binary is invoked with `--source catpaw` so BridgeServer can route
+/// the payload to the correct handler.
+public enum CatPawHookInstaller {
+    public static let managedTimeout = 86_400
+
+    private static let eventSpecs: [(name: String, matcher: String?, timeout: Int?)] = [
+        ("UserPromptSubmit", nil, nil),
+        ("SessionStart", nil, nil),
+        ("SessionEnd", nil, nil),
+        ("Stop", nil, nil),
+        ("StopFailure", nil, nil),
+        ("SubagentStart", nil, nil),
+        ("SubagentStop", nil, nil),
+        ("Notification", "*", nil),
+        ("PreToolUse", "*", nil),
+        ("PermissionRequest", "*", managedTimeout),
+        ("PostToolUse", "*", nil),
+        ("PostToolUseFailure", "*", nil),
+        ("PermissionDenied", "*", nil),
+        ("PreCompact", nil, nil),
+    ]
+
+    public static func hookCommand(for binaryPath: String) -> String {
+        "\(shellQuote(binaryPath)) --source catpaw"
+    }
+
+    public static func installSettingsJSON(
+        existingData: Data?,
+        hookCommand: String
+    ) throws -> CatPawHookFileMutation {
+        var rootObject = try loadRootObject(from: existingData)
+        let existingHooksObject = rootObject["hooks"] as? [String: Any] ?? [:]
+        var hooksObject: [String: Any] = [:]
+
+        // Preserve non-managed hooks from existing config.
+        for (eventName, value) in existingHooksObject {
+            let existingGroups = value as? [Any] ?? []
+            let cleanedGroups = sanitizeForInstall(groups: existingGroups, replacingCommand: hookCommand)
+            if !cleanedGroups.isEmpty {
+                hooksObject[eventName] = cleanedGroups
+            }
+        }
+
+        for spec in eventSpecs {
+            let existingGroups = hooksObject[spec.name] as? [Any] ?? []
+            let cleanedGroups = sanitizeForInstall(groups: existingGroups, replacingCommand: hookCommand)
+            hooksObject[spec.name] = cleanedGroups + [managedGroup(matcher: spec.matcher, timeout: spec.timeout, hookCommand: hookCommand)]
+        }
+
+        rootObject["hooks"] = hooksObject
+        let data = try serialize(rootObject)
+
+        return CatPawHookFileMutation(
+            contents: data,
+            changed: data != existingData,
+            managedHooksPresent: true
+        )
+    }
+
+    public static func uninstallSettingsJSON(
+        existingData: Data?,
+        managedCommand: String?
+    ) throws -> CatPawHookFileMutation {
+        guard let existingData else {
+            return CatPawHookFileMutation(contents: nil, changed: false, managedHooksPresent: false)
+        }
+
+        var rootObject = try loadRootObject(from: existingData)
+        var hooksObject = rootObject["hooks"] as? [String: Any] ?? [:]
+        var mutated = false
+
+        for spec in eventSpecs {
+            let existingGroups = hooksObject[spec.name] as? [Any] ?? []
+            let cleanedGroups = sanitize(groups: existingGroups, managedCommand: managedCommand)
+
+            if cleanedGroups.count != existingGroups.count || containsManagedHook(in: existingGroups, managedCommand: managedCommand) {
+                mutated = true
+            }
+
+            if cleanedGroups.isEmpty {
+                hooksObject.removeValue(forKey: spec.name)
+            } else {
+                hooksObject[spec.name] = cleanedGroups
+            }
+        }
+
+        if hooksObject.isEmpty {
+            rootObject.removeValue(forKey: "hooks")
+        } else {
+            rootObject["hooks"] = hooksObject
+        }
+
+        let contents = rootObject.isEmpty ? nil : try serialize(rootObject)
+        return CatPawHookFileMutation(
+            contents: contents,
+            changed: mutated || contents != existingData,
+            managedHooksPresent: mutated
+        )
+    }
+
+    // MARK: - Private helpers
+
+    private static func loadRootObject(from data: Data?) throws -> [String: Any] {
+        guard let data else { return [:] }
+
+        let object = try JSONSerialization.jsonObject(with: data)
+        guard let rootObject = object as? [String: Any] else {
+            throw CatPawHookInstallerError.invalidSettingsJSON
+        }
+
+        return rootObject
+    }
+
+    private static func serialize(_ object: [String: Any]) throws -> Data {
+        try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys])
+    }
+
+    private static func sanitize(groups: [Any], managedCommand: String?) -> [[String: Any]] {
+        groups.compactMap { item in
+            guard var group = item as? [String: Any] else { return nil }
+
+            let existingHooks = group["hooks"] as? [Any] ?? []
+            let filteredHooks = existingHooks.compactMap { hook -> [String: Any]? in
+                guard let hook = hook as? [String: Any] else { return nil }
+                return isManagedHook(hook, managedCommand: managedCommand) ? nil : hook
+            }
+
+            guard !filteredHooks.isEmpty else { return nil }
+            group["hooks"] = filteredHooks
+            return group
+        }
+    }
+
+    private static func sanitizeForInstall(groups: [Any], replacingCommand: String) -> [[String: Any]] {
+        groups.compactMap { item in
+            guard var group = item as? [String: Any] else { return nil }
+
+            let existingHooks = group["hooks"] as? [Any] ?? []
+            let filteredHooks = existingHooks.compactMap { hook -> [String: Any]? in
+                guard let hook = hook as? [String: Any] else { return nil }
+                return isManagedHookForInstall(hook, replacingCommand: replacingCommand) ? nil : hook
+            }
+
+            guard !filteredHooks.isEmpty else { return nil }
+            group["hooks"] = filteredHooks
+            return group
+        }
+    }
+
+    private static func containsManagedHook(in groups: [Any], managedCommand: String?) -> Bool {
+        groups.contains { item in
+            guard let group = item as? [String: Any],
+                  let hooks = group["hooks"] as? [Any] else { return false }
+            return hooks.contains { hook in
+                guard let hook = hook as? [String: Any] else { return false }
+                return isManagedHook(hook, managedCommand: managedCommand)
+            }
+        }
+    }
+
+    private static func managedGroup(
+        matcher: String?,
+        timeout: Int?,
+        hookCommand: String
+    ) -> [String: Any] {
+        var hook: [String: Any] = [
+            "type": "command",
+            "command": hookCommand,
+        ]
+        if let timeout {
+            hook["timeout"] = timeout
+        }
+
+        var group: [String: Any] = [
+            "hooks": [hook],
+        ]
+
+        if let matcher {
+            group["matcher"] = matcher
+        }
+
+        return group
+    }
+
+    private static func isManagedHook(_ hook: [String: Any], managedCommand: String?) -> Bool {
+        guard let command = hook["command"] as? String else { return false }
+        if let managedCommand, command == managedCommand { return true }
+        return isOpenIslandCatPawHookCommand(command)
+    }
+
+    private static func isManagedHookForInstall(_ hook: [String: Any], replacingCommand: String) -> Bool {
+        isManagedHook(hook, managedCommand: replacingCommand)
+    }
+
+    private static func isOpenIslandCatPawHookCommand(_ command: String) -> Bool {
+        let normalized = command.lowercased()
+        return (normalized.contains("openislandhooks") || normalized.contains("vibeislandhooks"))
+            && normalized.contains("catpaw")
+    }
+
+    private static func shellQuote(_ string: String) -> String {
+        guard !string.isEmpty else { return "''" }
+        return "'\(string.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+}
+

--- a/Sources/OpenIslandCore/CatPawHooks.swift
+++ b/Sources/OpenIslandCore/CatPawHooks.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+// CatPaw uses the same hook format as Claude Code.
+// All payload parsing is handled by ClaudeHookPayload with hookSource = "catpaw".
+
+public struct CatPawSessionMetadata: Equatable, Codable, Sendable {
+    public var transcriptPath: String?
+    public var initialUserPrompt: String?
+    public var lastUserPrompt: String?
+    public var lastAssistantMessage: String?
+    public var currentTool: String?
+    public var currentToolInputPreview: String?
+    public var model: String?
+
+    public init(
+        transcriptPath: String? = nil,
+        initialUserPrompt: String? = nil,
+        lastUserPrompt: String? = nil,
+        lastAssistantMessage: String? = nil,
+        currentTool: String? = nil,
+        currentToolInputPreview: String? = nil,
+        model: String? = nil
+    ) {
+        self.transcriptPath = transcriptPath
+        self.initialUserPrompt = initialUserPrompt
+        self.lastUserPrompt = lastUserPrompt
+        self.lastAssistantMessage = lastAssistantMessage
+        self.currentTool = currentTool
+        self.currentToolInputPreview = currentToolInputPreview
+        self.model = model
+    }
+
+    public var isEmpty: Bool {
+        transcriptPath == nil
+            && initialUserPrompt == nil
+            && lastUserPrompt == nil
+            && lastAssistantMessage == nil
+            && currentTool == nil
+            && currentToolInputPreview == nil
+            && model == nil
+    }
+}
+
+public extension ClaudeHookPayload {
+    /// Metadata extracted from a CatPaw hook payload.
+    var defaultCatPawMetadata: CatPawSessionMetadata {
+        CatPawSessionMetadata(
+            transcriptPath: transcriptPath ?? agentTranscriptPath,
+            initialUserPrompt: prompt ?? promptPreview,
+            lastUserPrompt: prompt ?? promptPreview,
+            lastAssistantMessage: lastAssistantMessage ?? assistantMessagePreview,
+            currentTool: toolName,
+            currentToolInputPreview: toolInputPreview,
+            model: model
+        )
+    }
+
+    var catPawSessionTitle: String {
+        "CatPaw · \(workspaceName)"
+    }
+}
+

--- a/Sources/OpenIslandCore/ClaudeHooks.swift
+++ b/Sources/OpenIslandCore/ClaudeHooks.swift
@@ -879,6 +879,8 @@ public extension ClaudeHookPayload {
             return .codebuddy
         case "kimi":
             return .kimiCLI
+        case "catpaw":
+            return .catPaw
         default:
             return .claudeCode
         }

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -70,7 +70,8 @@ public struct SessionState: Equatable, Sendable {
                 claudeMetadata: payload.claudeMetadata?.isEmpty == true ? nil : payload.claudeMetadata,
                 geminiMetadata: payload.geminiMetadata?.isEmpty == true ? nil : payload.geminiMetadata,
                 openCodeMetadata: payload.openCodeMetadata?.isEmpty == true ? nil : payload.openCodeMetadata,
-                cursorMetadata: payload.cursorMetadata?.isEmpty == true ? nil : payload.cursorMetadata
+                cursorMetadata: payload.cursorMetadata?.isEmpty == true ? nil : payload.cursorMetadata,
+                catPawMetadata: payload.catPawMetadata?.isEmpty == true ? nil : payload.catPawMetadata
             )
             session.isRemote = payload.isRemote
             session.isHookManaged = payload.origin == .live
@@ -204,6 +205,15 @@ public struct SessionState: Equatable, Sendable {
             session.updatedAt = payload.timestamp
             upsert(session)
 
+        case let .catPawSessionMetadataUpdated(payload):
+            guard var session = sessionsByID[payload.sessionID] else {
+                return
+            }
+
+            session.catPawMetadata = payload.catPawMetadata.isEmpty ? nil : payload.catPawMetadata
+            session.updatedAt = payload.timestamp
+            upsert(session)
+
         case let .actionableStateResolved(payload):
             guard var session = sessionsByID[payload.sessionID] else {
                 return
@@ -237,7 +247,7 @@ public struct SessionState: Equatable, Sendable {
         if resolution.isApproved {
             session.phase = .running
             switch session.tool {
-            case .claudeCode, .geminiCLI, .qoder, .qwenCode, .factory, .codebuddy, .kimiCLI:
+            case .claudeCode, .geminiCLI, .qoder, .qwenCode, .factory, .codebuddy, .kimiCLI, .catPaw:
                 session.summary = "Permission approved. \(session.tool.displayName) continued the tool."
             case .openCode:
                 session.summary = "Permission approved. OpenCode continued the tool."
@@ -247,7 +257,7 @@ public struct SessionState: Equatable, Sendable {
         } else {
             session.phase = .completed
             switch session.tool {
-            case .claudeCode, .geminiCLI, .qoder, .qwenCode, .factory, .codebuddy, .kimiCLI:
+            case .claudeCode, .geminiCLI, .qoder, .qwenCode, .factory, .codebuddy, .kimiCLI, .catPaw:
                 session.summary = "Permission denied in Open Island."
             case .openCode:
                 session.summary = "Permission denied in Open Island."

--- a/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
+++ b/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
@@ -16,10 +16,11 @@ struct OpenIslandHooksCLI {
         case cursor
         case gemini
         case kimi
+        case catpaw
 
         var isClaudeFormat: Bool {
             switch self {
-            case .claude, .qoder, .qwen, .factory, .droid, .codebuddy, .kimi:
+            case .claude, .qoder, .qwen, .factory, .droid, .codebuddy, .kimi, .catpaw:
                 return true
             case .codex, .cursor, .gemini:
                 return false
@@ -54,7 +55,7 @@ struct OpenIslandHooksCLI {
                 if let output = try CodexHookOutputEncoder.standardOutput(for: response) {
                     FileHandle.standardOutput.write(output)
                 }
-            case .claude, .qoder, .qwen, .factory, .droid, .codebuddy, .kimi:
+            case .claude, .qoder, .qwen, .factory, .droid, .codebuddy, .kimi, .catpaw:
                 var payload = try decoder
                     .decode(ClaudeHookPayload.self, from: input)
                     .withRuntimeContext(environment: ProcessInfo.processInfo.environment)


### PR DESCRIPTION
- Add CatPawHooks.swift: CatPawSessionMetadata model and ClaudeHookPayload extensions
- Add CatPawHookInstaller.swift: installs hooks into ~/.catpaw/settings.json (same format as Claude Code)
- Add CatPawHookInstallationManager.swift: manages install/uninstall/status lifecycle
- Update AgentSession.swift: add .catPaw to AgentTool enum, add catPawMetadata field
- Update AgentHookIntent.swift: add .catPaw to AgentIdentifier enum
- Update BridgeServer.swift: route catpaw hook source, synchronize CatPawSessionMetadata
- Update AgentEvent.swift: add catPawSessionMetadataUpdated event
- Update SessionState.swift: handle catPawSessionMetadataUpdated event
- Update ClaudeHooks.swift: resolve catpaw source to .catPaw AgentTool
- Update OpenIslandHooksCLI.swift: add catpaw HookSource case
- Update HookInstallationCoordinator.swift: full CatPaw hook install/uninstall/refresh
- Update AppModel.swift: expose CatPaw hook properties and methods
- Update SettingsView.swift: add CatPaw row in Setup pane with install/uninstall UI

CatPaw is a Claude Code fork by Meituan. It stores config under ~/.catpaw/ and uses the identical hook format as Claude Code. The hook binary is invoked with --source catpaw so BridgeServer can route payloads to the correct handler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CatPaw hook integration support, enabling installation and management from Settings.
  * Introduced CatPaw session metadata tracking to capture session context and activity details.
  * Extended hook installation configuration to include CatPaw alongside existing hook types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->