### PR TITLE
feat: stepper UI for multi-question prompts in notch

### DIFF
--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -634,24 +634,23 @@ final class OverlayPanelController {
             return Self.questionCardBaseHeight
         }
 
-        // Card chrome: outer padding + submit button ≈ 90pt.
-        // When the prompt title is suppressed (single question whose title
-        // matches the question text), reduce chrome by ~20pt.
         let titleSuppressed = prompt.questions.count == 1
             && prompt.title == prompt.questions.first?.question
-        let chromeHeight: CGFloat = titleSuppressed ? 70 : 90
+        let isStepper = prompt.questions.count > 1
+        let chromeHeight: CGFloat = titleSuppressed ? 70 : (isStepper ? 100 : 90)
         var contentHeight: CGFloat = 0
 
-        for question in prompt.questions {
-            if prompt.questions.count > 1 {
-                contentHeight += 16 // header
+        if isStepper {
+            let tallest = prompt.questions.map { question in
+                20 + CGFloat(question.options.count) * 30
+            }.max() ?? 0
+            contentHeight = tallest
+        } else {
+            for question in prompt.questions {
+                contentHeight += 20
+                contentHeight += CGFloat(question.options.count) * 30
             }
-            contentHeight += 20 // question text
-            contentHeight += CGFloat(question.options.count) * 30 // option rows
         }
-
-        // Inter-question spacing (only between questions, not after the last).
-        contentHeight += CGFloat(max(0, prompt.questions.count - 1)) * 10
 
         let estimated = chromeHeight + contentHeight
         return min(Self.questionCardMaxHeight, max(Self.questionCardBaseHeight, estimated))

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -153,6 +153,8 @@
 
 /* Island Panel - Question */
 "question.submit" = "Submit Answers";
+"question.next" = "Next";
+"question.back" = "Back";
 "question.answerNeeded" = "Answer needed";
 "question.otherPlaceholder" = "Type your answer…";
 

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -153,6 +153,8 @@
 
 /* Island Panel - Question */
 "question.submit" = "提交答案";
+"question.next" = "下一步";
+"question.back" = "上一步";
 "question.answerNeeded" = "需要回答";
 "question.otherPlaceholder" = "输入你的回答…";
 

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -152,6 +152,8 @@
 
 /* Island Panel - Question */
 "question.submit" = "提交答案";
+"question.next" = "下一步";
+"question.back" = "上一步";
 "question.answerNeeded" = "需要回答";
 "question.otherPlaceholder" = "輸入你的回答…";
 

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1659,7 +1659,7 @@ private struct StructuredQuestionPromptView: View {
 
             VStack(alignment: .leading, spacing: 10) {
                 if isStepper {
-                    if currentStep < structuredQuestions.count {
+                    if structuredQuestions.indices.contains(currentStep) {
                         questionRow(structuredQuestions[currentStep])
                             .id(currentStep)
                             .transition(.asymmetric(
@@ -1723,7 +1723,7 @@ private struct StructuredQuestionPromptView: View {
                 Button {
                     stepDirection = false
                     withAnimation(.easeInOut(duration: 0.2)) {
-                        currentStep -= 1
+                        currentStep = max(0, currentStep - 1)
                     }
                 } label: {
                     HStack(spacing: 4) {
@@ -1745,7 +1745,7 @@ private struct StructuredQuestionPromptView: View {
                 Button {
                     stepDirection = true
                     withAnimation(.easeInOut(duration: 0.2)) {
-                        currentStep += 1
+                        currentStep = min(max(0, structuredQuestions.count - 1), currentStep + 1)
                     }
                 } label: {
                     HStack(spacing: 4) {

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1629,10 +1629,28 @@ private struct StructuredQuestionPromptView: View {
 
     @State private var selections: [String: Set<String>] = [:]
     @State private var freeformTexts: [String: String] = [:]
+    @State private var currentStep: Int = 0
+    @State private var stepDirection: Bool = true
+
+    private var isStepper: Bool { structuredQuestions.count > 1 }
+    private var isLastStep: Bool { currentStep >= structuredQuestions.count - 1 }
+
+    private var currentStepHasSelection: Bool {
+        guard currentStep < structuredQuestions.count else { return false }
+        let question = structuredQuestions[currentStep]
+        let selected = selectedLabels(for: question)
+        guard !selected.isEmpty else { return false }
+        for option in question.options where option.allowsFreeform && selected.contains(option.label) {
+            if trimmedFreeform(for: question, option: option).isEmpty { return false }
+        }
+        return true
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            if showsPromptTitle {
+            if isStepper {
+                stepperHeader
+            } else if showsPromptTitle {
                 Text(promptTitle)
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(.yellow.opacity(0.96))
@@ -1640,15 +1658,26 @@ private struct StructuredQuestionPromptView: View {
             }
 
             VStack(alignment: .leading, spacing: 10) {
-                ForEach(structuredQuestions, id: \.question) { question in
-                    questionRow(question)
+                if isStepper {
+                    if currentStep < structuredQuestions.count {
+                        questionRow(structuredQuestions[currentStep])
+                            .id(currentStep)
+                            .transition(.asymmetric(
+                                insertion: .move(edge: stepDirection ? .trailing : .leading).combined(with: .opacity),
+                                removal: .move(edge: stepDirection ? .leading : .trailing).combined(with: .opacity)
+                            ))
+                    }
+                    stepperButtons
+                } else {
+                    ForEach(structuredQuestions, id: \.question) { question in
+                        questionRow(question)
+                    }
+                    Button(lang.t("question.submit")) {
+                        onAnswer(QuestionPromptResponse(answers: answerMap))
+                    }
+                    .buttonStyle(IslandWideButtonStyle(kind: .primary))
+                    .disabled(!hasCompleteSelection)
                 }
-
-                Button(lang.t("question.submit")) {
-                    onAnswer(QuestionPromptResponse(answers: answerMap))
-                }
-                .buttonStyle(IslandWideButtonStyle(kind: .primary))
-                .disabled(!hasCompleteSelection)
             }
         }
         .padding(.horizontal, 14)
@@ -1662,10 +1691,72 @@ private struct StructuredQuestionPromptView: View {
             RoundedRectangle(cornerRadius: 18, style: .continuous)
                 .strokeBorder(.white.opacity(0.06))
         )
+        .animation(.easeInOut(duration: 0.2), value: stepDirection)
+    }
+
+    // MARK: - Stepper chrome
+
+    private var stepperHeader: some View {
+        HStack {
+            if showsPromptTitle {
+                Text(promptTitle)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.yellow.opacity(0.96))
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 4)
+            Text("\(currentStep + 1)/\(structuredQuestions.count)")
+                .font(.system(size: 11, weight: .medium).monospacedDigit())
+                .foregroundStyle(.white.opacity(0.45))
+        }
+    }
+
+    private var stepperButtons: some View {
+        HStack(spacing: 8) {
+            if currentStep > 0 {
+                Button {
+                    stepDirection = false
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        currentStep -= 1
+                    }
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "chevron.left")
+                            .font(.system(size: 10, weight: .semibold))
+                        Text(lang.t("question.back"))
+                    }
+                }
+                .buttonStyle(IslandWideButtonStyle(kind: .secondary))
+            }
+
+            if isLastStep {
+                Button(lang.t("question.submit")) {
+                    onAnswer(QuestionPromptResponse(answers: answerMap))
+                }
+                .buttonStyle(IslandWideButtonStyle(kind: .primary))
+                .disabled(!hasCompleteSelection)
+            } else {
+                Button {
+                    stepDirection = true
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        currentStep += 1
+                    }
+                } label: {
+                    HStack(spacing: 4) {
+                        Text(lang.t("question.next"))
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 10, weight: .semibold))
+                    }
+                }
+                .buttonStyle(IslandWideButtonStyle(kind: .primary))
+                .disabled(!currentStepHasSelection)
+            }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {}
     }
 
     // MARK: - Per-question row
-
     /// Renders a single question with its header, text, and vertical option list.
     @ViewBuilder
     private func questionRow(_ question: QuestionPromptItem) -> some View {

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1691,6 +1691,12 @@ private struct StructuredQuestionPromptView: View {
             RoundedRectangle(cornerRadius: 18, style: .continuous)
                 .strokeBorder(.white.opacity(0.06))
         )
+        .onChange(of: prompt?.id) { _, _ in
+            selections = [:]
+            freeformTexts = [:]
+            currentStep = 0
+            stepDirection = true
+        }
         .animation(.easeInOut(duration: 0.2), value: stepDirection)
     }
 


### PR DESCRIPTION
## Summary

When AI agents ask multiple questions at once, the notch overlay now shows a **stepper** (one question at a time with Back/Next navigation) instead of a vertical list.

### Changes

**Commit 1 — Stepper UI** (`IslandPanelView.swift`, `OverlayPanelController.swift`)
- `StructuredQuestionPromptView`: when `questions.count > 1`, render one question per step with `1/N` counter, Back/Next buttons, Submit on last step
- Direction-aware slide transitions (forward = left-to-right, back = right-to-left)
- Tap isolation on stepper buttons to prevent parent `handlePrimaryTap` from triggering jump-back
- Panel height estimation uses tallest single question instead of sum of all
- Single-question prompts render unchanged (no regression)

**Commit 2 — i18n** (3× `Localizable.strings`)
- `question.next` / `question.back` in en, zh-Hans, zh-Hant

### Testing

Manually verified:
- Multi-question prompt → stepper with correct slide direction ✅
- Single question → unchanged behavior ✅
- Back/Next buttons don't trigger jump-back ✅
- Submit only on last step, disabled until all questions answered ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-question prompts now present as step-by-step flows with Back/Next navigation and a step counter.
  * Navigation buttons enable/disable based on selections; Submit only appears on the final step.
  * Prompt changes reset selections and return the flow to the first step.
  * Single-question prompts retain the inline layout with simplified sizing.

* **Localization**
  * Added question navigation labels (Next/Back) in English, Simplified Chinese and Traditional Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->