### PR TITLE
feat: distribute via Homebrew tap (closes #427)

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -18,6 +18,14 @@ Brief English summary of this release.
 
 ## Installation | 安装说明
 
+**Homebrew** (recommended | 推荐):
+
+```bash
+brew install --cask octane0411/tap/openisland
+```
+
+**Or download manually | 或手动下载**:
+
 1. Download **Open Island.dmg**, open it, and drag **Open Island** to **Applications**.
    下载 **Open Island.dmg**，打开后将 **Open Island** 拖入 **Applications**。
 

--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -18,19 +18,17 @@ Brief English summary of this release.
 
 ## Installation | 安装说明
 
-**Homebrew** (recommended | 推荐):
-
-```bash
-brew install --cask octane0411/tap/openisland
-```
-
-**Or download manually | 或手动下载**:
-
 1. Download **Open Island.dmg**, open it, and drag **Open Island** to **Applications**.
    下载 **Open Island.dmg**，打开后将 **Open Island** 拖入 **Applications**。
 
 2. Requires **macOS 14+**. Supports both **Apple Silicon** and **Intel** Macs.
    需要 **macOS 14+**。同时支持 **Apple Silicon** 和 **Intel** Mac。
+
+**Or via Homebrew | 或使用 Homebrew**:
+
+```bash
+brew install --cask octane0411/tap/openisland
+```
 
 > This build is signed and notarized with Apple Developer ID. You can open it directly without any security workaround.
 > 本版本已通过 Apple 签名公证，可直接打开运行，无需任何安全设置。

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,6 +239,54 @@ jobs:
           EOF
           )"
 
+      - name: Update Homebrew tap cask
+        if: vars.SKIP_HOMEBREW != 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if [[ -z "${GH_TOKEN}" ]]; then
+            echo "::warning::HOMEBREW_TAP_TOKEN not set — skipping homebrew tap update"
+            exit 0
+          fi
+
+          dmg_path="output/package/Open Island.dmg"
+          sha256="$(shasum -a 256 "$dmg_path" | awk '{print $1}')"
+          echo "DMG sha256: $sha256"
+
+          workdir="$(mktemp -d)"
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/Octane0411/homebrew-tap.git" "$workdir/tap"
+          cd "$workdir/tap"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          branch="bump/openisland-v${VERSION}"
+          git checkout -b "$branch"
+
+          sed -i '' \
+            -e "s/^  version \".*\"/  version \"${VERSION}\"/" \
+            -e "s/^  sha256 \".*\"/  sha256 \"${sha256}\"/" \
+            Casks/openisland.rb
+
+          if git diff --quiet; then
+            echo "Cask already at v${VERSION}, nothing to do"
+            exit 0
+          fi
+
+          git add Casks/openisland.rb
+          git commit -m "openisland: bump to v${VERSION}"
+          git push --force origin "$branch"
+
+          gh pr create \
+            --repo Octane0411/homebrew-tap \
+            --base main \
+            --head "$branch" \
+            --title "openisland: bump to v${VERSION}" \
+            --body "Automated bump from https://github.com/Octane0411/open-vibe-island/releases/tag/v${VERSION}"
+          gh pr merge "$branch" --repo Octane0411/homebrew-tap --merge --admin --delete-branch
+
       - name: Refresh contributors image cache via PR
         continue-on-error: true
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,7 +285,7 @@ jobs:
             --head "$branch" \
             --title "openisland: bump to v${VERSION}" \
             --body "Automated bump from https://github.com/Octane0411/open-vibe-island/releases/tag/v${VERSION}"
-          gh pr merge "$branch" --repo Octane0411/homebrew-tap --merge --admin --delete-branch
+          gh pr merge "$branch" --repo Octane0411/homebrew-tap --merge --delete-branch
 
       - name: Refresh contributors image cache via PR
         continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -109,17 +109,17 @@ Think of it as an open-source [Vibe Island](https://vibeisland.app/) — **free,
 
 ## Quick Start
 
-### Option 1: Homebrew
+### Option 1: Download
+
+Grab the latest DMG from [GitHub Releases](https://github.com/Octane0411/open-vibe-island/releases) — signed and notarized, ready to run.
+
+### Option 2: Homebrew
 
 ```bash
 brew install --cask octane0411/tap/openisland
 ```
 
 Upgrade later with `brew upgrade --cask openisland`.
-
-### Option 2: Download DMG
-
-Grab the latest DMG from [GitHub Releases](https://github.com/Octane0411/open-vibe-island/releases) — signed and notarized, ready to run.
 
 ### Option 3: Build from source
 

--- a/README.md
+++ b/README.md
@@ -109,11 +109,19 @@ Think of it as an open-source [Vibe Island](https://vibeisland.app/) — **free,
 
 ## Quick Start
 
-### Option 1: Download
+### Option 1: Homebrew
+
+```bash
+brew install --cask octane0411/tap/openisland
+```
+
+Upgrade later with `brew upgrade --cask openisland`.
+
+### Option 2: Download DMG
 
 Grab the latest DMG from [GitHub Releases](https://github.com/Octane0411/open-vibe-island/releases) — signed and notarized, ready to run.
 
-### Option 2: Build from source
+### Option 3: Build from source
 
 ```bash
 git clone https://github.com/Octane0411/open-vibe-island.git

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -109,17 +109,17 @@ Open Island 驻留在 Mac 的**刘海区域**（或顶部栏），为你的 AI c
 
 ## 快速开始
 
-### 方式一：Homebrew
+### 方式一：直接下载
+
+从 [GitHub Releases](https://github.com/Octane0411/open-vibe-island/releases) 下载最新 DMG——已签名公证，开箱即用。
+
+### 方式二：Homebrew
 
 ```bash
 brew install --cask octane0411/tap/openisland
 ```
 
 后续升级用 `brew upgrade --cask openisland`。
-
-### 方式二：直接下载 DMG
-
-从 [GitHub Releases](https://github.com/Octane0411/open-vibe-island/releases) 下载最新 DMG——已签名公证，开箱即用。
 
 ### 方式三：从源码构建
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -109,11 +109,19 @@ Open Island 驻留在 Mac 的**刘海区域**（或顶部栏），为你的 AI c
 
 ## 快速开始
 
-### 方式一：直接下载
+### 方式一：Homebrew
+
+```bash
+brew install --cask octane0411/tap/openisland
+```
+
+后续升级用 `brew upgrade --cask openisland`。
+
+### 方式二：直接下载 DMG
 
 从 [GitHub Releases](https://github.com/Octane0411/open-vibe-island/releases) 下载最新 DMG——已签名公证，开箱即用。
 
-### 方式二：从源码构建
+### 方式三：从源码构建
 
 ```bash
 git clone https://github.com/Octane0411/open-vibe-island.git


### PR DESCRIPTION
## Summary

Add Homebrew distribution alongside the existing DMG download, addressing #427.

- **Tap repo**: [`Octane0411/homebrew-tap`](https://github.com/Octane0411/homebrew-tap) — already created with an initial cask pinned to v1.0.28 (validated locally with `brew style` + `brew fetch`).
- **Install**: `brew install --cask octane0411/tap/openisland`
- **Auto-update**: Cask declares `auto_updates true` so Sparkle keeps working without fighting Homebrew. `brew upgrade --cask openisland` still pulls the latest pinned version.

## Changes in this PR

- `README.md` / `README.zh-CN.md`: surface Homebrew as Option 1 in Quick Start; downgrade DMG to Option 2.
- `.github/RELEASE_TEMPLATE.md`: lead with `brew install --cask`, keep manual DMG steps as fallback.
- `.github/workflows/release.yml`: new `Update Homebrew tap cask` step after the GitHub Release is created. Computes sha256 of the post-notarized DMG, clones the tap, bumps `version` + `sha256` in `Casks/openisland.rb`, opens an auto-merging PR. `continue-on-error: true` and a missing-token guard so a misconfigured PAT never blocks a release.

## Required action before next release

A repo secret named **`HOMEBREW_TAP_TOKEN`** must be added (fine-grained PAT scoped to `Octane0411/homebrew-tap` with Contents + Pull requests read/write). Without it the new step prints a warning and exits cleanly.

## Test plan

- [x] `brew style --cask octane0411/tap/openisland` → no offenses
- [x] `brew fetch --cask octane0411/tap/openisland` → DMG downloads, sha256 matches
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` → valid
- [ ] After merging + adding `HOMEBREW_TAP_TOKEN`, push the next `v*` tag and confirm the cask PR opens and auto-merges in the tap repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Homebrew cask install option with a brew install command for easy macOS installation.

* **Documentation**
  * Updated Quick Start in English and Chinese to present three install methods (download, Homebrew, build from source).
  * Release template now includes the Homebrew installation option and command.

* **Chores**
  * Release process now automates publishing/updating the Homebrew cask as part of releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->