### PR TITLE
feat: surface Codex token counters in the island

### DIFF
--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -247,7 +247,11 @@ final class HookInstallationCoordinator {
 
     var codexUsageStatusTitle: String {
         if codexUsageSnapshot?.isEmpty == false {
-            return "Codex rate limits detected"
+            if codexUsageSnapshot?.windows.isEmpty == false {
+                return "Codex rate limits detected"
+            }
+
+            return "Codex token usage detected"
         }
 
         return "Waiting for Codex rate limits"
@@ -258,7 +262,7 @@ final class HookInstallationCoordinator {
             return "Reading the latest local rollout token_count snapshots · \(summary)"
         }
 
-        return "Passively reading ~/.codex/sessions/**/rollout-*.jsonl and extracting token_count.rate_limits."
+        return "Passively reading ~/.codex/sessions/**/rollout-*.jsonl and extracting token_count.info/rate_limits."
     }
 
     var codexUsageSummaryText: String? {
@@ -270,6 +274,22 @@ final class HookInstallationCoordinator {
             "\(window.label) \(window.roundedUsedPercentage)%"
         }
 
+        if let lastTotalTokens = snapshot.lastTokenUsage?.totalTokens {
+            components.append("last \(abbreviatedTokenCount(lastTotalTokens)) tok")
+        }
+
+        if let totalTokens = snapshot.totalTokenUsage?.totalTokens {
+            components.append("total \(abbreviatedTokenCount(totalTokens)) tok")
+        }
+
+        if let recentRate = snapshot.recentTotalTokenRate?.tokensPerSecond {
+            components.append("recent \(abbreviatedTokenRate(recentRate)) tok/s")
+        }
+
+        if let modelContextWindow = snapshot.modelContextWindow {
+            components.append("ctx \(abbreviatedTokenCount(modelContextWindow))")
+        }
+
         if let planType = snapshot.planType {
             components.append("plan \(planType)")
         }
@@ -279,6 +299,74 @@ final class HookInstallationCoordinator {
         }
 
         return components.isEmpty ? nil : components.joined(separator: " · ")
+    }
+
+    func codexTokenUsageBreakdownText(_ usage: CodexTokenUsage) -> String? {
+        var components: [String] = []
+
+        if let totalTokens = usage.totalTokens {
+            components.append("total \(abbreviatedTokenCount(totalTokens))")
+        }
+        if let inputTokens = usage.inputTokens {
+            components.append("in \(abbreviatedTokenCount(inputTokens))")
+        }
+        if let cachedInputTokens = usage.cachedInputTokens {
+            components.append("cached \(abbreviatedTokenCount(cachedInputTokens))")
+        }
+        if let outputTokens = usage.outputTokens {
+            components.append("out \(abbreviatedTokenCount(outputTokens))")
+        }
+        if let reasoningOutputTokens = usage.reasoningOutputTokens {
+            components.append("reason \(abbreviatedTokenCount(reasoningOutputTokens))")
+        }
+
+        return components.isEmpty ? nil : components.joined(separator: " · ")
+    }
+
+    func codexRecentRateText(_ rate: CodexTokenRate) -> String {
+        "\(abbreviatedTokenRate(rate.tokensPerSecond)) tok/s over \(String(format: "%.1fs", rate.sampleInterval))"
+    }
+
+    func codexModelContextWindowText(_ tokens: Int) -> String {
+        "\(abbreviatedTokenCount(tokens)) tokens"
+    }
+
+    private func abbreviatedTokenCount(_ value: Int) -> String {
+        abbreviatedNumber(Double(value))
+    }
+
+    private func abbreviatedTokenRate(_ value: Double) -> String {
+        abbreviatedNumber(value)
+    }
+
+    private func abbreviatedNumber(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 1
+        formatter.minimumFractionDigits = 0
+
+        let absoluteValue = abs(value)
+        let divisor: Double
+        let suffix: String
+
+        switch absoluteValue {
+        case 1_000_000_000...:
+            divisor = 1_000_000_000
+            suffix = "B"
+        case 1_000_000...:
+            divisor = 1_000_000
+            suffix = "M"
+        case 1_000...:
+            divisor = 1_000
+            suffix = "k"
+        default:
+            divisor = 1
+            suffix = ""
+        }
+
+        let scaled = value / divisor
+        let number = NSNumber(value: scaled)
+        return (formatter.string(from: number) ?? String(format: "%.1f", scaled)) + suffix
     }
 
     var openCodePluginStatusTitle: String {

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -97,6 +97,9 @@ final class HookInstallationCoordinator {
     private var codexUsageMonitorTask: Task<Void, Never>?
 
     @ObservationIgnored
+    private let codexUsageRefreshInterval: Duration = .seconds(10)
+
+    @ObservationIgnored
     private var relativeTimestampFormatter: RelativeDateTimeFormatter {
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .short
@@ -1178,7 +1181,7 @@ final class HookInstallationCoordinator {
 
             while !Task.isCancelled {
                 self.refreshCodexUsageState()
-                try? await Task.sleep(for: .seconds(120))
+                try? await Task.sleep(for: self.codexUsageRefreshInterval)
             }
         }
     }

--- a/Sources/OpenIslandApp/Views/ControlCenterView.swift
+++ b/Sources/OpenIslandApp/Views/ControlCenterView.swift
@@ -169,6 +169,30 @@ struct ControlCenterView: View {
                         if let snapshot = model.codexUsageSnapshot {
                             metadataRow(title: "latest rollout", value: snapshot.sourceFilePath)
 
+                            if let totalTokenUsage = snapshot.totalTokenUsage,
+                               let breakdown = model.hooks.codexTokenUsageBreakdownText(totalTokenUsage) {
+                                metadataRow(title: "total", value: breakdown)
+                            }
+
+                            if let lastTokenUsage = snapshot.lastTokenUsage,
+                               let breakdown = model.hooks.codexTokenUsageBreakdownText(lastTokenUsage) {
+                                metadataRow(title: "last", value: breakdown)
+                            }
+
+                            if let recentTotalTokenRate = snapshot.recentTotalTokenRate {
+                                metadataRow(
+                                    title: "recent rate",
+                                    value: model.hooks.codexRecentRateText(recentTotalTokenRate)
+                                )
+                            }
+
+                            if let modelContextWindow = snapshot.modelContextWindow {
+                                metadataRow(
+                                    title: "context",
+                                    value: model.hooks.codexModelContextWindowText(modelContextWindow)
+                                )
+                            }
+
                             if let planType = snapshot.planType {
                                 metadataRow(title: "plan", value: planType)
                             }

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -389,6 +389,7 @@ struct IslandPanelView: View {
                             CentralActivityLabel(
                                 toolName: closedSpotlightSession?.currentToolName,
                                 preview: closedSpotlightSession?.currentCommandPreviewText,
+                                tokenLabel: closedCodexTokenLabel,
                                 isVisible: isExternalDisplayPlacement && hasClosedPresence
                             )
                         )
@@ -716,8 +717,10 @@ struct IslandPanelView: View {
                     UsageWindowPresentation(
                         id: "claude-5h",
                         label: "5h",
-                        usedPercentage: fiveHour.usedPercentage,
-                        resetsAt: fiveHour.resetsAt
+                        metric: .percentage(
+                            usedPercentage: fiveHour.usedPercentage,
+                            resetsAt: fiveHour.resetsAt
+                        )
                     )
                 )
             }
@@ -727,8 +730,10 @@ struct IslandPanelView: View {
                     UsageWindowPresentation(
                         id: "claude-7d",
                         label: "7d",
-                        usedPercentage: sevenDay.usedPercentage,
-                        resetsAt: sevenDay.resetsAt
+                        metric: .percentage(
+                            usedPercentage: sevenDay.usedPercentage,
+                            resetsAt: sevenDay.resetsAt
+                        )
                     )
                 )
             }
@@ -747,12 +752,28 @@ struct IslandPanelView: View {
         if model.showCodexUsage,
            let snapshot = model.codexUsageSnapshot,
            snapshot.isEmpty == false {
-            let windows = snapshot.windows.map { window in
+            var windows = snapshot.windows.map { window in
                 UsageWindowPresentation(
                     id: "codex-\(window.key)",
                     label: window.label,
-                    usedPercentage: window.usedPercentage,
-                    resetsAt: window.resetsAt
+                    metric: .percentage(
+                        usedPercentage: window.usedPercentage,
+                        resetsAt: window.resetsAt
+                    )
+                )
+            }
+
+            if windows.isEmpty,
+               let totalTokens = snapshot.totalTokenUsage?.totalTokens {
+                windows.append(
+                    UsageWindowPresentation(
+                        id: "codex-total-tokens",
+                        label: "tok",
+                        metric: .tokenCount(
+                            totalTokens: totalTokens,
+                            recentTokensPerSecond: snapshot.recentTotalTokenRate?.tokensPerSecond
+                        )
+                    )
                 )
             }
 
@@ -768,6 +789,16 @@ struct IslandPanelView: View {
         }
 
         return providers
+    }
+
+    private var closedCodexTokenLabel: String? {
+        guard model.showCodexUsage,
+              closedSpotlightSession?.currentToolName?.isEmpty != false,
+              let totalTokens = model.codexUsageSnapshot?.totalTokenUsage?.totalTokens else {
+            return nil
+        }
+
+        return "Codex · \(abbreviatedTokenCount(totalTokens)) tok"
     }
 
     private func splitUsageProviders(
@@ -902,18 +933,79 @@ struct IslandPanelView: View {
                     .foregroundStyle(.white.opacity(0.55))
             }
 
-            Text("\(window.roundedUsedPercentage)%")
-                .font(.system(size: 12, weight: .bold))
-                .foregroundStyle(usageColor(for: window.usedPercentage))
+            switch window.metric {
+            case let .percentage(usedPercentage, resetsAt):
+                Text("\(window.roundedUsedPercentage)%")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(usageColor(for: usedPercentage))
 
-            if layout.showsResetTime,
-               let resetsAt = window.resetsAt,
-               let remaining = remainingDurationString(until: resetsAt) {
-                Text(remaining)
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.35))
+                if layout.showsResetTime,
+                   let resetsAt,
+                   let remaining = remainingDurationString(until: resetsAt) {
+                    Text(remaining)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.white.opacity(0.35))
+                }
+            case let .tokenCount(totalTokens, recentTokensPerSecond):
+                tokenUsageValueText(totalTokens)
+
+                if layout.showsResetTime,
+                   let recentTokensPerSecond,
+                   recentTokensPerSecond > 0 {
+                    Text("+\(abbreviatedTokenRate(recentTokensPerSecond))/s")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.white.opacity(0.35))
+                        .monospacedDigit()
+                        .contentTransition(.numericText())
+                }
             }
         }
+    }
+
+    private func tokenUsageValueText(_ totalTokens: Int) -> some View {
+        Text(abbreviatedTokenCount(totalTokens))
+            .font(.system(size: 12, weight: .bold, design: .rounded))
+            .foregroundStyle(.mint.opacity(0.95))
+            .monospacedDigit()
+            .contentTransition(.numericText())
+    }
+
+    private func abbreviatedTokenCount(_ value: Int) -> String {
+        abbreviatedNumber(Double(value))
+    }
+
+    private func abbreviatedTokenRate(_ value: Double) -> String {
+        abbreviatedNumber(value)
+    }
+
+    private func abbreviatedNumber(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 1
+        formatter.minimumFractionDigits = 0
+
+        let absoluteValue = abs(value)
+        let divisor: Double
+        let suffix: String
+
+        switch absoluteValue {
+        case 1_000_000_000...:
+            divisor = 1_000_000_000
+            suffix = "B"
+        case 1_000_000...:
+            divisor = 1_000_000
+            suffix = "M"
+        case 1_000...:
+            divisor = 1_000
+            suffix = "k"
+        default:
+            divisor = 1
+            suffix = ""
+        }
+
+        let scaled = value / divisor
+        let number = NSNumber(value: scaled)
+        return (formatter.string(from: number) ?? String(format: "%.1f", scaled)) + suffix
     }
 
     private func usageSeparator(_ title: String, opacity: Double) -> some View {
@@ -986,11 +1078,29 @@ private struct UsageProviderPresentation: Identifiable {
 private struct UsageWindowPresentation: Identifiable {
     let id: String
     let label: String
-    let usedPercentage: Double
-    let resetsAt: Date?
+    let metric: UsageMetricPresentation
 
     var roundedUsedPercentage: Int {
-        Int(usedPercentage.rounded())
+        switch metric {
+        case let .percentage(usedPercentage, _):
+            Int(usedPercentage.rounded())
+        case .tokenCount:
+            0
+        }
+    }
+}
+
+private enum UsageMetricPresentation: Equatable {
+    case percentage(usedPercentage: Double, resetsAt: Date?)
+    case tokenCount(totalTokens: Int, recentTokensPerSecond: Double?)
+
+    var usedPercentage: Double {
+        switch self {
+        case let .percentage(usedPercentage, _):
+            usedPercentage
+        case .tokenCount:
+            0
+        }
     }
 }
 
@@ -2037,6 +2147,7 @@ private struct ClosedCountBadge: View {
 private struct CentralActivityLabel: View {
     let toolName: String?
     let preview: String?
+    let tokenLabel: String?
     let isVisible: Bool
 
     @State private var displayed: DisplayedActivity?
@@ -2062,9 +2173,20 @@ private struct CentralActivityLabel: View {
                 .foregroundStyle(.white.opacity(0.85))
                 .padding(.horizontal, 8)
                 .transition(.opacity.combined(with: .scale(scale: 0.96)))
+            } else if isVisible, let tokenLabel {
+                Text(tokenLabel)
+                    .font(.system(size: 10, weight: .semibold, design: .rounded))
+                    .foregroundStyle(.white.opacity(0.72))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .monospacedDigit()
+                    .contentTransition(.numericText())
+                    .padding(.horizontal, 8)
+                    .transition(.opacity.combined(with: .scale(scale: 0.96)))
             }
         }
         .animation(.easeOut(duration: 0.22), value: displayed)
+        .animation(.easeOut(duration: 0.18), value: tokenLabel)
         .onChange(of: trackingKey, initial: true) { _, _ in
             sync()
         }
@@ -2081,7 +2203,7 @@ private struct CentralActivityLabel: View {
 
     /// Composite key so `.onChange` fires on either tool or preview change.
     private var trackingKey: String {
-        "\(toolName ?? "")|\(preview ?? "")"
+        "\(toolName ?? "")|\(preview ?? "")|\(tokenLabel ?? "")"
     }
 
     /// Key used to (re)start the clear timer. Changes whenever we transition

--- a/Sources/OpenIslandCore/CodexUsage.swift
+++ b/Sources/OpenIslandCore/CodexUsage.swift
@@ -1,5 +1,47 @@
 import Foundation
 
+public struct CodexTokenUsage: Equatable, Codable, Sendable {
+    public var inputTokens: Int?
+    public var cachedInputTokens: Int?
+    public var outputTokens: Int?
+    public var reasoningOutputTokens: Int?
+    public var totalTokens: Int?
+
+    public init(
+        inputTokens: Int? = nil,
+        cachedInputTokens: Int? = nil,
+        outputTokens: Int? = nil,
+        reasoningOutputTokens: Int? = nil,
+        totalTokens: Int? = nil
+    ) {
+        self.inputTokens = inputTokens
+        self.cachedInputTokens = cachedInputTokens
+        self.outputTokens = outputTokens
+        self.reasoningOutputTokens = reasoningOutputTokens
+        self.totalTokens = totalTokens
+    }
+
+    public var isEmpty: Bool {
+        inputTokens == nil
+            && cachedInputTokens == nil
+            && outputTokens == nil
+            && reasoningOutputTokens == nil
+            && totalTokens == nil
+    }
+}
+
+public struct CodexTokenRate: Equatable, Codable, Sendable {
+    public var deltaTokens: Int
+    public var sampleInterval: TimeInterval
+    public var tokensPerSecond: Double
+
+    public init(deltaTokens: Int, sampleInterval: TimeInterval, tokensPerSecond: Double) {
+        self.deltaTokens = deltaTokens
+        self.sampleInterval = sampleInterval
+        self.tokensPerSecond = tokensPerSecond
+    }
+}
+
 public struct CodexUsageWindow: Equatable, Codable, Sendable, Identifiable {
     public var key: String
     public var label: String
@@ -39,23 +81,35 @@ public struct CodexUsageSnapshot: Equatable, Codable, Sendable {
     public var planType: String?
     public var limitID: String?
     public var windows: [CodexUsageWindow]
+    public var totalTokenUsage: CodexTokenUsage?
+    public var lastTokenUsage: CodexTokenUsage?
+    public var modelContextWindow: Int?
+    public var recentTotalTokenRate: CodexTokenRate?
 
     public init(
         sourceFilePath: String,
         capturedAt: Date?,
         planType: String? = nil,
         limitID: String? = nil,
-        windows: [CodexUsageWindow]
+        windows: [CodexUsageWindow],
+        totalTokenUsage: CodexTokenUsage? = nil,
+        lastTokenUsage: CodexTokenUsage? = nil,
+        modelContextWindow: Int? = nil,
+        recentTotalTokenRate: CodexTokenRate? = nil
     ) {
         self.sourceFilePath = sourceFilePath
         self.capturedAt = capturedAt
         self.planType = planType
         self.limitID = limitID
         self.windows = windows
+        self.totalTokenUsage = totalTokenUsage
+        self.lastTokenUsage = lastTokenUsage
+        self.modelContextWindow = modelContextWindow
+        self.recentTotalTokenRate = recentTotalTokenRate
     }
 
     public var isEmpty: Bool {
-        windows.isEmpty
+        windows.isEmpty && totalTokenUsage == nil && lastTokenUsage == nil
     }
 }
 
@@ -126,6 +180,7 @@ public enum CodexUsageLoader {
         }
 
         var latestSnapshot: CodexUsageSnapshot?
+        var previousSnapshot: CodexUsageSnapshot?
         contents.enumerateLines { line, _ in
             guard let snapshot = snapshot(
                 from: line,
@@ -135,9 +190,18 @@ public enum CodexUsageLoader {
                 return
             }
 
+            previousSnapshot = latestSnapshot
             latestSnapshot = snapshot
         }
 
+        guard var latestSnapshot else {
+            return nil
+        }
+
+        latestSnapshot.recentTotalTokenRate = tokenRate(
+            current: latestSnapshot,
+            previous: previousSnapshot
+        )
         return latestSnapshot
     }
 
@@ -152,15 +216,19 @@ public enum CodexUsageLoader {
         }
 
         let payload = object["payload"] as? [String: Any] ?? [:]
-        guard payload["type"] as? String == "token_count",
-              let rateLimits = payload["rate_limits"] as? [String: Any] else {
+        guard payload["type"] as? String == "token_count" else {
             return nil
         }
 
+        let rateLimits = payload["rate_limits"] as? [String: Any] ?? [:]
+        let info = payload["info"] as? [String: Any] ?? [:]
         let windows = ["primary", "secondary"].compactMap { key in
             usageWindow(for: key, in: rateLimits)
         }
-        guard !windows.isEmpty else {
+        let totalTokenUsage = tokenUsage(for: "total_token_usage", in: info)
+        let lastTokenUsage = tokenUsage(for: "last_token_usage", in: info)
+        let modelContextWindow = integer(from: info["model_context_window"])
+        guard !windows.isEmpty || totalTokenUsage != nil || lastTokenUsage != nil else {
             return nil
         }
 
@@ -169,8 +237,27 @@ public enum CodexUsageLoader {
             capturedAt: timestamp(from: object["timestamp"]) ?? fallbackTimestamp,
             planType: string(from: rateLimits["plan_type"]),
             limitID: string(from: rateLimits["limit_id"]),
-            windows: windows
+            windows: windows,
+            totalTokenUsage: totalTokenUsage,
+            lastTokenUsage: lastTokenUsage,
+            modelContextWindow: modelContextWindow
         )
+    }
+
+    private static func tokenUsage(for key: String, in info: [String: Any]) -> CodexTokenUsage? {
+        guard let payload = info[key] as? [String: Any] else {
+            return nil
+        }
+
+        let usage = CodexTokenUsage(
+            inputTokens: integer(from: payload["input_tokens"]),
+            cachedInputTokens: integer(from: payload["cached_input_tokens"]),
+            outputTokens: integer(from: payload["output_tokens"]),
+            reasoningOutputTokens: integer(from: payload["reasoning_output_tokens"]),
+            totalTokens: integer(from: payload["total_tokens"])
+        )
+
+        return usage.isEmpty ? nil : usage
     }
 
     private static func usageWindow(for key: String, in rateLimits: [String: Any]) -> CodexUsageWindow? {
@@ -213,6 +300,36 @@ public enum CodexUsageLoader {
         }
 
         return "\(minutes)m"
+    }
+
+    private static func tokenRate(
+        current: CodexUsageSnapshot,
+        previous: CodexUsageSnapshot?
+    ) -> CodexTokenRate? {
+        guard let previous,
+              let currentTimestamp = current.capturedAt,
+              let previousTimestamp = previous.capturedAt,
+              currentTimestamp > previousTimestamp,
+              let currentTotalTokens = current.totalTokenUsage?.totalTokens,
+              let previousTotalTokens = previous.totalTokenUsage?.totalTokens else {
+            return nil
+        }
+
+        let deltaTokens = currentTotalTokens - previousTotalTokens
+        guard deltaTokens >= 0 else {
+            return nil
+        }
+
+        let sampleInterval = currentTimestamp.timeIntervalSince(previousTimestamp)
+        guard sampleInterval > 0 else {
+            return nil
+        }
+
+        return CodexTokenRate(
+            deltaTokens: deltaTokens,
+            sampleInterval: sampleInterval,
+            tokensPerSecond: Double(deltaTokens) / sampleInterval
+        )
     }
 
     private static func jsonObject(for line: String) -> [String: Any]? {

--- a/Tests/OpenIslandCoreTests/CodexUsageTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexUsageTests.swift
@@ -23,8 +23,20 @@ struct CodexUsageTests {
                         "type": "token_count",
                         "info": [
                             "total_token_usage": [
+                                "input_tokens": 999_000,
+                                "cached_input_tokens": 900_000,
+                                "output_tokens": 999,
+                                "reasoning_output_tokens": 111,
                                 "total_tokens": 999_999,
                             ],
+                            "last_token_usage": [
+                                "input_tokens": 5_000,
+                                "cached_input_tokens": 4_000,
+                                "output_tokens": 80,
+                                "reasoning_output_tokens": 20,
+                                "total_tokens": 5_100,
+                            ],
+                            "model_context_window": 128_000,
                         ],
                         "rate_limits": [
                             "limit_id": "codex",
@@ -49,8 +61,20 @@ struct CodexUsageTests {
                         "type": "token_count",
                         "info": [
                             "total_token_usage": [
+                                "input_tokens": 1_234_000,
+                                "cached_input_tokens": 1_100_000,
+                                "output_tokens": 567,
+                                "reasoning_output_tokens": 111,
                                 "total_tokens": 1_234_567,
                             ],
+                            "last_token_usage": [
+                                "input_tokens": 8_000,
+                                "cached_input_tokens": 7_000,
+                                "output_tokens": 120,
+                                "reasoning_output_tokens": 30,
+                                "total_tokens": 8_150,
+                            ],
+                            "model_context_window": 258_400,
                         ],
                         "rate_limits": [
                             "limit_id": "codex",
@@ -85,7 +109,72 @@ struct CodexUsageTests {
         #expect(snapshot?.windows.map(\.roundedUsedPercentage) == [13, 25])
         #expect(snapshot?.windows.first?.leftPercentage == 87)
         #expect(snapshot?.windows.first?.resetsAt == Date(timeIntervalSince1970: 1_775_158_295))
+        #expect(snapshot?.totalTokenUsage?.totalTokens == 1_234_567)
+        #expect(snapshot?.totalTokenUsage?.inputTokens == 1_234_000)
+        #expect(snapshot?.lastTokenUsage?.totalTokens == 8_150)
+        #expect(snapshot?.modelContextWindow == 258_400)
+        #expect(snapshot?.recentTotalTokenRate?.deltaTokens == 234_568)
+        #expect(snapshot?.recentTotalTokenRate?.sampleInterval == 60)
+        #expect(abs((snapshot?.recentTotalTokenRate?.tokensPerSecond ?? 0) - 3_909.466_666_666_667) < 0.001)
         #expect(snapshot?.capturedAt == isoDate("2026-04-03T01:50:35.000Z"))
+    }
+
+    @Test
+    func codexUsageLoaderParsesInfoOnlySnapshotsWithoutRateLimitWindows() throws {
+        let rootURL = temporaryRootURL(named: "codex-usage-info-only")
+        let rolloutURL = rootURL
+            .appendingPathComponent("2026/04/22", isDirectory: true)
+            .appendingPathComponent("rollout-info-only.jsonl")
+
+        defer {
+            try? FileManager.default.removeItem(at: rootURL)
+        }
+
+        try writeRollout(
+            [
+                rolloutLine(
+                    timestamp: "2026-04-22T03:18:20.834Z",
+                    type: "event_msg",
+                    payload: [
+                        "type": "token_count",
+                        "info": [
+                            "total_token_usage": [
+                                "input_tokens": 44_012_009,
+                                "cached_input_tokens": 42_987_904,
+                                "output_tokens": 113_981,
+                                "reasoning_output_tokens": 40_485,
+                                "total_tokens": 44_125_990,
+                            ],
+                            "last_token_usage": [
+                                "input_tokens": 208_958,
+                                "cached_input_tokens": 208_768,
+                                "output_tokens": 37,
+                                "reasoning_output_tokens": 0,
+                                "total_tokens": 208_995,
+                            ],
+                            "model_context_window": 258_400,
+                        ],
+                        "rate_limits": [
+                            "limit_id": "codex",
+                            "primary": NSNull(),
+                            "secondary": NSNull(),
+                        ],
+                    ]
+                ),
+            ],
+            to: rolloutURL
+        )
+
+        let snapshot = try CodexUsageLoader.load(fromRootURL: rootURL)
+
+        #expect(resolvedPath(snapshot?.sourceFilePath) == rolloutURL.resolvingSymlinksInPath().path)
+        #expect(snapshot?.windows.isEmpty == true)
+        #expect(snapshot?.isEmpty == false)
+        #expect(snapshot?.limitID == "codex")
+        #expect(snapshot?.totalTokenUsage?.totalTokens == 44_125_990)
+        #expect(snapshot?.lastTokenUsage?.totalTokens == 208_995)
+        #expect(snapshot?.modelContextWindow == 258_400)
+        #expect(snapshot?.recentTotalTokenRate == nil)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- parse Codex `token_count.info` data from local rollout snapshots
- surface total, last, context-window, and recent token rate in the Codex usage card
- show Codex token counters in the island when rate-limit windows are unavailable

## Testing
- `swift build -c debug --product OpenIslandApp`
- `swift test --filter CodexUsageTests` *(still blocked in this repo environment by the existing `no such module Testing` issue)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Codex token usage diagnostics with detailed breakdown including total tokens, recent usage rate, and model context window
  * Added token usage indicators to activity status display

* **Improvements**
  * Refined token metrics display formatting for improved readability
  * Extended debug diagnostic panel with additional token usage information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->