### PR TITLE
fix: wire Launch at Login toggle to SMAppService (#392)

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -258,6 +258,21 @@ final class AppModel {
             UserDefaults.standard.set(suppressFrontmostNotifications, forKey: Self.suppressFrontmostNotificationsDefaultsKey)
         }
     }
+    var launchAtLoginEnabled: Bool = false {
+        didSet {
+            guard !isApplyingLaunchAtLogin, hasFinishedInit, launchAtLoginEnabled != oldValue else { return }
+            do {
+                try LaunchAtLoginService.shared.setEnabled(launchAtLoginEnabled)
+            } catch {
+                lastActionMessage = "Launch at Login failed: \(error.localizedDescription)"
+                isApplyingLaunchAtLogin = true
+                launchAtLoginEnabled = oldValue
+                isApplyingLaunchAtLogin = false
+            }
+        }
+    }
+    @ObservationIgnored
+    private var isApplyingLaunchAtLogin = false
     var isSoundMuted = false {
         didSet {
             guard isSoundMuted != oldValue else {
@@ -508,6 +523,7 @@ final class AppModel {
             )
         }
         completionReplyEnabled = UserDefaults.standard.bool(forKey: Self.completionReplyEnabledDefaultsKey)
+        launchAtLoginEnabled = LaunchAtLoginService.shared.isEnabled
         islandAppearanceMode = IslandAppearanceMode(
             rawValue: UserDefaults.standard.string(forKey: Self.islandAppearanceModeDefaultsKey) ?? ""
         ) ?? .default

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -264,12 +264,19 @@ final class AppModel {
             do {
                 try LaunchAtLoginService.shared.setEnabled(launchAtLoginEnabled)
             } catch {
-                lastActionMessage = "Launch at Login failed: \(error.localizedDescription)"
                 isApplyingLaunchAtLogin = true
                 launchAtLoginEnabled = oldValue
                 isApplyingLaunchAtLogin = false
+                presentLaunchAtLoginError(error)
             }
         }
+    }
+    private func presentLaunchAtLoginError(_ error: Error) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = lang.t("settings.general.launchAtLogin")
+        alert.informativeText = error.localizedDescription
+        alert.runModal()
     }
     @ObservationIgnored
     private var isApplyingLaunchAtLogin = false

--- a/Sources/OpenIslandApp/LaunchAtLoginService.swift
+++ b/Sources/OpenIslandApp/LaunchAtLoginService.swift
@@ -1,6 +1,5 @@
 import Foundation
 import ServiceManagement
-import os
 
 /// Wraps `SMAppService.mainApp` for registering/unregistering Open Island as a
 /// login item. `SMAppService.mainApp` is authoritative — the UI reads its
@@ -9,8 +8,6 @@ import os
 @MainActor
 final class LaunchAtLoginService {
     static let shared = LaunchAtLoginService()
-
-    private let log = Logger(subsystem: "app.openisland", category: "LaunchAtLogin")
 
     /// `.enabled` and `.requiresApproval` both count as "on": if the user
     /// approved, we run at login; if they haven't approved yet, the OS will
@@ -23,6 +20,7 @@ final class LaunchAtLoginService {
     func setEnabled(_ enabled: Bool) throws {
         let service = SMAppService.mainApp
         if enabled {
+            guard !isEnabled else { return }
             try service.register()
         } else {
             let status = service.status

--- a/Sources/OpenIslandApp/LaunchAtLoginService.swift
+++ b/Sources/OpenIslandApp/LaunchAtLoginService.swift
@@ -1,0 +1,33 @@
+import Foundation
+import ServiceManagement
+import os
+
+/// Wraps `SMAppService.mainApp` for registering/unregistering Open Island as a
+/// login item. `SMAppService.mainApp` is authoritative — the UI reads its
+/// status on demand so the toggle stays in sync with System Settings ->
+/// General -> Login Items changes that happen outside the app.
+@MainActor
+final class LaunchAtLoginService {
+    static let shared = LaunchAtLoginService()
+
+    private let log = Logger(subsystem: "app.openisland", category: "LaunchAtLogin")
+
+    /// `.enabled` and `.requiresApproval` both count as "on": if the user
+    /// approved, we run at login; if they haven't approved yet, the OS will
+    /// prompt them and our registration persists in the meantime.
+    var isEnabled: Bool {
+        let status = SMAppService.mainApp.status
+        return status == .enabled || status == .requiresApproval
+    }
+
+    func setEnabled(_ enabled: Bool) throws {
+        let service = SMAppService.mainApp
+        if enabled {
+            try service.register()
+        } else {
+            let status = service.status
+            guard status != .notRegistered, status != .notFound else { return }
+            try service.unregister()
+        }
+    }
+}

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -172,14 +172,15 @@ struct SettingsView: View {
 struct GeneralSettingsPane: View {
     var model: AppModel
 
-    @State private var launchAtLogin = false
-
     private var lang: LanguageManager { model.lang }
 
     var body: some View {
         Form {
             Section(lang.t("settings.section.system")) {
-                Toggle(lang.t("settings.general.launchAtLogin"), isOn: $launchAtLogin)
+                Toggle(lang.t("settings.general.launchAtLogin"), isOn: Binding(
+                    get: { model.launchAtLoginEnabled },
+                    set: { model.launchAtLoginEnabled = $0 }
+                ))
 
                 Picker(lang.t("settings.general.monitor"), selection: Binding(
                     get: { model.overlayDisplaySelectionID },


### PR DESCRIPTION
## Summary
- The Launch at Login toggle in Settings -> General was bound to a view-local `@State`, so the toggle reset every time the user switched tabs and no login item was ever registered (#392).
- Back the toggle with an `AppModel.launchAtLoginEnabled` property driven by `SMAppService.mainApp`. Status is read from the system on init so the UI stays in sync even when the user toggles login items from System Settings.
- Wrap the register/unregister calls in a small `LaunchAtLoginService`. If the OS rejects the request (e.g. bundle not found when running via `swift run`), surface the error via `lastActionMessage` and revert the toggle.

## Test plan
- [x] `swift build` — clean
- [x] `swift test` — 222 tests / 24 suites pass
- [ ] Manual: launch `Open Island Dev.app`, toggle Launch at Login in Settings -> General, switch tabs, confirm state is preserved; verify Open Island appears in System Settings -> General -> Login Items.
- [ ] Manual: turn the toggle off and confirm the entry is removed from Login Items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Launch at login" setting in General preferences so the app can be configured to start automatically at login.
* **Bug Fixes**
  * Improved behavior and rollback when enabling/disabling the setting, and show a user-facing error alert if the system call fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->