### PR TITLE
fix: activate app when reply input gets focus

### DIFF
--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1864,6 +1864,26 @@ private struct StructuredQuestionPromptView: View {
 
 // MARK: - Reply TextField (NSTextField wrapper for IME-safe Enter handling)
 
+/// NSTextField subclass that activates the app on first click. The overlay
+/// panel is `.nonactivatingPanel`, so a click into the panel makes it key
+/// but leaves the previously active app frontmost. Without an explicit
+/// activate, keystrokes continue to route to that other app and this field
+/// receives nothing — the user sees a focus ring but typing does not work.
+private final class ReplyNSTextField: NSTextField {
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+    override func mouseDown(with event: NSEvent) {
+        // Activate synchronously before the field starts editing so the
+        // very first keystroke routes here instead of the previously
+        // active app (e.g. the terminal hosting the agent session).
+        if !NSApp.isActive {
+            NSApp.activate(ignoringOtherApps: true)
+        }
+        window?.makeKey()
+        super.mouseDown(with: event)
+    }
+}
+
 /// NSTextField wrapper that fires `onSubmit` only when the IME composition
 /// is finished — pressing Enter during Chinese/Japanese IME composition
 /// confirms the candidate instead of submitting.
@@ -1873,7 +1893,7 @@ private struct ReplyTextField: NSViewRepresentable {
     var onSubmit: () -> Void
 
     func makeNSView(context: Context) -> NSTextField {
-        let field = NSTextField()
+        let field = ReplyNSTextField()
         field.isBordered = false
         field.drawsBackground = false
         field.focusRingType = .none
@@ -1910,6 +1930,15 @@ private struct ReplyTextField: NSViewRepresentable {
         init(text: Binding<String>, onSubmit: @escaping () -> Void) {
             self.text = text
             self.onSubmit = onSubmit
+        }
+
+        func controlTextDidBeginEditing(_ obj: Notification) {
+            // Safety net: even if the field gained focus through some path
+            // that bypassed mouseDown (e.g. tab key, programmatic focus),
+            // ensure the app is active so keystrokes are delivered here.
+            if !NSApp.isActive {
+                NSApp.activate(ignoringOtherApps: true)
+            }
         }
 
         func controlTextDidChange(_ obj: Notification) {


### PR DESCRIPTION
## Summary

会话卡片底部「回复 Claude…」输入框点击后看似获得焦点，但敲键盘没反应（issue #450）。

根因：overlay panel 使用 `.nonactivatingPanel`，点击输入框后 panel 成为 key window，但承载终端的那个 app 仍然是 active app，键盘事件继续被路由到那边，所以本输入框只显示一个 focus ring，每个按键都被静默丢弃。

修复：

- 给 `ReplyTextField` 加一个 `ReplyNSTextField` 子类，在 `mouseDown` 里同步调用 `NSApp.activate(ignoringOtherApps:)`，确保紧跟在点击后第一次按键就能落到本 app。
- 在 `controlTextDidBeginEditing` 里也加一遍 `NSApp.activate` 作为兜底，覆盖 Tab 键 / 程序化聚焦等非鼠标路径。

英文版：

The overlay uses `.nonactivatingPanel`, so clicking into the reply text field made the panel key but left the previously active app (the terminal hosting the agent session) frontmost. Keystrokes therefore continued to route to that app and the field showed a focus ring while silently dropping every keypress — i.e. the reply input rendered but could not actually be typed into.

Subclass `NSTextField` to call `NSApp.activate(ignoringOtherApps:)` on `mouseDown` (synchronously, before editing starts), and add the same activate as a safety net in `controlTextDidBeginEditing` for non-mouse focus paths (tab, programmatic).

Closes #450

## Test plan

- [x] `swift build` 通过
- [x] 手动验证：
  - [x] 启用 Settings → Behavior → Completion reply 开关
  - [x] 在 Ghostty 里跑一个 Claude Code 会话，等到 agent 进入 `.completed` 状态
  - [x] 通过 hover 打开 island（确保 panel 不是因点击进入 key 状态）
  - [x] 点击「回复 Claude…」输入框，立刻输入中文/英文，确认所有字符都被正确接收
  - [x] 按 Enter，确认文本通过 AppleScript 投递到 Ghostty 终端
  - [x] 同样路径测试 tmux 会话（任意终端 + tmux 内的 Claude Code）
  - [x] 确认点击「允许 / 拒绝」类按钮不会因为这次改动而把 app 切到前台（按钮只走 SwiftUI Button 路径，不会触碰 `ReplyNSTextField.mouseDown`）

## Note

仓库 `swift test` CLI 因预先存在的 `Testing` 模块缺失问题无法直接跑（与本次改动无关），需在 Xcode 中跑测试套件验证。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reply text field focus and keyboard input handling to ensure the field remains responsive and editable when clicked, even if the app is not the frontmost window. Improved activation behavior for both mouse and keyboard navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->