### PR TITLE
fix(menubar): render brand mark as AppKit template image (#428)

### DIFF
--- a/Sources/OpenIslandApp/OpenIslandApp.swift
+++ b/Sources/OpenIslandApp/OpenIslandApp.swift
@@ -126,7 +126,7 @@ struct OpenIslandApp: App {
         MenuBarExtra {
             MenuBarContentView(model: appDelegate.model)
         } label: {
-            OpenIslandBrandMark(size: 18, style: .template)
+            Image(nsImage: OpenIslandBrandMark.menuBarTemplateImage)
                 .accessibilityLabel("Open Island")
                 .background(SettingsOpenerRegistrar(model: appDelegate.model))
         }

--- a/Sources/OpenIslandApp/OpenIslandBrandMark.swift
+++ b/Sources/OpenIslandApp/OpenIslandBrandMark.swift
@@ -83,7 +83,7 @@ struct OpenIslandBrandMark: View {
         let image = NSImage(size: size, flipped: false) { _ in
             guard let ctx = NSGraphicsContext.current?.cgContext else { return false }
             for pixel in pixels {
-                let alpha: CGFloat = pixel.role == "E" ? 0.7 : 1.0
+                let alpha: CGFloat = pixel.role == "E" ? 0.9 : 1.0
                 ctx.setFillColor(NSColor.black.withAlphaComponent(alpha).cgColor)
                 let rect = CGRect(
                     x: padding + CGFloat(pixel.x) * pixelSize,

--- a/Sources/OpenIslandApp/OpenIslandBrandMark.swift
+++ b/Sources/OpenIslandApp/OpenIslandBrandMark.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct OpenIslandBrandMark: View {
@@ -68,5 +69,33 @@ struct OpenIslandBrandMark: View {
         case .template:
             return Color.primary.opacity(role == "E" ? 0.9 : 1.0)
         }
+    }
+
+    /// AppKit template image for the menu-bar status item. SwiftUI's
+    /// `MenuBarExtra` does not turn an arbitrary view into a real template
+    /// image, which is why the live SwiftUI mark renders as an inverted
+    /// black block when the menu bar item is highlighted (#428).
+    static let menuBarTemplateImage: NSImage = makeMenuBarTemplateImage()
+
+    static func makeMenuBarTemplateImage(pixelSize: CGFloat = 2, padding: CGFloat = 1) -> NSImage {
+        let dimension = CGFloat(8) * pixelSize + padding * 2
+        let size = NSSize(width: dimension, height: dimension)
+        let image = NSImage(size: size, flipped: false) { _ in
+            guard let ctx = NSGraphicsContext.current?.cgContext else { return false }
+            for pixel in pixels {
+                let alpha: CGFloat = pixel.role == "E" ? 0.7 : 1.0
+                ctx.setFillColor(NSColor.black.withAlphaComponent(alpha).cgColor)
+                let rect = CGRect(
+                    x: padding + CGFloat(pixel.x) * pixelSize,
+                    y: padding + CGFloat(7 - pixel.y) * pixelSize,
+                    width: pixelSize,
+                    height: pixelSize
+                )
+                ctx.fill(rect)
+            }
+            return true
+        }
+        image.isTemplate = true
+        return image
     }
 }


### PR DESCRIPTION
Closes #428.

## Symptom

Reported by @hetiansu and confirmed by @acewanghaha: the menu-bar status item icon renders incorrectly — nearly invisible while idle, then collapses into a solid black block when the popover is opened. (See screenshots in the issue.)

## Root cause

\`Sources/OpenIslandApp/OpenIslandApp.swift\` uses SwiftUI \`MenuBarExtra\` with \`OpenIslandBrandMark(size: 18, style: .template)\` as its \`label:\`. That label is an arbitrary SwiftUI view containing a \`.drawingGroup\` (which flattens it into an offscreen Metal texture) and \`Color.primary\` for fill.

\`MenuBarExtra\` renders the label, but the result is **not** a real macOS template image (\`NSImage.isTemplate = true\`). Two consequences fall out:

1. While idle, the system can't pick a contrast color → icon looks transparent / a faint block.
2. When the menu-bar item enters the highlighted (selected) state on click, AppKit applies its standard inversion / contrast routine to *non-template* images → the icon collapses into a solid filled block.

## Fix

Pre-rasterize the same 8×8 brand pattern (which is data-driven by \`scoutPattern\`) to an \`NSImage\` with \`isTemplate = true\` and use \`Image(nsImage:)\` as the \`MenuBarExtra\` label. AppKit then handles light / dark / highlight states correctly.

\`OpenIslandBrandMark\`'s SwiftUI \`body\` is **unchanged** — every other use site (island surface, settings panes, onboarding) keeps the duotone SwiftUI path.

## Files

- \`Sources/OpenIslandApp/OpenIslandBrandMark.swift\` (+29) — adds \`makeMenuBarTemplateImage\` and a cached \`menuBarTemplateImage\`. Reuses the existing \`pixels\` data, no duplication of the 8×8 pattern.
- \`Sources/OpenIslandApp/OpenIslandApp.swift\` (~1) — swaps the \`MenuBarExtra\` \`label:\` to \`Image(nsImage: OpenIslandBrandMark.menuBarTemplateImage)\`.

\`+30 / -1\`.

## Test plan

\`swift build\` passes. AppKit rendering can't be unit-tested usefully — manual verification:

- [ ] Light mode → icon is dark, recognizable as the brand pattern.
- [ ] Dark mode → icon auto-inverts to light, still recognizable.
- [ ] Click to open popover → menu-bar item enters highlighted state → icon stays clean and inverted, no longer collapses into a black block.
- [ ] Close popover → icon returns to idle look.
- [ ] Confirm island / settings / onboarding still show the colored duotone brand mark unchanged.

If you'd like, I can attach before/after screenshots of the three states once you've confirmed the approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS menu bar icon rendering and visual consistency by replacing the previous rendering with a template-based menu-bar image, resulting in crisper, correctly inverted pixel rendering and consistent opacity handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->