### PR TITLE
fix(jump): detect VS Code forks before VS Code in process tree (#415)

### DIFF
--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -405,13 +405,9 @@ struct ActiveAgentProcessDiscovery {
             return "Zellij"
         }
 
-        // VS Code family
-        if lowered.contains("/visual studio code.app/") || lowered.contains("/code helper") {
-            return "VS Code"
-        }
-        if lowered.contains("/visual studio code - insiders.app/") {
-            return "VS Code Insiders"
-        }
+        // VS Code family — check forks BEFORE plain VS Code so fork apps that
+        // retain the upstream "Code Helper" naming inside their Electron
+        // framework aren't misidentified as VS Code (#415).
         if lowered.contains("/cursor.app/") {
             return "Cursor"
         }
@@ -420,6 +416,18 @@ struct ActiveAgentProcessDiscovery {
         }
         if lowered.contains("/trae.app/") {
             return "Trae"
+        }
+        if lowered.contains("/qoder.app/") {
+            return "Qoder"
+        }
+        if lowered.contains("/codebuddy.app/") {
+            return "CodeBuddy"
+        }
+        if lowered.contains("/visual studio code - insiders.app/") {
+            return "VS Code Insiders"
+        }
+        if lowered.contains("/visual studio code.app/") {
+            return "VS Code"
         }
 
         // JetBrains IDEs

--- a/Sources/OpenIslandApp/TerminalJumpService.swift
+++ b/Sources/OpenIslandApp/TerminalJumpService.swift
@@ -169,7 +169,8 @@ struct TerminalJumpService {
             .map(\.bundleIdentifier)
     )
 
-    /// Bundle identifiers of VS Code family editors (VS Code, Insiders, Cursor, Windsurf, Trae).
+    /// Bundle identifiers of VS Code family editors (VS Code, Insiders, Cursor,
+    /// Windsurf, Trae, Qoder).
     private static let vscodeFamilyBundleIDs: Set<String> = [
         "com.microsoft.VSCode",
         "com.microsoft.VSCodeInsiders",
@@ -177,6 +178,7 @@ struct TerminalJumpService {
         "com.exafunction.windsurf",
         "com.trae.app",
         "cn.trae.app",
+        "com.qoder.qoder",
     ]
 
     /// Bundle identifiers of terminal emulators that commonly host Zellij,

--- a/Sources/OpenIslandApp/TerminalJumpService.swift
+++ b/Sources/OpenIslandApp/TerminalJumpService.swift
@@ -169,17 +169,9 @@ struct TerminalJumpService {
             .map(\.bundleIdentifier)
     )
 
-    /// Bundle identifiers of VS Code family editors (VS Code, Insiders, Cursor,
-    /// Windsurf, Trae, Qoder).
-    private static let vscodeFamilyBundleIDs: Set<String> = [
-        "com.microsoft.VSCode",
-        "com.microsoft.VSCodeInsiders",
-        "com.todesktop.230313mzl4w4u92",
-        "com.exafunction.windsurf",
-        "com.trae.app",
-        "cn.trae.app",
-        "com.qoder.qoder",
-    ]
+    /// Bundle identifiers of VS Code family editors. Derived from
+    /// `vscodeFamilyCLI` so the two maps cannot drift.
+    private static let vscodeFamilyBundleIDs: Set<String> = Set(vscodeFamilyCLI.keys)
 
     /// Bundle identifiers of terminal emulators that commonly host Zellij,
     /// derived from `knownApps` so it stays in sync automatically.
@@ -450,9 +442,11 @@ struct TerminalJumpService {
         return try runAppleScript(script) == "matched"
     }
 
-    // MARK: - VS Code family (VS Code, Insiders, Cursor, Windsurf, Trae)
+    // MARK: - VS Code family (VS Code, Insiders, Cursor, Windsurf, Trae, Qoder)
 
     /// Maps bundle identifiers to the CLI command used to open a workspace.
+    /// Single source of truth — `vscodeFamilyBundleIDs` is derived from these
+    /// keys, so adding a fork here automatically routes its activation case.
     private static let vscodeFamilyCLI: [String: String] = [
         "com.microsoft.VSCode": "code",
         "com.microsoft.VSCodeInsiders": "code-insiders",
@@ -460,6 +454,7 @@ struct TerminalJumpService {
         "com.exafunction.windsurf": "windsurf",
         "com.trae.app": "trae",
         "cn.trae.app": "trae",
+        "com.qoder.qoder": "qoder",
     ]
 
     private func jumpToVSCodeFamilyWorkspace(_ workspacePath: String, bundleIdentifier: String) -> Bool {

--- a/Tests/OpenIslandAppTests/ActiveAgentProcessDiscoveryTests.swift
+++ b/Tests/OpenIslandAppTests/ActiveAgentProcessDiscoveryTests.swift
@@ -94,4 +94,47 @@ struct ActiveAgentProcessDiscoveryTests {
             ),
         ])
     }
+
+    /// VS Code forks (Cursor, Windsurf, Trae, Qoder) bundle Electron's "Code
+    /// Helper" inside their .app bundles. Their helper paths therefore contain
+    /// both "/<fork>.app/" and "/code helper", and Open Island used to match
+    /// the broad "/code helper" check first → mis-attributed every fork to
+    /// stock VS Code (#415). Verify each fork is recognized correctly.
+    @Test(arguments: [
+        ("/Applications/Cursor.app/Contents/Frameworks/Code Helper.app/Contents/MacOS/Code Helper", "Cursor"),
+        ("/Applications/Windsurf.app/Contents/Frameworks/Code Helper.app/Contents/MacOS/Code Helper", "Windsurf"),
+        ("/Applications/Trae.app/Contents/Frameworks/Code Helper.app/Contents/MacOS/Code Helper", "Trae"),
+        ("/Applications/Qoder.app/Contents/Frameworks/Code Helper.app/Contents/MacOS/Code Helper", "Qoder"),
+        ("/Applications/Visual Studio Code.app/Contents/Frameworks/Code Helper.app/Contents/MacOS/Code Helper", "VS Code"),
+    ])
+    func recognizesVSCodeForkBeforeFallingBackToVSCode(parentCommand: String, expectedTerminal: String) {
+        let discovery = ActiveAgentProcessDiscovery { executablePath, arguments in
+            if executablePath == "/bin/ps" {
+                return """
+                  102 301 ttys002 /Users/test/.local/bin/claude
+                  301 900 ttys002 -/opt/homebrew/bin/fish
+                  900 1 ?? \(parentCommand)
+                """
+            }
+            guard executablePath == "/usr/sbin/lsof" else {
+                return nil
+            }
+            return """
+            fcwd
+            n/tmp/open-island
+            """
+        }
+
+        let snapshots = discovery.discover()
+
+        #expect(snapshots == [
+            .init(
+                tool: .claudeCode,
+                sessionID: nil,
+                workingDirectory: "/tmp/open-island",
+                terminalTTY: "/dev/ttys002",
+                terminalApp: expectedTerminal
+            ),
+        ])
+    }
 }


### PR DESCRIPTION
Closes #415. Thanks @vivaxy for the very precise root-cause writeup — your description matched the bug exactly.

## Root cause

VS Code forks (Cursor, Windsurf, Trae, Qoder, CodeBuddy) bundle Electron's \`Code Helper\` executable inside their \`.app\` bundles. Their helper command-line paths therefore contain **both** \`/<fork>.app/\` and \`/code helper\`. In \`ActiveAgentProcessDiscovery.recognizedTerminalApp(for:)\`, the broad \`/code helper\` check ran **before** the per-fork \`.app\` checks:

\`\`\`swift
// before
if lowered.contains(\"/visual studio code.app/\") || lowered.contains(\"/code helper\") {
    return \"VS Code\"     // ← Cursor / Windsurf / Trae / Qoder / CodeBuddy all hit here first
}
if lowered.contains(\"/cursor.app/\") { return \"Cursor\" }    // unreachable
\`\`\`

Even though Cursor / Windsurf / Trae had their own checks, those branches were unreachable for processes whose path contained the helper segment.

## Fix

Reorder the VS Code family block so each fork's \`.app\` marker is matched first, drop the now-redundant \`/code helper\` fallback (VS Code's own helper still matches the more specific \`/visual studio code.app/\` clause), and add Qoder and CodeBuddy.

Also add \`com.qoder.qoder\` to \`TerminalJumpService.vscodeFamilyBundleIDs\` so click-to-jump on a Qoder session goes through the workspace-open branch rather than falling all the way through.

CodeBuddy's bundle identifier isn't documented in the issue and I couldn't find a CodeBuddy install to read with \`mdls\` — I left it out of \`vscodeFamilyBundleIDs\` to avoid hard-coding a guess. With this PR, CodeBuddy sessions will at least be **identified correctly** as CodeBuddy in the island, and clicking them will fall back to \`open -b\` — which won't auto-open the workspace, but will at least activate the right app instead of VS Code. Happy to add the bundle id in a follow-up once we know it.

## Files

- \`Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift\` (~22 lines): reorder + add Qoder/CodeBuddy
- \`Sources/OpenIslandApp/TerminalJumpService.swift\` (~4 lines): add \`com.qoder.qoder\` to \`vscodeFamilyBundleIDs\`
- \`Tests/OpenIslandAppTests/ActiveAgentProcessDiscoveryTests.swift\` (+43): parametrized end-to-end test covering Cursor / Windsurf / Trae / Qoder forks **and** a VS Code regression case

\`+61 / -8\`.

## Test plan

- [x] \`swift build\` clean
- [x] New test \`recognizesVSCodeForkBeforeFallingBackToVSCode\` is parametrized over 5 cases (4 forks + VS Code regression). On \`main\` 4 of the 5 fail (every fork returns 'VS Code'); on this branch all 5 pass.
- [ ] Manual: install Cursor → run \`claude\` in its terminal → click the session in Open Island → Cursor (not VS Code) is activated.
- [ ] Manual: same for Qoder if you have it installed.
- [ ] Regression manual: still works for plain VS Code.

If you have a CodeBuddy install handy, sharing \`mdls -name kMDItemCFBundleIdentifier /Applications/CodeBuddy.app\` would let me round out the bundle-id table in a tiny follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved terminal app recognition for VS Code-family editors, adding explicit support for Qoder and CodeBuddy and refining detection for forks (Cursor, Windsurf, Trae).
  * Workspace-launch behavior updated to include Qoder so it routes to the correct editor.

* **Tests**
  * Added tests verifying correct detection of VS Code forks as terminal apps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->