### PR TITLE
debug: add ApprovalFlashDebug logs to trace approval-card auto-dismiss

### DIFF
--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -2,10 +2,13 @@ import AppKit
 import Foundation
 import Observation
 import OpenIslandCore
+import os
 
 @MainActor
 @Observable
 final class OverlayUICoordinator {
+
+    private static let approvalFlashLogger = Logger(subsystem: "app.openisland", category: "ApprovalFlashDebug")
 
     private static let notificationSurfaceAutoCollapseDelay: TimeInterval = 10
 
@@ -302,6 +305,7 @@ final class OverlayUICoordinator {
             return
         }
 
+        Self.approvalFlashLogger.info("[FLASH] presentNotificationSurface session=\(surface.sessionID ?? "nil", privacy: .public)")
         NotificationSoundService.playNotification(isMuted: isSoundMuted)
         notchOpen(reason: .notification, surface: surface)
     }
@@ -313,9 +317,13 @@ final class OverlayUICoordinator {
 
         let session = activeIslandCardSession
         guard islandSurface.matchesCurrentState(of: session) else {
+            let phaseDesc = session.map { String(describing: $0.phase) } ?? "no-session"
+            let hasPermission = session?.permissionRequest != nil
             if notchOpenReason == .notification {
+                Self.approvalFlashLogger.warning("[FLASH] reconcile → notchClose: surface session=\(self.islandSurface.sessionID ?? "nil", privacy: .public) phase=\(phaseDesc, privacy: .public) hasPermission=\(hasPermission)")
                 notchClose()
             } else {
+                Self.approvalFlashLogger.warning("[FLASH] reconcile → reset to sessionList (reason=\(String(describing: self.notchOpenReason), privacy: .public))")
                 islandSurface = .sessionList()
             }
             return

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -1,8 +1,11 @@
 import Dispatch
 import Darwin
 import Foundation
+import os
 
 public final class BridgeServer: @unchecked Sendable {
+    private static let approvalFlashLogger = Logger(subsystem: "app.openisland", category: "ApprovalFlashDebug")
+
     private struct ClientConnection {
         let id: UUID
         let fileDescriptor: Int32
@@ -691,6 +694,7 @@ public final class BridgeServer: @unchecked Sendable {
                     clientID: clientID,
                     kind: .permission(payload)
                 )
+                Self.approvalFlashLogger.info("[FLASH] Claude permission registered for session \(payload.sessionID, privacy: .public) (clientID=\(clientID.uuidString, privacy: .public)) tool=\(payload.toolName ?? "?", privacy: .public)")
             }
 
         case .postToolUse:
@@ -2482,6 +2486,7 @@ public final class BridgeServer: @unchecked Sendable {
 
         for sessionID in pendingClaudeSessionIDs {
             pendingClaudeInteractions.removeValue(forKey: sessionID)
+            Self.approvalFlashLogger.warning("[FLASH] Claude hook disconnected — emitting actionableStateResolved for session \(sessionID, privacy: .public) (clientID=\(clientID.uuidString, privacy: .public))")
             emit(
                 .actionableStateResolved(
                     ActionableStateResolved(
@@ -2500,6 +2505,7 @@ public final class BridgeServer: @unchecked Sendable {
 
         for sessionID in pendingOpenCodeSessionIDs {
             pendingOpenCodeInteractions.removeValue(forKey: sessionID)
+            Self.approvalFlashLogger.warning("[FLASH] OpenCode plugin disconnected — emitting actionableStateResolved for session \(sessionID, privacy: .public)")
             emit(
                 .actionableStateResolved(
                     ActionableStateResolved(
@@ -2518,6 +2524,7 @@ public final class BridgeServer: @unchecked Sendable {
 
         for sessionID in pendingCursorSessionIDs {
             pendingCursorInteractions.removeValue(forKey: sessionID)
+            Self.approvalFlashLogger.warning("[FLASH] Cursor hook disconnected — emitting actionableStateResolved for session \(sessionID, privacy: .public)")
             emit(
                 .actionableStateResolved(
                     ActionableStateResolved(

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -1,4 +1,7 @@
 import Foundation
+import os
+
+private let approvalFlashStateLogger = Logger(subsystem: "app.openisland", category: "ApprovalFlashDebug")
 
 public struct SessionState: Equatable, Sendable {
     public private(set) var sessionsByID: [String: AgentSession]
@@ -97,6 +100,9 @@ public struct SessionState: Equatable, Sendable {
             let preservesActionableState = keepsPendingApproval || keepsPendingQuestion
 
             if !preservesActionableState {
+                if session.permissionRequest != nil && payload.phase != .waitingForApproval {
+                    approvalFlashStateLogger.warning("[FLASH] activityUpdated clearing permissionRequest for session \(payload.sessionID, privacy: .public) — newPhase=\(String(describing: payload.phase), privacy: .public)")
+                }
                 session.phase = payload.phase
                 session.summary = payload.summary
                 if payload.phase != .waitingForApproval {
@@ -213,6 +219,7 @@ public struct SessionState: Equatable, Sendable {
                 return
             }
 
+            approvalFlashStateLogger.warning("[FLASH] actionableStateResolved clearing permission/question for session \(payload.sessionID, privacy: .public) — wasPhase=\(String(describing: session.phase), privacy: .public) summary=\(payload.summary, privacy: .public)")
             session.phase = .running
             session.summary = payload.summary
             session.permissionRequest = nil


### PR DESCRIPTION
## Summary
- Adds `os_log` instrumentation under subsystem `app.openisland`, category `ApprovalFlashDebug`, at the three points that together cause the approval/permission card to "弹一下就消失" (flash and hide).
- No behavioral changes — diagnostic only, intended to land before a follow-up fix so we can confirm which path triggers in real Claude/OpenCode/Cursor sessions.

## What's logged
- `BridgeServer.removeClient` → when a hook socket disconnects with a pending Claude/OpenCode/Cursor interaction, before the bridge auto-emits `actionableStateResolved`.
- `SessionState.apply` → when `actionableStateResolved` or `activityUpdated` clears a session's `permissionRequest`.
- `OverlayUICoordinator.reconcileIslandSurfaceAfterStateChange` → when the notification surface no longer matches state and `notchClose()` is forced (with current phase + whether `permissionRequest` is still set).

## Reproduction (verified locally)
A throwaway in-process probe (`OpenIslandFlashProbe`, not included in this PR) drove the bridge end-to-end:
1. Open observer client.
2. Send `processClaudeHook(.permissionRequest)` over a raw socket.
3. Close the socket without waiting for a directive (simulating hook timeout / agent cancel / hook crash).

Observer received: `permissionRequested` → `actionableStateResolved(summary: "Hook process disconnected.")` ⇒ `state.apply` clears `permissionRequest` ⇒ reconcile fires `notchClose()`. Both new os_log warnings fire as expected.

## How to capture in dev
```
/usr/bin/log stream --predicate 'subsystem == "app.openisland" && category == "ApprovalFlashDebug"' --style compact
```

## Test plan
- [ ] Build succeeds (`swift build`) — confirmed locally.
- [ ] Run dev app, trigger a real Claude permission prompt that exhibits the flash, observe `[FLASH]` markers and identify which path fires.
- [ ] No regressions in existing approval flow when the user actually clicks Allow/Deny (logs only fire on the buggy path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced diagnostic logging for notification surfaces and session state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->