### PR TITLE
feat: show Claude Code session title in session list

### DIFF
--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -148,6 +148,22 @@ extension AgentSession {
     }
 
     var spotlightHeadlineText: String {
+        // Prefer Claude Code's auto-generated session title when available so
+        // multiple sessions inside the same project can be told apart at a
+        // glance.  The workspace name is still appended after the title so the
+        // working directory remains visible.
+        if let title = spotlightClaudeTitleText {
+            var headline = title
+            let workspace = spotlightWorkspaceName.trimmedForSurface
+            if !workspace.isEmpty {
+                headline += " · \(workspace)"
+            }
+            if let branch = spotlightWorktreeBranch {
+                headline += " (\(branch))"
+            }
+            return headline
+        }
+
         var headline = spotlightWorkspaceName
 
         if let branch = spotlightWorktreeBranch {
@@ -159,6 +175,25 @@ extension AgentSession {
         }
 
         return "\(headline) · \(prompt)"
+    }
+
+    /// The Claude Code session title (`aiTitle`/legacy `summary`) extracted
+    /// from the transcript header, truncated to a single-line label.  Empty
+    /// when no title is available (e.g. non-Claude sessions, brand-new
+    /// transcripts before Claude assigns a title).
+    var spotlightClaudeTitleText: String? {
+        guard let raw = claudeMetadata?.aiTitle?.trimmedForSurface,
+              !raw.isEmpty else {
+            return nil
+        }
+
+        let maxLength = 60
+        guard raw.count > maxLength else {
+            return raw
+        }
+
+        let endIndex = raw.index(raw.startIndex, offsetBy: maxLength - 1)
+        return "\(raw[..<endIndex])…"
     }
 
     var spotlightHeadlinePromptText: String? {

--- a/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
+++ b/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
@@ -352,7 +352,8 @@ final class SessionDiscoveryCoordinator {
             agentID: discovered.agentID ?? existing.agentID,
             agentType: discovered.agentType ?? existing.agentType,
             worktreeBranch: discovered.worktreeBranch ?? existing.worktreeBranch,
-            activeSubagents: existing.activeSubagents.isEmpty ? discovered.activeSubagents : existing.activeSubagents
+            activeSubagents: existing.activeSubagents.isEmpty ? discovered.activeSubagents : existing.activeSubagents,
+            aiTitle: discovered.aiTitle ?? existing.aiTitle
         )
         return merged.isEmpty ? nil : merged
     }

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -2007,7 +2007,8 @@ public final class BridgeServer: @unchecked Sendable {
             agentType: update.agentType ?? existing?.agentType,
             worktreeBranch: update.worktreeBranch ?? existing?.worktreeBranch,
             activeSubagents: existing?.activeSubagents ?? [],
-            activeTasks: existing?.activeTasks ?? []
+            activeTasks: existing?.activeTasks ?? [],
+            aiTitle: update.aiTitle ?? existing?.aiTitle
         )
     }
 

--- a/Sources/OpenIslandCore/ClaudeHooks.swift
+++ b/Sources/OpenIslandCore/ClaudeHooks.swift
@@ -261,6 +261,10 @@ public struct ClaudeSessionMetadata: Equatable, Codable, Sendable {
     public var worktreeBranch: String?
     public var activeSubagents: [ClaudeSubagentInfo]
     public var activeTasks: [ClaudeTaskInfo]
+    /// Claude Code's auto-generated short title for the session (the
+    /// `aiTitle`/`summary` line at the top of the transcript JSONL).
+    /// Used as the primary label in the island session list when present.
+    public var aiTitle: String?
 
     public init(
         transcriptPath: String? = nil,
@@ -276,7 +280,8 @@ public struct ClaudeSessionMetadata: Equatable, Codable, Sendable {
         agentType: String? = nil,
         worktreeBranch: String? = nil,
         activeSubagents: [ClaudeSubagentInfo] = [],
-        activeTasks: [ClaudeTaskInfo] = []
+        activeTasks: [ClaudeTaskInfo] = [],
+        aiTitle: String? = nil
     ) {
         self.transcriptPath = transcriptPath
         self.initialUserPrompt = initialUserPrompt
@@ -292,6 +297,7 @@ public struct ClaudeSessionMetadata: Equatable, Codable, Sendable {
         self.worktreeBranch = worktreeBranch
         self.activeSubagents = activeSubagents
         self.activeTasks = activeTasks
+        self.aiTitle = aiTitle
     }
 
     public var isEmpty: Bool {
@@ -309,6 +315,7 @@ public struct ClaudeSessionMetadata: Equatable, Codable, Sendable {
             && worktreeBranch == nil
             && activeSubagents.isEmpty
             && activeTasks.isEmpty
+            && aiTitle == nil
     }
 }
 

--- a/Sources/OpenIslandCore/ClaudeTranscriptDiscovery.swift
+++ b/Sources/OpenIslandCore/ClaudeTranscriptDiscovery.swift
@@ -80,6 +80,7 @@ public final class ClaudeTranscriptDiscovery: @unchecked Sendable {
         var model: String?
         var currentTool: String?
         var currentToolInputPreview: String?
+        var aiTitle: String?
         var pendingToolUses: [String: (name: String, preview: String?)] = [:]
 
         for line in contents.split(separator: "\n") {
@@ -145,10 +146,18 @@ public final class ClaudeTranscriptDiscovery: @unchecked Sendable {
                         currentToolInputPreview = lastToolUse.preview
                     }
                 }
+            } else if topLevelType == "ai-title",
+                      let title = object["aiTitle"] as? String,
+                      let normalized = normalizedText(title) {
+                aiTitle = normalized
             } else if topLevelType == "summary",
                       let summary = object["summary"] as? String,
-                      !summary.isEmpty {
-                lastAssistantMessage = summary
+                      let normalized = normalizedText(summary) {
+                // Legacy transcript format used `{"type":"summary",...}` for the
+                // session title.  Treat it the same as `ai-title`.
+                if aiTitle == nil {
+                    aiTitle = normalized
+                }
             }
         }
 
@@ -164,7 +173,8 @@ public final class ClaudeTranscriptDiscovery: @unchecked Sendable {
             lastAssistantMessage: lastAssistantMessage,
             currentTool: currentTool,
             currentToolInputPreview: currentToolInputPreview,
-            model: model
+            model: model,
+            aiTitle: aiTitle
         )
         let summary = lastAssistantMessage
             ?? lastUserPrompt


### PR DESCRIPTION
Closes #371

## Summary / 概要

Each Claude Code session row in the expanded island list previously showed only the workspace (working directory). When several sessions live inside the same project they were impossible to tell apart. This change surfaces Claude Code's auto-generated session title so each row leads with a meaningful label, with the workspace and worktree branch still appended for context.

会话列表此前只显示工作目录，同一项目下的多个会话无法区分。本改动从 Claude Code 的会话 transcript 中提取自动生成的标题（`aiTitle`），在悬浮岛会话行优先展示该标题，工作目录和 worktree 分支作为副信息附在后面。

## Changes

- `ClaudeSessionMetadata` gains an optional `aiTitle: String?` field.
- `ClaudeTranscriptDiscovery` parses the `{"type":"ai-title","aiTitle":"..."}` line found in the JSONL transcript header (the current Claude Code format), and falls back to the legacy `{"type":"summary","summary":"..."}` line. The previous behavior of treating that legacy summary line as `lastAssistantMessage` (which it never was) is removed.
- `AgentSession.spotlightHeadlineText` (used by `IslandSessionRow`) now leads with the title (truncated to 60 chars with ellipsis) when available: `<title> · <workspace> (<branch>)`. Falls back to the existing `<workspace> · <prompt>` headline when no title is present (new sessions, Codex/OpenCode/etc.).

## Before / After

- Before: `open-vibe-island · 修复菜单栏图标渲染`
- After:  `fix-menubar-icon-rendering · open-vibe-island`

(Title comes from Claude Code's `aiTitle`; workspace name comes from the working directory as before.)

## Test plan

- [x] `swift build` passes locally
- [x] Manually verify on a Mac with multiple Claude Code sessions in the same project that titles render and truncate correctly
- [x] Verify Codex / OpenCode / Cursor session rows are unchanged (no `aiTitle` → fallback path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session headlines now prioritize AI-generated titles extracted from Claude Code transcripts, include workspace and branch info, and are formatted as single-line labels (with truncation).
  * Transcript-derived short titles are preserved and merged during session discovery and sync so they appear reliably in the UI.
* **Bug Fixes**
  * Legacy transcripts are handled so sensible fallback summaries remain when no AI title is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->