### PR TITLE
fix: track Codex app rollout aborts

### DIFF
--- a/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
+++ b/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
@@ -366,13 +366,9 @@ final class SessionDiscoveryCoordinator {
                   !transcriptPath.isEmpty else {
                 return nil
             }
-            // Codex.app sessions already get their lifecycle from hooks
-            // (and eventually app-server). The rollout watcher would
-            // duplicate completion notifications and is not needed.
-            if session.isCodexAppSession {
-                return nil
-            }
-
+            // Codex Desktop reliably records user-initiated stops as
+            // `turn_aborted` in the rollout even when the app-server does not
+            // emit a usable completion signal, so track app sessions too.
             return CodexRolloutWatchTarget(
                 sessionID: session.id,
                 transcriptPath: transcriptPath

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -231,9 +231,21 @@ struct AppModelSessionListTests {
         model.state = SessionState(sessions: [session])
         model.discovery.refreshCodexRolloutTracking()
 
-        try await Task.sleep(for: .milliseconds(200))
+        var observedSession = model.state.session(id: "codex-desktop-abort")
+        for _ in 0..<20 {
+            if observedSession?.phase == .completed,
+               observedSession?.summary == "Codex turn was interrupted." {
+                break
+            }
 
-        let updatedSession = try #require(model.state.session(id: "codex-desktop-abort"))
+            // Poll because rollout watcher delivery can vary on loaded CI
+            // runners, while the success path should still finish quickly.
+            await Task.yield()
+            try await Task.sleep(for: .milliseconds(10))
+            observedSession = model.state.session(id: "codex-desktop-abort")
+        }
+
+        let updatedSession = try #require(observedSession)
         #expect(updatedSession.phase == .completed)
         #expect(updatedSession.summary == "Codex turn was interrupted.")
     }

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -186,6 +186,58 @@ struct AppModelSessionListTests {
         #expect(!model.shouldShowSessionBootstrapPlaceholder)
     }
 
+    /// Verifies that Codex Desktop sessions consume rollout abort events so a
+    /// user clicking Stop clears the island's running state.
+    @Test
+    func codexDesktopRolloutAbortClearsRunningState() async throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-codex-app-abort-\(UUID().uuidString)", isDirectory: true)
+        let rolloutURL = rootURL.appendingPathComponent("rollout.jsonl")
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        try Data(
+            """
+            {"timestamp":"2026-04-24T03:09:32.992Z","type":"event_msg","payload":{"type":"turn_aborted","turn_id":"turn-1","reason":"interrupted"}}
+
+            """.utf8
+        ).write(to: rolloutURL)
+
+        let model = AppModel()
+        defer {
+            model.discovery.codexRolloutWatcher.stop()
+            try? FileManager.default.removeItem(at: rootURL)
+        }
+
+        var session = AgentSession(
+            id: "codex-desktop-abort",
+            title: "Codex · open-vibe-island",
+            tool: .codex,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Codex is working...",
+            updatedAt: Date(timeIntervalSince1970: 2_000),
+            jumpTarget: JumpTarget(
+                terminalApp: "Codex.app",
+                workspaceName: "open-vibe-island",
+                paneTitle: "Codex · open-vibe-island",
+                workingDirectory: "/tmp/open-vibe-island",
+                codexThreadID: "codex-desktop-abort"
+            ),
+            codexMetadata: CodexSessionMetadata(transcriptPath: rolloutURL.path)
+        )
+        session.isCodexAppSession = true
+        session.isProcessAlive = true
+
+        model.state = SessionState(sessions: [session])
+        model.discovery.refreshCodexRolloutTracking()
+
+        try await Task.sleep(for: .milliseconds(200))
+
+        let updatedSession = try #require(model.state.session(id: "codex-desktop-abort"))
+        #expect(updatedSession.phase == .completed)
+        #expect(updatedSession.summary == "Codex turn was interrupted.")
+    }
+
     @Test
     func jumpToSessionClosesOverlayBeforeTerminalJumpFinishes() async throws {
         let now = Date(timeIntervalSince1970: 2_000)


### PR DESCRIPTION
## Summary

- Track Codex Desktop rollout files instead of skipping `isCodexAppSession` sessions.
- Consume `turn_aborted` rollout events so manually stopped Codex turns clear the running state in Open Island.
- Add an AppModel regression test that reproduces a Codex Desktop abort from a rollout JSONL file.

## Verification

- `swift test --filter AppModelSessionListTests`
- `swift test --filter CodexAppServerCoordinatorTests` (no matching tests on the clean `origin/main` branch)

Fixes #403


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session tracking now includes Codex Desktop sessions so user-initiated stops are correctly captured in rollout monitoring.

* **Tests**
  * Added a regression test that simulates an aborted Codex transcript and verifies sessions update to the expected interrupted/completed state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->