### PR TITLE
feat: hide Open Island when an app is in fullscreen (#421)

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -26,6 +26,7 @@ final class AppModel {
     private static let showCodexUsageDefaultsKey = "app.showCodexUsage"
     private static let completionReplyEnabledDefaultsKey = "feature.completionReply.enabled"
     private static let suppressFrontmostNotificationsDefaultsKey = "app.suppressFrontmostNotifications"
+    private static let hideOverlayInFullscreenDefaultsKey = "app.hideOverlayInFullscreen"
 
     static let defaultStatusColors: [SessionPhase: String] = [
         .running: "#6E9FFF",
@@ -256,6 +257,13 @@ final class AppModel {
         didSet {
             guard hasFinishedInit, suppressFrontmostNotifications != oldValue else { return }
             UserDefaults.standard.set(suppressFrontmostNotifications, forKey: Self.suppressFrontmostNotificationsDefaultsKey)
+        }
+    }
+    var hideOverlayInFullscreen: Bool = true {
+        didSet {
+            guard hasFinishedInit, hideOverlayInFullscreen != oldValue else { return }
+            UserDefaults.standard.set(hideOverlayInFullscreen, forKey: Self.hideOverlayInFullscreenDefaultsKey)
+            overlay.hideOverlayInFullscreen = hideOverlayInFullscreen
         }
     }
     var launchAtLoginEnabled: Bool = false {
@@ -516,12 +524,14 @@ final class AppModel {
             Self.hapticFeedbackEnabledDefaultsKey: false,
             Self.completionReplyEnabledDefaultsKey: false,
             Self.suppressFrontmostNotificationsDefaultsKey: true,
+            Self.hideOverlayInFullscreenDefaultsKey: true,
         ])
         isSoundMuted = UserDefaults.standard.bool(forKey: Self.soundMutedDefaultsKey)
         selectedSoundName = NotificationSoundService.selectedSoundName
         showDockIcon = UserDefaults.standard.bool(forKey: Self.showDockIconDefaultsKey)
         hapticFeedbackEnabled = UserDefaults.standard.bool(forKey: Self.hapticFeedbackEnabledDefaultsKey)
         suppressFrontmostNotifications = UserDefaults.standard.bool(forKey: Self.suppressFrontmostNotificationsDefaultsKey)
+        hideOverlayInFullscreen = UserDefaults.standard.bool(forKey: Self.hideOverlayInFullscreenDefaultsKey)
         if UserDefaults.standard.object(forKey: Self.showCodexUsageDefaultsKey) != nil {
             showCodexUsage = UserDefaults.standard.bool(forKey: Self.showCodexUsageDefaultsKey)
         } else {
@@ -557,6 +567,7 @@ final class AppModel {
         }
 
         overlay.appModel = self
+        overlay.hideOverlayInFullscreen = hideOverlayInFullscreen
         overlay.restoreDisplayPreference()
         overlay.onStatusMessage = { [weak self] message in
             self?.lastActionMessage = message

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1306,6 +1306,17 @@ final class AppModel {
             return
         }
 
+        // While the overlay is suppressed by another app's fullscreen, only
+        // attention-required surfaces (`waitingForApproval`/`waitingForAnswer`)
+        // are allowed to break through. Informational notifications such as
+        // `.sessionCompleted` would otherwise force the panel back on top of
+        // the user's fullscreen app.
+        if hideOverlayInFullscreen,
+           overlay.isAppFullscreenActive,
+           !session.phase.requiresAttention {
+            return
+        }
+
         guard suppressFrontmostNotifications else {
             presentNotificationSurface(surface)
             return

--- a/Sources/OpenIslandApp/FullscreenWindowMonitor.swift
+++ b/Sources/OpenIslandApp/FullscreenWindowMonitor.swift
@@ -1,0 +1,168 @@
+import AppKit
+import Foundation
+
+/// Detects whether any application window is in macOS native fullscreen
+/// (Spaces fullscreen) on a given screen.
+///
+/// macOS does not expose a public "is in fullscreen Space" API for other
+/// apps' windows. We approximate it by enumerating on-screen windows on the
+/// normal layer (`kCGWindowLayer == 0`) and checking whether any of them
+/// match the screen's full `frame` (including the menu bar area). When an
+/// app is in native fullscreen on its own Space, its window covers the
+/// entire screen — including the area normally reserved for the menu bar
+/// and notch — which is something only fullscreen windows do.
+///
+/// Notifications used to drive re-evaluation:
+/// - `NSWorkspace.activeSpaceDidChangeNotification` — fires when the user
+///   enters or leaves a fullscreen Space.
+/// - `NSWorkspace.didActivateApplicationNotification` — fires when the
+///   frontmost app changes (covers app-switching while in fullscreen).
+/// - `NSApplication.didChangeScreenParametersNotification` — fires on
+///   display configuration changes.
+@MainActor
+final class FullscreenWindowMonitor {
+    /// Called whenever the fullscreen state may have changed. Recipients
+    /// should call `isFullscreenActive(on:)` to read the current value.
+    var onChange: (() -> Void)?
+
+    private var observers: [NSObjectProtocol] = []
+    private var isStarted = false
+
+    /// Window IDs we should ignore when scanning — typically the overlay's
+    /// own panel(s). Refreshed on each query via the `excludingWindowIDs`
+    /// parameter, so the property is unused; reserved for future use.
+    func start() {
+        guard !isStarted else { return }
+        isStarted = true
+
+        let workspaceCenter = NSWorkspace.shared.notificationCenter
+        let mainCenter = NotificationCenter.default
+
+        let spaceObserver = workspaceCenter.addObserver(
+            forName: NSWorkspace.activeSpaceDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.notifyChange() }
+        }
+
+        let activateObserver = workspaceCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.notifyChange() }
+        }
+
+        let screenObserver = mainCenter.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.notifyChange() }
+        }
+
+        observers = [spaceObserver, activateObserver, screenObserver]
+    }
+
+    func stop() {
+        let workspaceCenter = NSWorkspace.shared.notificationCenter
+        let mainCenter = NotificationCenter.default
+        for observer in observers {
+            workspaceCenter.removeObserver(observer)
+            mainCenter.removeObserver(observer)
+        }
+        observers.removeAll()
+        isStarted = false
+    }
+
+    private func notifyChange() {
+        onChange?()
+    }
+
+    /// Returns `true` when there is at least one on-screen normal-layer
+    /// window whose bounds match the supplied screen's full frame —
+    /// the signature of a macOS native fullscreen Space.
+    ///
+    /// `excludingWindowIDs` is used to skip Open Island's own panels so
+    /// the overlay never counts itself as fullscreen.
+    func isFullscreenActive(on screen: NSScreen, excludingWindowIDs: Set<CGWindowID>) -> Bool {
+        Self.isFullscreenActive(on: screen, excludingWindowIDs: excludingWindowIDs)
+    }
+
+    nonisolated static func isFullscreenActive(
+        on screen: NSScreen,
+        excludingWindowIDs: Set<CGWindowID>
+    ) -> Bool {
+        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        guard let windowInfoList = CGWindowListCopyWindowInfo(options, kCGNullWindowID)
+                as? [[String: Any]] else {
+            return false
+        }
+
+        let screenFrameCG = convertToCGCoordinates(screen.frame)
+        let ownPID = ProcessInfo.processInfo.processIdentifier
+
+        for info in windowInfoList {
+            // Skip the overlay's own windows.
+            if let windowNumber = info[kCGWindowNumber as String] as? CGWindowID,
+               excludingWindowIDs.contains(windowNumber) {
+                continue
+            }
+
+            // Open Island runs as a single process; skip any window owned by
+            // ourselves regardless of layer (defensive for future windows).
+            if let pid = info[kCGWindowOwnerPID as String] as? Int32,
+               pid == ownPID {
+                continue
+            }
+
+            // Only consider windows on the normal user layer. Fullscreen apps'
+            // primary content windows live on layer 0; menu bars, status items,
+            // overlays, etc. live on higher layers.
+            if let layer = info[kCGWindowLayer as String] as? Int, layer != 0 {
+                continue
+            }
+
+            guard let boundsDict = info[kCGWindowBounds as String] as? [String: Any],
+                  let rect = CGRect(dictionaryRepresentation: boundsDict as CFDictionary) else {
+                continue
+            }
+
+            // A window in a native fullscreen Space covers the entire screen
+            // frame, including the menu bar / notch region. Allow ~1pt slack
+            // for floating-point rounding.
+            if rectsApproximatelyEqual(rect, screenFrameCG, tolerance: 1.5) {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// CGWindow bounds use a Y-flipped origin (top-left of the primary
+    /// display is (0, 0), Y grows downward). Convert an `NSScreen.frame`
+    /// from AppKit coordinates (bottom-left origin) to CGWindow space.
+    nonisolated private static func convertToCGCoordinates(_ frame: NSRect) -> CGRect {
+        guard let primary = NSScreen.screens.first else {
+            return frame
+        }
+        let primaryHeight = primary.frame.height
+        return CGRect(
+            x: frame.origin.x,
+            y: primaryHeight - frame.origin.y - frame.height,
+            width: frame.width,
+            height: frame.height
+        )
+    }
+
+    nonisolated private static func rectsApproximatelyEqual(
+        _ a: CGRect,
+        _ b: CGRect,
+        tolerance: CGFloat
+    ) -> Bool {
+        abs(a.origin.x - b.origin.x) <= tolerance
+            && abs(a.origin.y - b.origin.y) <= tolerance
+            && abs(a.size.width - b.size.width) <= tolerance
+            && abs(a.size.height - b.size.height) <= tolerance
+    }
+}

--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -42,9 +42,30 @@ final class OverlayPanelController {
     private var hoverCancelGrace: DispatchWorkItem?
     weak var model: AppModel?
     private(set) var notchRect: NSRect = .zero
+    private(set) var isSuppressed = false
 
     var isVisible: Bool {
         panel?.isVisible == true
+    }
+
+    /// CGWindowID of the underlying panel, used by FullscreenWindowMonitor
+    /// to exclude the overlay's own window from fullscreen detection.
+    var panelWindowID: CGWindowID? {
+        guard let number = panel?.windowNumber, number > 0 else { return nil }
+        return CGWindowID(number)
+    }
+
+    /// Order the panel out of the screen list without losing its content.
+    /// Used to hide the overlay when an app enters native fullscreen.
+    func setSuppressed(_ suppressed: Bool) {
+        guard isSuppressed != suppressed else { return }
+        isSuppressed = suppressed
+        guard let panel else { return }
+        if suppressed {
+            panel.orderOut(nil)
+        } else {
+            panel.orderFrontRegardless()
+        }
     }
 
     nonisolated static func shouldActivatePanel(for reason: NotchOpenReason?) -> Bool {
@@ -60,7 +81,9 @@ final class OverlayPanelController {
         let panel = self.panel ?? makePanel(model: model)
         self.panel = panel
         positionPanel(panel, preferredScreenID: preferredScreenID, animated: false)
-        panel.orderFrontRegardless()
+        if !isSuppressed {
+            panel.orderFrontRegardless()
+        }
         panel.ignoresMouseEvents = true
         panel.acceptsMouseMovedEvents = false
         startEventMonitoring()
@@ -71,9 +94,11 @@ final class OverlayPanelController {
         let panel = self.panel ?? makePanel(model: model)
         self.panel = panel
         let diagnostics = positionPanel(panel, preferredScreenID: preferredScreenID, animated: true)
-        presentPanel(panel, activates: Self.shouldActivatePanel(for: model.notchOpenReason))
-        panel.ignoresMouseEvents = false
-        panel.acceptsMouseMovedEvents = true
+        if !isSuppressed {
+            presentPanel(panel, activates: Self.shouldActivatePanel(for: model.notchOpenReason))
+            panel.ignoresMouseEvents = false
+            panel.acceptsMouseMovedEvents = true
+        }
         startEventMonitoring()
         return diagnostics
     }
@@ -91,7 +116,7 @@ final class OverlayPanelController {
         panel.ignoresMouseEvents = !interactive
         panel.acceptsMouseMovedEvents = interactive
 
-        if interactive {
+        if interactive && !isSuppressed {
             presentPanel(panel, activates: Self.shouldActivatePanel(for: model?.notchOpenReason))
         }
     }

--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -213,8 +213,14 @@ final class OverlayUICoordinator {
 
     func ensureOverlayPanel() {
         guard let appModel else { return }
-        overlayPanelController.ensurePanel(model: appModel, preferredScreenID: preferredOverlayScreenID)
+        // Evaluate fullscreen suppression BEFORE the panel is materialised so
+        // it never flashes visible on top of an existing fullscreen app.
+        // `startFullscreenMonitoringIfNeeded()` already refreshes immediately
+        // on first start; for subsequent calls (monitor already running) the
+        // explicit refresh below ensures suppression is up-to-date.
         startFullscreenMonitoringIfNeeded()
+        refreshFullscreenState()
+        overlayPanelController.ensurePanel(model: appModel, preferredScreenID: preferredOverlayScreenID)
     }
 
     // MARK: - Fullscreen monitoring
@@ -312,10 +318,12 @@ final class OverlayUICoordinator {
     }
 
     func refreshOverlayPlacement() {
+        // Refresh fullscreen suppression BEFORE moving the panel so it never
+        // flashes visible while a fullscreen app is on the target display.
+        refreshFullscreenState()
         overlayPlacementDiagnostics = overlayPanelController.reposition(
             preferredScreenID: preferredOverlayScreenID
         )
-        refreshFullscreenState()
     }
 
     func refreshOverlayPlacementIfVisible() {

--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -260,8 +260,23 @@ final class OverlayUICoordinator {
     }
 
     private func applyFullscreenSuppression() {
+        let wasSuppressed = overlayPanelController.isSuppressed
         let shouldSuppress = hideOverlayInFullscreen && isAppFullscreenActive
         overlayPanelController.setSuppressed(shouldSuppress)
+
+        // When suppression clears, `setSuppressed` only re-orders the panel
+        // front. If the panel was opened, re-run the full present path so
+        // positioning and interactivity reflect any display configuration
+        // changes that happened while we were hidden.
+        if wasSuppressed,
+           !shouldSuppress,
+           notchStatus == .opened,
+           let appModel {
+            overlayPlacementDiagnostics = overlayPanelController.show(
+                model: appModel,
+                preferredScreenID: preferredOverlayScreenID
+            )
+        }
     }
 
     private func resolveOverlayScreen() -> NSScreen? {

--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -57,6 +57,22 @@ final class OverlayUICoordinator {
     @ObservationIgnored
     private var autoCollapseSurfaceHasBeenEntered = false
 
+    @ObservationIgnored
+    private let fullscreenMonitor = FullscreenWindowMonitor()
+
+    /// Whether a foreign app is currently in native fullscreen on the
+    /// overlay's target display. Recomputed from system notifications.
+    private(set) var isAppFullscreenActive = false
+
+    /// Whether the user wants the overlay to hide while another app is
+    /// fullscreen. Driven by a setting on `AppModel`.
+    var hideOverlayInFullscreen: Bool = true {
+        didSet {
+            guard hideOverlayInFullscreen != oldValue else { return }
+            applyFullscreenSuppression()
+        }
+    }
+
     /// Kept for API compatibility; always false now that the window never
     /// resizes and close transitions are pure SwiftUI.
     var isCloseTransitionPending: Bool { false }
@@ -198,6 +214,69 @@ final class OverlayUICoordinator {
     func ensureOverlayPanel() {
         guard let appModel else { return }
         overlayPanelController.ensurePanel(model: appModel, preferredScreenID: preferredOverlayScreenID)
+        startFullscreenMonitoringIfNeeded()
+    }
+
+    // MARK: - Fullscreen monitoring
+
+    private func startFullscreenMonitoringIfNeeded() {
+        fullscreenMonitor.onChange = { [weak self] in
+            self?.refreshFullscreenState()
+        }
+        fullscreenMonitor.start()
+        // Evaluate immediately so initial state matches reality.
+        refreshFullscreenState()
+    }
+
+    private func refreshFullscreenState() {
+        guard let screen = resolveOverlayScreen() else {
+            updateFullscreenActive(false)
+            return
+        }
+        var excluded: Set<CGWindowID> = []
+        if let id = overlayPanelController.panelWindowID {
+            excluded.insert(id)
+        }
+        let active = fullscreenMonitor.isFullscreenActive(
+            on: screen,
+            excludingWindowIDs: excluded
+        )
+        updateFullscreenActive(active)
+    }
+
+    private func updateFullscreenActive(_ active: Bool) {
+        guard isAppFullscreenActive != active else {
+            applyFullscreenSuppression()
+            return
+        }
+        isAppFullscreenActive = active
+        applyFullscreenSuppression()
+    }
+
+    private func applyFullscreenSuppression() {
+        let shouldSuppress = hideOverlayInFullscreen && isAppFullscreenActive
+        overlayPanelController.setSuppressed(shouldSuppress)
+    }
+
+    private func resolveOverlayScreen() -> NSScreen? {
+        let screens = NSScreen.screens
+        guard !screens.isEmpty else { return nil }
+        if let id = preferredOverlayScreenID,
+           let screen = screens.first(where: { Self.screenID(for: $0) == id }) {
+            return screen
+        }
+        if let notchScreen = screens.first(where: { $0.safeAreaInsets.top > 0 }) {
+            return notchScreen
+        }
+        return NSScreen.main ?? screens[0]
+    }
+
+    private static func screenID(for screen: NSScreen) -> String {
+        let key = NSDeviceDescriptionKey("NSScreenNumber")
+        if let number = screen.deviceDescription[key] as? NSNumber {
+            return "display-\(number.uint32Value)"
+        }
+        return screen.localizedName
     }
 
     // Legacy compatibility
@@ -236,6 +315,7 @@ final class OverlayUICoordinator {
         overlayPlacementDiagnostics = overlayPanelController.reposition(
             preferredScreenID: preferredOverlayScreenID
         )
+        refreshFullscreenState()
     }
 
     func refreshOverlayPlacementIfVisible() {

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -26,6 +26,7 @@
 "settings.general.showDockIcon" = "Show icon in Dock";
 "settings.general.hapticFeedback" = "Haptic feedback on hover";
 "settings.general.suppressFrontmostNotifications" = "Suppress notifications for focused sessions";
+"settings.general.hideOverlayInFullscreen" = "Hide Open Island when an app is in fullscreen";
 "settings.general.showCodexUsage" = "Show Codex usage";
 "settings.general.completionReply" = "Reply from completion card";
 "settings.general.cliHooks" = "CLI Hooks";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -26,6 +26,7 @@
 "settings.general.showDockIcon" = "在 Dock 中显示图标";
 "settings.general.hapticFeedback" = "悬停时震动反馈";
 "settings.general.suppressFrontmostNotifications" = "前台会话不弹出通知";
+"settings.general.hideOverlayInFullscreen" = "全屏应用时隐藏灵动岛";
 "settings.general.showCodexUsage" = "显示 Codex 用量";
 "settings.general.completionReply" = "在完成卡片中回复";
 "settings.general.cliHooks" = "CLI Hooks";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -26,6 +26,7 @@
 "settings.general.showDockIcon" = "在 Dock 中顯示圖示";
 "settings.general.hapticFeedback" = "懸停時震動回饋";
 "settings.general.suppressFrontmostNotifications" = "前台工作階段不彈出通知";
+"settings.general.hideOverlayInFullscreen" = "全螢幕模式時隱藏靈動島";
 "settings.general.showCodexUsage" = "顯示 Codex 用量";
 "settings.general.completionReply" = "在完成卡片中回覆";
 "settings.general.cliHooks" = "CLI Hooks";

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -223,6 +223,10 @@ struct GeneralSettingsPane: View {
                     get: { model.suppressFrontmostNotifications },
                     set: { model.suppressFrontmostNotifications = $0 }
                 ))
+                Toggle(lang.t("settings.general.hideOverlayInFullscreen"), isOn: Binding(
+                    get: { model.hideOverlayInFullscreen },
+                    set: { model.hideOverlayInFullscreen = $0 }
+                ))
             }
 
         }


### PR DESCRIPTION
Closes #421

## Summary
- Detect macOS native fullscreen via `CGWindowListCopyWindowInfo` on the overlay's target screen and call `orderOut` on the panel while active. Re-evaluate on `NSWorkspace.activeSpaceDidChangeNotification`, `NSWorkspace.didActivateApplicationNotification`, and `NSApplication.didChangeScreenParametersNotification` so transitions in/out of a fullscreen Space are picked up immediately.
- Add a General setting **"Hide Open Island when an app is in fullscreen"** (default **ON**), persisted under `app.hideOverlayInFullscreen`. Users who preferred the old behavior can re-enable it.
- The detection heuristic looks for any non-Open-Island, normal-layer (`kCGWindowLayer == 0`) window whose bounds match the screen's full frame (within 1.5pt) — the signature of a native fullscreen Space.

## 中文说明
- 当任意 App 进入 macOS 原生全屏时，自动隐藏灵动岛（在 “系统设置 > 通用” 中可关闭，默认开启）。
- 监听 Space / 前台应用 / 屏幕参数变化，离开全屏后恢复显示。
- 检测策略：扫描非 Open Island 自身、layer 为 0 且窗口尺寸与目标屏幕 frame 完全一致（容差 1.5pt）的窗口，作为全屏 Space 的特征。

## Test plan
- [x] `swift build`
- [x] Manually verify: enter Safari/VSCode native fullscreen → island hides; exit → island returns
- [x] Toggle setting OFF → island stays visible during fullscreen (legacy behavior)
- [x] Multi-display: fullscreen on the non-overlay screen does not hide the overlay

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persisted toggle in General settings to hide the overlay when another app is in native fullscreen.
  * Overlay now detects native fullscreen apps and suppresses itself (with exception for sessions that require attention).
  * Startup/placement improved to avoid flashing above fullscreen content.
  * Localized UI text added for English, Simplified Chinese, and Traditional Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->