### PR TITLE
fix: preserve remote Codex session state

### DIFF
--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -458,7 +458,8 @@ public final class BridgeServer: @unchecked Sendable {
                     summary: payload.implicitStartSummary,
                     timestamp: .now,
                     jumpTarget: payload.defaultJumpTarget,
-                    codexMetadata: payload.defaultCodexMetadata.isEmpty ? nil : payload.defaultCodexMetadata
+                    codexMetadata: payload.defaultCodexMetadata.isEmpty ? nil : payload.defaultCodexMetadata,
+                    isRemote: payload.remote == true
                 )
             )
 
@@ -1759,7 +1760,8 @@ public final class BridgeServer: @unchecked Sendable {
                     summary: payload.implicitStartSummary,
                     timestamp: .now,
                     jumpTarget: payload.defaultJumpTarget,
-                    codexMetadata: payload.defaultCodexMetadata.isEmpty ? nil : payload.defaultCodexMetadata
+                    codexMetadata: payload.defaultCodexMetadata.isEmpty ? nil : payload.defaultCodexMetadata,
+                    isRemote: payload.remote == true
                 )
             )
         )

--- a/Sources/OpenIslandCore/CodexHooks.swift
+++ b/Sources/OpenIslandCore/CodexHooks.swift
@@ -98,6 +98,8 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
     public var prompt: String?
     public var stopHookActive: Bool?
     public var lastAssistantMessage: String?
+    /// Set to `true` by remote hook shims to indicate an SSH-backed Codex session.
+    public var remote: Bool?
 
     private enum CodingKeys: String, CodingKey {
         case cwd
@@ -120,6 +122,7 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
         case prompt
         case stopHookActive = "stop_hook_active"
         case lastAssistantMessage = "last_assistant_message"
+        case remote
     }
 
     public init(
@@ -142,7 +145,8 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
         toolResponse: CodexHookJSONValue? = nil,
         prompt: String? = nil,
         stopHookActive: Bool? = nil,
-        lastAssistantMessage: String? = nil
+        lastAssistantMessage: String? = nil,
+        remote: Bool? = nil
     ) {
         self.cwd = cwd
         self.hookEventName = hookEventName
@@ -164,6 +168,7 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
         self.prompt = prompt
         self.stopHookActive = stopHookActive
         self.lastAssistantMessage = lastAssistantMessage
+        self.remote = remote
     }
 
     public init(from decoder: any Decoder) throws {
@@ -188,6 +193,7 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
         prompt = try container.decodeIfPresent(String.self, forKey: .prompt)
         stopHookActive = try container.decodeIfPresent(Bool.self, forKey: .stopHookActive)
         lastAssistantMessage = try container.decodeIfPresent(String.self, forKey: .lastAssistantMessage)
+        remote = try container.decodeIfPresent(Bool.self, forKey: .remote)
     }
 }
 

--- a/Tests/OpenIslandCoreTests/CodexHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexHooksTests.swift
@@ -86,4 +86,21 @@ struct CodexHooksTests {
         #expect(payload.warpPaneUUID == nil)
     }
 
+    @Test
+    func codexHookPayloadRoundTripsRemoteFlag() throws {
+        let payload = CodexHookPayload(
+            cwd: "/Users/u/project",
+            hookEventName: .sessionStart,
+            model: "gpt-4o",
+            permissionMode: .default,
+            sessionID: "remote-codex-session",
+            transcriptPath: "/tmp/rollout.jsonl",
+            remote: true
+        )
+
+        let data = try JSONEncoder().encode(payload)
+        let decoded = try JSONDecoder().decode(CodexHookPayload.self, from: data)
+
+        #expect(decoded.remote == true)
+    }
 }

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -557,6 +557,35 @@ struct SessionStateTests {
     }
 
     @Test
+    func codexSessionStartMarksRemoteSessionsAsRemote() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let payload = CodexHookPayload(
+            cwd: "/tmp/remote-worktree",
+            hookEventName: .sessionStart,
+            model: "gpt-5-codex",
+            permissionMode: .default,
+            sessionID: "codex-remote-session",
+            transcriptPath: nil,
+            remote: true
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(.processCodexHook(payload))
+
+        var iterator = stream.makeAsyncIterator()
+        let startedEvent = try await nextEvent(from: &iterator)
+
+        #expect(startedEvent.startedSession?.isRemote == true)
+    }
+
+    @Test
     func cursorHookPreservesToolMetadataAcrossNonStopEvents() async throws {
         let socketURL = BridgeSocketLocation.uniqueTestURL()
         let server = BridgeServer(socketURL: socketURL)
@@ -1019,6 +1048,14 @@ private extension AgentEvent {
             true
         } else {
             false
+        }
+    }
+
+    var startedSession: SessionStarted? {
+        if case let .sessionStarted(payload) = self {
+            payload
+        } else {
+            nil
         }
     }
 


### PR DESCRIPTION
## Summary
- preserve the remote flag from Codex hook payloads
- mark synthesized and session-started Codex sessions as remote when the hook indicates it
- add regression coverage for payload round-tripping and remote session startup

## Root cause
The remote Python hook already sends `remote=true`, but `CodexHookPayload` ignored it. That meant `SessionStarted.isRemote` stayed false and remote Codex sessions could be reconciled like local processes, causing the working status to disappear incorrectly.

## Verification
- swift test --filter 'CodexHooksTests/codexHookPayloadRoundTripsRemoteFlag|SessionStateTests/codexSessionStartMarksRemoteSessionsAsRemote'
- swift test --filter 'CodexHooksTests|SessionStateTests'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for identifying and tracking remote Codex sessions, enabling the system to distinguish between local and remote session types.

* **Tests**
  * Added comprehensive test coverage to verify proper serialization and handling of remote session identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->