### PR TITLE
fix(state): grace window in removeInvisibleSessions for transcript-discovered sessions (#424)

### DIFF
--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -184,7 +184,11 @@ final class ProcessMonitoringCoordinator {
         }
 
         // Phase 4: remove sessions that are no longer visible.
-        _ = local.removeInvisibleSessions()
+        // Grace window keeps freshly-discovered sessions (e.g. transcript
+        // discovery just imported them with `phase=.completed`,
+        // `isProcessAlive=false`) for a few poll cycles so the matcher above
+        // has a chance to mark them alive on a subsequent reconcile (#424).
+        _ = local.removeInvisibleSessions(graceWindow: 10)
 
         // Single state assignment — triggers didSet exactly once.
         // Compare against the original snapshot to catch all mutations

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -438,10 +438,26 @@ public struct SessionState: Equatable, Sendable {
         upsert(session)
     }
 
-    public mutating func removeInvisibleSessions() -> Bool {
+    /// Removes sessions whose `isVisibleInIsland` is false.
+    ///
+    /// - Parameter graceWindow: when greater than 0, sessions whose
+    ///   `updatedAt` is within this many seconds of `now` are kept regardless
+    ///   of visibility. Lets a freshly-discovered session survive a poll
+    ///   cycle while `sessionIDsWithAliveProcesses` catches up — fixes #424
+    ///   where transcript-discovered sessions (created with `phase=.completed`,
+    ///   `isProcessAlive=false`) were deleted before `markProcessLiveness`
+    ///   could rescue them.
+    /// - Parameter now: clock injection point for unit tests.
+    public mutating func removeInvisibleSessions(
+        graceWindow: TimeInterval = 0,
+        now: Date = .now
+    ) -> Bool {
         let before = sessionsByID.count
+        let cutoff = now.addingTimeInterval(-graceWindow)
         sessionsByID = sessionsByID.filter { _, session in
-            session.isVisibleInIsland
+            if session.isVisibleInIsland { return true }
+            if graceWindow > 0 && session.updatedAt > cutoff { return true }
+            return false
         }
         return sessionsByID.count != before
     }

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -359,6 +359,63 @@ struct SessionStateTests {
         #expect(state.runningCount == 2)
     }
 
+    /// Models a transcript-discovered Claude Code session — `.completed`
+    /// phase, no hook management, no live process — which is exactly the
+    /// shape `ClaudeTranscriptDiscovery` produces and which `isVisibleInIsland`
+    /// rejects (#424).
+    private static func transcriptDiscoveredSession(updatedAt: Date) -> AgentSession {
+        AgentSession(
+            id: "transcript-\(updatedAt.timeIntervalSince1970)",
+            title: "Claude · workspace",
+            tool: .claudeCode,
+            attachmentState: .stale,
+            phase: .completed,
+            summary: "From transcript",
+            updatedAt: updatedAt
+        )
+    }
+
+    @Test
+    func removeInvisibleSessionsKeepsRecentlyUpdatedInvisibleSession() {
+        let now = Date()
+        var state = SessionState(
+            sessions: [Self.transcriptDiscoveredSession(updatedAt: now.addingTimeInterval(-2))]
+        )
+
+        let mutated = state.removeInvisibleSessions(graceWindow: 10, now: now)
+
+        #expect(mutated == false)
+        #expect(state.sessions.count == 1)
+    }
+
+    @Test
+    func removeInvisibleSessionsDropsStaleInvisibleSession() {
+        let now = Date()
+        var state = SessionState(
+            sessions: [Self.transcriptDiscoveredSession(updatedAt: now.addingTimeInterval(-30))]
+        )
+
+        let mutated = state.removeInvisibleSessions(graceWindow: 10, now: now)
+
+        #expect(mutated == true)
+        #expect(state.sessions.isEmpty)
+    }
+
+    @Test
+    func removeInvisibleSessionsBackwardsCompatibleDefaultZero() {
+        let now = Date()
+        var state = SessionState(
+            sessions: [Self.transcriptDiscoveredSession(updatedAt: now.addingTimeInterval(-2))]
+        )
+
+        // No grace window → original behaviour: invisible sessions are
+        // dropped immediately regardless of recency.
+        let mutated = state.removeInvisibleSessions()
+
+        #expect(mutated == true)
+        #expect(state.sessions.isEmpty)
+    }
+
     @Test
     func bridgeEnvelopeRoundTripsThroughLineCodec() throws {
         let envelope = BridgeEnvelope.event(


### PR DESCRIPTION
Closes #424. Huge thanks @NoGroceries for the very precise diagnosis — your writeup pointed straight at the race.

## Root cause (your analysis, verified)

Transcript discovery (\`ClaudeTranscriptDiscovery.swift:173-189\`) creates Claude sessions with \`phase=.completed\`, \`isHookManaged=false\`, \`isProcessAlive=false\`.

\`isVisibleInIsland\` (\`AgentSession.swift:497-507\`) for that shape only returns \`true\` via the \`isProcessAlive\` branch — which depends on \`sessionIDsWithAliveProcesses\` matching the live process to the freshly-imported session **on the very first reconcile pass**.

The matcher does three passes (exact session ID, transcript path, TTY+CWD heuristic). Each pass can miss for legitimate reasons in real environments — \`lsof\` timing race before the agent has opened the JSONL, transcript path normalised differently between discovery and process snapshot, terminal probe not yet seeded, etc. When all three miss, \`removeInvisibleSessions()\` drops the session immediately. The very next poll cycle (~2s later) finds the process, but state no longer has the session to attach to → orphan PID, missing card.

## Fix

Opt-in \`graceWindow: TimeInterval\` parameter on \`SessionState.removeInvisibleSessions\`. When > 0, sessions whose \`updatedAt\` is within the window are kept regardless of visibility. Caller in \`ProcessMonitoringCoordinator\` passes \`10\`s — five 2-second poll cycles, plenty of retries for the matcher to succeed; well below the threshold where a stale session would feel sticky.

Default value is \`0\`, so existing call sites keep their behaviour without changes.

## Why this approach (vs. the two you suggested)

- **Your option A (front-load process matching)**: the existing reconcile already matches before removing — the order isn't the bug, single-shot match unreliability is. A reorder wouldn't fix the race.
- **Your option B (grace period)**: this PR. Smallest, safest, and \`updatedAt\` already exists so no schema change.
- Considered adding \`firstSeenAt\` instead of using \`updatedAt\` — would require a new stored property + Codable changes in \`AgentSession\`. Skipped because \`updatedAt\` is set at creation by the transcript discoverer and matches the semantic ('recently touched, give it room').

## Files

- \`Sources/OpenIslandCore/SessionState.swift\` (+20): add \`graceWindow:\` and \`now:\` parameters
- \`Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift\` (+5/-1): pass \`graceWindow: 10\`
- \`Tests/OpenIslandCoreTests/SessionStateTests.swift\` (+57): three new cases (kept-within-grace, dropped-after-grace, default-zero-backwards-compat)

\`+80 / -3\`.

## Test plan

- [x] \`swift build\` clean
- [x] New unit tests cover the grace window in both directions plus the backwards-compat default
- [x] Manual: run 3 \`claude\` sessions in different terminals with stale transcripts on disk; before this fix at least one is dropped from the island; with this fix all three appear and stay.

If you'd prefer a different grace value or want it controlled by an env var / debug toggle, easy to adjust.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced session management with a grace-window mechanism for cleanup. Sessions are now retained for several polling cycles before removal, even when temporarily not visible, improving reliability and preventing unexpected loss of active monitoring sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->