### PR TITLE
feat: add 'expand only on hover' option and arrow key session navigation

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -26,6 +26,7 @@ final class AppModel {
     private static let showCodexUsageDefaultsKey = "app.showCodexUsage"
     private static let completionReplyEnabledDefaultsKey = "feature.completionReply.enabled"
     private static let suppressFrontmostNotificationsDefaultsKey = "app.suppressFrontmostNotifications"
+    private static let expandOnlyOnHoverDefaultsKey = "app.expandOnlyOnHover"
 
     static let defaultStatusColors: [SessionPhase: String] = [
         .running: "#6E9FFF",
@@ -256,6 +257,12 @@ final class AppModel {
         didSet {
             guard hasFinishedInit, suppressFrontmostNotifications != oldValue else { return }
             UserDefaults.standard.set(suppressFrontmostNotifications, forKey: Self.suppressFrontmostNotificationsDefaultsKey)
+        }
+    }
+    var expandOnlyOnHover: Bool = false {
+        didSet {
+            guard hasFinishedInit, expandOnlyOnHover != oldValue else { return }
+            UserDefaults.standard.set(expandOnlyOnHover, forKey: Self.expandOnlyOnHoverDefaultsKey)
         }
     }
     var launchAtLoginEnabled: Bool = false {
@@ -522,6 +529,7 @@ final class AppModel {
         showDockIcon = UserDefaults.standard.bool(forKey: Self.showDockIconDefaultsKey)
         hapticFeedbackEnabled = UserDefaults.standard.bool(forKey: Self.hapticFeedbackEnabledDefaultsKey)
         suppressFrontmostNotifications = UserDefaults.standard.bool(forKey: Self.suppressFrontmostNotificationsDefaultsKey)
+        expandOnlyOnHover = UserDefaults.standard.bool(forKey: Self.expandOnlyOnHoverDefaultsKey)
         if UserDefaults.standard.object(forKey: Self.showCodexUsageDefaultsKey) != nil {
             showCodexUsage = UserDefaults.standard.bool(forKey: Self.showCodexUsageDefaultsKey)
         } else {

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -10,6 +10,9 @@ extension Notification.Name {
     /// user to the right place without `SettingsView`'s `@State` having
     /// to leak into `AppModel`.
     static let openIslandSelectSetupTab = Notification.Name("openIslandSelectSetupTab")
+    static let sessionSelectionMoveUp = Notification.Name("openIslandSessionSelectionMoveUp")
+    static let sessionSelectionMoveDown = Notification.Name("openIslandSessionSelectionMoveDown")
+    static let sessionSelectionActivate = Notification.Name("openIslandSessionSelectionActivate")
 }
 
 @MainActor
@@ -27,6 +30,7 @@ final class AppModel {
     private static let completionReplyEnabledDefaultsKey = "feature.completionReply.enabled"
     private static let suppressFrontmostNotificationsDefaultsKey = "app.suppressFrontmostNotifications"
     private static let expandOnlyOnHoverDefaultsKey = "app.expandOnlyOnHover"
+    private static let keyboardNavEnabledDefaultsKey = "app.keyboardNavEnabled"
 
     static let defaultStatusColors: [SessionPhase: String] = [
         .running: "#6E9FFF",
@@ -265,6 +269,17 @@ final class AppModel {
             UserDefaults.standard.set(expandOnlyOnHover, forKey: Self.expandOnlyOnHoverDefaultsKey)
         }
     }
+    var keyboardNavEnabled: Bool = true {
+        didSet {
+            guard hasFinishedInit, keyboardNavEnabled != oldValue else { return }
+            UserDefaults.standard.set(keyboardNavEnabled, forKey: Self.keyboardNavEnabledDefaultsKey)
+            if keyboardNavEnabled {
+                setupKeyboardNavMonitor()
+            } else {
+                teardownKeyboardNavMonitor()
+            }
+        }
+    }
     var launchAtLoginEnabled: Bool = false {
         didSet {
             guard !isApplyingLaunchAtLogin, hasFinishedInit, launchAtLoginEnabled != oldValue else { return }
@@ -473,6 +488,9 @@ final class AppModel {
         watchRelay = nil
     }
 
+    @ObservationIgnored
+    private var keyboardNavMonitor: Any?
+
     var ignoresPointerExitDuringHarness = false
     var disablesOverlayEventMonitoringDuringHarness = false
 
@@ -530,6 +548,13 @@ final class AppModel {
         hapticFeedbackEnabled = UserDefaults.standard.bool(forKey: Self.hapticFeedbackEnabledDefaultsKey)
         suppressFrontmostNotifications = UserDefaults.standard.bool(forKey: Self.suppressFrontmostNotificationsDefaultsKey)
         expandOnlyOnHover = UserDefaults.standard.bool(forKey: Self.expandOnlyOnHoverDefaultsKey)
+        if UserDefaults.standard.object(forKey: Self.keyboardNavEnabledDefaultsKey) != nil {
+            keyboardNavEnabled = UserDefaults.standard.bool(forKey: Self.keyboardNavEnabledDefaultsKey)
+        } else {
+            keyboardNavEnabled = true
+        }
+
+        overlay.appModel = self
         if UserDefaults.standard.object(forKey: Self.showCodexUsageDefaultsKey) != nil {
             showCodexUsage = UserDefaults.standard.bool(forKey: Self.showCodexUsageDefaultsKey)
         } else {
@@ -829,6 +854,7 @@ final class AppModel {
         }
         refreshOverlayDisplayConfiguration()
         ensureOverlayPanel()
+        if keyboardNavEnabled { setupKeyboardNavMonitor() }
         if shouldPerformBootAnimation {
             performBootAnimation()
         }
@@ -935,6 +961,34 @@ final class AppModel {
 
     func select(sessionID: String) {
         selectedSessionID = sessionID
+    }
+
+    // MARK: - Keyboard navigation
+
+    func setupKeyboardNavMonitor() {
+        teardownKeyboardNavMonitor()
+        keyboardNavMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self, self.keyboardNavEnabled, self.isOverlayVisible else { return event }
+            guard event.modifierFlags.intersection([.command, .shift, .option, .control]).isEmpty else { return event }
+
+            switch event.keyCode {
+            case 126: // Up arrow
+                NotificationCenter.default.post(name: .sessionSelectionMoveUp, object: nil)
+                return nil
+            case 125: // Down arrow
+                NotificationCenter.default.post(name: .sessionSelectionMoveDown, object: nil)
+                return nil
+            case 36, 76: // Return, Enter
+                NotificationCenter.default.post(name: .sessionSelectionActivate, object: nil)
+                return nil
+            default:
+                return event
+            }
+        }
+    }
+
+    func teardownKeyboardNavMonitor() {
+        if let m = keyboardNavMonitor { NSEvent.removeMonitor(m); keyboardNavMonitor = nil }
     }
 
     // MARK: - Overlay forwarding

--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -98,6 +98,10 @@ final class OverlayUICoordinator {
     }
 
     func notchOpen(reason: NotchOpenReason, surface: IslandSurface = .sessionList()) {
+        if appModel?.expandOnlyOnHover == true, reason != .hover {
+            return
+        }
+
         transitionOverlay(
             to: .opened,
             reason: reason,

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -245,6 +245,24 @@ struct IslandPanelView: View {
         } message: {
             Text(model.lang.t("island.quit.confirmMessage"))
         }
+        .onReceive(NotificationCenter.default.publisher(for: .sessionSelectionMoveUp)) { _ in
+            handleSelectionMove(.up)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .sessionSelectionMoveDown)) { _ in
+            handleSelectionMove(.down)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .sessionSelectionActivate)) { _ in
+            model.jumpToFocusedSession()
+        }
+    }
+
+    private func handleSelectionMove(_ direction: SessionListNavigationDirection) {
+        let ids = model.islandListSessions.map(\.id)
+        model.selectedSessionID = SessionListKeyboardNavigator.nextSelection(
+            currentID: model.selectedSessionID,
+            ids: ids,
+            direction: direction
+        )
     }
 
     @ViewBuilder

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -227,6 +227,10 @@ struct GeneralSettingsPane: View {
                     get: { model.expandOnlyOnHover },
                     set: { model.expandOnlyOnHover = $0 }
                 ))
+                Toggle("Arrow key session navigation", isOn: Binding(
+                    get: { model.keyboardNavEnabled },
+                    set: { model.keyboardNavEnabled = $0 }
+                ))
             }
 
         }

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -223,6 +223,10 @@ struct GeneralSettingsPane: View {
                     get: { model.suppressFrontmostNotifications },
                     set: { model.suppressFrontmostNotifications = $0 }
                 ))
+                Toggle("Expand island only on hover", isOn: Binding(
+                    get: { model.expandOnlyOnHover },
+                    set: { model.expandOnlyOnHover = $0 }
+                ))
             }
 
         }

--- a/Sources/OpenIslandCore/SessionListKeyboardNavigator.swift
+++ b/Sources/OpenIslandCore/SessionListKeyboardNavigator.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public enum SessionListNavigationDirection {
+    case up
+    case down
+}
+
+public enum SessionListKeyboardNavigator {
+    public static func normalizedSelection(currentID: String?, ids: [String]) -> String? {
+        guard !ids.isEmpty else { return nil }
+        guard let currentID, ids.contains(currentID) else { return ids.first }
+        return currentID
+    }
+
+    public static func nextSelection(
+        currentID: String?,
+        ids: [String],
+        direction: SessionListNavigationDirection
+    ) -> String? {
+        guard !ids.isEmpty else { return nil }
+
+        guard let currentID,
+              let currentIndex = ids.firstIndex(of: currentID) else {
+            return ids.first
+        }
+
+        switch direction {
+        case .up:
+            return ids[max(currentIndex - 1, 0)]
+        case .down:
+            return ids[min(currentIndex + 1, ids.count - 1)]
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds "Expand island only on hover" toggle — when enabled, the island only expands on mouse hover, suppressing expansion from clicks, notifications, and keyboard shortcuts
- Adds arrow key navigation (up/down) to navigate sessions when the island is open; Enter jumps to the selected session
- Arrow key navigation is configurable via "Arrow key session navigation" toggle
- Both toggles in Settings > General > Behavior

## Test plan
- [ ] Build passes
- [ ] "Expand only on hover" on: clicking the notch does nothing, hovering still opens
- [ ] "Expand only on hover" off: existing behavior preserved
- [ ] Arrow keys navigate sessions when overlay is open
- [ ] Enter jumps to selected session
- [ ] Toggle off disables keyboard navigation
- [ ] Settings persist across app restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyboard navigation for session selection using arrow keys (up/down) and Enter to activate.
  * Added setting to enable/disable keyboard navigation (enabled by default).
  * Added setting to expand interface only on hover.

* **Settings**
  * Two new behavior toggles now available in Settings to control keyboard navigation and hover-expand behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->