### PR TITLE
fix: recover terminalApp when hook env is stripped

### DIFF
--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -1883,6 +1883,15 @@ public final class BridgeServer: @unchecked Sendable {
            !existingUUID.isEmpty {
             merged.warpPaneUUID = existingUUID
         }
+        // Don't let a later hook with a stripped environment regress a
+        // previously-resolved terminal app back to "Unknown". Once we've
+        // identified the terminal, keep it pinned unless incoming has a
+        // concrete non-Unknown replacement.
+        if merged.terminalApp.isEmpty || merged.terminalApp == "Unknown",
+           let existingApp = existing?.terminalApp,
+           !existingApp.isEmpty, existingApp != "Unknown" {
+            merged.terminalApp = existingApp
+        }
         return merged
     }
 

--- a/Sources/OpenIslandCore/ClaudeHooks.swift
+++ b/Sources/OpenIslandCore/ClaudeHooks.swift
@@ -1233,6 +1233,56 @@ public extension ClaudeHookPayload {
             return "IntelliJ IDEA"  // Fallback for unknown JetBrains IDE
         }
 
+        // Last resort: some launchers (notably certain managed Claude Code
+        // setups) strip TERM_PROGRAM / GHOSTTY_RESOURCES_DIR / ITERM_*
+        // before spawning the hook. Walk the process ancestry and match
+        // the terminal by executable path. Unlike env vars, parent-chain
+        // lookup can't be fooled by GUI inheritance because every pane has
+        // its own real parent.
+        return inferTerminalAppFromProcessAncestry()
+    }
+
+    private func inferTerminalAppFromProcessAncestry() -> String? {
+        var pid = getppid()
+        var hops = 0
+        while pid > 1, hops < 12 {
+            guard let command = commandOutput(
+                executablePath: "/bin/ps",
+                arguments: ["-p", "\(pid)", "-o", "command="]
+            )?.lowercased() else {
+                return nil
+            }
+
+            if let app = Self.terminalAppName(forProcessCommand: command) {
+                return app
+            }
+
+            guard let ppidRaw = commandOutput(
+                executablePath: "/bin/ps",
+                arguments: ["-p", "\(pid)", "-o", "ppid="]
+            )?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  let next = Int32(ppidRaw), next > 1, next != pid else {
+                return nil
+            }
+            pid = next
+            hops += 1
+        }
+        return nil
+    }
+
+    private static func terminalAppName(forProcessCommand command: String) -> String? {
+        if command.contains("/ghostty.app/") || command.contains("ghostty-helper") { return "Ghostty" }
+        if command.contains("/iterm.app/") || command.contains("/iterm2") { return "iTerm" }
+        if command.contains("/warp.app/") || command.contains("/warp-stable") { return "Warp" }
+        if command.contains("/wezterm.app/") || command.contains("wezterm-gui") { return "WezTerm" }
+        if command.contains("/kaku.app/") { return "Kaku" }
+        if command.contains("/cmux.app/") { return "cmux" }
+        if command.contains("/terminal.app/") { return "Terminal" }
+        if command.contains("/visual studio code.app/") || command.contains("/code helper") { return "VS Code" }
+        if command.contains("/visual studio code - insiders.app/") { return "VS Code Insiders" }
+        if command.contains("/cursor.app/") { return "Cursor" }
+        if command.contains("/windsurf.app/") { return "Windsurf" }
+        if command.contains("/trae.app/") { return "Trae" }
         return nil
     }
 


### PR DESCRIPTION
## Problem

Open Island sometimes shows the **Unknown** terminal badge on Claude sessions even when the user is clearly running them inside Ghostty / iTerm2 / Warp etc. Once that "Unknown" stamp lands, terminal-specific actions (precision jump, pane targeting) all fall back to the no-op path.

I traced two independent causes:

### 1. Hook environment is sometimes stripped

In a few setups (certain managed Claude Code installs, Claude launched via wrapper scripts, hooks invoked via `sh -c`), the hook binary inherits an environment **without** `TERM_PROGRAM` / `GHOSTTY_RESOURCES_DIR` / `ITERM_SESSION_ID` / `LC_TERMINAL`. Every signal `inferTerminalApp` consults returns nothing, so the function returns `nil`. `defaultJumpTarget.terminalApp` then ternary-falls to `"Unknown"`.

### 2. "Unknown" can overwrite a good value

`BridgeServer.mergeJumpTargetPreservingExistingResolvedFields` was protecting `terminalSessionID` and `warpPaneUUID` but **not** `terminalApp`. Once one stripped-env hook arrives during a session, its `terminalApp = "Unknown"` overwrites whatever a prior hook had correctly resolved, and the badge stays "Unknown" until app restart.

## Fix

**(a) Process-ancestry fallback** — at the very end of `ClaudeHookPayload.inferTerminalApp` (after `TERM_PROGRAM`, all the env-var fallbacks, JetBrains detection), walk the parent chain via `/bin/ps -p <pid> -o command=`, up to 12 hops. For each hop, match against known terminal / IDE bundle paths (`/Ghostty.app/`, `/iTerm.app/`, `/Warp.app/`, `/WezTerm.app/`, `/Kaku.app/`, `/cmux.app/`, `/Terminal.app/`, VS Code family, Cursor, Windsurf, Trae). Unlike env vars, the parent chain can't be poisoned by GUI inheritance — every shell pane has its own real parent.

**(b) Merge protection** — extend `mergeJumpTargetPreservingExistingResolvedFields` to keep the existing `terminalApp` when the incoming value is empty or `"Unknown"`.

The two fixes are complementary: (a) maximizes the chance of resolving the terminal at all (especially on first hook), and (b) preserves whatever was resolved against later regressions.

## Scope

- 2 files, +59 lines
- No new public APIs, no schema changes, no new dependencies
- Behavior is purely additive: the existing env-based path stays identical, the new fallback only fires when env-based detection returns nil

## Test plan

- [x] `swift build` clean
- [x] Manually verified on a setup where Ghostty hook env was missing TERM_PROGRAM:
  - Before: badge shows "Unknown", click-to-jump no-ops.
  - After: badge shows "Ghostty", precise pane jump works.
- [x] Walked through the existing Ghostty / iTerm / Warp paths to confirm the new fallback only triggers when nothing else matched.
- [x] `process_command` matching is case-insensitive (`.lowercased()` once at read).

## Notes

- 12-hop cap on the ancestry walk is deliberate — even a deeply nested `tmux`-inside-`zellij`-inside-`Ghostty` setup is well under that.
- Each `ps` call has the existing `processCommandTimeout` budget inherited from `commandOutput`, so a hung `ps` can't stall the hook longer than a normal env probe would.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Terminal application information is now better preserved during session updates, preventing previously detected terminal identities from being lost or overwritten with incomplete data.
  * Terminal detection now includes enhanced fallback mechanisms to reliably identify the terminal application when standard environment-based detection methods fail or return incomplete results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->