### PR TITLE
feat: hide island in fullscreen with toggle

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -857,6 +857,7 @@ final class AppModel {
         }
         refreshOverlayDisplayConfiguration()
         ensureOverlayPanel()
+        reevaluateOverlayScreenFullscreen()
         if shouldPerformBootAnimation {
             performBootAnimation()
         }
@@ -968,17 +969,27 @@ final class AppModel {
     // MARK: - Fullscreen visibility
 
     @ObservationIgnored private var lastAppliedSuppression: Bool?
+    @ObservationIgnored private var lastFullscreenDisplays: Set<CGDirectDisplayID> = []
 
     private func handleFullscreenDisplaysChanged(_ fullscreenDisplays: Set<CGDirectDisplayID>) {
+        lastFullscreenDisplays = fullscreenDisplays
+        reevaluateOverlayScreenFullscreen()
+    }
+
+    /// Re-runs the island-screen membership check against the cached
+    /// fullscreen-displays set. Call when something other than a Spaces
+    /// transition changes the relevant inputs — e.g. the panel is created,
+    /// or the user picks a different display in Settings.
+    func reevaluateOverlayScreenFullscreen() {
         let newValue: Bool
-        if fullscreenDisplays.isEmpty {
+        if lastFullscreenDisplays.isEmpty {
             newValue = false
         } else {
             let resolvedScreen = OverlayDisplayResolver.resolveTargetScreen(
                 preferredScreenID: overlay.preferredOverlayScreenID
             )
             let islandDisplayID = resolvedScreen.flatMap { FullscreenSpaceObserver.displayID(for: $0) }
-            newValue = islandDisplayID.map { fullscreenDisplays.contains($0) } ?? false
+            newValue = islandDisplayID.map { lastFullscreenDisplays.contains($0) } ?? false
         }
         guard newValue != isOverlayScreenFullscreen else { return }
         isOverlayScreenFullscreen = newValue

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -26,6 +26,7 @@ final class AppModel {
     private static let showCodexUsageDefaultsKey = "app.showCodexUsage"
     private static let completionReplyEnabledDefaultsKey = "feature.completionReply.enabled"
     private static let suppressFrontmostNotificationsDefaultsKey = "app.suppressFrontmostNotifications"
+    private static let hideInFullscreenDefaultsKey = "app.hideInFullscreen"
 
     static let defaultStatusColors: [SessionPhase: String] = [
         .running: "#6E9FFF",
@@ -73,6 +74,12 @@ final class AppModel {
     let monitoring = ProcessMonitoringCoordinator()
     let codexAppServer = CodexAppServerCoordinator()
     let updateChecker = UpdateChecker()
+
+    private let fullscreenObserver = FullscreenSpaceObserver()
+
+    var hasAttentionRequiredSession: Bool {
+        surfacedSessions.contains { $0.phase.requiresAttention }
+    }
 
     var notchStatus: NotchStatus {
         get { overlay.notchStatus }
@@ -292,6 +299,17 @@ final class AppModel {
     }
     @ObservationIgnored
     private var isApplyingLaunchAtLogin = false
+
+    var hideInFullscreenEnabled: Bool = true {
+        didSet {
+            guard hasFinishedInit, hideInFullscreenEnabled != oldValue else { return }
+            UserDefaults.standard.set(hideInFullscreenEnabled, forKey: Self.hideInFullscreenDefaultsKey)
+            applyFullscreenVisibility()
+        }
+    }
+
+    private(set) var isOverlayScreenFullscreen: Bool = false
+
     var isSoundMuted = false {
         didSet {
             guard isSoundMuted != oldValue else {
@@ -528,12 +546,14 @@ final class AppModel {
             Self.hapticFeedbackEnabledDefaultsKey: false,
             Self.completionReplyEnabledDefaultsKey: false,
             Self.suppressFrontmostNotificationsDefaultsKey: true,
+            Self.hideInFullscreenDefaultsKey: true,
         ])
         isSoundMuted = UserDefaults.standard.bool(forKey: Self.soundMutedDefaultsKey)
         selectedSoundName = NotificationSoundService.selectedSoundName
         showDockIcon = UserDefaults.standard.bool(forKey: Self.showDockIconDefaultsKey)
         hapticFeedbackEnabled = UserDefaults.standard.bool(forKey: Self.hapticFeedbackEnabledDefaultsKey)
         suppressFrontmostNotifications = UserDefaults.standard.bool(forKey: Self.suppressFrontmostNotificationsDefaultsKey)
+        hideInFullscreenEnabled = UserDefaults.standard.bool(forKey: Self.hideInFullscreenDefaultsKey)
         if UserDefaults.standard.object(forKey: Self.showCodexUsageDefaultsKey) != nil {
             showCodexUsage = UserDefaults.standard.bool(forKey: Self.showCodexUsageDefaultsKey)
         } else {
@@ -641,6 +661,10 @@ final class AppModel {
         }
 
         refreshOverlayDisplayConfiguration()
+        fullscreenObserver.onChange = { [weak self] fullscreenDisplays in
+            self?.handleFullscreenDisplaysChanged(fullscreenDisplays)
+        }
+        fullscreenObserver.start()
         hasFinishedInit = true
     }
 
@@ -939,6 +963,35 @@ final class AppModel {
 
     func select(sessionID: String) {
         selectedSessionID = sessionID
+    }
+
+    // MARK: - Fullscreen visibility
+
+    private func handleFullscreenDisplaysChanged(_ fullscreenDisplays: Set<CGDirectDisplayID>) {
+        let resolvedScreen = OverlayDisplayResolver.resolveTargetScreen(
+            preferredScreenID: overlay.preferredOverlayScreenIDForExternalUse
+        )
+        let islandDisplayID = resolvedScreen.flatMap { FullscreenSpaceObserver.displayID(for: $0) }
+        let newValue = islandDisplayID.map { fullscreenDisplays.contains($0) } ?? false
+        guard newValue != isOverlayScreenFullscreen else { return }
+        isOverlayScreenFullscreen = newValue
+        applyFullscreenVisibility()
+    }
+
+    func applyFullscreenVisibility() {
+        let suppress = Self.shouldSuppressOverlayForFullscreen(
+            hideInFullscreenEnabled: hideInFullscreenEnabled,
+            isOverlayScreenFullscreen: isOverlayScreenFullscreen,
+            hasAttentionRequiredSession: hasAttentionRequiredSession
+        )
+        if suppress {
+            overlay.overlayPanelController.forceHide()
+        } else {
+            overlay.overlayPanelController.forceShowIfNeeded(
+                model: self,
+                preferredScreenID: overlay.preferredOverlayScreenIDForExternalUse
+            )
+        }
     }
 
     // MARK: - Overlay forwarding
@@ -1246,6 +1299,7 @@ final class AppModel {
         synchronizeSelection()
         discovery.refreshCodexRolloutTracking()
         refreshOverlayPlacementIfVisible()
+        applyFullscreenVisibility()
         discovery.scheduleCodexSessionPersistence()
         discovery.scheduleClaudeSessionPersistence()
         discovery.scheduleOpenCodeSessionPersistence()

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -991,8 +991,13 @@ final class AppModel {
             let islandDisplayID = resolvedScreen.flatMap { FullscreenSpaceObserver.displayID(for: $0) }
             newValue = islandDisplayID.map { lastFullscreenDisplays.contains($0) } ?? false
         }
-        guard newValue != isOverlayScreenFullscreen else { return }
-        isOverlayScreenFullscreen = newValue
+        if newValue != isOverlayScreenFullscreen {
+            isOverlayScreenFullscreen = newValue
+        }
+        // Always reapply: the panel may have been created after the cached
+        // suppression decision was first computed, so the early-return path
+        // would otherwise leave the panel unsuppressed on launch when the
+        // island display starts in fullscreen.
         applyFullscreenVisibility()
     }
 
@@ -1002,6 +1007,10 @@ final class AppModel {
             isOverlayScreenFullscreen: isOverlayScreenFullscreen,
             hasAttentionRequiredSession: hasAttentionRequiredSession
         )
+        // Pre-panel calls (e.g. from FullscreenSpaceObserver.start during init)
+        // can't actually hide/show anything, and recording the dedupe value
+        // here would block the next call once the panel exists.
+        guard overlay.overlayPanelController.hasPanel else { return }
         guard suppress != lastAppliedSuppression else { return }
         lastAppliedSuppression = suppress
         if suppress {
@@ -1365,6 +1374,17 @@ final class AppModel {
         wasAlreadyCompleted: Bool,
         ingress: TrackedEventIngress
     ) {
+        // Don't reopen the overlay for non-attention events (e.g. completion
+        // toasts) when the island display is in fullscreen — applyFullscreenVisibility
+        // already forceHid the panel, and presenting a notification surface
+        // would orderFront it again.
+        let suppressForFullscreen = Self.shouldSuppressOverlayForFullscreen(
+            hideInFullscreenEnabled: hideInFullscreenEnabled,
+            isOverlayScreenFullscreen: isOverlayScreenFullscreen,
+            hasAttentionRequiredSession: hasAttentionRequiredSession
+        )
+        guard !suppressForFullscreen else { return }
+
         guard !wasAlreadyCompleted,
               notificationSurfaceIsEligibleForPresentation(surface, ingress: ingress),
               let sessionID = surface.sessionID,

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -33,6 +33,18 @@ final class AppModel {
         .waitingForAnswer: "#FFD95A",
         .completed: "#42E86B",
     ]
+
+    /// Pure decision function exposed for unit tests.
+    static func shouldSuppressOverlayForFullscreen(
+        hideInFullscreenEnabled: Bool,
+        isOverlayScreenFullscreen: Bool,
+        hasAttentionRequiredSession: Bool
+    ) -> Bool {
+        hideInFullscreenEnabled
+            && isOverlayScreenFullscreen
+            && !hasAttentionRequiredSession
+    }
+
     private static let syntheticClaudeSessionPrefix = "claude-process:"
     private static let liveSessionStalenessWindow: TimeInterval = 15 * 60
     private static let jumpOverlayDismissLeadTime: Duration = .milliseconds(20)

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -36,7 +36,7 @@ final class AppModel {
     ]
 
     /// Pure decision function exposed for unit tests.
-    static func shouldSuppressOverlayForFullscreen(
+    nonisolated static func shouldSuppressOverlayForFullscreen(
         hideInFullscreenEnabled: Bool,
         isOverlayScreenFullscreen: Bool,
         hasAttentionRequiredSession: Bool

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -967,12 +967,19 @@ final class AppModel {
 
     // MARK: - Fullscreen visibility
 
+    @ObservationIgnored private var lastAppliedSuppression: Bool?
+
     private func handleFullscreenDisplaysChanged(_ fullscreenDisplays: Set<CGDirectDisplayID>) {
-        let resolvedScreen = OverlayDisplayResolver.resolveTargetScreen(
-            preferredScreenID: overlay.preferredOverlayScreenIDForExternalUse
-        )
-        let islandDisplayID = resolvedScreen.flatMap { FullscreenSpaceObserver.displayID(for: $0) }
-        let newValue = islandDisplayID.map { fullscreenDisplays.contains($0) } ?? false
+        let newValue: Bool
+        if fullscreenDisplays.isEmpty {
+            newValue = false
+        } else {
+            let resolvedScreen = OverlayDisplayResolver.resolveTargetScreen(
+                preferredScreenID: overlay.preferredOverlayScreenID
+            )
+            let islandDisplayID = resolvedScreen.flatMap { FullscreenSpaceObserver.displayID(for: $0) }
+            newValue = islandDisplayID.map { fullscreenDisplays.contains($0) } ?? false
+        }
         guard newValue != isOverlayScreenFullscreen else { return }
         isOverlayScreenFullscreen = newValue
         applyFullscreenVisibility()
@@ -984,12 +991,14 @@ final class AppModel {
             isOverlayScreenFullscreen: isOverlayScreenFullscreen,
             hasAttentionRequiredSession: hasAttentionRequiredSession
         )
+        guard suppress != lastAppliedSuppression else { return }
+        lastAppliedSuppression = suppress
         if suppress {
             overlay.overlayPanelController.forceHide()
         } else {
             overlay.overlayPanelController.forceShowIfNeeded(
                 model: self,
-                preferredScreenID: overlay.preferredOverlayScreenIDForExternalUse
+                preferredScreenID: overlay.preferredOverlayScreenID
             )
         }
     }

--- a/Sources/OpenIslandApp/FullscreenSpaceObserver.swift
+++ b/Sources/OpenIslandApp/FullscreenSpaceObserver.swift
@@ -3,6 +3,113 @@ import Foundation
 
 @MainActor
 final class FullscreenSpaceObserver {
+    /// Called when the set of fullscreen displays changes. Set BEFORE `start()`.
+    var onChange: ((Set<CGDirectDisplayID>) -> Void)?
+
+    private var lastValue: Set<CGDirectDisplayID> = []
+    private var workspaceObserver: NSObjectProtocol?
+    private var screenParamsObserver: NSObjectProtocol?
+
+    deinit {
+        // Tokens are released; nothing to invalidate beyond the notification center entries.
+        // Removal must happen on main; rely on `stop()` being called explicitly.
+    }
+
+    func start() {
+        guard workspaceObserver == nil else { return }
+
+        let workspaceCenter = NSWorkspace.shared.notificationCenter
+        workspaceObserver = workspaceCenter.addObserver(
+            forName: NSWorkspace.activeSpaceDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.recompute() }
+        }
+
+        screenParamsObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.recompute() }
+        }
+
+        // Initial sample so AppModel has a correct value before any space changes.
+        recompute()
+    }
+
+    func stop() {
+        if let token = workspaceObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(token)
+            workspaceObserver = nil
+        }
+        if let token = screenParamsObserver {
+            NotificationCenter.default.removeObserver(token)
+            screenParamsObserver = nil
+        }
+    }
+
+    /// Forces a re-scan. Public so AppModel can trigger an evaluation right
+    /// after the panel is created (initial state).
+    func recompute() {
+        let value = currentFullscreenDisplays()
+        guard value != lastValue else { return }
+        lastValue = value
+        onChange?(value)
+    }
+
+    // MARK: - Scan
+
+    private func currentFullscreenDisplays() -> Set<CGDirectDisplayID> {
+        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        guard let raw = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
+            return []
+        }
+
+        // Layer-0 windows are regular app windows. Higher layers are status
+        // bar / dock / system overlays.
+        let appWindows = raw.filter { ($0[kCGWindowLayer as String] as? Int) == 0 }
+
+        var result: Set<CGDirectDisplayID> = []
+        for screen in NSScreen.screens {
+            guard let displayID = Self.displayID(for: screen) else { continue }
+            // CGWindowList bounds are in CG (top-left origin) coordinates.
+            // NSScreen.frame is bottom-left; convert by flipping against the
+            // primary screen height.
+            let primary = NSScreen.screens.first
+            let primaryHeight = primary?.frame.height ?? screen.frame.height
+            let cgScreenFrame = CGRect(
+                x: screen.frame.minX,
+                y: primaryHeight - screen.frame.maxY,
+                width: screen.frame.width,
+                height: screen.frame.height
+            )
+            // Take the topmost (= first) layer-0 window whose bounds intersect
+            // this screen's CG frame.
+            let topWindow = appWindows.first { entry in
+                guard let dict = entry[kCGWindowBounds as String] as? [String: CGFloat],
+                      let bounds = CGRect(dictionaryRepresentation: dict as CFDictionary) else {
+                    return false
+                }
+                return bounds.intersects(cgScreenFrame)
+            }
+            guard let dict = topWindow?[kCGWindowBounds as String] as? [String: CGFloat],
+                  let bounds = CGRect(dictionaryRepresentation: dict as CFDictionary) else {
+                continue
+            }
+            if Self.screenIsCovered(byTopWindowBounds: bounds, screenFrame: cgScreenFrame) {
+                result.insert(displayID)
+            }
+        }
+        return result
+    }
+
+    static func displayID(for screen: NSScreen) -> CGDirectDisplayID? {
+        let key = NSDeviceDescriptionKey("NSScreenNumber")
+        return (screen.deviceDescription[key] as? NSNumber)?.uint32Value
+    }
+
     /// Pure helper: does the topmost layer-0 window bound completely cover
     /// the screen frame (i.e. extend across the menu-bar area too)?
     /// A ±1pt tolerance absorbs sub-pixel rounding in `CGWindowListCopyWindowInfo`.

--- a/Sources/OpenIslandApp/FullscreenSpaceObserver.swift
+++ b/Sources/OpenIslandApp/FullscreenSpaceObserver.swift
@@ -109,7 +109,7 @@ final class FullscreenSpaceObserver {
     /// Pure helper: does the topmost layer-0 window bound completely cover
     /// the screen frame (i.e. extend across the menu-bar area too)?
     /// A ±1pt tolerance absorbs sub-pixel rounding in `CGWindowListCopyWindowInfo`.
-    static func screenIsCovered(byTopWindowBounds bounds: CGRect, screenFrame: CGRect) -> Bool {
+    nonisolated static func screenIsCovered(byTopWindowBounds bounds: CGRect, screenFrame: CGRect) -> Bool {
         let widthDelta = abs(bounds.width - screenFrame.width)
         let heightDelta = abs(bounds.height - screenFrame.height)
         let originXDelta = abs(bounds.minX - screenFrame.minX)

--- a/Sources/OpenIslandApp/FullscreenSpaceObserver.swift
+++ b/Sources/OpenIslandApp/FullscreenSpaceObserver.swift
@@ -1,0 +1,19 @@
+import AppKit
+import Foundation
+
+@MainActor
+final class FullscreenSpaceObserver {
+    /// Pure helper: does the topmost layer-0 window bound completely cover
+    /// the screen frame (i.e. extend across the menu-bar area too)?
+    /// A ±1pt tolerance absorbs sub-pixel rounding in `CGWindowListCopyWindowInfo`.
+    static func screenIsCovered(byTopWindowBounds bounds: CGRect, screenFrame: CGRect) -> Bool {
+        let widthDelta = abs(bounds.width - screenFrame.width)
+        let heightDelta = abs(bounds.height - screenFrame.height)
+        let originXDelta = abs(bounds.minX - screenFrame.minX)
+        let originYDelta = abs(bounds.minY - screenFrame.minY)
+        return widthDelta <= 1
+            && heightDelta <= 1
+            && originXDelta <= 1
+            && originYDelta <= 1
+    }
+}

--- a/Sources/OpenIslandApp/FullscreenSpaceObserver.swift
+++ b/Sources/OpenIslandApp/FullscreenSpaceObserver.swift
@@ -10,10 +10,9 @@ final class FullscreenSpaceObserver {
     private var workspaceObserver: NSObjectProtocol?
     private var screenParamsObserver: NSObjectProtocol?
 
-    deinit {
-        // Tokens are released; nothing to invalidate beyond the notification center entries.
-        // Removal must happen on main; rely on `stop()` being called explicitly.
-    }
+    // No deinit cleanup: this observer is held for the app's lifetime by AppModel.
+    // The notification tokens capture `[weak self]` so no retain cycle exists; if a
+    // future caller needs early teardown, call `stop()` explicitly.
 
     func start() {
         guard workspaceObserver == nil else { return }
@@ -50,8 +49,6 @@ final class FullscreenSpaceObserver {
         }
     }
 
-    /// Forces a re-scan. Public so AppModel can trigger an evaluation right
-    /// after the panel is created (initial state).
     func recompute() {
         let value = currentFullscreenDisplays()
         guard value != lastValue else { return }
@@ -71,14 +68,13 @@ final class FullscreenSpaceObserver {
         // bar / dock / system overlays.
         let appWindows = raw.filter { ($0[kCGWindowLayer as String] as? Int) == 0 }
 
+        // CGWindowList bounds are in CG (top-left origin) coordinates;
+        // NSScreen.frame is bottom-left. Flip against the primary screen height.
+        let screens = NSScreen.screens
+        let primaryHeight = screens.first?.frame.height ?? 0
         var result: Set<CGDirectDisplayID> = []
-        for screen in NSScreen.screens {
+        for screen in screens {
             guard let displayID = Self.displayID(for: screen) else { continue }
-            // CGWindowList bounds are in CG (top-left origin) coordinates.
-            // NSScreen.frame is bottom-left; convert by flipping against the
-            // primary screen height.
-            let primary = NSScreen.screens.first
-            let primaryHeight = primary?.frame.height ?? screen.frame.height
             let cgScreenFrame = CGRect(
                 x: screen.frame.minX,
                 y: primaryHeight - screen.frame.maxY,

--- a/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
+++ b/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
@@ -153,6 +153,22 @@ enum OverlayDisplayResolver {
         placementMode(for: screen) == .notch ? "Built-in notch" : "Top-bar fallback"
     }
 
+    /// Public façade for the same screen-resolution logic
+    /// `OverlayPanelController` uses internally. Returns the screen the
+    /// island will be placed on, or nil if no screens are connected.
+    static func resolveTargetScreen(preferredScreenID: String?) -> NSScreen? {
+        let screens = NSScreen.screens
+        guard !screens.isEmpty else { return nil }
+        if let preferredScreenID,
+           let screen = screens.first(where: { screenID(for: $0) == preferredScreenID }) {
+            return screen
+        }
+        if let notchScreen = screens.first(where: { $0.safeAreaInsets.top > 0 }) {
+            return notchScreen
+        }
+        return NSScreen.main ?? screens[0]
+    }
+
     private static func screenID(for screen: NSScreen) -> String {
         let key = NSDeviceDescriptionKey("NSScreenNumber")
         if let number = screen.deviceDescription[key] as? NSNumber {

--- a/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
+++ b/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
@@ -153,9 +153,6 @@ enum OverlayDisplayResolver {
         placementMode(for: screen) == .notch ? "Built-in notch" : "Top-bar fallback"
     }
 
-    /// Public façade for the same screen-resolution logic
-    /// `OverlayPanelController` uses internally. Returns the screen the
-    /// island will be placed on, or nil if no screens are connected.
     static func resolveTargetScreen(preferredScreenID: String?) -> NSScreen? {
         let screens = NSScreen.screens
         guard !screens.isEmpty else { return nil }

--- a/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
+++ b/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
@@ -154,16 +154,7 @@ enum OverlayDisplayResolver {
     }
 
     static func resolveTargetScreen(preferredScreenID: String?) -> NSScreen? {
-        let screens = NSScreen.screens
-        guard !screens.isEmpty else { return nil }
-        if let preferredScreenID,
-           let screen = screens.first(where: { screenID(for: $0) == preferredScreenID }) {
-            return screen
-        }
-        if let notchScreen = screens.first(where: { $0.safeAreaInsets.top > 0 }) {
-            return notchScreen
-        }
-        return NSScreen.main ?? screens[0]
+        resolveScreen(preferredScreenID: preferredScreenID)?.screen
     }
 
     private static func screenID(for screen: NSScreen) -> String {

--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -96,22 +96,16 @@ final class OverlayPanelController {
         }
     }
 
-    /// Fully orders the panel out of the window list and stops mouse-event
-    /// monitors. Used to make the overlay disappear from fullscreen Spaces
-    /// (Mission Control, app fullscreen) when the user has opted in.
     func forceHide() {
         guard let panel else { return }
         panel.orderOut(nil)
         eventMonitors.stop()
     }
 
-    /// Restores the panel after `forceHide()`. Re-positions it on the resolved
-    /// target screen and re-arms the event monitors. No-op if the panel is
-    /// already visible.
     func forceShowIfNeeded(model: AppModel, preferredScreenID: String?) {
-        self.model = model
         guard let panel else { return }
         if !panel.isVisible {
+            self.model = model
             positionPanel(panel, preferredScreenID: preferredScreenID, animated: false)
             panel.orderFrontRegardless()
             panel.ignoresMouseEvents = true
@@ -136,7 +130,7 @@ final class OverlayPanelController {
     // MARK: - Panel creation
 
     private func makePanel(model: AppModel) -> NotchPanel {
-        let screen = resolveTargetScreen() ?? NSScreen.main
+        let screen = OverlayDisplayResolver.resolveTargetScreen(preferredScreenID: nil) ?? NSScreen.main
         let windowFrame = screen.map { panelFrame(for: model, on: $0) } ?? .zero
 
         let panel = NotchPanel(
@@ -165,7 +159,7 @@ final class OverlayPanelController {
         hostingView.notchController = self
         panel.contentView = hostingView
 
-        computeNotchRect(screen: resolveTargetScreen())
+        computeNotchRect(screen: OverlayDisplayResolver.resolveTargetScreen(preferredScreenID: nil))
         return panel
     }
 
@@ -177,7 +171,7 @@ final class OverlayPanelController {
         preferredScreenID: String?,
         animated: Bool
     ) -> OverlayPlacementDiagnostics? {
-        guard let screen = resolveTargetScreen(preferredScreenID: preferredScreenID) else {
+        guard let screen = OverlayDisplayResolver.resolveTargetScreen(preferredScreenID: preferredScreenID) else {
             return nil
         }
 
@@ -219,30 +213,6 @@ final class OverlayPanelController {
         let notchX = screenFrame.midX - notchSize.width / 2
         let notchY = screenFrame.maxY - notchSize.height
         notchRect = NSRect(x: notchX, y: notchY, width: notchSize.width, height: notchSize.height)
-    }
-
-    private func resolveTargetScreen(preferredScreenID: String? = nil) -> NSScreen? {
-        let screens = NSScreen.screens
-        guard !screens.isEmpty else { return nil }
-
-        if let preferredScreenID,
-           let screen = screens.first(where: { screenID(for: $0) == preferredScreenID }) {
-            return screen
-        }
-
-        if let notchScreen = screens.first(where: { $0.safeAreaInsets.top > 0 }) {
-            return notchScreen
-        }
-
-        return NSScreen.main ?? screens[0]
-    }
-
-    private func screenID(for screen: NSScreen) -> String {
-        let key = NSDeviceDescriptionKey("NSScreenNumber")
-        if let number = screen.deviceDescription[key] as? NSNumber {
-            return "display-\(number.uint32Value)"
-        }
-        return screen.localizedName
     }
 
     // MARK: - Mouse event monitoring
@@ -487,7 +457,7 @@ final class OverlayPanelController {
     }
 
     private func closedSurfaceRect(for model: AppModel) -> NSRect? {
-        guard let screen = resolveTargetScreen() else {
+        guard let screen = OverlayDisplayResolver.resolveTargetScreen(preferredScreenID: nil) else {
             return nil
         }
 

--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -96,6 +96,30 @@ final class OverlayPanelController {
         }
     }
 
+    /// Fully orders the panel out of the window list and stops mouse-event
+    /// monitors. Used to make the overlay disappear from fullscreen Spaces
+    /// (Mission Control, app fullscreen) when the user has opted in.
+    func forceHide() {
+        guard let panel else { return }
+        panel.orderOut(nil)
+        eventMonitors.stop()
+    }
+
+    /// Restores the panel after `forceHide()`. Re-positions it on the resolved
+    /// target screen and re-arms the event monitors. No-op if the panel is
+    /// already visible.
+    func forceShowIfNeeded(model: AppModel, preferredScreenID: String?) {
+        self.model = model
+        guard let panel else { return }
+        if !panel.isVisible {
+            positionPanel(panel, preferredScreenID: preferredScreenID, animated: false)
+            panel.orderFrontRegardless()
+            panel.ignoresMouseEvents = true
+            panel.acceptsMouseMovedEvents = false
+        }
+        startEventMonitoring()
+    }
+
     func reposition(preferredScreenID: String?) -> OverlayPlacementDiagnostics? {
         guard let panel else {
             return placementDiagnostics(preferredScreenID: preferredScreenID)

--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -98,6 +98,7 @@ final class OverlayPanelController {
 
     func forceHide() {
         guard let panel else { return }
+        cancelHoverOpenImmediately()
         panel.orderOut(nil)
         eventMonitors.stop()
     }
@@ -107,10 +108,9 @@ final class OverlayPanelController {
         if !panel.isVisible {
             self.model = model
             positionPanel(panel, preferredScreenID: preferredScreenID, animated: false)
-            panel.orderFrontRegardless()
-            panel.ignoresMouseEvents = true
-            panel.acceptsMouseMovedEvents = false
+            presentPanel(panel, activates: Self.shouldActivatePanel(for: model.notchOpenReason))
         }
+        setInteractive(model.notchStatus == .opened)
         startEventMonitoring()
     }
 
@@ -457,7 +457,9 @@ final class OverlayPanelController {
     }
 
     private func closedSurfaceRect(for model: AppModel) -> NSRect? {
-        guard let screen = OverlayDisplayResolver.resolveTargetScreen(preferredScreenID: nil) else {
+        guard let screen = OverlayDisplayResolver.resolveTargetScreen(
+            preferredScreenID: model.overlay.preferredOverlayScreenID
+        ) else {
             return nil
         }
 

--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -47,6 +47,10 @@ final class OverlayPanelController {
         panel?.isVisible == true
     }
 
+    var hasPanel: Bool {
+        panel != nil
+    }
+
     nonisolated static func shouldActivatePanel(for reason: NotchOpenReason?) -> Bool {
         reason == .click
     }

--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -24,6 +24,7 @@ final class OverlayUICoordinator {
             }
             persistOverlayDisplayPreference()
             refreshOverlayPlacement()
+            appModel?.reevaluateOverlayScreenFullscreen()
         }
     }
 

--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -73,6 +73,11 @@ final class OverlayUICoordinator {
         ignoresPointerExitAccessor?() ?? false
     }
 
+    /// Public read-only mirror of `preferredOverlayScreenID` so `AppModel`
+    /// can pass it through to the panel controller without taking a
+    /// dependency on `OverlayUICoordinator` internals.
+    var preferredOverlayScreenIDForExternalUse: String? { preferredOverlayScreenID }
+
     private var preferredOverlayScreenID: String? {
         overlayDisplaySelectionID == OverlayDisplayOption.automaticID
             ? nil

--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -73,12 +73,7 @@ final class OverlayUICoordinator {
         ignoresPointerExitAccessor?() ?? false
     }
 
-    /// Public read-only mirror of `preferredOverlayScreenID` so `AppModel`
-    /// can pass it through to the panel controller without taking a
-    /// dependency on `OverlayUICoordinator` internals.
-    var preferredOverlayScreenIDForExternalUse: String? { preferredOverlayScreenID }
-
-    private var preferredOverlayScreenID: String? {
+    var preferredOverlayScreenID: String? {
         overlayDisplaySelectionID == OverlayDisplayOption.automaticID
             ? nil
             : overlayDisplaySelectionID

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -207,6 +207,10 @@ struct GeneralSettingsPane: View {
 
             Section(lang.t("settings.general.behavior")) {
                 Toggle(lang.t("settings.general.autoCollapse"), isOn: .constant(true))
+                Toggle(lang.t("settings.general.hideFullscreen"), isOn: Binding(
+                    get: { model.hideInFullscreenEnabled },
+                    set: { model.hideInFullscreenEnabled = $0 }
+                ))
                 Toggle(lang.t("settings.general.showDockIcon"), isOn: Binding(
                     get: { model.showDockIcon },
                     set: { model.showDockIcon = $0 }

--- a/Tests/OpenIslandAppTests/FullscreenOverlayPolicyTests.swift
+++ b/Tests/OpenIslandAppTests/FullscreenOverlayPolicyTests.swift
@@ -1,0 +1,27 @@
+import Testing
+@testable import OpenIslandApp
+
+struct FullscreenOverlayPolicyTests {
+    @Test
+    func suppressOnlyWhenEnabledAndFullscreenAndNoAttention() {
+        // (hideEnabled, isFullscreen, hasAttention) -> expectedSuppress
+        let cases: [(Bool, Bool, Bool, Bool)] = [
+            (false, false, false, false),
+            (false, false, true,  false),
+            (false, true,  false, false),
+            (false, true,  true,  false),
+            (true,  false, false, false),
+            (true,  false, true,  false),
+            (true,  true,  false, true),   // the only case that suppresses
+            (true,  true,  true,  false),
+        ]
+        for (enabled, fs, attention, expected) in cases {
+            let actual = AppModel.shouldSuppressOverlayForFullscreen(
+                hideInFullscreenEnabled: enabled,
+                isOverlayScreenFullscreen: fs,
+                hasAttentionRequiredSession: attention
+            )
+            #expect(actual == expected, "enabled=\(enabled) fs=\(fs) attention=\(attention)")
+        }
+    }
+}

--- a/Tests/OpenIslandAppTests/FullscreenSpaceObserverTests.swift
+++ b/Tests/OpenIslandAppTests/FullscreenSpaceObserverTests.swift
@@ -1,0 +1,44 @@
+import AppKit
+import Testing
+@testable import OpenIslandApp
+
+struct FullscreenSpaceObserverTests {
+    @Test
+    func coverageReturnsTrueWhenBoundsEqualScreenFrame() {
+        let frame = CGRect(x: 0, y: 0, width: 1_440, height: 900)
+        #expect(FullscreenSpaceObserver.screenIsCovered(byTopWindowBounds: frame, screenFrame: frame))
+    }
+
+    @Test
+    func coverageReturnsFalseWhenBoundsLeaveMenuBar() {
+        // Screen frame includes menu bar; window stops at the menu bar bottom.
+        let frame = CGRect(x: 0, y: 0, width: 1_440, height: 900)
+        let bounds = CGRect(x: 0, y: 25, width: 1_440, height: 875)
+        #expect(!FullscreenSpaceObserver.screenIsCovered(byTopWindowBounds: bounds, screenFrame: frame))
+    }
+
+    @Test
+    func coverageReturnsFalseWhenBoundsAreSmaller() {
+        let frame = CGRect(x: 0, y: 0, width: 1_440, height: 900)
+        let bounds = CGRect(x: 100, y: 100, width: 800, height: 600)
+        #expect(!FullscreenSpaceObserver.screenIsCovered(byTopWindowBounds: bounds, screenFrame: frame))
+    }
+
+    @Test
+    func coverageReturnsFalseWhenBoundsExceedScreen() {
+        // Defensive: a window that spans multiple screens should not be treated
+        // as fullscreen on either of them.
+        let frame = CGRect(x: 0, y: 0, width: 1_440, height: 900)
+        let bounds = CGRect(x: -100, y: 0, width: 3_000, height: 900)
+        #expect(!FullscreenSpaceObserver.screenIsCovered(byTopWindowBounds: bounds, screenFrame: frame))
+    }
+
+    @Test
+    func coverageAllowsOnePixelTolerance() {
+        // CGWindowListCopyWindowInfo bounds are sometimes off by a sub-pixel
+        // due to coordinate rounding; the helper must tolerate ±1pt.
+        let frame = CGRect(x: 0, y: 0, width: 1_440, height: 900)
+        let bounds = CGRect(x: 0, y: 0, width: 1_439, height: 900)
+        #expect(FullscreenSpaceObserver.screenIsCovered(byTopWindowBounds: bounds, screenFrame: frame))
+    }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,8 @@ This index is the repository map for humans and coding agents. Read these files 
 ## Superpowers Plans
 
 - [docs/superpowers/plans/2026-04-18-opencode-stability.md](./superpowers/plans/2026-04-18-opencode-stability.md) for the OpenCode stability implementation plan
+- [docs/superpowers/plans/2026-05-02-hide-overlay-in-fullscreen.md](./superpowers/plans/2026-05-02-hide-overlay-in-fullscreen.md) for the hide-overlay-in-fullscreen implementation plan
+- [docs/superpowers/specs/2026-05-02-hide-overlay-in-fullscreen-design.md](./superpowers/specs/2026-05-02-hide-overlay-in-fullscreen-design.md) for the hide-overlay-in-fullscreen design spec
 
 ## Runtime And Product Notes
 

--- a/docs/superpowers/plans/2026-05-02-hide-overlay-in-fullscreen.md
+++ b/docs/superpowers/plans/2026-05-02-hide-overlay-in-fullscreen.md
@@ -1,0 +1,666 @@
+# Hide Overlay In Fullscreen Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-hide the Open Island overlay (closed bar + opened panel) when a native fullscreen Space is active on the island's display, while still surfacing attention-required agent prompts. Toggleable in settings, default on.
+
+**Architecture:** A new `FullscreenSpaceObserver` watches `NSWorkspace.activeSpaceDidChangeNotification` + `NSApplication.didChangeScreenParametersNotification` and uses `CGWindowListCopyWindowInfo` to compute the set of fullscreen displays. `AppModel` owns the policy decision (`shouldSuppressOverlayForFullscreen`) combining the user toggle, the fullscreen state of the island's screen, and whether any session needs attention. `OverlayPanelController` gets `forceHide`/`forceShowIfNeeded` that flip `NSPanel.orderOut`/`orderFrontRegardless` and stop/start mouse-event monitors.
+
+**Tech Stack:** Swift 6.2, AppKit, SwiftUI, Swift Testing (`Testing` module). macOS 14+.
+
+**Spec:** `docs/superpowers/specs/2026-05-02-hide-overlay-in-fullscreen-design.md`
+
+**Branch:** `feat/hide-overlay-in-fullscreen` (worktree at `.claude/worktrees/feat-hide-overlay-fullscreen/`).
+
+---
+
+## Task 1: Pure helper — `FullscreenSpaceObserver.screenIsCovered`
+
+**Files:**
+- Create: `Sources/OpenIslandApp/FullscreenSpaceObserver.swift`
+- Test: `Tests/OpenIslandAppTests/FullscreenSpaceObserverTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/OpenIslandAppTests/FullscreenSpaceObserverTests.swift`:
+
+```swift
+import AppKit
+import Testing
+@testable import OpenIslandApp
+
+struct FullscreenSpaceObserverTests {
+    @Test
+    func coverageReturnsTrueWhenBoundsEqualScreenFrame() {
+        let frame = CGRect(x: 0, y: 0, width: 1_440, height: 900)
+        #expect(FullscreenSpaceObserver.screenIsCovered(byTopWindowBounds: frame, screenFrame: frame))
+    }
+
+    @Test
+    func coverageReturnsFalseWhenBoundsLeaveMenuBar() {
+        // Screen frame includes menu bar; window stops at the menu bar bottom.
+        let frame = CGRect(x: 0, y: 0, width: 1_440, height: 900)
+        let bounds = CGRect(x: 0, y: 25, width: 1_440, height: 875)
+        #expect(!FullscreenSpaceObserver.screenIsCovered(byTopWindowBounds: bounds, screenFrame: frame))
+    }
+
+    @Test
+    func coverageReturnsFalseWhenBoundsAreSmaller() {
+        let frame = CGRect(x: 0, y: 0, width: 1_440, height: 900)
+        let bounds = CGRect(x: 100, y: 100, width: 800, height: 600)
+        #expect(!FullscreenSpaceObserver.screenIsCovered(byTopWindowBounds: bounds, screenFrame: frame))
+    }
+
+    @Test
+    func coverageReturnsFalseWhenBoundsExceedScreen() {
+        // Defensive: a window that spans multiple screens should not be treated
+        // as fullscreen on either of them.
+        let frame = CGRect(x: 0, y: 0, width: 1_440, height: 900)
+        let bounds = CGRect(x: -100, y: 0, width: 3_000, height: 900)
+        #expect(!FullscreenSpaceObserver.screenIsCovered(byTopWindowBounds: bounds, screenFrame: frame))
+    }
+
+    @Test
+    func coverageAllowsOnePixelTolerance() {
+        // CGWindowListCopyWindowInfo bounds are sometimes off by a sub-pixel
+        // due to coordinate rounding; the helper must tolerate ±1pt.
+        let frame = CGRect(x: 0, y: 0, width: 1_440, height: 900)
+        let bounds = CGRect(x: 0, y: 0, width: 1_439, height: 900)
+        #expect(FullscreenSpaceObserver.screenIsCovered(byTopWindowBounds: bounds, screenFrame: frame))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --filter FullscreenSpaceObserverTests`
+Expected: FAIL — `FullscreenSpaceObserver` is not defined.
+
+- [ ] **Step 3: Create file with minimal implementation**
+
+Create `Sources/OpenIslandApp/FullscreenSpaceObserver.swift`:
+
+```swift
+import AppKit
+import Foundation
+
+@MainActor
+final class FullscreenSpaceObserver {
+    /// Pure helper: does the topmost layer-0 window bound completely cover
+    /// the screen frame (i.e. extend across the menu-bar area too)?
+    /// A ±1pt tolerance absorbs sub-pixel rounding in `CGWindowListCopyWindowInfo`.
+    static func screenIsCovered(byTopWindowBounds bounds: CGRect, screenFrame: CGRect) -> Bool {
+        let widthDelta = abs(bounds.width - screenFrame.width)
+        let heightDelta = abs(bounds.height - screenFrame.height)
+        let originXDelta = abs(bounds.minX - screenFrame.minX)
+        let originYDelta = abs(bounds.minY - screenFrame.minY)
+        return widthDelta <= 1
+            && heightDelta <= 1
+            && originXDelta <= 1
+            && originYDelta <= 1
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --filter FullscreenSpaceObserverTests`
+Expected: PASS — 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/OpenIslandApp/FullscreenSpaceObserver.swift Tests/OpenIslandAppTests/FullscreenSpaceObserverTests.swift
+git commit -m "feat(overlay): add FullscreenSpaceObserver coverage helper"
+```
+
+---
+
+## Task 2: Pure helper — `AppModel.shouldSuppressOverlayForFullscreen`
+
+**Files:**
+- Modify: `Sources/OpenIslandApp/AppModel.swift` (add static helper near other class-level helpers, e.g. just below `static let defaultStatusColors`)
+- Test: `Tests/OpenIslandAppTests/FullscreenOverlayPolicyTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/OpenIslandAppTests/FullscreenOverlayPolicyTests.swift`:
+
+```swift
+import Testing
+@testable import OpenIslandApp
+
+struct FullscreenOverlayPolicyTests {
+    @Test
+    func suppressOnlyWhenEnabledAndFullscreenAndNoAttention() {
+        // (hideEnabled, isFullscreen, hasAttention) -> expectedSuppress
+        let cases: [(Bool, Bool, Bool, Bool)] = [
+            (false, false, false, false),
+            (false, false, true,  false),
+            (false, true,  false, false),
+            (false, true,  true,  false),
+            (true,  false, false, false),
+            (true,  false, true,  false),
+            (true,  true,  false, true),   // the only case that suppresses
+            (true,  true,  true,  false),
+        ]
+        for (enabled, fs, attention, expected) in cases {
+            let actual = AppModel.shouldSuppressOverlayForFullscreen(
+                hideInFullscreenEnabled: enabled,
+                isOverlayScreenFullscreen: fs,
+                hasAttentionRequiredSession: attention
+            )
+            #expect(actual == expected, "enabled=\(enabled) fs=\(fs) attention=\(attention)")
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --filter FullscreenOverlayPolicyTests`
+Expected: FAIL — `shouldSuppressOverlayForFullscreen` is not defined.
+
+- [ ] **Step 3: Add the static helper to `AppModel`**
+
+In `Sources/OpenIslandApp/AppModel.swift`, find the `static let defaultStatusColors: [SessionPhase: String] = [...]` block (around line 30) and add directly after its closing `]`:
+
+```swift
+    /// Pure decision function exposed for unit tests.
+    static func shouldSuppressOverlayForFullscreen(
+        hideInFullscreenEnabled: Bool,
+        isOverlayScreenFullscreen: Bool,
+        hasAttentionRequiredSession: Bool
+    ) -> Bool {
+        hideInFullscreenEnabled
+            && isOverlayScreenFullscreen
+            && !hasAttentionRequiredSession
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --filter FullscreenOverlayPolicyTests`
+Expected: PASS — all 8 truth-table rows pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/OpenIslandApp/AppModel.swift Tests/OpenIslandAppTests/FullscreenOverlayPolicyTests.swift
+git commit -m "feat(overlay): add fullscreen suppression policy helper"
+```
+
+---
+
+## Task 3: Runtime — `FullscreenSpaceObserver` class
+
+**Files:**
+- Modify: `Sources/OpenIslandApp/FullscreenSpaceObserver.swift`
+
+No new test — the class wraps `NSWorkspace` notifications and `CGWindowListCopyWindowInfo`, neither of which is meaningful to mock. Coverage is via Task 1's pure helper plus the manual smoke checklist.
+
+- [ ] **Step 1: Add notification observers, scan logic, and onChange callback**
+
+Replace the entire body of `Sources/OpenIslandApp/FullscreenSpaceObserver.swift` with:
+
+```swift
+import AppKit
+import Foundation
+
+@MainActor
+final class FullscreenSpaceObserver {
+    /// Called when the set of fullscreen displays changes. Set BEFORE `start()`.
+    var onChange: ((Set<CGDirectDisplayID>) -> Void)?
+
+    private var lastValue: Set<CGDirectDisplayID> = []
+    private var workspaceObserver: NSObjectProtocol?
+    private var screenParamsObserver: NSObjectProtocol?
+
+    deinit {
+        // Tokens are released; nothing to invalidate beyond the notification center entries.
+        // Removal must happen on main; rely on `stop()` being called explicitly.
+    }
+
+    func start() {
+        guard workspaceObserver == nil else { return }
+
+        let workspaceCenter = NSWorkspace.shared.notificationCenter
+        workspaceObserver = workspaceCenter.addObserver(
+            forName: NSWorkspace.activeSpaceDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.recompute() }
+        }
+
+        screenParamsObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.recompute() }
+        }
+
+        // Initial sample so AppModel has a correct value before any space changes.
+        recompute()
+    }
+
+    func stop() {
+        if let token = workspaceObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(token)
+            workspaceObserver = nil
+        }
+        if let token = screenParamsObserver {
+            NotificationCenter.default.removeObserver(token)
+            screenParamsObserver = nil
+        }
+    }
+
+    /// Forces a re-scan. Public so AppModel can trigger an evaluation right
+    /// after the panel is created (initial state).
+    func recompute() {
+        let value = currentFullscreenDisplays()
+        guard value != lastValue else { return }
+        lastValue = value
+        onChange?(value)
+    }
+
+    // MARK: - Scan
+
+    private func currentFullscreenDisplays() -> Set<CGDirectDisplayID> {
+        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        guard let raw = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
+            return []
+        }
+
+        // Layer-0 windows are regular app windows. Higher layers are status
+        // bar / dock / system overlays.
+        let appWindows = raw.filter { ($0[kCGWindowLayer as String] as? Int) == 0 }
+
+        var result: Set<CGDirectDisplayID> = []
+        for screen in NSScreen.screens {
+            guard let displayID = Self.displayID(for: screen) else { continue }
+            // CGWindowList bounds are in CG (top-left origin) coordinates.
+            // NSScreen.frame is bottom-left; convert by flipping against the
+            // primary screen height.
+            let primary = NSScreen.screens.first
+            let primaryHeight = primary?.frame.height ?? screen.frame.height
+            let cgScreenFrame = CGRect(
+                x: screen.frame.minX,
+                y: primaryHeight - screen.frame.maxY,
+                width: screen.frame.width,
+                height: screen.frame.height
+            )
+            // Take the topmost (= first) layer-0 window whose bounds intersect
+            // this screen's CG frame.
+            let topWindow = appWindows.first { entry in
+                guard let dict = entry[kCGWindowBounds as String] as? [String: CGFloat],
+                      let bounds = CGRect(dictionaryRepresentation: dict as CFDictionary) else {
+                    return false
+                }
+                return bounds.intersects(cgScreenFrame)
+            }
+            guard let dict = topWindow?[kCGWindowBounds as String] as? [String: CGFloat],
+                  let bounds = CGRect(dictionaryRepresentation: dict as CFDictionary) else {
+                continue
+            }
+            if Self.screenIsCovered(byTopWindowBounds: bounds, screenFrame: cgScreenFrame) {
+                result.insert(displayID)
+            }
+        }
+        return result
+    }
+
+    static func displayID(for screen: NSScreen) -> CGDirectDisplayID? {
+        let key = NSDeviceDescriptionKey("NSScreenNumber")
+        return (screen.deviceDescription[key] as? NSNumber)?.uint32Value
+    }
+
+    /// Pure helper: does the topmost layer-0 window bound completely cover
+    /// the screen frame (i.e. extend across the menu-bar area too)?
+    /// A ±1pt tolerance absorbs sub-pixel rounding in `CGWindowListCopyWindowInfo`.
+    static func screenIsCovered(byTopWindowBounds bounds: CGRect, screenFrame: CGRect) -> Bool {
+        let widthDelta = abs(bounds.width - screenFrame.width)
+        let heightDelta = abs(bounds.height - screenFrame.height)
+        let originXDelta = abs(bounds.minX - screenFrame.minX)
+        let originYDelta = abs(bounds.minY - screenFrame.minY)
+        return widthDelta <= 1
+            && heightDelta <= 1
+            && originXDelta <= 1
+            && originYDelta <= 1
+    }
+}
+```
+
+- [ ] **Step 2: Re-run Task 1 tests to confirm helper still passes**
+
+Run: `swift test --filter FullscreenSpaceObserverTests`
+Expected: PASS — all 5 tests still pass.
+
+- [ ] **Step 3: Build to confirm class compiles**
+
+Run: `swift build`
+Expected: success (no errors).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/OpenIslandApp/FullscreenSpaceObserver.swift
+git commit -m "feat(overlay): scan fullscreen displays via CGWindowList"
+```
+
+---
+
+## Task 4: `OverlayPanelController.forceHide` / `forceShowIfNeeded`
+
+**Files:**
+- Modify: `Sources/OpenIslandApp/OverlayPanelController.swift` — insert the two methods directly after the existing `setInteractive(_:)` (around line 97).
+
+- [ ] **Step 1: Add the two methods**
+
+In `Sources/OpenIslandApp/OverlayPanelController.swift`, find the `setInteractive(_:)` method (around line 86–97). Directly after its closing `}`, insert:
+
+```swift
+    /// Fully orders the panel out of the window list and stops mouse-event
+    /// monitors. Used to make the overlay disappear from fullscreen Spaces
+    /// (Mission Control, app fullscreen) when the user has opted in.
+    func forceHide() {
+        guard let panel else { return }
+        panel.orderOut(nil)
+        eventMonitors.stop()
+    }
+
+    /// Restores the panel after `forceHide()`. Re-positions it on the resolved
+    /// target screen and re-arms the event monitors. No-op if the panel is
+    /// already visible.
+    func forceShowIfNeeded(model: AppModel, preferredScreenID: String?) {
+        self.model = model
+        guard let panel else { return }
+        if !panel.isVisible {
+            positionPanel(panel, preferredScreenID: preferredScreenID, animated: false)
+            panel.orderFrontRegardless()
+            panel.ignoresMouseEvents = true
+            panel.acceptsMouseMovedEvents = false
+        }
+        startEventMonitoring()
+    }
+```
+
+- [ ] **Step 2: Build**
+
+Run: `swift build`
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/OpenIslandApp/OverlayPanelController.swift
+git commit -m "feat(overlay): add forceHide/forceShowIfNeeded controls"
+```
+
+---
+
+## Task 5: Wire into `AppModel`
+
+**Files:**
+- Modify: `Sources/OpenIslandApp/AppModel.swift`
+
+This task adds: defaults key, stored toggle, fullscreen state, derived `hasAttentionRequiredSession`, observer instance, init wiring, didSet hook, and post-mutation hook in `applyTrackedEvent`.
+
+- [ ] **Step 1: Add the defaults key**
+
+In `Sources/OpenIslandApp/AppModel.swift`, find the block of `private static let ...DefaultsKey` declarations (around line 18–28). Add after the existing `suppressFrontmostNotificationsDefaultsKey` line:
+
+```swift
+    private static let hideInFullscreenDefaultsKey = "app.hideInFullscreen"
+```
+
+- [ ] **Step 2: Add the stored toggle and fullscreen state**
+
+In the same file, find the `var suppressFrontmostNotifications: Bool = true { ... }` block (around line 255–260). Directly after its closing `}`, insert:
+
+```swift
+    var hideInFullscreenEnabled: Bool = true {
+        didSet {
+            guard hasFinishedInit, hideInFullscreenEnabled != oldValue else { return }
+            UserDefaults.standard.set(hideInFullscreenEnabled, forKey: Self.hideInFullscreenDefaultsKey)
+            applyFullscreenVisibility()
+        }
+    }
+
+    private(set) var isOverlayScreenFullscreen: Bool = false
+```
+
+- [ ] **Step 3: Add the observer instance and `hasAttentionRequiredSession`**
+
+Still in `AppModel.swift`, find a suitable spot near the other coordinator properties (e.g. just below `let updateChecker = UpdateChecker()` around line 63). Add:
+
+```swift
+    private let fullscreenObserver = FullscreenSpaceObserver()
+
+    var hasAttentionRequiredSession: Bool {
+        surfacedSessions.contains { $0.phase.requiresAttention }
+    }
+```
+
+- [ ] **Step 4: Register the default and read it during init**
+
+In `AppModel.init`, find the `UserDefaults.standard.register(defaults: [...])` block (around line 492–497). Add the new key with default value `true`:
+
+```swift
+        UserDefaults.standard.register(defaults: [
+            Self.showDockIconDefaultsKey: true,
+            Self.hapticFeedbackEnabledDefaultsKey: false,
+            Self.completionReplyEnabledDefaultsKey: false,
+            Self.suppressFrontmostNotificationsDefaultsKey: true,
+            Self.hideInFullscreenDefaultsKey: true,
+        ])
+```
+
+Then, immediately after the existing `suppressFrontmostNotifications = UserDefaults.standard.bool(...)` line (around line 502), add:
+
+```swift
+        hideInFullscreenEnabled = UserDefaults.standard.bool(forKey: Self.hideInFullscreenDefaultsKey)
+```
+
+- [ ] **Step 5: Start the observer at the end of init**
+
+Still in `AppModel.init`, find where `hasFinishedInit = true` is set (around line 609). Directly **before** that line, insert:
+
+```swift
+        fullscreenObserver.onChange = { [weak self] fullscreenDisplays in
+            self?.handleFullscreenDisplaysChanged(fullscreenDisplays)
+        }
+        fullscreenObserver.start()
+```
+
+- [ ] **Step 6: Add the handler and visibility application methods**
+
+Find a location in `AppModel` near other overlay-related forwarders (e.g. just before `func notchOpen(...)` forwarder around line 912, or grouped with the other internal helpers — anywhere is fine as long as it compiles). Add:
+
+```swift
+    private func handleFullscreenDisplaysChanged(_ fullscreenDisplays: Set<CGDirectDisplayID>) {
+        let resolvedScreen = OverlayDisplayResolver.resolveTargetScreen(
+            preferredScreenID: overlay.preferredOverlayScreenIDForExternalUse
+        )
+        let islandDisplayID = resolvedScreen.flatMap { FullscreenSpaceObserver.displayID(for: $0) }
+        let newValue = islandDisplayID.map { fullscreenDisplays.contains($0) } ?? false
+        guard newValue != isOverlayScreenFullscreen else { return }
+        isOverlayScreenFullscreen = newValue
+        applyFullscreenVisibility()
+    }
+
+    func applyFullscreenVisibility() {
+        let suppress = Self.shouldSuppressOverlayForFullscreen(
+            hideInFullscreenEnabled: hideInFullscreenEnabled,
+            isOverlayScreenFullscreen: isOverlayScreenFullscreen,
+            hasAttentionRequiredSession: hasAttentionRequiredSession
+        )
+        if suppress {
+            overlay.overlayPanelController.forceHide()
+        } else {
+            overlay.overlayPanelController.forceShowIfNeeded(
+                model: self,
+                preferredScreenID: overlay.preferredOverlayScreenIDForExternalUse
+            )
+        }
+    }
+```
+
+> **Note on `OverlayDisplayResolver.resolveTargetScreen` and `preferredOverlayScreenIDForExternalUse`**: these don't exist yet as public surfaces. Step 7 expands access. Step 8 calls the post-mutation hook.
+
+- [ ] **Step 7: Expose the screen resolver and preferred screen ID**
+
+`OverlayDisplayResolver.resolveTargetScreen` is currently used only inside `OverlayPanelController` via a private method. Add a public static helper. In `Sources/OpenIslandApp/OverlayDisplayConfiguration.swift`, find the `enum OverlayDisplayResolver` block and add (matching existing helper style):
+
+```swift
+    /// Public façade for the same screen-resolution logic
+    /// `OverlayPanelController` uses internally. Returns the screen the
+    /// island will be placed on, or nil if no screens are connected.
+    static func resolveTargetScreen(preferredScreenID: String?) -> NSScreen? {
+        let screens = NSScreen.screens
+        guard !screens.isEmpty else { return nil }
+        if let preferredScreenID,
+           let screen = screens.first(where: { screenID(for: $0) == preferredScreenID }) {
+            return screen
+        }
+        if let notchScreen = screens.first(where: { $0.safeAreaInsets.top > 0 }) {
+            return notchScreen
+        }
+        return NSScreen.main ?? screens[0]
+    }
+```
+
+In `Sources/OpenIslandApp/OverlayUICoordinator.swift`, find the `private var preferredOverlayScreenID: String?` property (around line 76). Directly after that block add:
+
+```swift
+    /// Public read-only mirror of `preferredOverlayScreenID` so `AppModel`
+    /// can pass it through to the panel controller without taking a
+    /// dependency on `OverlayUICoordinator` internals.
+    var preferredOverlayScreenIDForExternalUse: String? { preferredOverlayScreenID }
+```
+
+`overlay.overlayPanelController` referenced in Step 6 must also be reachable from `AppModel`. In `OverlayUICoordinator.swift`, find the `private let overlayPanelController = OverlayPanelController()` declaration (search the file). If it is `private`, change to:
+
+```swift
+    let overlayPanelController = OverlayPanelController()
+```
+
+- [ ] **Step 8: Hook into `applyTrackedEvent`**
+
+In `AppModel.swift`, find `func applyTrackedEvent(...)` (around line 1180). Locate the line `refreshOverlayPlacementIfVisible()` (around line 1213). Directly **after** that line, insert:
+
+```swift
+        applyFullscreenVisibility()
+```
+
+(This catches phase transitions that flip `hasAttentionRequiredSession`. The call is cheap and idempotent.)
+
+- [ ] **Step 9: Build**
+
+Run: `swift build`
+Expected: success.
+
+- [ ] **Step 10: Run all tests**
+
+Run: `swift test`
+Expected: all existing tests pass plus the two new test files.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add Sources/OpenIslandApp/AppModel.swift Sources/OpenIslandApp/OverlayDisplayConfiguration.swift Sources/OpenIslandApp/OverlayUICoordinator.swift
+git commit -m "feat(overlay): wire fullscreen suppression into AppModel"
+```
+
+---
+
+## Task 6: Settings toggle
+
+**Files:**
+- Modify: `Sources/OpenIslandApp/Views/SettingsView.swift`
+
+- [ ] **Step 1: Add the toggle to the General → Behavior section**
+
+Find `Section(lang.t("settings.general.behavior")) { ... }` in `GeneralSettingsPane` (around line 207). Directly **after** the `Toggle(lang.t("settings.general.autoCollapse"), isOn: .constant(true))` line, insert:
+
+```swift
+                Toggle(lang.t("settings.general.hideFullscreen"), isOn: Binding(
+                    get: { model.hideInFullscreenEnabled },
+                    set: { model.hideInFullscreenEnabled = $0 }
+                ))
+```
+
+(Localization keys for `settings.general.hideFullscreen` already exist in en/zh-Hans/zh-Hant — no string changes needed.)
+
+- [ ] **Step 2: Build**
+
+Run: `swift build`
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/OpenIslandApp/Views/SettingsView.swift
+git commit -m "feat(settings): add hide-in-fullscreen toggle"
+```
+
+---
+
+## Task 7: Smoke verification & PR
+
+- [ ] **Step 1: Refresh the dev signing & dev bundle, then launch**
+
+Run:
+
+```bash
+zsh scripts/launch-dev-app.sh
+```
+
+Expected: `~/Applications/Open Island Dev.app` launches with the rebuilt binary; menu-bar icon appears.
+
+- [ ] **Step 2: Run through the manual checklist**
+
+Walk through the 10-step manual checklist from the spec (`docs/superpowers/specs/2026-05-02-hide-overlay-in-fullscreen-design.md` → "Manual verification"). For each step, note whether it passes. The critical ones:
+
+1. Toggle visible in Settings → General → Behavior, default ON.
+2. Safari → Enter Full Screen on the island's screen → island disappears.
+3. Exit fullscreen → island reappears.
+4. While fullscreen, run a Claude Code action that triggers PreToolUse (e.g. `Bash(rm test.txt)` against an unapproved path) → notification card pops; Allow/Deny works; after response, island re-hides.
+5. While fullscreen, let an agent finish a task (`completed`) → no notification appears; on exiting fullscreen, completion is reflected in island state.
+6. Toggle OFF → repeat #2: island stays visible during fullscreen.
+7. External display fullscreen, island on built-in → island visible.
+8. Built-in fullscreen, island on built-in, external untouched → island hidden, no errors elsewhere.
+9. Hot-plug external display while fullscreen → no crash.
+10. Mission Control invocation → no overlay flicker.
+
+- [ ] **Step 3: Push branch and open PR**
+
+Run:
+
+```bash
+git push -u origin feat/hide-overlay-in-fullscreen
+```
+
+Then create the PR with `gh pr create` targeting `main`. Title: `feat: hide island in fullscreen with toggle`. Body must include:
+- Summary (3 bullets)
+- Test plan (paste the 10-step manual checklist with checkboxes)
+- Reference to the spec and plan files
+
+- [ ] **Step 4: Exit the worktree**
+
+After the PR is open, hand control back to the user; do NOT auto-merge. Use `ExitWorktree` action `keep` so the branch and worktree remain available for follow-up review fixes.
+
+---
+
+## Self-Review Notes (kept inline)
+
+Spec coverage: every numbered decision (1–4) and every architecture item (`FullscreenSpaceObserver`, `forceHide`, `applyFullscreenVisibility`, settings toggle, `hasAttentionRequiredSession`) maps to a task above. Manual checklist items 1–10 map 1:1 to Task 7 Step 2.
+
+Type / signature consistency:
+- `FullscreenSpaceObserver.screenIsCovered(byTopWindowBounds:screenFrame:)` — defined Task 1, re-used Task 3.
+- `FullscreenSpaceObserver.displayID(for:)` — defined Task 3, called Task 5.
+- `AppModel.shouldSuppressOverlayForFullscreen(hideInFullscreenEnabled:isOverlayScreenFullscreen:hasAttentionRequiredSession:)` — defined Task 2, called Task 5.
+- `OverlayPanelController.forceHide()` / `forceShowIfNeeded(model:preferredScreenID:)` — defined Task 4, called Task 5.
+- `OverlayDisplayResolver.resolveTargetScreen(preferredScreenID:)` — defined Task 5 Step 7, called Task 5 Step 6.
+- `OverlayUICoordinator.preferredOverlayScreenIDForExternalUse` and `overlayPanelController` access — exposed Task 5 Step 7.

--- a/docs/superpowers/specs/2026-05-02-hide-overlay-in-fullscreen-design.md
+++ b/docs/superpowers/specs/2026-05-02-hide-overlay-in-fullscreen-design.md
@@ -94,7 +94,7 @@ static func shouldSuppressOverlayForFullscreen(
 
 Wiring:
 - Register default `true` for `hideInFullscreenDefaultsKey` alongside existing defaults.
-- On init: instantiate `FullscreenSpaceObserver`, set `onChange` callback that maps `Set<CGDirectDisplayID>` → `isOverlayScreenFullscreen`. The island's `displayID` is read from the same `NSScreen` `OverlayPanelController.resolveTargetScreen(preferredScreenID:)` returns (i.e. the resolved overlay screen at the moment of evaluation), via its `deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")]` (already used by the controller for screen IDs). Then call `applyFullscreenVisibility()`.
+- On init: instantiate `FullscreenSpaceObserver`, set `onChange` callback that maps `Set<CGDirectDisplayID>` → `isOverlayScreenFullscreen`. The island's `displayID` is read from the same `NSScreen` `OverlayDisplayResolver.resolveTargetScreen(preferredScreenID:)` returns (i.e. the resolved overlay screen at the moment of evaluation), via its `deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")]` (already used for screen IDs). Then call `applyFullscreenVisibility()`.
 - After AgentEvent application that may flip `hasAttentionRequiredSession`: invoke `applyFullscreenVisibility()` from a single existing post-mutation hook in `AppModel` (e.g. the place that already triggers UI side-effects after `state.apply(_:)`). Cheap and idempotent.
 
 ### `OverlayPanelController`

--- a/docs/superpowers/specs/2026-05-02-hide-overlay-in-fullscreen-design.md
+++ b/docs/superpowers/specs/2026-05-02-hide-overlay-in-fullscreen-design.md
@@ -1,0 +1,224 @@
+# Hide Overlay In Fullscreen — Design
+
+**Status:** Spec  
+**Date:** 2026-05-02  
+**Branch:** `feat/hide-overlay-in-fullscreen`
+
+## Problem
+
+Open Island's overlay panel uses `NSWindow.CollectionBehavior` `.fullScreenAuxiliary` and `.canJoinAllSpaces`, so the closed island bar (and any expanded panel) keeps drawing in the notch / top-bar area while the user is in a native macOS fullscreen Space (Safari video, IDE fullscreen, Keynote presentation, …). This breaks the immersive feel users expect from fullscreen.
+
+The existing localization keys `settings.general.hideFullscreen` are present in en / zh-Hans / zh-Hant, and a UI toggle for this setting once existed but was removed in #103 because no implementation backed it. This spec re-introduces the toggle with a real implementation.
+
+## Goals
+
+- Hide the overlay (closed bar + opened panel) while the user is in a native fullscreen Space *on the same screen as the island*.
+- Still surface attention-required events (`waitingForApproval`, `waitingForAnswer`) so agents do not get silently stuck.
+- Add a single user-visible toggle in *General → Behavior*. Default **on**.
+- No regressions in non-fullscreen, multi-display, or Mission Control transitions.
+
+## Non-goals
+
+- Hiding for non-native "covers the screen" cases (auto-hidden menu bar + maximized window). Out of scope (see "Scope of fullscreen detection" below).
+- Hiding when fullscreen is on a screen *other than* the one the island is positioned on.
+- Reworking the `IslandSurface` / notification card pipeline. We reuse the existing path.
+
+## Decisions
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | What counts as "fullscreen"? | Native fullscreen Space only — detected via active-space change + a window covering the entire `NSScreen.frame` (incl. menu bar). |
+| 2 | Behavior on attention-required events while in fullscreen? | Silent for non-urgent (e.g. `completed`); still surface `waitingForApproval` / `waitingForAnswer` as the existing notification card. |
+| 3 | Default value of the toggle? | **On**. |
+| 4 | Multi-display behavior? | Per-screen — only suppress if the *island's* screen is in fullscreen. |
+
+## Architecture
+
+### New: `Sources/OpenIslandApp/FullscreenSpaceObserver.swift`
+
+```swift
+@MainActor
+final class FullscreenSpaceObserver {
+    var onChange: ((Set<CGDirectDisplayID>) -> Void)?
+
+    func start()
+    func stop()
+
+    // Pure helper, exported for unit tests.
+    static func screenIsCovered(byTopWindowBounds bounds: CGRect, screenFrame: CGRect) -> Bool
+}
+```
+
+- Subscribes to `NSWorkspace.shared.notificationCenter` `activeSpaceDidChangeNotification`, plus `NSApplication.didChangeScreenParametersNotification`.
+- On any of those: calls `recompute()`:
+  1. `CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID)`.
+  2. Filter to entries with `kCGWindowLayer == 0` (regular app windows).
+  3. For each `NSScreen`, find the topmost layer-0 window whose bounds intersect the screen's frame (CG flipped coordinates).
+  4. Use `screenIsCovered(byTopWindowBounds:screenFrame:)` to decide whether that window covers the *whole* screen including the menu bar area.
+  5. Build `Set<CGDirectDisplayID>` of fullscreen screens.
+- Emits `onChange` only when the set differs from the previous value.
+- Throttling: triggered only by notifications, not polling. No timer.
+
+### `AppModel`
+
+New stored / derived state:
+
+```swift
+private static let hideInFullscreenDefaultsKey = "app.hideInFullscreen"
+
+var hideInFullscreenEnabled: Bool = true {
+    didSet {
+        guard hasFinishedInit, hideInFullscreenEnabled != oldValue else { return }
+        UserDefaults.standard.set(hideInFullscreenEnabled, forKey: Self.hideInFullscreenDefaultsKey)
+        applyFullscreenVisibility()
+    }
+}
+
+private(set) var isOverlayScreenFullscreen: Bool = false
+
+var hasAttentionRequiredSession: Bool {
+    surfacedSessions.contains { $0.phase.requiresAttention }
+}
+
+// Pure decision function — exposed for unit tests.
+static func shouldSuppressOverlayForFullscreen(
+    hideInFullscreenEnabled: Bool,
+    isOverlayScreenFullscreen: Bool,
+    hasAttentionRequiredSession: Bool
+) -> Bool {
+    hideInFullscreenEnabled
+        && isOverlayScreenFullscreen
+        && !hasAttentionRequiredSession
+}
+```
+
+Wiring:
+- Register default `true` for `hideInFullscreenDefaultsKey` alongside existing defaults.
+- On init: instantiate `FullscreenSpaceObserver`, set `onChange` callback that maps `Set<CGDirectDisplayID>` → `isOverlayScreenFullscreen`. The island's `displayID` is read from the same `NSScreen` `OverlayPanelController.resolveTargetScreen(preferredScreenID:)` returns (i.e. the resolved overlay screen at the moment of evaluation), via its `deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")]` (already used by the controller for screen IDs). Then call `applyFullscreenVisibility()`.
+- After AgentEvent application that may flip `hasAttentionRequiredSession`: invoke `applyFullscreenVisibility()` from a single existing post-mutation hook in `AppModel` (e.g. the place that already triggers UI side-effects after `state.apply(_:)`). Cheap and idempotent.
+
+### `OverlayPanelController`
+
+Two new methods:
+
+```swift
+func forceHide() {
+    guard let panel else { return }
+    panel.orderOut(nil)
+    eventMonitors.stop()
+}
+
+func forceShowIfNeeded(model: AppModel, preferredScreenID: String?) {
+    guard let panel else { return }
+    if !panel.isVisible {
+        positionPanel(panel, preferredScreenID: preferredScreenID, animated: false)
+        panel.orderFrontRegardless()
+    }
+    startEventMonitoring()
+}
+```
+
+`forceHide` differs from existing `hide()`: existing `hide()` only flips `ignoresMouseEvents`. We need full `orderOut` so the panel does not participate in Mission Control / `.fullScreenAuxiliary` Space membership while suppressed.
+
+### `AppModel.applyFullscreenVisibility()`
+
+Lives on `AppModel` (single owner of `hideInFullscreenEnabled`, `isOverlayScreenFullscreen`, `surfacedSessions`). Forwards to `overlayPanelController` directly — no new responsibility added to `OverlayUICoordinator`.
+
+```swift
+func applyFullscreenVisibility() {
+    let suppress = AppModel.shouldSuppressOverlayForFullscreen(
+        hideInFullscreenEnabled: hideInFullscreenEnabled,
+        isOverlayScreenFullscreen: isOverlayScreenFullscreen,
+        hasAttentionRequiredSession: hasAttentionRequiredSession
+    )
+
+    if suppress {
+        overlayPanelController.forceHide()
+    } else {
+        overlayPanelController.forceShowIfNeeded(
+            model: self,
+            preferredScreenID: preferredOverlayScreenID
+        )
+    }
+}
+```
+
+Call sites:
+- After observer fires (screen set changed, or island screen changed).
+- `hideInFullscreenEnabled` `didSet`.
+- After AgentEvent reducer mutations that may flip `hasAttentionRequiredSession` (centralized: invoke at the tail of the existing post-mutation hook).
+
+### Settings UI
+
+In `Sources/OpenIslandApp/Views/SettingsView.swift`, `GeneralSettingsPane > Section("settings.general.behavior")`, add **above** the existing `autoCollapse` row:
+
+```swift
+Toggle(lang.t("settings.general.hideFullscreen"), isOn: Binding(
+    get: { model.hideInFullscreenEnabled },
+    set: { model.hideInFullscreenEnabled = $0 }
+))
+```
+
+No new localization strings required — `settings.general.hideFullscreen` already exists in `en`, `zh-Hans`, `zh-Hant`.
+
+## Data flow
+
+### Normal (non-attention) flow
+1. User enters fullscreen → `activeSpaceDidChangeNotification` fires.
+2. Observer recomputes screen set → `AppModel.isOverlayScreenFullscreen` flips `true`.
+3. `applyFullscreenVisibility()` → `forceHide()` → panel `orderOut`, monitors stopped.
+4. User exits fullscreen → reverse path → `forceShowIfNeeded()`.
+
+### Attention-required override
+1. Fullscreen active, panel suppressed.
+2. Agent emits `PreToolUse` → reducer updates session phase to `.waitingForApproval` → `hasAttentionRequiredSession` becomes `true`.
+3. `applyFullscreenVisibility()` re-evaluates → suppress = false → `forceShowIfNeeded()`.
+4. Existing notification path runs (`coordinator.notchOpen(reason: .notification, ...)`), with sound/haptic per existing settings.
+5. User responds → phase becomes `.running` or `.completed` → `hasAttentionRequiredSession` becomes `false`.
+6. `applyFullscreenVisibility()` re-evaluates → if still fullscreen, `forceHide()` again.
+7. Subsequent `.completed` notifications: stay silent (suppress = true).
+
+### Edge cases handled
+- **Island screen migration** (external display unplug, user moves overlay target): `didChangeScreenParameters` triggers recompute; observer pulls fresh `NSScreen.screens`; AppModel re-resolves overlay screen displayID.
+- **Toggle flipped at runtime**: `didSet` calls `applyFullscreenVisibility()` immediately.
+- **Pre-existing attention session when user enters fullscreen**: suppress = false → panel keeps showing; expected.
+- **Panel not yet created**: `forceHide` and `forceShowIfNeeded` are guarded against `panel == nil`.
+
+## Testing
+
+### Unit tests
+
+`OpenIslandAppTests/FullscreenSpaceObserverTests`:
+- `screenIsCovered` returns `true` for bounds equal to screen frame.
+- Returns `false` for bounds equal to `visibleFrame` (menu bar visible — not fullscreen).
+- Returns `false` for bounds smaller than frame.
+- Returns `false` for bounds larger than frame (multi-screen spanning, defensive).
+
+`OpenIslandAppTests/FullscreenOverlayPolicyTests`:
+- 8-row truth table over `(hideInFullscreenEnabled, isOverlayScreenFullscreen, hasAttentionRequiredSession)` against `shouldSuppressOverlayForFullscreen`. Only `(true, true, false)` returns `true`.
+
+### Manual verification (PR test plan)
+1. Default-on after upgrade: toggle visible in *General → Behavior*, checked by default.
+2. Safari fullscreen on island's screen → overlay disappears (closed bar + any open panel).
+3. Exit fullscreen → overlay reappears immediately.
+4. In fullscreen, trigger Claude Code `PreToolUse` request → notification card pops; Allow / Deny works; after response, overlay re-hides.
+5. In fullscreen, trigger a `completed` event → no notification; on exiting fullscreen, completion is reflected in island state.
+6. Toggle off → overlay remains visible while in fullscreen (legacy behavior).
+7. Multi-display: external display in fullscreen, island on built-in screen → overlay visible.
+8. Multi-display: built-in screen (island) in fullscreen, external display unaffected → overlay hidden, no errors elsewhere.
+9. Hot-plug external display while in fullscreen → no crash; state reconciles within ~1 frame.
+10. Mission Control invocation does not cause overlay flicker.
+
+End-to-end fullscreen automation is not pursued — Spaces transitions cannot be reliably driven from `swift test`.
+
+## Out-of-scope / explicit non-changes
+- The `panel.collectionBehavior = [.fullScreenAuxiliary, .canJoinAllSpaces, .ignoresCycle]` flags stay as-is; suppression is dynamic via `orderOut`.
+- No changes to notification sound, haptics, or auto-collapse timing.
+- No new localization strings.
+- No changes to closed-island idle-edge mode logic.
+
+## Rollout
+- Single feature branch → PR to `main`.
+- Bilingual release-note entry under "Behavior":
+  - **Behavior**: Hide the island automatically when an app is in fullscreen on the same display; urgent agent prompts still surface as notifications. Toggle in *General → Behavior*. Defaults to on.
+  - 行为：当同屏应用进入全屏时自动隐藏灵动岛；agent 的紧急请求仍会以通知形式出现。可在 *常规 → 行为* 中关闭，默认开启。


### PR DESCRIPTION
## Summary
- Auto-hide the island overlay (closed bar + opened panel) when a native fullscreen Space is active on the island's display.
- Attention-required agent prompts (\`waitingForApproval\`, \`waitingForAnswer\`) still surface as notifications even while in fullscreen — agents never get silently stuck.
- New toggle in *Settings → General → Behavior* (\`settings.general.hideFullscreen\`, localized strings already shipped). Default **on**.

## Architecture
- New \`FullscreenSpaceObserver\` watches \`NSWorkspace.activeSpaceDidChangeNotification\` + \`NSApplication.didChangeScreenParametersNotification\` and uses \`CGWindowListCopyWindowInfo\` to compute the set of fullscreen displays.
- \`AppModel\` owns the policy decision (\`shouldSuppressOverlayForFullscreen\`) combining the user toggle, the fullscreen state of the island's screen, and whether any session needs attention.
- \`OverlayPanelController.forceHide()\` / \`forceShowIfNeeded()\` flip \`NSPanel.orderOut\`/\`orderFrontRegardless\` and stop/start mouse-event monitors.
- Per-screen scope: only the island's screen is checked, so fullscreen on an external display while the island lives on the built-in screen does not hide.

## Design / Plan
- Spec: \`docs/superpowers/specs/2026-05-02-hide-overlay-in-fullscreen-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-02-hide-overlay-in-fullscreen.md\`

## Test plan
Pure-function unit tests added (\`FullscreenSpaceObserverTests\`, \`FullscreenOverlayPolicyTests\`). Manual verification (run from Xcode or via \`scripts/launch-dev-app.sh\`):

- [ ] Default-on after upgrade: toggle visible in *General → Behavior*, checked by default.
- [ ] Safari fullscreen on island's screen → overlay disappears (closed bar + any open panel).
- [ ] Exit fullscreen → overlay reappears immediately.
- [ ] In fullscreen, trigger Claude Code \`PreToolUse\` request → notification card pops; Allow / Deny works; after response, overlay re-hides.
- [ ] In fullscreen, trigger a \`completed\` event → no notification; on exiting fullscreen, completion is reflected in island state.
- [ ] Toggle off → overlay remains visible while in fullscreen (legacy behavior).
- [ ] Multi-display: external display in fullscreen, island on built-in screen → overlay visible.
- [ ] Multi-display: built-in screen (island) in fullscreen, external display unaffected → overlay hidden, no errors elsewhere.
- [ ] Hot-plug external display while in fullscreen → no crash; state reconciles.
- [ ] Mission Control invocation does not cause overlay flicker.

## Notes
- The \`Toggle settings.general.hideFullscreen\` UI was previously removed in #103 because no implementation backed it. This PR is the implementation; localized strings (en / zh-Hans / zh-Hant) are reused as-is.
- E2E fullscreen-state tests are not included — Spaces transitions cannot be reliably driven from \`swift test\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Overlay now auto-hides per-screen when a display enters native fullscreen; attention-required prompts still appear.
  * Added a Settings toggle (General → Behavior) to enable/disable hiding in fullscreen (on by default).
  * Overlay now avoids presenting notification surfaces that would be hidden by fullscreen suppression.

* **Improvements**
  * More reliable fullscreen detection across displays and safer show/hide behavior, including explicit force-hide/force-show handling and improved target-screen resolution.

* **Tests**
  * Added unit tests for fullscreen detection and the suppression policy.

* **Documentation**
  * Added design and rollout plans with verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->