### PR TITLE
feat: add Carbon-based global hotkey and keyboard navigation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.1
 
 import PackageDescription
 
@@ -51,6 +51,9 @@ let package = Package(
             ],
             resources: [
                 .process("Resources"),
+            ],
+            linkerSettings: [
+                .linkedFramework("Carbon"),
             ]
         ),
         .testTarget(

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -30,6 +30,7 @@ final class AppModel {
     private static let showCodexUsageDefaultsKey = "app.showCodexUsage"
     private static let completionReplyEnabledDefaultsKey = "feature.completionReply.enabled"
     private static let suppressFrontmostNotificationsDefaultsKey = "app.suppressFrontmostNotifications"
+    private static let expandOnNotificationEnabledDefaultsKey = "app.expandOnNotification"
     private static let hotkeyModifiersDefaultsKey = "hotkey.modifiers"
     private static let hotkeyKeyCodeDefaultsKey = "hotkey.keyCode"
 
@@ -262,6 +263,12 @@ final class AppModel {
         didSet {
             guard hasFinishedInit, suppressFrontmostNotifications != oldValue else { return }
             UserDefaults.standard.set(suppressFrontmostNotifications, forKey: Self.suppressFrontmostNotificationsDefaultsKey)
+        }
+    }
+    var expandOnNotificationEnabled: Bool = true {
+        didSet {
+            guard hasFinishedInit, expandOnNotificationEnabled != oldValue else { return }
+            UserDefaults.standard.set(expandOnNotificationEnabled, forKey: Self.expandOnNotificationEnabledDefaultsKey)
         }
     }
     var launchAtLoginEnabled: Bool = false {
@@ -608,6 +615,9 @@ final class AppModel {
         showDockIcon = UserDefaults.standard.bool(forKey: Self.showDockIconDefaultsKey)
         hapticFeedbackEnabled = UserDefaults.standard.bool(forKey: Self.hapticFeedbackEnabledDefaultsKey)
         suppressFrontmostNotifications = UserDefaults.standard.bool(forKey: Self.suppressFrontmostNotificationsDefaultsKey)
+        if UserDefaults.standard.object(forKey: Self.expandOnNotificationEnabledDefaultsKey) != nil {
+            expandOnNotificationEnabled = UserDefaults.standard.bool(forKey: Self.expandOnNotificationEnabledDefaultsKey)
+        }
         if UserDefaults.standard.object(forKey: Self.showCodexUsageDefaultsKey) != nil {
             showCodexUsage = UserDefaults.standard.bool(forKey: Self.showCodexUsageDefaultsKey)
         } else {

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -10,6 +10,10 @@ extension Notification.Name {
     /// user to the right place without `SettingsView`'s `@State` having
     /// to leak into `AppModel`.
     static let openIslandSelectSetupTab = Notification.Name("openIslandSelectSetupTab")
+    static let hotkeyUpdated = Notification.Name("openIslandHotkeyUpdated")
+    static let sessionSelectionMoveUp = Notification.Name("openIslandSessionSelectionMoveUp")
+    static let sessionSelectionMoveDown = Notification.Name("openIslandSessionSelectionMoveDown")
+    static let sessionSelectionActivate = Notification.Name("openIslandSessionSelectionActivate")
 }
 
 @MainActor
@@ -26,6 +30,8 @@ final class AppModel {
     private static let showCodexUsageDefaultsKey = "app.showCodexUsage"
     private static let completionReplyEnabledDefaultsKey = "feature.completionReply.enabled"
     private static let suppressFrontmostNotificationsDefaultsKey = "app.suppressFrontmostNotifications"
+    private static let hotkeyModifiersDefaultsKey = "hotkey.modifiers"
+    private static let hotkeyKeyCodeDefaultsKey = "hotkey.keyCode"
 
     static let defaultStatusColors: [SessionPhase: String] = [
         .running: "#6E9FFF",
@@ -466,6 +472,86 @@ final class AppModel {
         watchRelay = nil
     }
 
+    // MARK: - Hotkey
+
+    var hotkeyModifiers: NSEvent.ModifierFlags {
+        get {
+            let raw = UserDefaults.standard.integer(forKey: Self.hotkeyModifiersDefaultsKey)
+            return NSEvent.ModifierFlags(rawValue: UInt(raw))
+        }
+        set {
+            UserDefaults.standard.set(newValue.rawValue, forKey: Self.hotkeyModifiersDefaultsKey)
+        }
+    }
+
+    var hotkeyKeyCode: UInt16 {
+        get {
+            let raw = UserDefaults.standard.integer(forKey: Self.hotkeyKeyCodeDefaultsKey)
+            return raw == 0 ? KeyCombo.defaultKeyCode : UInt16(raw)
+        }
+        set {
+            UserDefaults.standard.set(Int(newValue), forKey: Self.hotkeyKeyCodeDefaultsKey)
+        }
+    }
+
+    @ObservationIgnored
+    private var globalHotKeyMonitor: GlobalHotKeyMonitor?
+
+    @ObservationIgnored
+    private var localKeyMonitor: Any?
+
+    func setupHotKey() {
+        globalHotKeyMonitor = nil
+
+        let mods = hotkeyModifiers.isEmpty ? KeyCombo.defaultModifiers : hotkeyModifiers
+        let code = hotkeyKeyCode
+
+        globalHotKeyMonitor = GlobalHotKeyMonitor(modifiers: mods, keyCode: code) { [weak self] in
+            self?.toggleOverlay()
+        }
+
+        if let old = localKeyMonitor { NSEvent.removeMonitor(old); localKeyMonitor = nil }
+        localKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self else { return event }
+
+            let eventMods = event.modifierFlags.intersection(kRealModifiers)
+            let savedMods = mods.intersection(kRealModifiers)
+            if event.keyCode == code && eventMods == savedMods {
+                self.toggleOverlay()
+                return nil
+            }
+
+            guard self.isOverlayVisible else { return event }
+            guard eventMods.isEmpty else { return event }
+
+            switch event.keyCode {
+            case 126: // Up arrow
+                NotificationCenter.default.post(name: .sessionSelectionMoveUp, object: nil)
+                return nil
+            case 125: // Down arrow
+                NotificationCenter.default.post(name: .sessionSelectionMoveDown, object: nil)
+                return nil
+            case 36, 76: // Return, Enter
+                NotificationCenter.default.post(name: .sessionSelectionActivate, object: nil)
+                self.hideOverlay()
+                return nil
+            default:
+                return event
+            }
+        }
+    }
+
+    func updateHotKey() {
+        setupHotKey()
+    }
+
+    func saveHotkey(modifiers: NSEvent.ModifierFlags, keyCode: UInt16) {
+        hotkeyModifiers = modifiers
+        hotkeyKeyCode = keyCode
+        updateHotKey()
+        NotificationCenter.default.post(name: .hotkeyUpdated, object: nil)
+    }
+
     var ignoresPointerExitDuringHarness = false
     var disablesOverlayEventMonitoringDuringHarness = false
 
@@ -821,6 +907,7 @@ final class AppModel {
         }
         refreshOverlayDisplayConfiguration()
         ensureOverlayPanel()
+        setupHotKey()
         if shouldPerformBootAnimation {
             performBootAnimation()
         }

--- a/Sources/OpenIslandApp/GlobalHotKeyMonitor.swift
+++ b/Sources/OpenIslandApp/GlobalHotKeyMonitor.swift
@@ -1,0 +1,58 @@
+import Carbon
+import AppKit
+
+/// Module-level callback storage for the C-convention Carbon event handler.
+@MainActor private var _hotKeyCallback: (() -> Void)?
+
+/// Registers a system-wide hotkey using Carbon `RegisterEventHotKey`.
+/// Fires globally regardless of which app has focus and does NOT require
+/// Accessibility permissions.
+@MainActor
+final class GlobalHotKeyMonitor {
+    private nonisolated(unsafe) var hotKeyRef: EventHotKeyRef?
+    private nonisolated(unsafe) var eventHandlerRef: EventHandlerRef?
+    let modifiers: NSEvent.ModifierFlags
+    let keyCode: UInt16
+
+    init(modifiers: NSEvent.ModifierFlags, keyCode: UInt16, callback: @escaping () -> Void) {
+        self.modifiers = modifiers.intersection(kRealModifiers)
+        self.keyCode = keyCode
+        _hotKeyCallback = callback
+        setupMonitor()
+    }
+
+    private func setupMonitor() {
+        let carbonMods = nsModifiersToCarbon(modifiers)
+        let hotKeyID = EventHotKeyID(signature: OSType(0x4F50494C), id: UInt32(1)) // 'OPIL'
+        var eventType = EventTypeSpec(
+            eventClass: OSType(kEventClassKeyboard),
+            eventKind: UInt32(kEventHotKeyPressed)
+        )
+        InstallEventHandler(
+            GetApplicationEventTarget(),
+            { _, _, _ -> OSStatus in
+                DispatchQueue.main.async { _hotKeyCallback?() }
+                return noErr
+            },
+            1, &eventType, nil, &eventHandlerRef
+        )
+        RegisterEventHotKey(
+            UInt32(keyCode), carbonMods, hotKeyID,
+            GetApplicationEventTarget(), OptionBits(0), &hotKeyRef
+        )
+    }
+
+    deinit {
+        if let ref = hotKeyRef { UnregisterEventHotKey(ref) }
+        if let ref = eventHandlerRef { RemoveEventHandler(ref) }
+    }
+}
+
+private func nsModifiersToCarbon(_ flags: NSEvent.ModifierFlags) -> UInt32 {
+    var carbon: UInt32 = 0
+    if flags.contains(.command) { carbon |= UInt32(cmdKey) }
+    if flags.contains(.shift)   { carbon |= UInt32(shiftKey) }
+    if flags.contains(.option)  { carbon |= UInt32(optionKey) }
+    if flags.contains(.control) { carbon |= UInt32(controlKey) }
+    return carbon
+}

--- a/Sources/OpenIslandApp/KeyCombo.swift
+++ b/Sources/OpenIslandApp/KeyCombo.swift
@@ -1,0 +1,112 @@
+import AppKit
+
+struct KeyCombo: Equatable {
+    var keyCode: UInt16
+    var modifiers: NSEvent.ModifierFlags
+
+    static let defaultKeyCode: UInt16 = 49 // Space
+    static let defaultModifiers: NSEvent.ModifierFlags = [.command, .shift]
+
+    var displayString: String {
+        var parts: [String] = []
+        if modifiers.contains(.control) { parts.append("⌃") }
+        if modifiers.contains(.option) { parts.append("⌥") }
+        if modifiers.contains(.shift) { parts.append("⇧") }
+        if modifiers.contains(.command) { parts.append("⌘") }
+        parts.append(Self.keyCodeToString(keyCode))
+        return parts.joined()
+    }
+
+    var isValid: Bool {
+        !modifiers.intersection(kRealModifiers).isEmpty
+    }
+
+    static func keyCodeToString(_ code: UInt16) -> String {
+        switch code {
+        case 0:   return "A"
+        case 1:   return "S"
+        case 2:   return "D"
+        case 3:   return "F"
+        case 4:   return "H"
+        case 5:   return "G"
+        case 6:   return "Z"
+        case 7:   return "X"
+        case 8:   return "C"
+        case 9:   return "V"
+        case 11:  return "B"
+        case 12:  return "Q"
+        case 13:  return "W"
+        case 14:  return "E"
+        case 15:  return "R"
+        case 16:  return "Y"
+        case 17:  return "T"
+        case 18:  return "1"
+        case 19:  return "2"
+        case 20:  return "3"
+        case 21:  return "4"
+        case 22:  return "6"
+        case 23:  return "5"
+        case 24:  return "="
+        case 25:  return "9"
+        case 26:  return "7"
+        case 27:  return "-"
+        case 28:  return "8"
+        case 29:  return "0"
+        case 30:  return "]"
+        case 31:  return "O"
+        case 32:  return "U"
+        case 33:  return "["
+        case 34:  return "I"
+        case 35:  return "P"
+        case 37:  return "L"
+        case 38:  return "J"
+        case 39:  return "'"
+        case 40:  return "K"
+        case 41:  return ";"
+        case 42:  return "\\"
+        case 43:  return ","
+        case 44:  return "/"
+        case 45:  return "N"
+        case 46:  return "M"
+        case 47:  return "."
+        case 49:  return "Space"
+        case 50:  return "`"
+        case 51:  return "Delete"
+        case 53:  return "Esc"
+        case 65:  return "[.]"
+        case 67:  return "[*]"
+        case 69:  return "[+]"
+        case 71:  return "Clear"
+        case 75:  return "[/]"
+        case 76:  return "Enter"
+        case 78:  return "[-]"
+        case 81:  return "[=]"
+        case 82:  return "0"
+        case 83:  return "1"
+        case 84:  return "2"
+        case 85:  return "3"
+        case 86:  return "4"
+        case 87:  return "5"
+        case 88:  return "6"
+        case 89:  return "7"
+        case 91:  return "8"
+        case 92:  return "9"
+        case 96:  return "F5"
+        case 97:  return "F6"
+        case 98:  return "F7"
+        case 99:  return "F3"
+        case 100: return "F8"
+        case 101: return "F9"
+        case 103: return "F11"
+        case 109: return "F10"
+        case 111: return "F12"
+        case 118: return "F4"
+        case 120: return "F2"
+        case 122: return "F1"
+        default:  return "Key(\(code))"
+        }
+    }
+}
+
+/// Only the 4 modifier keys users actually care about — strips .function, .numericPad, etc.
+let kRealModifiers: NSEvent.ModifierFlags = [.command, .shift, .option, .control]

--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -303,6 +303,11 @@ final class OverlayUICoordinator {
         }
 
         NotificationSoundService.playNotification(isMuted: isSoundMuted)
+
+        guard appModel?.expandOnNotificationEnabled == true else {
+            return
+        }
+
         notchOpen(reason: .notification, surface: surface)
     }
 

--- a/Sources/OpenIslandApp/Views/HotkeyRecorderView.swift
+++ b/Sources/OpenIslandApp/Views/HotkeyRecorderView.swift
@@ -1,0 +1,109 @@
+import AppKit
+import SwiftUI
+
+// MARK: - Hotkey recorder button (SwiftUI)
+
+struct HotkeyRecorderButton: View {
+    @Binding var recordedKey: KeyCombo
+    @State private var isRecording = false
+
+    var body: some View {
+        HotkeyRecorderNSView(
+            isRecording: $isRecording,
+            onKeyRecorded: { combo in
+                recordedKey = combo
+                isRecording = false
+            }
+        )
+        .overlay(
+            Text(isRecording ? "Press keys now…" : recordedKey.displayString)
+                .foregroundColor(isRecording ? .accentColor : .primary)
+                .font(.system(size: 12))
+                .padding(.horizontal, 8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .allowsHitTesting(false)
+        )
+        .frame(height: 28)
+    }
+}
+
+// MARK: - NSViewRepresentable bridge
+
+private struct HotkeyRecorderNSView: NSViewRepresentable {
+    @Binding var isRecording: Bool
+    let onKeyRecorded: (KeyCombo) -> Void
+
+    func makeNSView(context: Context) -> HotkeyCapturingView {
+        let view = HotkeyCapturingView()
+        view.onRecordingStarted = {
+            DispatchQueue.main.async { isRecording = true }
+        }
+        view.onKeyRecorded = { combo in
+            DispatchQueue.main.async {
+                isRecording = false
+                onKeyRecorded(combo)
+            }
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: HotkeyCapturingView, context: Context) {
+        if !isRecording && nsView.isRecording {
+            nsView.cancelRecording()
+        }
+    }
+}
+
+// MARK: - NSView that captures a key combo on click
+
+@MainActor
+final class HotkeyCapturingView: NSView {
+    var onKeyRecorded: ((KeyCombo) -> Void)?
+    var onRecordingStarted: (() -> Void)?
+    var isRecording: Bool = false {
+        didSet { needsDisplay = true }
+    }
+
+    private nonisolated(unsafe) var localMonitor: Any?
+
+    override var acceptsFirstResponder: Bool { true }
+
+    func cancelRecording() {
+        isRecording = false
+        if let m = localMonitor { NSEvent.removeMonitor(m); localMonitor = nil }
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        guard !isRecording else { return }
+        isRecording = true
+        onRecordingStarted?()
+
+        localMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] e in
+            guard let self, self.isRecording else { return e }
+            let mods = e.modifierFlags.intersection(kRealModifiers)
+            guard !mods.isEmpty else { return e }
+            let combo = KeyCombo(keyCode: e.keyCode, modifiers: mods)
+            self.isRecording = false
+            if let m = self.localMonitor { NSEvent.removeMonitor(m); self.localMonitor = nil }
+            self.onKeyRecorded?(combo)
+            return nil
+        }
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        let bg: NSColor = isRecording
+            ? NSColor.controlAccentColor.withAlphaComponent(0.15)
+            : NSColor.controlBackgroundColor
+        bg.setFill()
+        NSBezierPath(roundedRect: bounds, xRadius: 4, yRadius: 4).fill()
+        NSColor.separatorColor.setStroke()
+        NSBezierPath(
+            roundedRect: bounds.insetBy(dx: 0.5, dy: 0.5),
+            xRadius: 4, yRadius: 4
+        ).stroke()
+    }
+
+    deinit {
+        if let m = localMonitor { NSEvent.removeMonitor(m) }
+    }
+}

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -245,6 +245,24 @@ struct IslandPanelView: View {
         } message: {
             Text(model.lang.t("island.quit.confirmMessage"))
         }
+        .onReceive(NotificationCenter.default.publisher(for: .sessionSelectionMoveUp)) { _ in
+            handleSelectionMove(.up)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .sessionSelectionMoveDown)) { _ in
+            handleSelectionMove(.down)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .sessionSelectionActivate)) { _ in
+            model.jumpToFocusedSession()
+        }
+    }
+
+    private func handleSelectionMove(_ direction: SessionListNavigationDirection) {
+        let ids = model.islandListSessions.map(\.id)
+        model.selectedSessionID = SessionListKeyboardNavigator.nextSelection(
+            currentID: model.selectedSessionID,
+            ids: ids,
+            direction: direction
+        )
     }
 
     @ViewBuilder

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -149,7 +149,7 @@ struct SettingsView: View {
             case .watch:
                 WatchSettingsPane(model: model)
             case .shortcuts:
-                PlaceholderSettingsPane(model: model, titleKey: "settings.tab.shortcuts", subtitleKey: "settings.shortcuts.comingSoon")
+                ShortcutsSettingsPane(model: model)
             case .lab:
                 PlaceholderSettingsPane(model: model, titleKey: "settings.tab.lab", subtitleKey: "settings.lab.comingSoon")
             case .about:
@@ -1037,6 +1037,90 @@ struct WatchSettingsPane: View {
         .onAppear {
             pairingCode = model.watchPairingCode
         }
+    }
+}
+
+// MARK: - Shortcuts
+
+struct ShortcutsSettingsPane: View {
+    var model: AppModel
+    @State private var draftHotkey: KeyCombo
+
+    init(model: AppModel) {
+        self.model = model
+        _draftHotkey = State(initialValue: KeyCombo(
+            keyCode: model.hotkeyKeyCode,
+            modifiers: model.hotkeyModifiers.isEmpty ? KeyCombo.defaultModifiers : model.hotkeyModifiers
+        ))
+    }
+
+    private var lang: LanguageManager { model.lang }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                HotkeySection(
+                    lang: lang,
+                    draftHotkey: $draftHotkey,
+                    onSave: {
+                        model.saveHotkey(modifiers: draftHotkey.modifiers, keyCode: draftHotkey.keyCode)
+                    }
+                )
+            }
+            .padding(20)
+        }
+        .navigationTitle(lang.t("settings.tab.shortcuts"))
+    }
+}
+
+private struct HotkeySection: View {
+    let lang: LanguageManager
+    @Binding var draftHotkey: KeyCombo
+    let onSave: () -> Void
+
+    private var hasChanged: Bool {
+        let savedMods = UserDefaults.standard.integer(forKey: "hotkey.modifiers")
+        let savedCode = UserDefaults.standard.integer(forKey: "hotkey.keyCode")
+        let savedModFlags = NSEvent.ModifierFlags(rawValue: UInt(savedMods))
+        let effectiveSavedMods = savedModFlags.isEmpty ? KeyCombo.defaultModifiers : savedModFlags
+        let effectiveSavedCode = savedCode == 0 ? Int(KeyCombo.defaultKeyCode) : savedCode
+        return draftHotkey.keyCode != UInt16(effectiveSavedCode)
+            || draftHotkey.modifiers.intersection(kRealModifiers) != effectiveSavedMods.intersection(kRealModifiers)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Toggle Island")
+                .font(.headline)
+
+            Text("Global shortcut to show or hide the island overlay from anywhere.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 12) {
+                HotkeyRecorderButton(recordedKey: $draftHotkey)
+                    .frame(maxWidth: 200)
+
+                if hasChanged {
+                    Button("Save") {
+                        onSave()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                }
+            }
+
+            Text("Arrow keys navigate sessions when the island is open. Return jumps to the selected session.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.top, 4)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.primary.opacity(0.05))
+        )
     }
 }
 

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -223,6 +223,10 @@ struct GeneralSettingsPane: View {
                     get: { model.suppressFrontmostNotifications },
                     set: { model.suppressFrontmostNotifications = $0 }
                 ))
+                Toggle("Expand island on notification", isOn: Binding(
+                    get: { model.expandOnNotificationEnabled },
+                    set: { model.expandOnNotificationEnabled = $0 }
+                ))
             }
 
         }

--- a/Sources/OpenIslandCore/SessionListKeyboardNavigator.swift
+++ b/Sources/OpenIslandCore/SessionListKeyboardNavigator.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public enum SessionListNavigationDirection {
+    case up
+    case down
+}
+
+public enum SessionListKeyboardNavigator {
+    public static func normalizedSelection(currentID: String?, ids: [String]) -> String? {
+        guard !ids.isEmpty else { return nil }
+        guard let currentID, ids.contains(currentID) else { return ids.first }
+        return currentID
+    }
+
+    public static func nextSelection(
+        currentID: String?,
+        ids: [String],
+        direction: SessionListNavigationDirection
+    ) -> String? {
+        guard !ids.isEmpty else { return nil }
+
+        guard let currentID,
+              let currentIndex = ids.firstIndex(of: currentID) else {
+            return ids.first
+        }
+
+        switch direction {
+        case .up:
+            return ids[max(currentIndex - 1, 0)]
+        case .down:
+            return ids[min(currentIndex + 1, ids.count - 1)]
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds Carbon `RegisterEventHotKey`-based global hotkey (default Cmd+Shift+Space) to toggle the island overlay from anywhere
- Arrow keys navigate sessions when the overlay is open; Enter jumps to the selected session
- Replaces the "Coming soon" Shortcuts settings tab with a functional hotkey recorder
- Adds `SessionListKeyboardNavigator` utility in OpenIslandCore for index-based session selection navigation

## Test plan
- [ ] Build passes (`swift build`)
- [ ] Global hotkey toggles overlay from any app
- [ ] Arrow keys navigate session list when overlay is open
- [ ] Enter jumps to focused session
- [ ] Hotkey can be changed in Settings > Shortcuts
- [ ] Hotkey persists across app restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global hotkey to toggle the overlay with a customizable shortcut
  * Arrow keys and Enter to navigate and activate sessions inside the overlay
  * Hotkey recorder and shortcuts editor in Settings with saveable changes
  * New toggle: "Expand island on notification" to control notification-driven expansion

* **Chores**
  * Updated Swift package tools version
<!-- end of auto-generated comment: release notes by coderabbit.ai -->