### PR TITLE
fix: defer hook-disconnect actionableStateResolved by a grace window (with debug logs)

### DIFF
--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -2,10 +2,13 @@ import AppKit
 import Foundation
 import Observation
 import OpenIslandCore
+import os
 
 @MainActor
 @Observable
 final class OverlayUICoordinator {
+
+    private static let approvalFlashLogger = Logger(subsystem: "app.openisland", category: "ApprovalFlashDebug")
 
     private static let notificationSurfaceAutoCollapseDelay: TimeInterval = 10
 
@@ -302,6 +305,7 @@ final class OverlayUICoordinator {
             return
         }
 
+        Self.approvalFlashLogger.info("[FLASH] presentNotificationSurface session=\(surface.sessionID ?? "nil", privacy: .public)")
         NotificationSoundService.playNotification(isMuted: isSoundMuted)
         notchOpen(reason: .notification, surface: surface)
     }
@@ -313,9 +317,13 @@ final class OverlayUICoordinator {
 
         let session = activeIslandCardSession
         guard islandSurface.matchesCurrentState(of: session) else {
+            let phaseDesc = session.map { String(describing: $0.phase) } ?? "no-session"
+            let hasPermission = session?.permissionRequest != nil
             if notchOpenReason == .notification {
+                Self.approvalFlashLogger.warning("[FLASH] reconcile → notchClose: surface session=\(self.islandSurface.sessionID ?? "nil", privacy: .public) phase=\(phaseDesc, privacy: .public) hasPermission=\(hasPermission)")
                 notchClose()
             } else {
+                Self.approvalFlashLogger.warning("[FLASH] reconcile → reset to sessionList (reason=\(String(describing: self.notchOpenReason), privacy: .public))")
                 islandSurface = .sessionList()
             }
             return

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -63,6 +63,16 @@ public final class BridgeServer: @unchecked Sendable {
     private var pendingClaudeInteractions: [String: PendingClaudeInteraction] = [:]
     private var pendingOpenCodeInteractions: [String: PendingOpenCodeInteraction] = [:]
     private var pendingCursorInteractions: [String: PendingCursorInteraction] = [:]
+    /// Pending grace-window work items that defer the actionableStateResolved
+    /// emit when a hook client disconnects. Keyed by sessionID. If a fresh
+    /// hook re-registers a pending interaction for the same sessionID before
+    /// the timer fires, the deferred emit is skipped — this prevents the
+    /// approval card from flickering when an agent quickly respawns its hook
+    /// (Claude Code, in particular, can tear down + relaunch the hook
+    /// subprocess between retries or when the agent cancels and re-issues
+    /// a tool call).
+    private var pendingDisconnectResolutions: [String: DispatchWorkItem] = [:]
+    private static let hookDisconnectGracePeriod: TimeInterval = 0.5
     /// Caches Agent tool description from preToolUse for use by the next subagentStart.
     private var pendingAgentDescriptions: [String: String] = [:]
     /// Maps toolUseID → temporary task ID for TaskCreate, so postToolUse can update with real ID.
@@ -177,6 +187,8 @@ public final class BridgeServer: @unchecked Sendable {
         pendingClaudeToolContexts.removeAll()
         pendingOpenCodeInteractions.removeAll()
         pendingCursorInteractions.removeAll()
+        pendingDisconnectResolutions.values.forEach { $0.cancel() }
+        pendingDisconnectResolutions.removeAll()
 
         let activeConnections = Array(clients.values)
         activeConnections.forEach { $0.readSource.cancel() }
@@ -661,6 +673,7 @@ public final class BridgeServer: @unchecked Sendable {
                     )
                 )
 
+                cancelPendingDisconnectResolution(for: payload.sessionID)
                 pendingClaudeInteractions[payload.sessionID] = PendingClaudeInteraction(
                     clientID: clientID,
                     kind: .question(payload, prompt)
@@ -687,6 +700,7 @@ public final class BridgeServer: @unchecked Sendable {
                     )
                 )
 
+                cancelPendingDisconnectResolution(for: payload.sessionID)
                 pendingClaudeInteractions[payload.sessionID] = PendingClaudeInteraction(
                     clientID: clientID,
                     kind: .permission(payload)
@@ -1036,6 +1050,7 @@ public final class BridgeServer: @unchecked Sendable {
                 )
             )
 
+            cancelPendingDisconnectResolution(for: payload.sessionID)
             pendingOpenCodeInteractions[payload.sessionID] = PendingOpenCodeInteraction(
                 clientID: clientID,
                 kind: .permission(payload)
@@ -1060,6 +1075,7 @@ public final class BridgeServer: @unchecked Sendable {
                 )
             )
 
+            cancelPendingDisconnectResolution(for: payload.sessionID)
             pendingOpenCodeInteractions[payload.sessionID] = PendingOpenCodeInteraction(
                 clientID: clientID,
                 kind: .question(payload)
@@ -2434,6 +2450,53 @@ public final class BridgeServer: @unchecked Sendable {
         broadcast([.event(event)])
     }
 
+    /// Defers `actionableStateResolved` for a hook disconnect so a quickly
+    /// respawned hook (same sessionID, new clientID) can take over without
+    /// the approval card flickering closed. If no replacement registers
+    /// within `hookDisconnectGracePeriod`, the resolved event is emitted.
+    /// Must be called on `queue`.
+    private func scheduleDisconnectResolution(
+        sessionID: String,
+        summary: String,
+        hasOtherPendingInteraction: @escaping @Sendable () -> Bool
+    ) {
+        // Supersede any earlier deferred resolution for this sessionID — we
+        // only need the most recent disconnect to drive the eventual emit.
+        pendingDisconnectResolutions.removeValue(forKey: sessionID)?.cancel()
+
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.pendingDisconnectResolutions.removeValue(forKey: sessionID)
+
+            // A fresh hook re-registered before the grace period elapsed —
+            // skip the resolved emit so the approval card stays put.
+            if hasOtherPendingInteraction() {
+                return
+            }
+
+            self.emit(
+                .actionableStateResolved(
+                    ActionableStateResolved(
+                        sessionID: sessionID,
+                        summary: summary,
+                        timestamp: .now
+                    )
+                )
+            )
+        }
+
+        pendingDisconnectResolutions[sessionID] = workItem
+        queue.asyncAfter(deadline: .now() + Self.hookDisconnectGracePeriod, execute: workItem)
+    }
+
+    /// Called whenever a fresh pending hook interaction is registered for
+    /// `sessionID` so any in-flight grace timer (from a prior hook crash on
+    /// the same session) is cancelled before it can clobber the new state.
+    /// Must be called on `queue`.
+    private func cancelPendingDisconnectResolution(for sessionID: String) {
+        pendingDisconnectResolutions.removeValue(forKey: sessionID)?.cancel()
+    }
+
     private func hasSession(id: String) -> Bool {
         localState.session(id: id) != nil || localState.session(id: id) != nil
     }
@@ -2482,14 +2545,12 @@ public final class BridgeServer: @unchecked Sendable {
 
         for sessionID in pendingClaudeSessionIDs {
             pendingClaudeInteractions.removeValue(forKey: sessionID)
-            emit(
-                .actionableStateResolved(
-                    ActionableStateResolved(
-                        sessionID: sessionID,
-                        summary: "Hook process disconnected.",
-                        timestamp: .now
-                    )
-                )
+            scheduleDisconnectResolution(
+                sessionID: sessionID,
+                summary: "Hook process disconnected.",
+                hasOtherPendingInteraction: { [weak self] in
+                    self?.pendingClaudeInteractions[sessionID] != nil
+                }
             )
         }
 
@@ -2500,14 +2561,12 @@ public final class BridgeServer: @unchecked Sendable {
 
         for sessionID in pendingOpenCodeSessionIDs {
             pendingOpenCodeInteractions.removeValue(forKey: sessionID)
-            emit(
-                .actionableStateResolved(
-                    ActionableStateResolved(
-                        sessionID: sessionID,
-                        summary: "Plugin process disconnected.",
-                        timestamp: .now
-                    )
-                )
+            scheduleDisconnectResolution(
+                sessionID: sessionID,
+                summary: "Plugin process disconnected.",
+                hasOtherPendingInteraction: { [weak self] in
+                    self?.pendingOpenCodeInteractions[sessionID] != nil
+                }
             )
         }
 
@@ -2518,14 +2577,12 @@ public final class BridgeServer: @unchecked Sendable {
 
         for sessionID in pendingCursorSessionIDs {
             pendingCursorInteractions.removeValue(forKey: sessionID)
-            emit(
-                .actionableStateResolved(
-                    ActionableStateResolved(
-                        sessionID: sessionID,
-                        summary: "Hook process disconnected.",
-                        timestamp: .now
-                    )
-                )
+            scheduleDisconnectResolution(
+                sessionID: sessionID,
+                summary: "Hook process disconnected.",
+                hasOtherPendingInteraction: { [weak self] in
+                    self?.pendingCursorInteractions[sessionID] != nil
+                }
             )
         }
 

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -1,8 +1,11 @@
 import Dispatch
 import Darwin
 import Foundation
+import os
 
 public final class BridgeServer: @unchecked Sendable {
+    private static let approvalFlashLogger = Logger(subsystem: "app.openisland", category: "ApprovalFlashDebug")
+
     private struct ClientConnection {
         let id: UUID
         let fileDescriptor: Int32
@@ -705,6 +708,7 @@ public final class BridgeServer: @unchecked Sendable {
                     clientID: clientID,
                     kind: .permission(payload)
                 )
+                Self.approvalFlashLogger.info("[FLASH] Claude permission registered for session \(payload.sessionID, privacy: .public) (clientID=\(clientID.uuidString, privacy: .public)) tool=\(payload.toolName ?? "?", privacy: .public)")
             }
 
         case .postToolUse:
@@ -2458,8 +2462,12 @@ public final class BridgeServer: @unchecked Sendable {
     private func scheduleDisconnectResolution(
         sessionID: String,
         summary: String,
+        originLabel: String,
+        clientID: UUID,
         hasOtherPendingInteraction: @escaping @Sendable () -> Bool
     ) {
+        Self.approvalFlashLogger.warning("[FLASH] \(originLabel, privacy: .public) hook disconnected — deferring actionableStateResolved for session \(sessionID, privacy: .public) (clientID=\(clientID.uuidString, privacy: .public)) by \(Self.hookDisconnectGracePeriod)s")
+
         // Supersede any earlier deferred resolution for this sessionID — we
         // only need the most recent disconnect to drive the eventual emit.
         pendingDisconnectResolutions.removeValue(forKey: sessionID)?.cancel()
@@ -2471,9 +2479,11 @@ public final class BridgeServer: @unchecked Sendable {
             // A fresh hook re-registered before the grace period elapsed —
             // skip the resolved emit so the approval card stays put.
             if hasOtherPendingInteraction() {
+                Self.approvalFlashLogger.info("[FLASH] grace cancelled — replacement hook owns session \(sessionID, privacy: .public)")
                 return
             }
 
+            Self.approvalFlashLogger.warning("[FLASH] grace expired — emitting actionableStateResolved for session \(sessionID, privacy: .public)")
             self.emit(
                 .actionableStateResolved(
                     ActionableStateResolved(
@@ -2494,7 +2504,11 @@ public final class BridgeServer: @unchecked Sendable {
     /// the same session) is cancelled before it can clobber the new state.
     /// Must be called on `queue`.
     private func cancelPendingDisconnectResolution(for sessionID: String) {
-        pendingDisconnectResolutions.removeValue(forKey: sessionID)?.cancel()
+        guard let workItem = pendingDisconnectResolutions.removeValue(forKey: sessionID) else {
+            return
+        }
+        Self.approvalFlashLogger.info("[FLASH] new pending interaction for session \(sessionID, privacy: .public) — cancelling deferred actionableStateResolved")
+        workItem.cancel()
     }
 
     private func hasSession(id: String) -> Bool {
@@ -2548,6 +2562,8 @@ public final class BridgeServer: @unchecked Sendable {
             scheduleDisconnectResolution(
                 sessionID: sessionID,
                 summary: "Hook process disconnected.",
+                originLabel: "Claude",
+                clientID: clientID,
                 hasOtherPendingInteraction: { [weak self] in
                     self?.pendingClaudeInteractions[sessionID] != nil
                 }
@@ -2564,6 +2580,8 @@ public final class BridgeServer: @unchecked Sendable {
             scheduleDisconnectResolution(
                 sessionID: sessionID,
                 summary: "Plugin process disconnected.",
+                originLabel: "OpenCode",
+                clientID: clientID,
                 hasOtherPendingInteraction: { [weak self] in
                     self?.pendingOpenCodeInteractions[sessionID] != nil
                 }
@@ -2580,6 +2598,8 @@ public final class BridgeServer: @unchecked Sendable {
             scheduleDisconnectResolution(
                 sessionID: sessionID,
                 summary: "Hook process disconnected.",
+                originLabel: "Cursor",
+                clientID: clientID,
                 hasOtherPendingInteraction: { [weak self] in
                     self?.pendingCursorInteractions[sessionID] != nil
                 }

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -1,4 +1,7 @@
 import Foundation
+import os
+
+private let approvalFlashStateLogger = Logger(subsystem: "app.openisland", category: "ApprovalFlashDebug")
 
 public struct SessionState: Equatable, Sendable {
     public private(set) var sessionsByID: [String: AgentSession]
@@ -97,6 +100,9 @@ public struct SessionState: Equatable, Sendable {
             let preservesActionableState = keepsPendingApproval || keepsPendingQuestion
 
             if !preservesActionableState {
+                if session.permissionRequest != nil && payload.phase != .waitingForApproval {
+                    approvalFlashStateLogger.warning("[FLASH] activityUpdated clearing permissionRequest for session \(payload.sessionID, privacy: .public) — newPhase=\(String(describing: payload.phase), privacy: .public)")
+                }
                 session.phase = payload.phase
                 session.summary = payload.summary
                 if payload.phase != .waitingForApproval {
@@ -213,6 +219,7 @@ public struct SessionState: Equatable, Sendable {
                 return
             }
 
+            approvalFlashStateLogger.warning("[FLASH] actionableStateResolved clearing permission/question for session \(payload.sessionID, privacy: .public) — wasPhase=\(String(describing: session.phase), privacy: .public) summary=\(payload.summary, privacy: .public)")
             session.phase = .running
             session.summary = payload.summary
             session.permissionRequest = nil


### PR DESCRIPTION
## Summary
- Fixes the approval/permission card flashing open and closed almost instantly when an agent's hook subprocess briefly disconnects.
- Adds a 500 ms grace window after a hook disconnect: if a fresh hook for the same sessionID re-registers within the window, the deferred `actionableStateResolved` emit is cancelled and the card stays put. If nobody reconnects, the resolution still fires so a genuinely dead hook does not leave a stale card behind.
- Bundles `ApprovalFlashDebug` `os_log` instrumentation across BridgeServer, SessionState, and OverlayUICoordinator so the entire flow can be observed at runtime — useful both for confirming the fix in production and for triaging any future regression on the same path.

## Commits
1. `fix: defer hook-disconnect actionableStateResolved by a grace window` — the actual fix.
2. `debug: add ApprovalFlashDebug logs for the disconnect grace path` — observability for the same flow.

(Originally split into two PRs but combined here because they touch the same file in `BridgeServer.swift` and the project policy forbids chained PRs.)

## Root cause
1. Claude/OpenCode hook subprocess registers `pendingClaudeInteractions[sessionID]` and the bridge emits `permissionRequested` → notification card opens.
2. The hook subprocess disconnects briefly (agent retry, agent cancel, hook timeout, hook crash).
3. `BridgeServer.removeClient` immediately emits `actionableStateResolved` with summary `"Hook process disconnected."`.
4. `SessionState.apply` resets phase to `.running` and clears `permissionRequest`.
5. `OverlayUICoordinator.reconcileIslandSurfaceAfterStateChange` sees the notification surface no longer matches state and (because `notchOpenReason == .notification`) calls `notchClose()` → card closes.

In practice agents commonly respawn the hook subprocess for the same sessionID within tens of milliseconds, so the brief disconnect should not be user-visible.

## Change
- `BridgeServer`: introduce `pendingDisconnectResolutions: [String: DispatchWorkItem]` and `hookDisconnectGracePeriod = 0.5`.
- `removeClient` no longer emits directly; it calls a new `scheduleDisconnectResolution(...)` that schedules the resolved emit on `queue.asyncAfter`.
- The deferred work item checks whether `pendingClaudeInteractions[sessionID]` (or the corresponding OpenCode/Cursor map) has been re-populated; if so, the emit is skipped.
- New `cancelPendingDisconnectResolution(for:)` is called at every site that registers a fresh `pendingClaudeInteractions` / `pendingOpenCodeInteractions` entry, and pending timers are cancelled in `stopLocked`.
- Diagnostic logs at every transition point in the flow.

## Test plan
Verified live against a dev `OpenIslandApp` with two targeted hook-replay runs (full os_log captures available from the `[FLASH]` markers):
- [x] **Hard disconnect, no replacement**: hook killed mid-permission. Logs show `Claude hook disconnected — deferring … by 0.5s` then ~531 ms later `grace expired — emitting actionableStateResolved` followed by `reconcile → notchClose`. Card closes after the grace, as expected.
- [x] **Hot-replace within grace**: hook killed, replacement hook for same sessionID respawned within ~200 ms. Logs show `Claude hook disconnected — deferring …` then `new pending interaction … cancelling deferred actionableStateResolved`, followed by the replacement registration. No `notchClose`, no `clearing permission/question`. Card stays open through the swap.
- [x] `swift build` clean.

## Capture in dev
```
/usr/bin/log stream --predicate 'subsystem == "app.openisland" && category == "ApprovalFlashDebug"' --level info --style compact
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)