### PR TITLE
fix: register openWindow from MenuBarExtra label to fix settings not opening

### DIFF
--- a/Sources/OpenIslandApp/OpenIslandApp.swift
+++ b/Sources/OpenIslandApp/OpenIslandApp.swift
@@ -128,14 +128,32 @@ struct OpenIslandApp: App {
         } label: {
             OpenIslandBrandMark(size: 18, style: .template)
                 .accessibilityLabel("Open Island")
+                .background(SettingsOpenerRegistrar(model: appDelegate.model))
         }
         .menuBarExtraStyle(.window)
     }
 }
 
-/// Injects the SwiftUI `openWindow` action into `AppModel` so that
-/// `model.showSettings()` can materialize the window even if it has
-/// never been shown before (SwiftUI `Window` scenes are lazy).
+/// Registers `openWindow` into `AppModel` from the MenuBarExtra label,
+/// which is always rendered at app startup — guaranteeing that
+/// `model.showSettings()` works even before the settings window has
+/// ever been opened.
+private struct SettingsOpenerRegistrar: View {
+    var model: AppModel
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        Color.clear
+            .onAppear {
+                model.openSettingsWindow = { [openWindow] in
+                    openWindow(id: "settings")
+                }
+            }
+    }
+}
+
+/// Refreshes the `openWindow` registration each time the settings
+/// window opens, keeping the closure current after window recreation.
 private struct SettingsWindowContent: View {
     var model: AppModel
     @Environment(\.openWindow) private var openWindow


### PR DESCRIPTION
## 问题

macOS 设置页面（点击齿轮图标或 ⌘,）在 app 启动后首次点击时无响应。

**根本原因：** `model.openSettingsWindow` 是一个存储了 SwiftUI `openWindow` action 的闭包，只在 `SettingsWindowContent.onAppear` 里赋值。但 `hideAllAppWindows()` 在 launch 时会立即隐藏设置窗口，导致 `onAppear` 永远不触发，闭包始终为 nil。

## 修法

在 `MenuBarExtra` 的 label 视图（菜单栏图标，app 启动即渲染）上挂一个 `SettingsOpenerRegistrar` 背景视图。该视图的 `onAppear` 在启动时立即触发，将 `openWindow` 注册到 `model.openSettingsWindow`，确保从第一次点击起就能正常打开设置。

保留了 `SettingsWindowContent.onAppear` 中的原有注册，作为每次设置窗口打开时刷新闭包的机制。

## 测试

- [ ] 冷启动 app 后，直接点击 island 齿轮按钮 → 设置窗口正常打开
- [ ] ⌘, 快捷键仍然有效
- [ ] 设置窗口关闭后再次打开正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Redesigned settings window opening mechanism to ensure reliable startup registration and operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->