### PR TITLE
fix: surface "Open Island hooks not installed" in diagnostics

### DIFF
--- a/Sources/OpenIslandCore/HookHealthCheck.swift
+++ b/Sources/OpenIslandCore/HookHealthCheck.swift
@@ -130,6 +130,7 @@ public enum HookHealthCheck {
         // 2. Check config file
         let settingsPath = settingsURL.path
         var configMalformed = false
+        var configReadFailed = false
         if fileManager.fileExists(atPath: settingsPath) {
             if let data = try? Data(contentsOf: settingsURL) {
                 // Check JSON validity
@@ -155,18 +156,26 @@ public enum HookHealthCheck {
                         issues.append(.otherHooksDetected(names: otherNames.sorted()))
                     }
                 }
+            } else {
+                // File exists but couldn't be read (permissions / IO error).
+                // Don't trust subsequent re-reads of the file, and don't claim
+                // "not installed" when we genuinely don't know what's there.
+                configReadFailed = true
             }
         }
 
         // 3. Detect missing Open Island installation. The presence of the
         // .claude directory is a strong signal that the user runs Claude
         // Code; if our hooks aren't there we should surface it as an error
-        // rather than silently reporting "all healthy".
+        // rather than silently reporting "all healthy". Suppress when the
+        // config couldn't be read or parsed — those failures shouldn't
+        // masquerade as "not installed".
         let claudeDirExists = fileManager.fileExists(atPath: claudeDirectory.path)
-        let openIslandInstalled = !configMalformed
+        let configUntrusted = configMalformed || configReadFailed
+        let openIslandInstalled = !configUntrusted
             && fileManager.fileExists(atPath: settingsPath)
             && hasOpenIslandHooks(in: settingsURL, fileManager: fileManager)
-        if claudeDirExists && !openIslandInstalled && !configMalformed {
+        if claudeDirExists && !openIslandInstalled && !configUntrusted {
             issues.append(.notInstalled(configPath: settingsPath))
         }
 
@@ -215,6 +224,7 @@ public enum HookHealthCheck {
         // 2. Check config file
         let hooksPath = hooksURL.path
         var configMalformed = false
+        var configReadFailed = false
         if fileManager.fileExists(atPath: hooksPath) {
             if let data = try? Data(contentsOf: hooksURL) {
                 if (try? JSONSerialization.jsonObject(with: data)) == nil {
@@ -231,16 +241,19 @@ public enum HookHealthCheck {
                         issues.append(.otherHooksDetected(names: otherNames.sorted()))
                     }
                 }
+            } else {
+                configReadFailed = true
             }
         }
 
         // 3. Detect missing Open Island installation. See the analogous
         // block in checkClaude for the rationale.
         let codexDirExists = fileManager.fileExists(atPath: codexDirectory.path)
-        let openIslandInstalled = !configMalformed
+        let configUntrusted = configMalformed || configReadFailed
+        let openIslandInstalled = !configUntrusted
             && fileManager.fileExists(atPath: hooksPath)
             && hasOpenIslandHooks(in: hooksURL, fileManager: fileManager)
-        if codexDirExists && !openIslandInstalled && !configMalformed {
+        if codexDirExists && !openIslandInstalled && !configUntrusted {
             issues.append(.notInstalled(configPath: hooksPath))
         }
 

--- a/Sources/OpenIslandCore/HookHealthCheck.swift
+++ b/Sources/OpenIslandCore/HookHealthCheck.swift
@@ -24,6 +24,9 @@ public struct HookHealthReport: Equatable, Sendable {
         case manifestMissing(expectedPath: String)
         /// The OpenCode plugin file is missing even though it should be installed.
         case pluginMissing(expectedPath: String)
+        /// The agent appears to be installed (config dir or settings file exists), but no
+        /// Open Island managed hooks are present in its config — events won't be received.
+        case notInstalled(configPath: String)
 
         public var description: String {
             switch self {
@@ -41,6 +44,8 @@ public struct HookHealthReport: Equatable, Sendable {
                 "Installation manifest missing: \(expectedPath)"
             case .pluginMissing(let expectedPath):
                 "OpenCode plugin file is missing: \(expectedPath)"
+            case .notInstalled(let configPath):
+                "Open Island hooks are not installed in \(configPath) — events won't be received."
             }
         }
 
@@ -55,7 +60,7 @@ public struct HookHealthReport: Equatable, Sendable {
 
         public var isAutoRepairable: Bool {
             switch self {
-            case .staleCommandPath, .binaryNotExecutable, .manifestMissing, .pluginMissing:
+            case .staleCommandPath, .binaryNotExecutable, .manifestMissing, .pluginMissing, .notInstalled:
                 true
             default:
                 false
@@ -124,11 +129,13 @@ public enum HookHealthCheck {
 
         // 2. Check config file
         let settingsPath = settingsURL.path
+        var configMalformed = false
         if fileManager.fileExists(atPath: settingsPath) {
             if let data = try? Data(contentsOf: settingsURL) {
                 // Check JSON validity
                 if (try? JSONSerialization.jsonObject(with: data)) == nil {
                     issues.append(.configMalformedJSON(path: settingsPath))
+                    configMalformed = true
                 } else {
                     // Check command paths in hooks
                     let staleCommands = findStaleCommandPaths(
@@ -151,9 +158,20 @@ public enum HookHealthCheck {
             }
         }
 
-        // 3. Check manifest
-        if fileManager.fileExists(atPath: settingsPath),
-           hasOpenIslandHooks(in: settingsURL, fileManager: fileManager) {
+        // 3. Detect missing Open Island installation. The presence of the
+        // .claude directory is a strong signal that the user runs Claude
+        // Code; if our hooks aren't there we should surface it as an error
+        // rather than silently reporting "all healthy".
+        let claudeDirExists = fileManager.fileExists(atPath: claudeDirectory.path)
+        let openIslandInstalled = !configMalformed
+            && fileManager.fileExists(atPath: settingsPath)
+            && hasOpenIslandHooks(in: settingsURL, fileManager: fileManager)
+        if claudeDirExists && !openIslandInstalled && !configMalformed {
+            issues.append(.notInstalled(configPath: settingsPath))
+        }
+
+        // 4. Check manifest
+        if openIslandInstalled {
             let legacyManifestURL = claudeDirectory.appendingPathComponent(ClaudeHookInstallerManifest.legacyFileName)
             if !fileManager.fileExists(atPath: manifestURL.path) && !fileManager.fileExists(atPath: legacyManifestURL.path) {
                 issues.append(.manifestMissing(expectedPath: manifestURL.path))
@@ -196,10 +214,12 @@ public enum HookHealthCheck {
 
         // 2. Check config file
         let hooksPath = hooksURL.path
+        var configMalformed = false
         if fileManager.fileExists(atPath: hooksPath) {
             if let data = try? Data(contentsOf: hooksURL) {
                 if (try? JSONSerialization.jsonObject(with: data)) == nil {
                     issues.append(.configMalformedJSON(path: hooksPath))
+                    configMalformed = true
                 } else {
                     let staleCommands = findStaleCommandPaths(in: data, fileManager: fileManager)
                     for cmd in staleCommands {
@@ -214,9 +234,18 @@ public enum HookHealthCheck {
             }
         }
 
-        // 3. Check manifest
-        if fileManager.fileExists(atPath: hooksPath),
-           hasOpenIslandHooks(in: hooksURL, fileManager: fileManager) {
+        // 3. Detect missing Open Island installation. See the analogous
+        // block in checkClaude for the rationale.
+        let codexDirExists = fileManager.fileExists(atPath: codexDirectory.path)
+        let openIslandInstalled = !configMalformed
+            && fileManager.fileExists(atPath: hooksPath)
+            && hasOpenIslandHooks(in: hooksURL, fileManager: fileManager)
+        if codexDirExists && !openIslandInstalled && !configMalformed {
+            issues.append(.notInstalled(configPath: hooksPath))
+        }
+
+        // 4. Check manifest
+        if openIslandInstalled {
             let legacyManifestURL = codexDirectory.appendingPathComponent(CodexHookInstallerManifest.legacyFileName)
             if !fileManager.fileExists(atPath: manifestURL.path) && !fileManager.fileExists(atPath: legacyManifestURL.path) {
                 issues.append(.manifestMissing(expectedPath: manifestURL.path))

--- a/Tests/OpenIslandCoreTests/HookHealthCheckTests.swift
+++ b/Tests/OpenIslandCoreTests/HookHealthCheckTests.swift
@@ -1,0 +1,223 @@
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+struct HookHealthCheckTests {
+    // MARK: - Claude
+
+    @Test
+    func claudeReportsNotInstalledWhenConfigHasOnlyThirdPartyHooks() throws {
+        let env = try TempEnv()
+        defer { env.cleanup() }
+
+        try env.writeBinary("OpenIslandHooks", at: env.binaryURL)
+        try env.writeJSON([
+            "hooks": [
+                "Stop": [
+                    [
+                        "hooks": [
+                            ["type": "command", "command": "$HOME/.vibe-island/bin/vibe-island-bridge --source claude"],
+                        ],
+                    ],
+                ],
+            ],
+        ], at: env.claudeSettingsURL)
+
+        let report = HookHealthCheck.checkClaude(
+            claudeDirectory: env.claudeDirURL,
+            hooksBinaryURL: env.binaryURL,
+            managedHooksBinaryURL: env.binaryURL
+        )
+
+        #expect(report.errors.contains { issue in
+            if case .notInstalled = issue { return true }
+            return false
+        })
+        #expect(!report.isHealthy)
+    }
+
+    @Test
+    func claudeReportsNotInstalledWhenSettingsMissingButDirExists() throws {
+        let env = try TempEnv()
+        defer { env.cleanup() }
+
+        try env.writeBinary("OpenIslandHooks", at: env.binaryURL)
+        // Create only the .claude directory, no settings.json.
+
+        let report = HookHealthCheck.checkClaude(
+            claudeDirectory: env.claudeDirURL,
+            hooksBinaryURL: env.binaryURL,
+            managedHooksBinaryURL: env.binaryURL
+        )
+
+        #expect(report.errors.contains { issue in
+            if case .notInstalled = issue { return true }
+            return false
+        })
+    }
+
+    @Test
+    func claudeIsHealthyWhenOpenIslandHooksPresent() throws {
+        let env = try TempEnv()
+        defer { env.cleanup() }
+
+        try env.writeBinary("OpenIslandHooks", at: env.binaryURL)
+        try env.writeJSON([
+            "hooks": [
+                "Stop": [
+                    [
+                        "hooks": [
+                            ["type": "command", "command": "'\(env.binaryURL.path)' --source claude"],
+                        ],
+                    ],
+                ],
+            ],
+        ], at: env.claudeSettingsURL)
+        // A manifest must exist or a .manifestMissing issue would fire — but
+        // that's not the focus of this test, so write a minimal one.
+        try env.writeJSON(["version": 1], at: env.claudeManifestURL)
+
+        let report = HookHealthCheck.checkClaude(
+            claudeDirectory: env.claudeDirURL,
+            hooksBinaryURL: env.binaryURL,
+            managedHooksBinaryURL: env.binaryURL
+        )
+
+        #expect(report.isHealthy, "Expected healthy report; got issues: \(report.issues)")
+        #expect(!report.errors.contains { issue in
+            if case .notInstalled = issue { return true }
+            return false
+        })
+    }
+
+    @Test
+    func claudeSkipsNotInstalledWhenConfigDirAbsent() throws {
+        let env = try TempEnv(createConfigDirs: false)
+        defer { env.cleanup() }
+
+        try env.writeBinary("OpenIslandHooks", at: env.binaryURL)
+
+        let report = HookHealthCheck.checkClaude(
+            claudeDirectory: env.claudeDirURL,
+            hooksBinaryURL: env.binaryURL,
+            managedHooksBinaryURL: env.binaryURL
+        )
+
+        #expect(!report.errors.contains { issue in
+            if case .notInstalled = issue { return true }
+            return false
+        }, "Should not nag users who aren't running Claude Code at all")
+    }
+
+    @Test
+    func claudeSkipsNotInstalledWhenConfigMalformed() throws {
+        let env = try TempEnv()
+        defer { env.cleanup() }
+
+        try env.writeBinary("OpenIslandHooks", at: env.binaryURL)
+        try Data("{ this is not json".utf8).write(to: env.claudeSettingsURL)
+
+        let report = HookHealthCheck.checkClaude(
+            claudeDirectory: env.claudeDirURL,
+            hooksBinaryURL: env.binaryURL,
+            managedHooksBinaryURL: env.binaryURL
+        )
+
+        #expect(report.errors.contains { issue in
+            if case .configMalformedJSON = issue { return true }
+            return false
+        })
+        // Don't pile on a confusing notInstalled when we couldn't even parse the file.
+        #expect(!report.errors.contains { issue in
+            if case .notInstalled = issue { return true }
+            return false
+        })
+    }
+
+    // MARK: - Codex
+
+    @Test
+    func codexReportsNotInstalledWhenConfigDirExistsWithoutOurHooks() throws {
+        let env = try TempEnv()
+        defer { env.cleanup() }
+
+        try env.writeBinary("OpenIslandHooks", at: env.binaryURL)
+        try env.writeJSON([
+            "hooks": [
+                "Stop": [
+                    [
+                        "hooks": [
+                            ["type": "command", "command": "/some/other/binary"],
+                        ],
+                    ],
+                ],
+            ],
+        ], at: env.codexHooksURL)
+
+        let report = HookHealthCheck.checkCodex(
+            codexDirectory: env.codexDirURL,
+            hooksBinaryURL: env.binaryURL,
+            managedHooksBinaryURL: env.binaryURL
+        )
+
+        #expect(report.errors.contains { issue in
+            if case .notInstalled = issue { return true }
+            return false
+        })
+    }
+
+    // MARK: - Issue properties
+
+    @Test
+    func notInstalledIssueIsErrorAndAutoRepairable() {
+        let issue = HookHealthReport.Issue.notInstalled(configPath: "/x/y")
+        #expect(issue.severity == .error)
+        #expect(issue.isAutoRepairable)
+    }
+}
+
+// MARK: - Test fixtures
+
+private struct TempEnv {
+    let rootURL: URL
+    let claudeDirURL: URL
+    let codexDirURL: URL
+    let binaryURL: URL
+
+    var claudeSettingsURL: URL { claudeDirURL.appendingPathComponent("settings.json") }
+    var claudeManifestURL: URL { claudeDirURL.appendingPathComponent(ClaudeHookInstallerManifest.fileName) }
+    var codexHooksURL: URL { codexDirURL.appendingPathComponent("hooks.json") }
+
+    init(createConfigDirs: Bool = true) throws {
+        let fm = FileManager.default
+        rootURL = fm.temporaryDirectory.appendingPathComponent("OpenIslandHookHealthCheckTests-\(UUID().uuidString)", isDirectory: true)
+        claudeDirURL = rootURL.appendingPathComponent(".claude", isDirectory: true)
+        codexDirURL = rootURL.appendingPathComponent(".codex", isDirectory: true)
+        binaryURL = rootURL.appendingPathComponent("bin/OpenIslandHooks")
+
+        try fm.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        try fm.createDirectory(at: binaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        if createConfigDirs {
+            try fm.createDirectory(at: claudeDirURL, withIntermediateDirectories: true)
+            try fm.createDirectory(at: codexDirURL, withIntermediateDirectories: true)
+        }
+    }
+
+    func writeBinary(_ name: String, at url: URL) throws {
+        let fm = FileManager.default
+        try fm.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("#!/bin/sh\nexit 0\n".utf8).write(to: url)
+        try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+    }
+
+    func writeJSON(_ object: Any, at url: URL) throws {
+        let fm = FileManager.default
+        try fm.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let data = try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted])
+        try data.write(to: url)
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: rootURL)
+    }
+}

--- a/Tests/OpenIslandCoreTests/HookHealthCheckTests.swift
+++ b/Tests/OpenIslandCoreTests/HookHealthCheckTests.swift
@@ -110,6 +110,41 @@ struct HookHealthCheckTests {
     }
 
     @Test
+    func claudeSkipsNotInstalledWhenSettingsFileUnreadable() throws {
+        // Regression for CodeRabbit's review on PR #426: a permissions / IO
+        // failure on settings.json should not silently degrade to
+        // ".notInstalled" — that would hide the real problem.
+        let env = try TempEnv()
+        defer { env.cleanup() }
+
+        try env.writeBinary("OpenIslandHooks", at: env.binaryURL)
+        try env.writeJSON(["hooks": [String: Any]()], at: env.claudeSettingsURL)
+
+        let fm = FileManager.default
+        try fm.setAttributes([.posixPermissions: 0o000], ofItemAtPath: env.claudeSettingsURL.path)
+        defer {
+            try? fm.setAttributes([.posixPermissions: 0o644], ofItemAtPath: env.claudeSettingsURL.path)
+        }
+
+        // Sanity: skip the test if running as root, where chmod 000 doesn't
+        // actually deny reads (CI / sandboxed environments are typically not root).
+        guard (try? Data(contentsOf: env.claudeSettingsURL)) == nil else {
+            return
+        }
+
+        let report = HookHealthCheck.checkClaude(
+            claudeDirectory: env.claudeDirURL,
+            hooksBinaryURL: env.binaryURL,
+            managedHooksBinaryURL: env.binaryURL
+        )
+
+        #expect(!report.errors.contains { issue in
+            if case .notInstalled = issue { return true }
+            return false
+        }, "Unreadable config should not be reported as 'not installed'")
+    }
+
+    @Test
     func claudeSkipsNotInstalledWhenConfigMalformed() throws {
         let env = try TempEnv()
         defer { env.cleanup() }


### PR DESCRIPTION
## Summary

The Control Center's **Hooks 诊断 / Hook diagnostics** panel reports "All hooks are healthy" / "所有 Hooks 运行正常" even when **no Open Island hook entries are wired into the agent's config file**. The diagnostic only verifies:

1. ✅ Open Island's own hook *binary* exists at `~/Library/Application Support/OpenIsland/bin/OpenIslandHooks`
2. ✅ `~/.claude/settings.json` (or `~/.codex/hooks.json`) is valid JSON
3. ⓘ Detects third-party hook commands — but flags them only as `.info` severity

It never asks the question: *"is there actually a hook entry that calls our binary?"* So a user with `settings.json` containing only legacy / third-party / forked-product hooks (and no Open Island entry) sees a green checkmark while `Stop`, `SessionEnd`, etc. fire into the void. Sessions appear permanently "running" in the island, which makes the product look broken even though the rest of the integration is fine.

I hit this exact false-positive while testing this dev branch on a machine that previously had a forked product installed: the diagnostic reported all green, but the dev app received zero hook events.

## Fix

`Sources/OpenIslandCore/HookHealthCheck.swift`:

- New `Issue.notInstalled(configPath:)` case
  - `severity = .error`
  - `isAutoRepairable = true` → the existing **Repair** button reinstalls hooks, fixing it in one click
- Emitted from `checkClaude` and `checkCodex` when the agent's config directory exists *and* `hasOpenIslandHooks(...)` returns false
- Suppressed when the config file is malformed JSON (already covered by `.configMalformedJSON`, no need to pile on)
- Suppressed when the agent's config directory doesn't exist (don't nag users who aren't running that agent)

OpenCode already has the analogous `.pluginMissing` issue and is unchanged.

## Test plan

- [x] `swift build` succeeds
- [x] `swift test` — full suite passes (229 tests, 25 suites)
- [x] New `HookHealthCheckTests` (7 tests) covers:
  - third-party-only hooks → `.notInstalled` reported
  - `settings.json` missing but `~/.claude/` exists → `.notInstalled` reported
  - Open Island hooks correctly installed → healthy
  - no `~/.claude/` directory at all → no `.notInstalled` (don't nag)
  - malformed JSON → only `.configMalformedJSON` (no `.notInstalled` pile-on)
  - Codex variant → `.notInstalled` reported when only foreign hooks present
  - `Issue.notInstalled` properties: severity = error, isAutoRepairable = true
- [x] Manual UI verification of the new state in Control Center is covered by existing render paths (`issue.description` is rendered as-is by both `SettingsView.issueList` and `ControlCenterView`); no UI-string code changes required.

## Notes

- No new public API on `HookHealthReport` other than the new enum case.
- Existing call sites that switch over `Issue` will get a compile error if exhaustive — checked: no exhaustive switches over `Issue` exist outside the enum's own `description` / `severity` / `isAutoRepairable` properties, all updated.
- The new check is conservative: it only reports `.notInstalled` when we have positive evidence the agent is in use (its config directory is present), so first-time users who don't run Claude Code / Codex won't see false alarms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved health diagnostics to report a new "not installed" hook state and offer automatic repair when hooks are missing.
  * Detection refined to avoid reporting missing hooks when configuration files are unreadable or malformed.

* **Tests**
  * Added comprehensive tests covering various installation, unreadable/malformed config, and healthy scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->