### PR TITLE
feat: add notification level setting for subagent filtering

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -12,10 +12,18 @@ extension Notification.Name {
     static let openIslandSelectSetupTab = Notification.Name("openIslandSelectSetupTab")
 }
 
+enum NotificationLevel: String, CaseIterable, Identifiable {
+    case all
+    case mainAgentOnly
+
+    var id: String { rawValue }
+}
+
 @MainActor
 @Observable
 final class AppModel {
     private static let soundMutedDefaultsKey = "overlay.sound.muted"
+    private static let notificationLevelDefaultsKey = "app.notificationLevel"
     private static let showDockIconDefaultsKey = "app.showDockIcon"
     private static let hapticFeedbackEnabledDefaultsKey = "app.hapticFeedbackEnabled"
     private static let islandAppearanceModeDefaultsKey = "appearance.island.mode"
@@ -280,6 +288,12 @@ final class AppModel {
     }
     @ObservationIgnored
     private var isApplyingLaunchAtLogin = false
+    var notificationLevel: NotificationLevel = .mainAgentOnly {
+        didSet {
+            guard hasFinishedInit, notificationLevel != oldValue else { return }
+            UserDefaults.standard.set(notificationLevel.rawValue, forKey: Self.notificationLevelDefaultsKey)
+        }
+    }
     var isSoundMuted = false {
         didSet {
             guard isSoundMuted != oldValue else {
@@ -516,12 +530,16 @@ final class AppModel {
             Self.hapticFeedbackEnabledDefaultsKey: false,
             Self.completionReplyEnabledDefaultsKey: false,
             Self.suppressFrontmostNotificationsDefaultsKey: true,
+            Self.notificationLevelDefaultsKey: NotificationLevel.mainAgentOnly.rawValue,
         ])
         isSoundMuted = UserDefaults.standard.bool(forKey: Self.soundMutedDefaultsKey)
         selectedSoundName = NotificationSoundService.selectedSoundName
         showDockIcon = UserDefaults.standard.bool(forKey: Self.showDockIconDefaultsKey)
         hapticFeedbackEnabled = UserDefaults.standard.bool(forKey: Self.hapticFeedbackEnabledDefaultsKey)
         suppressFrontmostNotifications = UserDefaults.standard.bool(forKey: Self.suppressFrontmostNotificationsDefaultsKey)
+        notificationLevel = NotificationLevel(
+            rawValue: UserDefaults.standard.string(forKey: Self.notificationLevelDefaultsKey) ?? ""
+        ) ?? .mainAgentOnly
         if UserDefaults.standard.object(forKey: Self.showCodexUsageDefaultsKey) != nil {
             showCodexUsage = UserDefaults.standard.bool(forKey: Self.showCodexUsageDefaultsKey)
         } else {
@@ -1266,11 +1284,21 @@ final class AppModel {
         }
 
         if let surface = IslandSurface.notificationSurface(for: event) {
-            scheduleNotificationSurfacePresentationIfNeeded(
-                surface,
-                wasAlreadyCompleted: wasAlreadyCompleted,
-                ingress: ingress
-            )
+            let isSubagentEvent: Bool = {
+                switch event {
+                case let .activityUpdated(payload): return payload.isSubagentCompletion
+                case let .sessionCompleted(payload): return payload.isSubagentCompletion == true
+                default: return false
+                }
+            }()
+
+            if !isSubagentEvent || notificationLevel == .all {
+                scheduleNotificationSurfacePresentationIfNeeded(
+                    surface,
+                    wasAlreadyCompleted: wasAlreadyCompleted,
+                    ingress: ingress
+                )
+            }
         }
     }
 

--- a/Sources/OpenIslandApp/IslandSurface.swift
+++ b/Sources/OpenIslandApp/IslandSurface.swift
@@ -28,6 +28,8 @@ enum IslandSurface: Equatable {
             .sessionList(actionableSessionID: payload.sessionID)
         case let .sessionCompleted(payload):
             payload.isInterrupt == true ? nil : .sessionList(actionableSessionID: payload.sessionID)
+        case let .activityUpdated(payload) where payload.isSubagentCompletion:
+            .sessionList(actionableSessionID: payload.sessionID)
         default:
             nil
         }

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -26,6 +26,9 @@
 "settings.general.showDockIcon" = "Show icon in Dock";
 "settings.general.hapticFeedback" = "Haptic feedback on hover";
 "settings.general.suppressFrontmostNotifications" = "Suppress notifications for focused sessions";
+"settings.general.notificationLevel" = "Notification level";
+"settings.general.notificationLevel.mainAgentOnly" = "Main agent only";
+"settings.general.notificationLevel.all" = "All (including subagents)";
 "settings.general.showCodexUsage" = "Show Codex usage";
 "settings.general.completionReply" = "Reply from completion card";
 "settings.general.cliHooks" = "CLI Hooks";

--- a/Sources/OpenIslandApp/Resources/open-island-opencode.js
+++ b/Sources/OpenIslandApp/Resources/open-island-opencode.js
@@ -135,6 +135,8 @@ export default async ({ client, serverUrl }) => {
   const msgRoles = new Map();
   const sessionCwd = new Map();
   const sessions = new Map();
+  const busySessions = new Set();
+  const subagentSessions = new Set();
 
   function getSession(sid) {
     if (!sessions.has(sid)) sessions.set(sid, { lastAssistantText: "" });
@@ -149,13 +151,18 @@ export default async ({ client, serverUrl }) => {
     if (t === "session.created" && p.info) {
       const cwd = p.info.directory || "";
       sessionCwd.set(p.info.id, cwd);
-      return makePayload("SessionStart", p.info.id, cwd);
+      if (busySessions.size > 0) subagentSessions.add(p.info.id);
+      return makePayload("SessionStart", p.info.id, cwd, {
+        ...(subagentSessions.has(p.info.id) ? { is_subagent: true } : {}),
+      });
     }
 
     // session.deleted
     if (t === "session.deleted" && p.info) {
       sessions.delete(p.info.id);
       sessionCwd.delete(p.info.id);
+      busySessions.delete(p.info.id);
+      subagentSessions.delete(p.info.id);
       return makePayload("SessionEnd", p.info.id, sessionCwd.get(p.info.id));
     }
 
@@ -173,10 +180,17 @@ export default async ({ client, serverUrl }) => {
     // session.status → idle = Stop (busy is ignored; session creation
     // comes from session.created or ensureOpenCodeSessionExists on first event)
     if (t === "session.status" && p.sessionID) {
+      if (p.status?.type === "busy") {
+        busySessions.add(p.sessionID);
+        return null;
+      }
       if (p.status?.type === "idle") {
+        busySessions.delete(p.sessionID);
         const s = getSession(p.sessionID);
+        const isSubagent = subagentSessions.has(p.sessionID);
         return makePayload("Stop", p.sessionID, sessionCwd.get(p.sessionID), {
           last_assistant_message: s.lastAssistantText || undefined,
+          ...(isSubagent ? { is_subagent: true } : {}),
         });
       }
       return null;

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -26,6 +26,9 @@
 "settings.general.showDockIcon" = "在 Dock 中显示图标";
 "settings.general.hapticFeedback" = "悬停时震动反馈";
 "settings.general.suppressFrontmostNotifications" = "前台会话不弹出通知";
+"settings.general.notificationLevel" = "通知级别";
+"settings.general.notificationLevel.mainAgentOnly" = "仅主代理";
+"settings.general.notificationLevel.all" = "全部（包括子代理）";
 "settings.general.showCodexUsage" = "显示 Codex 用量";
 "settings.general.completionReply" = "在完成卡片中回复";
 "settings.general.cliHooks" = "CLI Hooks";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -26,6 +26,9 @@
 "settings.general.showDockIcon" = "在 Dock 中顯示圖示";
 "settings.general.hapticFeedback" = "懸停時震動回饋";
 "settings.general.suppressFrontmostNotifications" = "前台工作階段不彈出通知";
+"settings.general.notificationLevel" = "通知層級";
+"settings.general.notificationLevel.mainAgentOnly" = "僅主代理";
+"settings.general.notificationLevel.all" = "全部（包括子代理）";
 "settings.general.showCodexUsage" = "顯示 Codex 用量";
 "settings.general.completionReply" = "在完成卡片中回覆";
 "settings.general.cliHooks" = "CLI Hooks";

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -223,6 +223,13 @@ struct GeneralSettingsPane: View {
                     get: { model.suppressFrontmostNotifications },
                     set: { model.suppressFrontmostNotifications = $0 }
                 ))
+                Picker(lang.t("settings.general.notificationLevel"), selection: Binding(
+                    get: { model.notificationLevel },
+                    set: { model.notificationLevel = $0 }
+                )) {
+                    Text(lang.t("settings.general.notificationLevel.mainAgentOnly")).tag(NotificationLevel.mainAgentOnly)
+                    Text(lang.t("settings.general.notificationLevel.all")).tag(NotificationLevel.all)
+                }
             }
 
         }

--- a/Sources/OpenIslandCore/AgentEvent.swift
+++ b/Sources/OpenIslandCore/AgentEvent.swift
@@ -54,17 +54,23 @@ public struct SessionActivityUpdated: Equatable, Codable, Sendable {
     public var summary: String
     public var phase: SessionPhase
     public var timestamp: Date
+    /// When `true`, this activity update represents a subagent finishing its
+    /// work (e.g. Claude Code's `SubagentStop` hook). Used by the notification
+    /// system to optionally surface subagent completions to the user.
+    public var isSubagentCompletion: Bool
 
     public init(
         sessionID: String,
         summary: String,
         phase: SessionPhase,
-        timestamp: Date
+        timestamp: Date,
+        isSubagentCompletion: Bool = false
     ) {
         self.sessionID = sessionID
         self.summary = summary
         self.phase = phase
         self.timestamp = timestamp
+        self.isSubagentCompletion = isSubagentCompletion
     }
 }
 
@@ -110,19 +116,22 @@ public struct SessionCompleted: Equatable, Codable, Sendable {
     /// turn-level completion (`Stop`/`StopFailure`) where the CLI is still
     /// running and waiting for the next user prompt.
     public var isSessionEnd: Bool?
+    public var isSubagentCompletion: Bool?
 
     public init(
         sessionID: String,
         summary: String,
         timestamp: Date,
         isInterrupt: Bool? = nil,
-        isSessionEnd: Bool? = nil
+        isSessionEnd: Bool? = nil,
+        isSubagentCompletion: Bool? = nil
     ) {
         self.sessionID = sessionID
         self.summary = summary
         self.timestamp = timestamp
         self.isInterrupt = isInterrupt
         self.isSessionEnd = isSessionEnd
+        self.isSubagentCompletion = isSubagentCompletion
     }
 }
 

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -893,7 +893,8 @@ public final class BridgeServer: @unchecked Sendable {
                         sessionID: payload.sessionID,
                         summary: summary,
                         phase: .running,
-                        timestamp: .now
+                        timestamp: .now,
+                        isSubagentCompletion: true
                     )
                 )
             )
@@ -1075,7 +1076,8 @@ public final class BridgeServer: @unchecked Sendable {
                     SessionCompleted(
                         sessionID: payload.sessionID,
                         summary: payload.lastAssistantMessage ?? payload.assistantMessagePreview ?? "OpenCode completed the turn.",
-                        timestamp: .now
+                        timestamp: .now,
+                        isSubagentCompletion: payload.isSubagent == true ? true : nil
                     )
                 )
             )

--- a/Sources/OpenIslandCore/OpenCodeHooks.swift
+++ b/Sources/OpenIslandCore/OpenCodeHooks.swift
@@ -30,6 +30,7 @@ public struct OpenCodeHookPayload: Equatable, Codable, Sendable {
     public var terminalSessionID: String?
     public var terminalTTY: String?
     public var terminalTitle: String?
+    public var isSubagent: Bool?
 
     private enum CodingKeys: String, CodingKey {
         case hookEventName = "hook_event_name"
@@ -50,6 +51,7 @@ public struct OpenCodeHookPayload: Equatable, Codable, Sendable {
         case terminalSessionID = "terminal_session_id"
         case terminalTTY = "terminal_tty"
         case terminalTitle = "terminal_title"
+        case isSubagent = "is_subagent"
     }
 
     public init(
@@ -70,7 +72,8 @@ public struct OpenCodeHookPayload: Equatable, Codable, Sendable {
         terminalApp: String? = nil,
         terminalSessionID: String? = nil,
         terminalTTY: String? = nil,
-        terminalTitle: String? = nil
+        terminalTitle: String? = nil,
+        isSubagent: Bool? = nil
     ) {
         self.hookEventName = hookEventName
         self.sessionID = sessionID
@@ -90,6 +93,7 @@ public struct OpenCodeHookPayload: Equatable, Codable, Sendable {
         self.terminalSessionID = terminalSessionID
         self.terminalTTY = terminalTTY
         self.terminalTitle = terminalTitle
+        self.isSubagent = isSubagent
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a **Notification Level** setting so users can choose whether to receive notifications for subagent completions or only for the main agent.

- **Main agent only** (default): subagent completions are silenced
- **All (including subagents)**: all completions trigger notifications

### Changes

**Commit 1 — Core models** (`AgentEvent.swift`, `OpenCodeHooks.swift`)
- Add `isSubagentCompletion` flag to `SessionActivityUpdated` and `SessionCompleted`
- Add `isSubagent` to `OpenCodeHookPayload` for OpenCode hook detection

**Commit 2 — Bridge + Plugin** (`BridgeServer.swift`, `open-island-opencode.js`)
- BridgeServer propagates `isSubagentCompletion` on Claude Code `SubagentStop` and OpenCode `Stop` events
- OpenCode plugin tracks `busySessions`/`subagentSessions` to detect subagent lifecycle, sends `is_subagent` in payloads

**Commit 3 — UI + Filtering + i18n** (`AppModel.swift`, `IslandSurface.swift`, `SettingsView.swift`, Localizable.strings ×3)
- `NotificationLevel` enum with UserDefaults persistence
- Settings picker in General > Behavior
- Subagent notification filtering in `applyTrackedEvent`
- `IslandSurface.notificationSurface` extended for `activityUpdated` subagent completions
- i18n: en, zh-Hans, zh-Hant

### Supports

- **Claude Code**: `SubagentStop` hook events → `activityUpdated` with `isSubagentCompletion`
- **OpenCode**: separate subagent sessions detected via `busySessions` tracking in JS plugin → `sessionCompleted` with `isSubagentCompletion`

### Testing

Manually verified both modes:
- Main agent only → subagent completions silenced ✅
- All → subagent completions trigger notifications ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New "Notification Level" setting (picker in Settings) to choose between showing notifications for main agent only or for all agents.
  * Notifications now respect that setting: subagent completion events only produce notifications when "All" is selected.
  * Session tracking updated to recognize and mark subagent activity and include subagent flags in session events.

* **Localization**
  * Added English, Simplified Chinese, and Traditional Chinese labels for the new setting and its options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->