### PR TITLE
feat(opencode): structured question flow with notch notification

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1205,6 +1205,7 @@ final class AppModel {
         updateLastActionMessage: Bool = true,
         ingress: TrackedEventIngress = .bridge
     ) {
+
         // Snapshot whether this session was already completed before applying
         // the event. Used to suppress duplicate/stale completion notifications
         // (e.g. rollout watcher re-discovering an old completion on startup,
@@ -1287,6 +1288,12 @@ final class AppModel {
         }
 
         guard suppressFrontmostNotifications else {
+            presentNotificationSurface(surface)
+            return
+        }
+
+        let isActionable = session.phase == .waitingForApproval || session.phase == .waitingForAnswer
+        if isActionable {
             presentNotificationSurface(surface)
             return
         }

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1293,12 +1293,6 @@ final class AppModel {
         }
 
         let isActionable = session.phase == .waitingForApproval || session.phase == .waitingForAnswer
-        if isActionable {
-            notificationPresentationTask?.cancel()
-            notificationPresentationTask = nil
-            presentNotificationSurface(surface)
-            return
-        }
 
         notificationPresentationTask?.cancel()
         notificationPresentationTask = Task { @MainActor [weak self] in
@@ -1307,10 +1301,18 @@ final class AppModel {
             }
 
             let shouldSuppress = await self.isNotificationSessionAlreadyFrontmost(session)
-            guard !Task.isCancelled,
-                  !shouldSuppress,
-                  self.notificationSurfaceIsEligibleForPresentation(surface, ingress: ingress) else {
+            guard !Task.isCancelled, !shouldSuppress else {
                 return
+            }
+
+            // Actionable sessions (permission/question) skip the post-await
+            // re-eligibility check: the session phase can change from
+            // waitingForApproval/waitingForAnswer to running while the
+            // async frontmost probe runs, causing a false dismissal.
+            if !isActionable {
+                guard self.notificationSurfaceIsEligibleForPresentation(surface, ingress: ingress) else {
+                    return
+                }
             }
 
             self.presentNotificationSurface(surface)

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1288,6 +1288,8 @@ final class AppModel {
         }
 
         guard suppressFrontmostNotifications else {
+            notificationPresentationTask?.cancel()
+            notificationPresentationTask = nil
             presentNotificationSurface(surface)
             return
         }

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1294,6 +1294,8 @@ final class AppModel {
 
         let isActionable = session.phase == .waitingForApproval || session.phase == .waitingForAnswer
         if isActionable {
+            notificationPresentationTask?.cancel()
+            notificationPresentationTask = nil
             presentNotificationSurface(surface)
             return
         }

--- a/Sources/OpenIslandApp/Resources/open-island-opencode.js
+++ b/Sources/OpenIslandApp/Resources/open-island-opencode.js
@@ -42,20 +42,30 @@ function sendAndWaitResponse(json, timeoutMs = 300000) {
       let buf = "";
       sock.on("data", (chunk) => {
         buf += chunk.toString();
-        // BridgeServer sends hello first, then response after processing
         const lines = buf.split("\n").filter(Boolean);
-        if (lines.length >= 2) {
-          sock.destroy();
-          try { resolve(JSON.parse(lines[1])); } catch { resolve(null); }
+        for (const line of lines) {
+          try {
+            const parsed = JSON.parse(line);
+            if (parsed.type === "response") {
+              sock.destroy();
+              resolve(parsed);
+              return;
+            }
+          } catch {}
         }
       });
       sock.on("end", () => {
         const lines = buf.split("\n").filter(Boolean);
-        if (lines.length >= 2) {
-          try { resolve(JSON.parse(lines[1])); } catch { resolve(null); }
-        } else {
-          resolve(null);
+        for (const line of lines) {
+          try {
+            const parsed = JSON.parse(line);
+            if (parsed.type === "response") {
+              resolve(parsed);
+              return;
+            }
+          } catch {}
         }
+        resolve(null);
       });
       sock.on("error", () => resolve(null));
       sock.setTimeout(timeoutMs, () => { sock.destroy(); resolve(null); });
@@ -259,6 +269,15 @@ export default async ({ client, serverUrl }) => {
       return makePayload("QuestionAsked", p.sessionID, sessionCwd.get(p.sessionID), {
         question_id: p.id,
         question_text: (p.questions || []).map(q => q.question).join("; ") || "OpenCode has a question",
+        questions: (p.questions || []).map(q => ({
+          question: q.question || "",
+          header: q.header || "",
+          options: (q.options || []).map(o => ({
+            label: o.label || "",
+            description: o.description || "",
+          })),
+          multiple: q.multiple || false,
+        })),
         _opencode_request_id: p.id,
       });
     }
@@ -308,7 +327,15 @@ export default async ({ client, serverUrl }) => {
             if (!response) return;
             const directive = response?.response?.directive;
             if (!directive) return;
-            if (directive.type === "answer") {
+            if (directive.type === "structuredAnswer" && directive.answers) {
+              try {
+                await internalFetch(new Request(`http://localhost:${serverPort}/question/${requestId}/reply`, {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ answers: directive.answers }),
+                }));
+              } catch {}
+            } else if (directive.type === "answer") {
               try {
                 await internalFetch(new Request(`http://localhost:${serverPort}/question/${requestId}/reply`, {
                   method: "POST",

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -1046,15 +1046,40 @@ public final class BridgeServer: @unchecked Sendable {
             synchronizeOpenCodeJumpTarget(for: payload)
             synchronizeOpenCodeMetadata(for: payload)
 
-            let questionTitle = payload.questionText ?? "OpenCode has a question for you."
+            let prompt: QuestionPrompt
+            if let rawQuestions = payload.questions, !rawQuestions.isEmpty {
+                let items = rawQuestions.map { q in
+                    var resolvedOptions = q.options.map { o in
+                        QuestionOption(label: o.label, description: o.description)
+                    }
+                    // Mirror Claude behavior: add a freeform "Other" option
+                    resolvedOptions.append(
+                        QuestionOption(label: "Other", description: "", allowsFreeform: true)
+                    )
+                    return QuestionPromptItem(
+                        question: q.question,
+                        header: q.header,
+                        options: resolvedOptions,
+                        multiSelect: q.multiple
+                    )
+                }
+                let title: String
+                if items.count == 1, let first = items.first {
+                    title = first.question
+                } else {
+                    title = "OpenCode has \(items.count) questions for you."
+                }
+                prompt = QuestionPrompt(title: title, questions: items)
+            } else {
+                let questionTitle = payload.questionText ?? "OpenCode has a question for you."
+                prompt = QuestionPrompt(title: questionTitle, options: [])
+            }
+
             emit(
                 .questionAsked(
                     QuestionAsked(
                         sessionID: payload.sessionID,
-                        prompt: QuestionPrompt(
-                            title: questionTitle,
-                            options: []
-                        ),
+                        prompt: prompt,
                         timestamp: .now
                     )
                 )
@@ -1722,10 +1747,25 @@ public final class BridgeServer: @unchecked Sendable {
             )
         )
 
-        send(
-            .response(.openCodeHookDirective(.answer(text: answerText))),
-            to: pendingInteraction.clientID
-        )
+        let structuredAnswers: [[String]] = response.answers
+            .keys
+            .sorted()
+            .map { key in
+                let value = response.answers[key] ?? ""
+                return value.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+            }
+
+        if !structuredAnswers.isEmpty {
+            send(
+                .response(.openCodeHookDirective(.structuredAnswer(answers: structuredAnswers))),
+                to: pendingInteraction.clientID
+            )
+        } else {
+            send(
+                .response(.openCodeHookDirective(.answer(text: answerText))),
+                to: pendingInteraction.clientID
+            )
+        }
     }
 
     private func clearStaleClaudeInteractionIfNeeded(for sessionID: String) {

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -1747,13 +1747,18 @@ public final class BridgeServer: @unchecked Sendable {
             )
         )
 
-        let structuredAnswers: [[String]] = response.answers
-            .keys
-            .sorted()
-            .map { key in
-                let value = response.answers[key] ?? ""
-                return value.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
-            }
+        let orderedKeys: [String]
+        if case let .question(payload) = pendingInteraction.kind,
+           let questions = payload.questions, !questions.isEmpty {
+            orderedKeys = questions.map { $0.header }
+        } else {
+            orderedKeys = response.answers.keys.sorted()
+        }
+
+        let structuredAnswers: [[String]] = orderedKeys.compactMap { key in
+            guard let value = response.answers[key] else { return nil }
+            return value.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+        }
 
         if !structuredAnswers.isEmpty {
             send(

--- a/Sources/OpenIslandCore/OpenCodeHooks.swift
+++ b/Sources/OpenIslandCore/OpenCodeHooks.swift
@@ -11,6 +11,35 @@ public enum OpenCodeHookEventName: String, Codable, Sendable {
     case stop = "Stop"
 }
 
+public struct OpenCodeQuestionOption: Equatable, Codable, Sendable {
+    public var label: String
+    public var description: String
+
+    public init(label: String, description: String = "") {
+        self.label = label
+        self.description = description
+    }
+}
+
+public struct OpenCodeQuestion: Equatable, Codable, Sendable {
+    public var question: String
+    public var header: String
+    public var options: [OpenCodeQuestionOption]
+    public var multiple: Bool
+
+    public init(
+        question: String,
+        header: String = "",
+        options: [OpenCodeQuestionOption] = [],
+        multiple: Bool = false
+    ) {
+        self.question = question
+        self.header = header
+        self.options = options
+        self.multiple = multiple
+    }
+}
+
 public struct OpenCodeHookPayload: Equatable, Codable, Sendable {
     public var hookEventName: OpenCodeHookEventName
     public var sessionID: String
@@ -22,6 +51,7 @@ public struct OpenCodeHookPayload: Equatable, Codable, Sendable {
     public var permissionDescription: String?
     public var questionID: String?
     public var questionText: String?
+    public var questions: [OpenCodeQuestion]?
     public var messageContent: String?
     public var model: String?
     public var prompt: String?
@@ -42,6 +72,7 @@ public struct OpenCodeHookPayload: Equatable, Codable, Sendable {
         case permissionDescription = "permission_description"
         case questionID = "question_id"
         case questionText = "question_text"
+        case questions
         case messageContent = "message_content"
         case model
         case prompt
@@ -63,6 +94,7 @@ public struct OpenCodeHookPayload: Equatable, Codable, Sendable {
         permissionDescription: String? = nil,
         questionID: String? = nil,
         questionText: String? = nil,
+        questions: [OpenCodeQuestion]? = nil,
         messageContent: String? = nil,
         model: String? = nil,
         prompt: String? = nil,
@@ -82,6 +114,7 @@ public struct OpenCodeHookPayload: Equatable, Codable, Sendable {
         self.permissionDescription = permissionDescription
         self.questionID = questionID
         self.questionText = questionText
+        self.questions = questions
         self.messageContent = messageContent
         self.model = model
         self.prompt = prompt
@@ -97,17 +130,20 @@ public enum OpenCodeHookDirective: Equatable, Codable, Sendable {
     case allow
     case deny(reason: String?)
     case answer(text: String)
+    case structuredAnswer(answers: [[String]])
 
     private enum CodingKeys: String, CodingKey {
         case type
         case reason
         case text
+        case answers
     }
 
     private enum DirectiveType: String, Codable {
         case allow
         case deny
         case answer
+        case structuredAnswer
     }
 
     public init(from decoder: any Decoder) throws {
@@ -121,6 +157,8 @@ public enum OpenCodeHookDirective: Equatable, Codable, Sendable {
             self = .deny(reason: try container.decodeIfPresent(String.self, forKey: .reason))
         case .answer:
             self = .answer(text: try container.decode(String.self, forKey: .text))
+        case .structuredAnswer:
+            self = .structuredAnswer(answers: try container.decode([[String]].self, forKey: .answers))
         }
     }
 
@@ -136,6 +174,9 @@ public enum OpenCodeHookDirective: Equatable, Codable, Sendable {
         case let .answer(text):
             try container.encode(DirectiveType.answer, forKey: .type)
             try container.encode(text, forKey: .text)
+        case let .structuredAnswer(answers):
+            try container.encode(DirectiveType.structuredAnswer, forKey: .type)
+            try container.encode(answers, forKey: .answers)
         }
     }
 }


### PR DESCRIPTION
## Summary

Enable OpenCode's interactive QCM (multiple-choice) questions to display as actionable notifications in the notch island, with clickable option buttons and structured answer responses.

## Problem

When OpenCode emits `question.asked` events (e.g. asking the user to pick between options), the notch island would briefly expand then immediately collapse — making the question unreadable and unanswerable from the island UI.

**Three root causes were identified:**

1. **Plugin socket disconnect (main cause):** `sendAndWaitResponse` used line-counting (`lines.length >= 2`) to detect the bridge response. But `BridgeServer.broadcast()` sends events to ALL connected clients — including the plugin itself. The plugin saw: hello (line 1) + broadcast event (line 2) → `sock.destroy()` → BridgeServer detected disconnect → emitted `actionableStateResolved("Plugin process disconnected.")` → phase reset to `running` → notification dismissed.

2. **Race condition on async notification:** `isNotificationSessionAlreadyFrontmost` is async and takes a few ms. During that window, other OpenCode events arrived and changed the phase from `waitingForAnswer` back to `running`, invalidating the notification before it could present.

3. **Missing structured options:** The plugin flattened questions to plain text. BridgeServer constructed `QuestionPrompt(title: questionText, options: [])` — no clickable buttons.

## Changes

### `Sources/OpenIslandApp/Resources/open-island-opencode.js` (plugin)
- `sendAndWaitResponse` now filters on `parsed.type === "response"` instead of counting lines
- Sends structured `questions` array (question text, header, options with labels, multiple-select flag)
- Response handler supports `structuredAnswer` directive with `answers: [[label]]`

### `Sources/OpenIslandApp/AppModel.swift`
- Bypass async frontmost check for actionable events (question/permission) — present immediately to avoid race

### `Sources/OpenIslandCore/BridgeServer.swift`
- `handleOpenCodeHook(.questionAsked)` builds complete `QuestionPromptItem` with labeled options + "Other" freeform option
- `resolvePendingOpenCodeQuestion` sends `structuredAnswer` with selected labels

### `Sources/OpenIslandCore/OpenCodeHooks.swift`
- New types: `OpenCodeQuestionOption`, `OpenCodeQuestion`
- `questions: [OpenCodeQuestion]?` field in `OpenCodeHookPayload`
- `structuredAnswer(answers: [[String]])` directive in `OpenCodeHookDirective`

## Testing

Manually tested end-to-end: OpenCode question → notch expands → options displayed as buttons → user clicks option → answer sent back to OpenCode → notch collapses. Confirmed working by the contributor.

## Notes

All code in this PR was produced by AI, per CONTRIBUTING.md guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured multi-question prompts: per-question headers, options (includes an "Other" freeform choice), multi-select support, and a native structured-answer submission path.
  * Actionable notifications now present reliably when waiting for approval/answers, avoiding premature dismissal.

* **Bug Fixes**
  * More robust handling of streaming, newline-delimited responses and improved parsing/handling of incoming question and answer payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->