### PR TITLE
fix: reliable Claude Code 2.1+ session-to-process matching

### DIFF
--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -274,8 +274,26 @@ struct ActiveAgentProcessDiscovery {
         let transcriptPath = lsofOutput.flatMap {
             bestClaudeTranscriptPath(in: $0, workingDirectory: workingDirectory)
         }
+        // Claude Code 2.1.x stopped keeping the JSONL transcript file open
+        // (writes are batched then closed), so lsof no longer reports the
+        // `~/.claude/projects/<encoded>/<uuid>.jsonl` path. The CLI still
+        // holds an fd on `~/.claude/tasks/<uuid>/` (the session state
+        // directory), and the trailing UUID is the session ID. Falling
+        // back to that pattern restores the Pass 1 (sessionID) match in
+        // ProcessMonitoringCoordinator and prevents the "session disappears
+        // after a few seconds" symptom.
+        let tasksSessionID = lsofOutput.flatMap {
+            claudeTasksDirSessionID(in: $0)
+        }
         let sessionID = transcriptPath.flatMap(firstUUID(in:))
+            ?? tasksSessionID
             ?? claudeSessionID(from: process.command)
+
+        // Reconstruct the transcript path when only `tasks/` was visible —
+        // Pass 2 (transcriptPath match) and the rename poller both depend
+        // on `claudeMetadata.transcriptPath` being populated.
+        let resolvedTranscriptPath = transcriptPath
+            ?? sessionID.flatMap { reconstructClaudeTranscriptPath(sessionID: $0, cwd: workingDirectory) }
 
         guard workingDirectory != nil || sessionID != nil else {
             return nil
@@ -287,7 +305,7 @@ struct ActiveAgentProcessDiscovery {
             workingDirectory: workingDirectory,
             terminalTTY: process.terminalTTY,
             terminalApp: terminalApp(for: process, processesByPID: processesByPID),
-            transcriptPath: transcriptPath
+            transcriptPath: resolvedTranscriptPath
         )
 
         // If terminalApp is nil and we have a TTY, try to resolve tmux info
@@ -324,6 +342,37 @@ struct ActiveAgentProcessDiscovery {
         }
 
         return paths.first
+    }
+
+    /// Claude Code 2.1+ keeps `~/.claude/tasks/<sessionID>/` open even after
+    /// it closes the JSONL transcript file. The trailing path component is
+    /// the session UUID — extract it as a fallback identifier.
+    private func claudeTasksDirSessionID(in lsofOutput: String) -> String? {
+        for line in lsofOutput.split(whereSeparator: \.isNewline) {
+            guard line.first == "n" else {
+                continue
+            }
+            let value = String(line.dropFirst()).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard value.contains("/.claude/tasks/") else {
+                continue
+            }
+            if let uuid = firstUUID(in: value) {
+                return uuid
+            }
+        }
+        return nil
+    }
+
+    /// Reconstruct `~/.claude/projects/<encoded-cwd>/<sessionID>.jsonl` when
+    /// lsof showed only the `tasks/` directory. The encoding rule used by
+    /// Claude Code is `cwd.replacingOccurrences(of: "/", with: "-")`.
+    private func reconstructClaudeTranscriptPath(sessionID: String, cwd: String?) -> String? {
+        guard let cwd, !cwd.isEmpty else {
+            return nil
+        }
+        let home = NSHomeDirectory()
+        let encodedCWD = cwd.replacingOccurrences(of: "/", with: "-")
+        return "\(home)/.claude/projects/\(encodedCWD)/\(sessionID).jsonl"
     }
 
     private func allMatchingPaths(in lsofOutput: String, containing fragment: String, suffix: String) -> [String] {

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -289,6 +289,12 @@ final class ProcessMonitoringCoordinator {
         let claudeProcesses = activeProcesses.filter { $0.tool == .claudeCode }
         let trackedClaudeSessions = sessions.filter { $0.tool == .claudeCode && !isSyntheticClaudeSession($0) }
         var claimedSessionIDs: Set<String> = []
+        // Track which processes have already been matched. Pass 3's CWD-only
+        // fallback would otherwise re-assign already-matched processes to
+        // unrelated sessions sharing the same cwd, marking stale closed
+        // sessions as alive forever (the "TV-Pine / US-ETF stuck visible"
+        // bug in setups with several Claude sessions in $HOME).
+        var matchedProcessKeys: Set<String> = []
 
         // Pass 1: exact session ID match.
         for process in claudeProcesses {
@@ -298,10 +304,11 @@ final class ProcessMonitoringCoordinator {
                   }) else { continue }
             aliveIDs.insert(matched.id)
             claimedSessionIDs.insert(matched.id)
+            matchedProcessKeys.insert(processIdentityKey(process))
         }
 
         // Pass 2: transcript path match.
-        for process in claudeProcesses {
+        for process in claudeProcesses where !matchedProcessKeys.contains(processIdentityKey(process)) {
             guard let transcriptPath = process.transcriptPath,
                   let matched = trackedClaudeSessions.first(where: {
                       !claimedSessionIDs.contains($0.id)
@@ -309,10 +316,11 @@ final class ProcessMonitoringCoordinator {
                   }) else { continue }
             aliveIDs.insert(matched.id)
             claimedSessionIDs.insert(matched.id)
+            matchedProcessKeys.insert(processIdentityKey(process))
         }
 
         // Pass 3: TTY + CWD fallback match.
-        for process in claudeProcesses {
+        for process in claudeProcesses where !matchedProcessKeys.contains(processIdentityKey(process)) {
             guard let matched = uniqueTrackedClaudeSession(
                 for: process,
                 sessions: trackedClaudeSessions,
@@ -320,6 +328,51 @@ final class ProcessMonitoringCoordinator {
             ) else { continue }
             aliveIDs.insert(matched.id)
             claimedSessionIDs.insert(matched.id)
+            matchedProcessKeys.insert(processIdentityKey(process))
+        }
+
+        // Pass 4: cwd + transcript mtime heuristic.
+        // Claude 2.1+ stops holding fds on `~/.claude/projects/<uuid>.jsonl`
+        // and on `~/.claude/tasks/<uuid>/` while resuming a session
+        // interactively (`claude -r` before the user picks a session). In
+        // that state lsof reports neither path, so Pass 1/2 fail; if
+        // multiple Claude processes share the same cwd, Pass 3 also fails.
+        // For each remaining process, claim the unclaimed session in the
+        // same cwd whose transcript file is most recently mtime-fresh.
+        // This runs LAST so it never overrides an exact-ID match.
+        for process in claudeProcesses where !matchedProcessKeys.contains(processIdentityKey(process)) {
+            guard let cwd = normalizedPathForMatching(process.workingDirectory) else {
+                continue
+            }
+            let cwdCandidates = trackedClaudeSessions.filter { session in
+                guard !claimedSessionIDs.contains(session.id) else { return false }
+                guard let path = session.claudeMetadata?.transcriptPath, !path.isEmpty else {
+                    return false
+                }
+                guard normalizedPathForMatching(session.jumpTarget?.workingDirectory) == cwd else {
+                    return false
+                }
+                return true
+            }
+            // Pick by transcript mtime (real ground truth for "actively
+            // being written"). Fall back to session.updatedAt if mtime
+            // unavailable. Cap to "fresh" (< 5 min) to avoid claiming
+            // stale sessions that happen to share the cwd.
+            let now = Date()
+            let freshness: TimeInterval = 300
+            let scored: [(AgentSession, Date)] = cwdCandidates.compactMap { session in
+                let path = session.claudeMetadata?.transcriptPath
+                let mtime: Date? = path.flatMap {
+                    (try? FileManager.default.attributesOfItem(atPath: $0)[.modificationDate]) as? Date
+                }
+                let stamp = mtime ?? session.updatedAt
+                guard now.timeIntervalSince(stamp) < freshness else { return nil }
+                return (session, stamp)
+            }
+            guard let pick = scored.max(by: { $0.1 < $1.1 })?.0 else { continue }
+            aliveIDs.insert(pick.id)
+            claimedSessionIDs.insert(pick.id)
+            matchedProcessKeys.insert(processIdentityKey(process))
         }
 
         // OpenCode sessions are hook-managed, but OpenCode does not expose a stable
@@ -755,42 +808,86 @@ final class ProcessMonitoringCoordinator {
         var sessions = localState.sessions
         var changed = false
 
-        for process in claudeProcesses {
+        let now = Date()
+        let freshness: TimeInterval = 300
+        let fileManager = FileManager.default
+
+        // Helper: index-by-id lookup so we can mutate by id without breaking
+        // the index after each adoption.
+        func indexOfSession(id: String) -> Int? {
+            sessions.firstIndex(where: { $0.id == id })
+        }
+
+        // Sort processes so signal-rich ones (with `sessionID` extracted from
+        // lsof tasks/UUID) are processed FIRST. Otherwise a same-cwd process
+        // without a sessionID could greedy-grab the freshest session via the
+        // mtime fallback, leaving the rightful owner unmatched.
+        let orderedProcesses = claudeProcesses.sorted { lhs, rhs in
+            (lhs.sessionID != nil ? 0 : 1) < (rhs.sessionID != nil ? 0 : 1)
+        }
+
+        var ttyClaimedSessionIDs: Set<String> = []
+
+        for process in orderedProcesses {
             guard let processTTY = process.terminalTTY, !processTTY.isEmpty else { continue }
             let processCWD = normalizedPathForMatching(process.workingDirectory)
 
-            for index in sessions.indices {
-                let session = sessions[index]
+            // 1) If we know the session ID (Pass-1-equivalent), adopt onto
+            //    that exact session even when its TTY is already set — the
+            //    UUID match is authoritative.
+            if let processSessionID = process.sessionID,
+               let idx = indexOfSession(id: processSessionID),
+               !ttyClaimedSessionIDs.contains(processSessionID),
+               sessions[idx].tool == .claudeCode,
+               !isSyntheticClaudeSession(sessions[idx]),
+               let jt = sessions[idx].jumpTarget,
+               normalizedPathForMatching(jt.workingDirectory) == processCWD,
+               normalizedTTYForMatching(jt.terminalTTY) != normalizedTTYForMatching(processTTY) {
+                sessions[idx].jumpTarget?.terminalTTY = processTTY
+                sessions[idx].attachmentState = .attached
+                sessions[idx].updatedAt = .now
+                ttyClaimedSessionIDs.insert(processSessionID)
+                changed = true
+                continue
+            }
+
+            // 2) No sessionID — fall back to "freshest unclaimed session
+            //    in same cwd whose TTY is still nil and whose transcript
+            //    has been written within the freshness window".
+            struct AdoptionCandidate {
+                let id: String
+                let index: Int
+                let mtime: Date
+            }
+
+            let candidates: [AdoptionCandidate] = sessions.indices.compactMap { idx in
+                let session = sessions[idx]
                 guard session.tool == .claudeCode,
                       !isSyntheticClaudeSession(session),
+                      !ttyClaimedSessionIDs.contains(session.id),
                       let jumpTarget = session.jumpTarget,
                       normalizedPathForMatching(jumpTarget.workingDirectory) == processCWD,
-                      normalizedTTYForMatching(jumpTarget.terminalTTY) != normalizedTTYForMatching(processTTY) else {
-                    continue
+                      normalizedTTYForMatching(jumpTarget.terminalTTY) == nil else {
+                    return nil
                 }
-
-                // Only adopt if no other session already owns this TTY.
-                let ttyAlreadyClaimed = sessions.contains { other in
-                    other.id != session.id
-                        && other.tool == .claudeCode
-                        && normalizedTTYForMatching(other.jumpTarget?.terminalTTY) == normalizedTTYForMatching(processTTY)
+                let path = session.claudeMetadata?.transcriptPath
+                let mtime: Date? = path.flatMap {
+                    (try? fileManager.attributesOfItem(atPath: $0)[.modificationDate]) as? Date
                 }
-                guard !ttyAlreadyClaimed else { continue }
-
-                // Only adopt if no other process has the same cwd and already
-                // matches this session's TTY (would mean a different process owns it).
-                let sessionOwnedByOtherProcess = claudeProcesses.contains { other in
-                    normalizedTTYForMatching(other.terminalTTY) == normalizedTTYForMatching(session.jumpTarget?.terminalTTY)
-                        && normalizedPathForMatching(other.workingDirectory) == processCWD
-                }
-                guard !sessionOwnedByOtherProcess else { continue }
-
-                sessions[index].jumpTarget?.terminalTTY = processTTY
-                sessions[index].attachmentState = .attached
-                sessions[index].updatedAt = .now
-                changed = true
-                break
+                let stamp = mtime ?? session.updatedAt
+                guard now.timeIntervalSince(stamp) < freshness else { return nil }
+                return AdoptionCandidate(id: session.id, index: idx, mtime: stamp)
             }
+
+            guard let pick = candidates.max(by: { $0.mtime < $1.mtime }) else {
+                continue
+            }
+
+            sessions[pick.index].jumpTarget?.terminalTTY = processTTY
+            sessions[pick.index].attachmentState = .attached
+            sessions[pick.index].updatedAt = .now
+            ttyClaimedSessionIDs.insert(pick.id)
+            changed = true
         }
 
         if changed {

--- a/Sources/OpenIslandCore/ClaudeTranscriptDiscovery.swift
+++ b/Sources/OpenIslandCore/ClaudeTranscriptDiscovery.swift
@@ -92,7 +92,12 @@ public final class ClaudeTranscriptDiscovery: @unchecked Sendable {
                 sessionID = value
             }
 
-            if let value = object["cwd"] as? String, !value.isEmpty {
+            // First-wins on cwd: Claude Code records every tool-call's cwd
+            // here, including child workdirs (`cd subdir && cmd`). The
+            // session-startup cwd is what `lsof fcwd` reports for the
+            // actual claude PID, so use the first non-empty entry to keep
+            // process matching consistent across passes.
+            if cwd == nil, let value = object["cwd"] as? String, !value.isEmpty {
                 cwd = value
             }
 


### PR DESCRIPTION
## Problem

With Claude Code 2.1.x and several concurrent Claude sessions sharing a working directory (e.g. multiple `claude` instances launched from `\$HOME`), Open Island shows broken session state:

- **Live sessions disappear**: A real `claude` process is running, but its session ticks to invisible and gets pruned by `removeInvisibleSessions`.
- **Closed sessions stay visible**: Stale sessions from hours ago keep showing as alive (grey dot) and never expire.
- **Wrong session adopts a TTY**: Click-to-jump opens the wrong terminal tab because `adoptProcessTTYsForClaudeSessions` glued the live PID's TTY onto a stale session.

I traced three independent root causes inside the process-matching pipeline.

## Root Causes

### 1. Claude 2.1+ closes the JSONL transcript fd between writes

Claude Code 2.1.x batches transcript writes and closes the fd between them. As a result, `lsof -Fn` on a running `claude` PID **no longer surfaces** the `~/.claude/projects/<encoded-cwd>/<uuid>.jsonl` path that `ActiveAgentProcessDiscovery.bestClaudeTranscriptPath` was relying on for sessionID extraction. Every running PID came back with `sessionID = nil` and `transcriptPath = nil`. Pass 1 (exact session-ID match) and Pass 2 (transcript-path match) in `ProcessMonitoringCoordinator.sessionIDsWithAliveProcesses` therefore failed across the board.

### 2. CWD parsed with last-wins semantics

`ClaudeTranscriptDiscovery.parseSession` recorded `cwd` with last-wins semantics. But Claude Code writes **every tool-call's cwd** to the transcript, including child workdirs from things like `cd subdir && cmd`. The session's `jumpTarget.workingDirectory` therefore drifted into a sub-directory that no longer matches what the kernel reports for the actual `claude` PID via `lsof fcwd`. Every cwd-based matching path silently failed.

### 3. Pass 3 CWD fallback ignored "already matched"

`sessionIDsWithAliveProcesses`'s Pass 3 (TTY+CWD fallback, third form: CWD-only `max-by-updatedAt`) was run for every PID in the loop — including ones already matched by Pass 1 / Pass 2. When multiple Claude sessions share a cwd, an already-matched PID would happily grab another stale session in the same cwd, marking dead sessions alive **forever**. This is what kept TV-Pine / US-ETF style closed sessions on the island indefinitely.

The same class of "first match wins, no per-process gating" bug existed in `adoptProcessTTYsForClaudeSessions`, where the loop adopted the first cwd-matching session it saw — frequently a stale one — and then bailed at the `sessionOwnedByOtherProcess` guard, leaving the actual unmatched live PID's TTY without an adoption target.

## Fix

### `~/.claude/tasks/<UUID>` as a fallback sessionID source
`Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift`
- Claude 2.1+ still holds an fd on `~/.claude/tasks/<sessionID>/` (the session-state directory). Parse the trailing UUID with the existing `firstUUID` helper.
- Reconstruct `~/.claude/projects/<encoded-cwd>/<uuid>.jsonl` from sessionID + cwd so Pass 2 also keeps working.

### First-wins cwd in transcript discovery
`Sources/OpenIslandCore/ClaudeTranscriptDiscovery.swift`
- One-line guard: only set `cwd` if it is currently `nil`.
- Documented the rationale inline (Claude Code's per-tool-call cwd records vs. the session-startup cwd that `lsof fcwd` reports).

### Per-process gating + new Pass 4
`Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift`
- `sessionIDsWithAliveProcesses` now tracks `matchedProcessKeys` across passes. Pass 2, Pass 3, and the new Pass 4 skip processes already matched by an earlier pass.
- **Pass 4 (new)**: for any still-unmatched PID with a known cwd, pick the unclaimed session in the same cwd whose transcript file mtime is the freshest within the last 5 minutes. This is the cleanest signal of "this PID is the one actively writing this transcript". The 5-minute cap is what excludes hours-old stale sessions from accidentally being claimed.
- `adoptProcessTTYsForClaudeSessions` rewritten on the same model: process signal-rich PIDs (with `sessionID` from lsof) first to adopt directly onto the matching session by ID; PIDs without sessionID fall back to "freshest unclaimed mtime in cwd, < 5 min". `ttyClaimedSessionIDs` prevents double-adoption.

## Scope

- **3 files**, +180 / -29 lines
- **No new public APIs**, no schema changes, no new dependencies.
- All changes are inside the existing matching pipeline; observable behavior is purely an improvement (correct PIDs find their sessions, stale sessions correctly tick out).

## Test plan

- [x] `swift build` clean
- [x] Reproduced the original break with three concurrent Claude sessions in `\$HOME`:
  - Before: one or two sessions showed correctly; some lived TV-Pine / US-ETF style sessions stuck visible; click-to-jump occasionally opened the wrong tab.
  - After: all running PIDs map to their correct session, stale sessions disappear within the existing grace window, click-to-jump precisely targets the right iTerm2 tab.
- [x] Verified the `~/.claude/tasks/<UUID>` fd is reliably present on Claude 2.1.119 even between user prompts (the fd that `lsof` shows on the projects/ JSONL is the one that goes away, not this one).
- [x] Verified that adopting onto a session whose `jumpTarget.workingDirectory` was already a sub-directory failed before this PR and now passes.

## Notes

- The 5-minute freshness cap in Pass 4 / `adoptProcessTTYs` is deliberately conservative. Sessions truly idle for > 5 minutes whose only fd is `~/.claude/tasks/<UUID>` (i.e. lsof shows the tasks dir but the transcript hasn't been written recently) will still match via Pass 1 (sessionID), since that fd reliably exists. Pass 4 is only needed for the `claude -r` interactive-resume window where neither path is held.
- Independent of #410 (Unknown-terminal recovery). They touch different functions and either can land first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude process discovery to handle newer Claude Code behavior and edge cases with multiple processes.
  * Enhanced process-to-session matching with deduplication and freshness validation to prevent incorrect attachments.
  * Fixed working directory tracking to use initial startup directory rather than potentially later modified values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->