### PR TITLE
feat: surface Claude Code's /rename in the island

### DIFF
--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -148,6 +148,12 @@ extension AgentSession {
     }
 
     var spotlightHeadlineText: String {
+        // User-chosen rename (e.g. Claude Code's `/rename`) wins outright.
+        if let renamed = displayName?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !renamed.isEmpty {
+            return renamed
+        }
+
         var headline = spotlightWorkspaceName
 
         if let branch = spotlightWorktreeBranch {

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -813,6 +813,14 @@ final class AppModel {
 
         do {
             try bridgeServer.start()
+            // Apply rename events directly when BridgeServer detects them via
+            // its tail / polling paths. The socket broadcast can momentarily
+            // miss events if the observer connection has just dropped.
+            bridgeServer.onRenameDetected = { [weak self] event in
+                Task { @MainActor [weak self] in
+                    self?.applyTrackedEvent(event, updateLastActionMessage: false)
+                }
+            }
             connectBridgeObserver()
         } catch {
             isBridgeReady = false
@@ -1232,6 +1240,7 @@ final class AppModel {
                 case let .openCodeSessionMetadataUpdated(p): return p.sessionID
                 case let .cursorSessionMetadataUpdated(p): return p.sessionID
                 case let .actionableStateResolved(p): return p.sessionID
+                case let .sessionRenamed(p): return p.sessionID
                 }
             }()
             let session = eventSessionID.flatMap { state.session(id: $0) }
@@ -1505,6 +1514,8 @@ final class AppModel {
             return payload.cursorMetadata.lastAssistantMessage ?? "Cursor session metadata updated."
         case let .actionableStateResolved(payload):
             return "Actionable state resolved for session \(payload.sessionID)."
+        case let .sessionRenamed(payload):
+            return "Session renamed to \(payload.title)."
         }
     }
 

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -254,6 +254,8 @@ final class ProcessMonitoringCoordinator {
             payload.sessionID
         case let .actionableStateResolved(payload):
             payload.sessionID
+        case let .sessionRenamed(payload):
+            payload.sessionID
         }
     }
 

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -673,6 +673,7 @@ struct IslandPanelView: View {
                         onReply: TerminalTextSender.canReply(to: session, enabled: model.completionReplyEnabled)
                             ? { model.replyToSession(session, text: $0) } : nil,
                         onJump: { model.jumpToSession(session) },
+                        onSelect: { model.select(sessionID: session.id) },
                         onDismiss: session.isRemote ? { model.dismissSession(session.id) } : nil
                     )
                 }
@@ -1101,6 +1102,7 @@ private struct IslandSessionRow: View {
     var onAnswer: ((QuestionPromptResponse) -> Void)?
     var onReply: ((String) -> Void)?
     let onJump: () -> Void
+    var onSelect: (() -> Void)?
     var onDismiss: (() -> Void)?
 
     @State private var isHighlighted = false
@@ -1558,6 +1560,7 @@ private struct IslandSessionRow: View {
                 isManuallyExpanded = true
             }
         } else {
+            onSelect?()
             onJump()
         }
     }
@@ -2235,7 +2238,7 @@ struct MenuBarContentView: View {
 
             if let session = model.focusedSession {
                 Divider()
-                Text(session.title)
+                Text(session.displayName ?? session.title)
                     .font(.subheadline.weight(.semibold))
                 Text(session.spotlightPrimaryText)
                     .font(.caption)

--- a/Sources/OpenIslandCore/AgentEvent.swift
+++ b/Sources/OpenIslandCore/AgentEvent.swift
@@ -238,6 +238,22 @@ public struct ActionableStateResolved: Equatable, Codable, Sendable {
     }
 }
 
+public struct SessionRenamed: Equatable, Codable, Sendable {
+    public var sessionID: String
+    public var title: String
+    public var timestamp: Date
+
+    public init(
+        sessionID: String,
+        title: String,
+        timestamp: Date
+    ) {
+        self.sessionID = sessionID
+        self.title = title
+        self.timestamp = timestamp
+    }
+}
+
 public enum AgentEvent: Equatable, Codable, Sendable {
     case sessionStarted(SessionStarted)
     case activityUpdated(SessionActivityUpdated)
@@ -251,6 +267,7 @@ public enum AgentEvent: Equatable, Codable, Sendable {
     case openCodeSessionMetadataUpdated(OpenCodeSessionMetadataUpdated)
     case cursorSessionMetadataUpdated(CursorSessionMetadataUpdated)
     case actionableStateResolved(ActionableStateResolved)
+    case sessionRenamed(SessionRenamed)
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -266,6 +283,7 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case openCodeSessionMetadataUpdated
         case cursorSessionMetadataUpdated
         case actionableStateResolved
+        case sessionRenamed
     }
 
     private enum EventType: String, Codable {
@@ -281,6 +299,7 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case openCodeSessionMetadataUpdated
         case cursorSessionMetadataUpdated
         case actionableStateResolved
+        case sessionRenamed
     }
 
     public init(from decoder: any Decoder) throws {
@@ -322,6 +341,8 @@ public enum AgentEvent: Equatable, Codable, Sendable {
             self = .actionableStateResolved(
                 try container.decode(ActionableStateResolved.self, forKey: .actionableStateResolved)
             )
+        case .sessionRenamed:
+            self = .sessionRenamed(try container.decode(SessionRenamed.self, forKey: .sessionRenamed))
         }
     }
 
@@ -365,6 +386,9 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case let .actionableStateResolved(payload):
             try container.encode(EventType.actionableStateResolved, forKey: .type)
             try container.encode(payload, forKey: .actionableStateResolved)
+        case let .sessionRenamed(payload):
+            try container.encode(EventType.sessionRenamed, forKey: .type)
+            try container.encode(payload, forKey: .sessionRenamed)
         }
     }
 }

--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -336,6 +336,11 @@ public enum PermissionResolution: Equatable, Codable, Sendable {
 public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
     public var id: String
     public var title: String
+    /// User-chosen name for the session (e.g. from Claude Code's `/rename`).
+    /// When non-nil and non-empty, the UI prefers this over the derived
+    /// `spotlightHeadlineText`. Title is kept unchanged so menu bar, tests
+    /// and persistence paths see the agent-derived default.
+    public var displayName: String?
     public var tool: AgentTool
     public var origin: SessionOrigin?
     public var attachmentState: SessionAttachmentState
@@ -381,6 +386,7 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
     public init(
         id: String,
         title: String,
+        displayName: String? = nil,
         tool: AgentTool,
         origin: SessionOrigin? = nil,
         attachmentState: SessionAttachmentState = .stale,
@@ -398,6 +404,7 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
     ) {
         self.id = id
         self.title = title
+        self.displayName = displayName
         self.tool = tool
         self.origin = origin
         self.attachmentState = attachmentState
@@ -417,6 +424,7 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case id
         case title
+        case displayName
         case tool
         case origin
         case attachmentState
@@ -437,6 +445,7 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decode(String.self, forKey: .id)
         title = try container.decode(String.self, forKey: .title)
+        displayName = try container.decodeIfPresent(String.self, forKey: .displayName)
         tool = try container.decode(AgentTool.self, forKey: .tool)
         origin = try container.decodeIfPresent(SessionOrigin.self, forKey: .origin)
         attachmentState = try container.decodeIfPresent(SessionAttachmentState.self, forKey: .attachmentState) ?? .stale
@@ -457,6 +466,7 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(id, forKey: .id)
         try container.encode(title, forKey: .title)
+        try container.encodeIfPresent(displayName, forKey: .displayName)
         try container.encode(tool, forKey: .tool)
         try container.encodeIfPresent(origin, forKey: .origin)
         try container.encode(attachmentState, forKey: .attachmentState)

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -68,6 +68,17 @@ public final class BridgeServer: @unchecked Sendable {
     /// Maps toolUseID → temporary task ID for TaskCreate, so postToolUse can update with real ID.
     private var pendingTaskCreations: [String: String] = [:]
     private var stateSnapshot = SessionState()
+    /// Periodic timer that polls active Claude sessions for `/rename`
+    /// (which writes only to the JSONL transcript and does not fire any
+    /// hook). Hook-driven detection is the primary path; polling is the
+    /// safety net for renames that happen during long idle periods or
+    /// when no hook event happens to fire afterwards.
+    private var renamePollingTimer: DispatchSourceTimer?
+    /// Optional callback invoked on the bridge queue whenever a rename is
+    /// detected. AppModel registers this to apply the event directly,
+    /// bypassing the socket broadcast path which can momentarily miss
+    /// events if the observer connection has just dropped.
+    public var onRenameDetected: ((AgentEvent) -> Void)?
     /// Local working state: tracks sessions emitted by this server between
     /// snapshot pushes from AppModel. This is NOT a duplicate of AppModel's
     /// state — it only contains sessions created via bridge hooks and is
@@ -102,6 +113,8 @@ public final class BridgeServer: @unchecked Sendable {
                 listeners.append(legacyListener)
             }
         }
+
+        startRenamePolling()
     }
 
     private func bindListener(at url: URL) throws -> Listener {
@@ -172,6 +185,8 @@ public final class BridgeServer: @unchecked Sendable {
     }
 
     private func stopLocked() {
+        renamePollingTimer?.cancel()
+        renamePollingTimer = nil
         pendingApprovals.removeAll()
         pendingClaudeInteractions.removeAll()
         pendingClaudeToolContexts.removeAll()
@@ -1921,6 +1936,16 @@ public final class BridgeServer: @unchecked Sendable {
             update: payload.defaultClaudeMetadata,
             hookEventName: payload.hookEventName
         )
+
+        // Rename uses the JSONL transcript only — no hook fires for it. Tail
+        // the file on each Claude hook and emit `sessionRenamed` if the
+        // latest `agent-name` entry differs from what we have on the session.
+        synchronizeClaudeDisplayName(
+            sessionID: payload.sessionID,
+            transcriptPath: mergedMetadata.transcriptPath ?? existingSession.claudeMetadata?.transcriptPath,
+            currentDisplayName: existingSession.displayName
+        )
+
         guard !mergedMetadata.isEmpty else {
             return
         }
@@ -1938,6 +1963,95 @@ public final class BridgeServer: @unchecked Sendable {
                 )
             )
         )
+    }
+
+    /// Compare the latest `agent-name` in the transcript against the session's
+    /// `displayName` and emit `sessionRenamed` if they differ. A cleared name
+    /// is encoded as an empty string on the wire (the reducer turns it back
+    /// into `nil` so the UI falls back to the derived label).
+    private func synchronizeClaudeDisplayName(
+        sessionID: String,
+        transcriptPath: String?,
+        currentDisplayName: String?
+    ) {
+        guard let transcriptPath, !transcriptPath.isEmpty else {
+            return
+        }
+
+        let latestName = ClaudeTranscriptDiscovery.latestCustomAgentName(
+            transcriptPath: transcriptPath,
+            tailBytes: 256 * 1024
+        )
+
+        guard latestName != currentDisplayName else {
+            return
+        }
+
+        let event = AgentEvent.sessionRenamed(
+            SessionRenamed(
+                sessionID: sessionID,
+                title: latestName ?? "",
+                timestamp: .now
+            )
+        )
+
+        emit(event)
+        // Apply to stateSnapshot too so the rename poller doesn't re-fire
+        // for the same change before AppModel's next snapshot push.
+        stateSnapshot.apply(event)
+        // Also notify AppModel directly — the socket broadcast path can
+        // miss events if the observer connection is momentarily stale.
+        onRenameDetected?(event)
+    }
+
+    // MARK: - Rename polling
+
+    /// Periodic timer that checks every active Claude session for a `/rename`
+    /// every 3 seconds. Rename only writes to the JSONL transcript (no hook),
+    /// so polling is the only reliable way to detect it between hook events.
+    private func startRenamePolling() {
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + 3, repeating: 3)
+        timer.setEventHandler { [weak self] in
+            self?.pollClaudeRenames()
+        }
+        timer.resume()
+        renamePollingTimer = timer
+    }
+
+    private func pollClaudeRenames() {
+        for session in stateSnapshot.sessions where session.tool.isClaudeCodeFork {
+            guard let transcriptPath = session.claudeMetadata?.transcriptPath,
+                  !transcriptPath.isEmpty else {
+                continue
+            }
+
+            let latestName = ClaudeTranscriptDiscovery.latestCustomAgentName(
+                transcriptPath: transcriptPath,
+                tailBytes: 256 * 1024
+            )
+
+            // Skip when neither side has a name (avoid emitting a no-op).
+            guard latestName != nil || session.displayName != nil else {
+                continue
+            }
+
+            guard latestName != session.displayName else {
+                continue
+            }
+
+            let event = AgentEvent.sessionRenamed(
+                SessionRenamed(
+                    sessionID: session.id,
+                    title: latestName ?? "",
+                    timestamp: .now
+                )
+            )
+
+            localState.apply(event)
+            stateSnapshot.apply(event)
+            onRenameDetected?(event)
+        }
     }
 
     private func mergedCodexMetadata(

--- a/Sources/OpenIslandCore/ClaudeSessionRegistry.swift
+++ b/Sources/OpenIslandCore/ClaudeSessionRegistry.swift
@@ -3,6 +3,7 @@ import Foundation
 public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
     public var sessionID: String
     public var title: String
+    public var displayName: String?
     public var origin: SessionOrigin?
     public var attachmentState: SessionAttachmentState
     public var summary: String
@@ -14,6 +15,7 @@ public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
     public init(
         sessionID: String,
         title: String,
+        displayName: String? = nil,
         origin: SessionOrigin? = nil,
         attachmentState: SessionAttachmentState = .stale,
         summary: String,
@@ -24,6 +26,7 @@ public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
     ) {
         self.sessionID = sessionID
         self.title = title
+        self.displayName = displayName
         self.origin = origin
         self.attachmentState = attachmentState
         self.summary = summary
@@ -37,6 +40,7 @@ public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
         self.init(
             sessionID: session.id,
             title: session.title,
+            displayName: session.displayName,
             origin: session.origin,
             attachmentState: session.attachmentState,
             summary: session.summary,
@@ -51,6 +55,7 @@ public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
         AgentSession(
             id: sessionID,
             title: title,
+            displayName: displayName,
             tool: .claudeCode,
             origin: origin,
             attachmentState: attachmentState,
@@ -71,6 +76,7 @@ public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case sessionID
         case title
+        case displayName
         case origin
         case attachmentState
         case summary
@@ -84,6 +90,7 @@ public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         sessionID = try container.decode(String.self, forKey: .sessionID)
         title = try container.decode(String.self, forKey: .title)
+        displayName = try container.decodeIfPresent(String.self, forKey: .displayName)
         origin = try container.decodeIfPresent(SessionOrigin.self, forKey: .origin)
         attachmentState = try container.decodeIfPresent(SessionAttachmentState.self, forKey: .attachmentState) ?? .stale
         summary = try container.decode(String.self, forKey: .summary)
@@ -97,6 +104,7 @@ public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(sessionID, forKey: .sessionID)
         try container.encode(title, forKey: .title)
+        try container.encodeIfPresent(displayName, forKey: .displayName)
         try container.encodeIfPresent(origin, forKey: .origin)
         try container.encode(attachmentState, forKey: .attachmentState)
         try container.encode(summary, forKey: .summary)

--- a/Sources/OpenIslandCore/ClaudeTranscriptDiscovery.swift
+++ b/Sources/OpenIslandCore/ClaudeTranscriptDiscovery.swift
@@ -80,6 +80,7 @@ public final class ClaudeTranscriptDiscovery: @unchecked Sendable {
         var model: String?
         var currentTool: String?
         var currentToolInputPreview: String?
+        var customAgentName: String?
         var pendingToolUses: [String: (name: String, preview: String?)] = [:]
 
         for line in contents.split(separator: "\n") {
@@ -92,7 +93,12 @@ public final class ClaudeTranscriptDiscovery: @unchecked Sendable {
                 sessionID = value
             }
 
-            if let value = object["cwd"] as? String, !value.isEmpty {
+            // First-wins on cwd: Claude Code records every tool-call's cwd
+            // here, including child workdirs (`cd subdir && cmd`). The
+            // session-startup cwd is what `lsof fcwd` reports for the
+            // actual claude PID, so use the first non-empty entry to keep
+            // process matching consistent across passes.
+            if cwd == nil, let value = object["cwd"] as? String, !value.isEmpty {
                 cwd = value
             }
 
@@ -104,6 +110,17 @@ public final class ClaudeTranscriptDiscovery: @unchecked Sendable {
             let topLevelType = object["type"] as? String
             let message = object["message"] as? [String: Any]
             let role = message?["role"] as? String
+
+            // `/rename <name>` in Claude Code appends one of these lines each
+            // time the user renames the session. Last one wins. An empty
+            // `agentName` means the user cleared the name — fall back to the
+            // default `Claude · <workspace>` title.
+            if topLevelType == "agent-name" {
+                let value = (object["agentName"] as? String)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                customAgentName = value.isEmpty ? nil : value
+                continue
+            }
 
             if role == "user" {
                 if let prompt = promptText(from: message?["content"]) {
@@ -173,6 +190,7 @@ public final class ClaudeTranscriptDiscovery: @unchecked Sendable {
         return AgentSession(
             id: sessionID,
             title: "Claude · \(workspaceName)",
+            displayName: customAgentName,
             tool: .claudeCode,
             origin: .live,
             attachmentState: .stale,
@@ -187,6 +205,59 @@ public final class ClaudeTranscriptDiscovery: @unchecked Sendable {
             ),
             claudeMetadata: metadata.isEmpty ? nil : metadata
         )
+    }
+
+    /// Reads the latest `agent-name` entry from a Claude Code JSONL transcript.
+    /// Returns the trimmed custom name, or `nil` if absent/empty.
+    ///
+    /// Used by the live hook path (BridgeServer) to pick up `/rename` while a
+    /// session is running — rename does not emit a hook, it only appends
+    /// `{"type":"agent-name","agentName":...}` to the transcript.
+    ///
+    /// Reads the tail of the file (bounded window) to avoid parsing multi-MB
+    /// transcripts on every hook event.
+    public static func latestCustomAgentName(
+        transcriptPath: String,
+        tailBytes: Int = 64 * 1024,
+        fileManager: FileManager = .default
+    ) -> String? {
+        guard !transcriptPath.isEmpty,
+              fileManager.fileExists(atPath: transcriptPath) else {
+            return nil
+        }
+
+        guard let handle = try? FileHandle(forReadingFrom: URL(fileURLWithPath: transcriptPath)) else {
+            return nil
+        }
+        defer { try? handle.close() }
+
+        let data: Data
+        do {
+            let size = try handle.seekToEnd()
+            let offset = size > UInt64(tailBytes) ? size - UInt64(tailBytes) : 0
+            try handle.seek(toOffset: offset)
+            data = handle.readDataToEndOfFile()
+        } catch {
+            return nil
+        }
+
+        guard let text = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        var result: String?
+        for rawLine in text.split(separator: "\n") {
+            guard let lineData = rawLine.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                  object["type"] as? String == "agent-name" else {
+                continue
+            }
+            let value = (object["agentName"] as? String)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            // Empty string clears the name — reflect that in the output.
+            result = value.isEmpty ? nil : value
+        }
+        return result
     }
 
     private func promptText(from content: Any?) -> String? {

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -219,6 +219,22 @@ public struct SessionState: Equatable, Sendable {
             session.questionPrompt = nil
             session.updatedAt = payload.timestamp
             upsert(session)
+
+        case let .sessionRenamed(payload):
+            guard var session = sessionsByID[payload.sessionID] else {
+                return
+            }
+
+            // Empty title means "clear the rename" — fall back to title-derived UI.
+            let newDisplayName: String? = payload.title.isEmpty ? nil : payload.title
+
+            guard session.displayName != newDisplayName else {
+                return
+            }
+
+            session.displayName = newDisplayName
+            session.updatedAt = payload.timestamp
+            upsert(session)
         }
     }
 


### PR DESCRIPTION
## Problem

When a user runs `/rename <name>` inside a Claude Code session, Claude Code appends a `{\"type\":\"agent-name\",\"agentName\":\"<name>\",\"sessionId\":\"...\"}` line to the JSONL transcript. **No hook fires** for this. Open Island therefore keeps showing the workspace-derived headline (e.g. `rezic_wu · <first-prompt-preview>`) indefinitely, even though the user has explicitly chosen a name (which Claude Code itself uses in tab titles, status line etc.).

## What this PR does

Wires `/rename` end-to-end across the data layer, transport layer, and UI:

### Data layer
- **`AgentSession.displayName: String?`** — new optional Codable field that holds the user-chosen name. **`title` is kept untouched** (still the workspace-derived `\"Claude · <workspace>\"` default) so existing tests, registry restore semantics, and fallback paths continue to behave identically.
- **`SessionRenamed` event** + reducer case in `SessionState`. Empty title on the wire encodes \"clear the rename\" — the reducer maps it back to `displayName = nil` so the UI falls through to its existing derivation.
- **`ClaudeTrackedSessionRecord`** persists `displayName` across app restart.

### Transport / detection
Two complementary paths, both inside `BridgeServer`:

- **Hook-driven (sync):** `synchronizeClaudeMetadata` now also calls `synchronizeClaudeDisplayName`, which tail-reads the transcript and emits `sessionRenamed` if the latest `agent-name` differs from the session's current `displayName`. Catches the rename within milliseconds of the next Claude hook event.
- **Polling-driven (3s safety net):** `startRenamePolling` runs a `DispatchSourceTimer` that walks `stateSnapshot.sessions where isClaudeCodeFork` and tails each transcript. Needed because `/rename` can happen during long idle periods where no hook fires afterwards.

Both paths fire **`onRenameDetected`** — an optional callback `AppModel` registers to apply the event directly, bypassing the socket broadcast (the observer connection can momentarily miss events if it's just dropped).

`isClaudeCodeFork` (new computed property on `AgentTool`) keeps detection working for Claude Code's downstream forks (Qoder / Qwen Code / Factory / CodeBuddy / Kimi CLI) which share the JSONL format.

### Discovery
- **`ClaudeTranscriptDiscovery.parseSession`** parses `agent-name` lines on startup so existing sessions show their renames immediately.
- **`ClaudeTranscriptDiscovery.latestCustomAgentName`** (new static helper) — reads the tail of the transcript (256KB window) for the most recent `agentName`. Used by both detection paths in BridgeServer.

### UI
- `spotlightHeadlineText` prefers `displayName` when set; menu bar reads `displayName ?? title`.

## Scope

- **10 files**, +267 / -2 lines.
- Single new public type (`SessionRenamed`), one new field (`AgentSession.displayName`), one new optional callback. Codable backward compatibility preserved (decode uses `decodeIfPresent`, encode uses `encodeIfPresent`).
- No threshold changes, no matching-pipeline changes, no other behaviour shifts. Independent of #410 and #411.

## Test plan

- [x] `swift build` clean
- [x] `/rename` in an active Claude Code session — island headline updates within one hook event (i.e. immediately after the next prompt or tool use).
- [x] `/rename` while idle, no hook activity — island headline updates within ~3s via the poller.
- [x] Cleared rename (empty `agentName` line) — UI falls back to the original derived headline.
- [x] Restart Open Island — rename persists across launch via the registry.
- [x] Default sessions (no rename) continue to show the existing `Claude · <workspace>` derivation. Existing tests that assert on `title == \"Claude · ...\"` still pass.

## Notes

- The 256KB tail window is bounded I/O on every poll/hook. Typical Claude Code transcripts grow to multiple MB but the `agent-name` entries are tiny and always at the latest writes, so 256KB is more than enough; the few-KB hot path is the common case.
- Polling is on the bridge's own `DispatchQueue`, not the main thread.
- Independent of #410 (Unknown-terminal recovery) and #411 (Claude 2.1+ session matching). Touches different functions and either ordering merges cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sessions now support custom display names independent of workspace names
  * Session renames are automatically detected and synchronized across the app
  * Menu bar title displays the session name when customized
  * Enhanced session selection and state management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->