### PR TITLE
fix: add missing 'auto' case to ClaudePermissionMode enum

### DIFF
--- a/Sources/OpenIslandCore/ClaudeHooks.swift
+++ b/Sources/OpenIslandCore/ClaudeHooks.swift
@@ -8,6 +8,7 @@ public enum ClaudePermissionMode: String, Codable, Sendable {
     case plan
     case dontAsk
     case bypassPermissions
+    case auto
 }
 
 public enum ClaudePermissionBehavior: String, Codable, Sendable {
@@ -163,6 +164,8 @@ public enum ClaudePermissionUpdate: Equatable, Codable, Sendable {
                 return "Plan Mode"
             case .default:
                 return "Manual Mode"
+            case .auto:
+                return "Auto Mode"
             }
         case .replaceRules:
             return "Update Rules"


### PR DESCRIPTION
## Summary

Adds the missing `auto` case to `ClaudePermissionMode` so that Claude Code 2.x hook payloads decode successfully when users enable `"defaultMode": "auto"` in `~/.claude/settings.json`.

Fixes #399.

## Root cause

Claude Code 2.x injects `"permission_mode": "auto"` into every hook stdin JSON when the user's settings include `"permissions": { "defaultMode": "auto" }`. The enum defined at `Sources/OpenIslandCore/ClaudeHooks.swift` is missing the `auto` case, so `JSONDecoder.decode(ClaudeHookPayload.self, ...)` throws:

```
dataCorrupted(Swift.DecodingError.Context(
  codingPath: [CodingKeys(stringValue: "permission_mode", intValue: nil)],
  debugDescription: "Cannot initialize ClaudePermissionMode from invalid String value auto",
  underlyingError: nil
))
```

The `do/catch` in `Sources/OpenIslandHooks/OpenIslandHooksCLI.swift` (intended to keep hooks fail-open when the bridge is unreachable) also swallows this decode error. The CLI exits 0, nothing reaches `BridgeServer`, and the Island UI stays permanently on the historical-snapshot state reconstructed from `~/.claude/projects/*.jsonl` at launch (every session appears as a green "completed"). Notifications never fire because their triggers live on the same dropped hook stream.

## Reproduce (before this patch)

1. In `~/.claude/settings.json`:
   ```json
   "permissions": { "defaultMode": "auto" },
   "skipAutoPermissionPrompt": true
   ```
2. Send a representative payload to the installed hook binary:
   ```bash
   echo '{"hook_event_name":"PreToolUse","session_id":"x","cwd":"/tmp","permission_mode":"auto","tool_name":"Bash","tool_input":{"command":"ls"}}' \
     | "$HOME/Library/Application Support/OpenIsland/bin/OpenIslandHooks" --source claude
   ```
3. Observe the `dataCorrupted` line on stderr, `exit=0`, and that nothing shows up in `~/Library/Application Support/open-island/claude-session-registry.json`.

## Change

Two edits in `Sources/OpenIslandCore/ClaudeHooks.swift`:

1. `ClaudePermissionMode` enum — add `case auto`
2. `ClaudePermissionUpdate.displayLabel` — add `case .auto: return "Auto Mode"` so the exhaustive `switch mode` continues to build (Swift compiler flagged this second one).

Total: 3 net-added lines.

## Verification (locally with this patch)

Built via `scripts/package-app.sh` (ad-hoc signed), installed over v1.0.27 on macOS 15 + Claude Code 2.1.119.

| Check | Result |
|---|---|
| `swift build -c release --product OpenIslandApp` | clean |
| `scripts/package-app.sh` smoke test (app boots outside repo) | passes |
| Same reproduce payload with `permission_mode: "auto"` | no stderr, exit 0, bridge receives it |
| `SessionStart` → `UserPromptSubmit` → `PreToolUse` chain with `permission_mode: "auto"` | registry entry written with `phase: "running"`, `claudeMetadata.permissionMode: "auto"`, `currentTool: "Bash"`, `summary: "Running Bash: ls"` |
| UI | live session row rendered in running state, not stuck on "completed" |

## Test plan

- [x] Manual end-to-end: `permission_mode:"auto"` payload → registry update → UI live state
- [x] Control case: `permission_mode:"default"` payload still works (unchanged behavior)
- [x] Control case: payload without `permission_mode` still works (unchanged behavior)
- [x] `swift build` clean for all three products (`OpenIslandApp`, `OpenIslandHooks`, `OpenIslandSetup`)
- [x] `scripts/package-app.sh` produces bundle, smoke test passes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Auto Mode" option to Claude permission settings, providing automatic configuration capabilities for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->