### PR TITLE
feat: detect embedded-terminal hosts via process tree

### DIFF
--- a/Sources/OpenIslandApp/TerminalJumpService.swift
+++ b/Sources/OpenIslandApp/TerminalJumpService.swift
@@ -160,6 +160,11 @@ struct TerminalJumpService {
             bundleIdentifier: "com.jetbrains.rustrover",
             aliases: ["rustrover"]
         ),
+        TerminalAppDescriptor(
+            displayName: "Obsidian",
+            bundleIdentifier: "md.obsidian",
+            aliases: ["obsidian"]
+        ),
     ]
 
     /// Bundle identifiers of JetBrains IDEs.
@@ -383,6 +388,14 @@ struct TerminalJumpService {
                     try openAction(["-b", id])
                     return "Activated \(descriptor.displayName)."
                 }
+            case "md.obsidian":
+                // Obsidian hosts a terminal plugin but has no per-pane
+                // jump primitive available. Just bring the app to front —
+                // do NOT pass the working directory as a document arg,
+                // since Obsidian would treat that as a "open vault"
+                // request and may prompt the user.
+                try openAction(["-b", "md.obsidian"])
+                return "Activated Obsidian."
             default:
                 break
             }

--- a/Sources/OpenIslandCore/ClaudeHooks.swift
+++ b/Sources/OpenIslandCore/ClaudeHooks.swift
@@ -939,7 +939,8 @@ public extension ClaudeHookPayload {
             environment: environment,
             currentTTYProvider: { currentTTY() },
             terminalLocatorProvider: { terminalLocator(for: $0) },
-            warpPaneResolver: Self.defaultWarpPaneResolver
+            warpPaneResolver: Self.defaultWarpPaneResolver,
+            embeddedHostResolver: { EmbeddedTerminalResolver.resolveCurrentHostContext() }
         )
     }
 
@@ -965,12 +966,24 @@ public extension ClaudeHookPayload {
         environment: [String: String],
         currentTTYProvider: () -> String?,
         terminalLocatorProvider: (String) -> (sessionID: String?, tty: String?, title: String?),
-        warpPaneResolver: (String) -> String? = Self.defaultWarpPaneResolver
+        warpPaneResolver: (String) -> String? = Self.defaultWarpPaneResolver,
+        embeddedHostResolver: () -> EmbeddedTerminalResolver.HostContext? = {
+            EmbeddedTerminalResolver.resolveCurrentHostContext()
+        }
     ) -> ClaudeHookPayload {
         var payload = self
 
         if payload.terminalApp == nil {
             payload.terminalApp = inferTerminalApp(from: environment)
+        }
+
+        // Process-tree fallback: env-based inference is authoritative when
+        // TERM_PROGRAM/TERMINAL_EMULATOR are set, but plugins like
+        // Obsidian's terminal don't set them. The process tree always
+        // does. Only fills in when nil so a present env var stays in
+        // charge — see #173.
+        if payload.terminalApp == nil, let host = embeddedHostResolver() {
+            payload.terminalApp = host.host.displayName
         }
 
         // Resolve Warp pane UUID from the live SQLite state.

--- a/Sources/OpenIslandCore/CodexHooks.swift
+++ b/Sources/OpenIslandCore/CodexHooks.swift
@@ -392,7 +392,8 @@ public extension CodexHookPayload {
             environment: environment,
             currentTTYProvider: { currentTTY() },
             terminalLocatorProvider: { terminalLocator(for: $0) },
-            warpPaneResolver: Self.defaultWarpPaneResolver
+            warpPaneResolver: Self.defaultWarpPaneResolver,
+            embeddedHostResolver: { EmbeddedTerminalResolver.resolveCurrentHostContext() }
         )
     }
 
@@ -415,12 +416,22 @@ public extension CodexHookPayload {
         environment: [String: String],
         currentTTYProvider: () -> String?,
         terminalLocatorProvider: (String) -> (sessionID: String?, tty: String?, title: String?),
-        warpPaneResolver: (String) -> String? = Self.defaultWarpPaneResolver
+        warpPaneResolver: (String) -> String? = Self.defaultWarpPaneResolver,
+        embeddedHostResolver: () -> EmbeddedTerminalResolver.HostContext? = {
+            EmbeddedTerminalResolver.resolveCurrentHostContext()
+        }
     ) -> CodexHookPayload {
         var payload = self
 
         if payload.terminalApp == nil {
             payload.terminalApp = inferTerminalApp(from: environment)
+        }
+
+        // Process-tree fallback for hosts the env vars don't reach
+        // (Obsidian terminal plugin, agents launched without inherited
+        // TERM_PROGRAM). See ClaudeHookPayload.withRuntimeContext.
+        if payload.terminalApp == nil, let host = embeddedHostResolver() {
+            payload.terminalApp = host.host.displayName
         }
 
         if payload.terminalApp == "Warp", payload.warpPaneUUID == nil {

--- a/Sources/OpenIslandCore/EmbeddedTerminalResolver.swift
+++ b/Sources/OpenIslandCore/EmbeddedTerminalResolver.swift
@@ -17,7 +17,7 @@ import Darwin
 public enum EmbeddedTerminalResolver {
 
     /// A single embedded host the resolver can recognize.
-    public enum EmbeddedHost: Sendable, Equatable {
+    public enum EmbeddedHost: Sendable, Equatable, Codable {
         case vscodeFamily(bundleID: String, displayName: String)
         case jetbrains(bundleID: String, displayName: String)
         case obsidian
@@ -42,13 +42,19 @@ public enum EmbeddedTerminalResolver {
     }
 
     /// Identifies the embedded host found above the calling process.
-    public struct HostContext: Sendable, Equatable {
+    public struct HostContext: Sendable, Equatable, Codable {
         public let host: EmbeddedHost
-        /// PID of the host process (the IDE / editor itself).
+        /// PID of the first ancestor whose command matches a known host
+        /// `.app` bundle path. For helper-heavy hosts like VS Code this
+        /// can be a helper inside the bundle (e.g. `Code Helper (Plugin)`)
+        /// rather than the outer app's PID — the bundle path alone is
+        /// enough for current callers, which dispatch by bundle ID. A
+        /// future phase that needs the outer-app PID should walk further
+        /// up while the classification stays the same.
         public let hostPID: pid_t
-        /// PID of the direct child of the host. For most IDEs this is the
-        /// shell that owns the embedded terminal pane — useful later for
-        /// per-pane focus precision.
+        /// PID of the direct child of `hostPID`. For most IDEs this is
+        /// the shell that owns the embedded terminal pane — useful later
+        /// for per-pane focus precision.
         public let shellPID: pid_t
 
         public init(host: EmbeddedHost, hostPID: pid_t, shellPID: pid_t) {

--- a/Sources/OpenIslandCore/EmbeddedTerminalResolver.swift
+++ b/Sources/OpenIslandCore/EmbeddedTerminalResolver.swift
@@ -1,0 +1,216 @@
+import Foundation
+import Darwin
+
+/// Walks the calling process's ancestor chain to detect when an agent is
+/// running inside an embedded terminal hosted by a known IDE or editor app
+/// (VS Code family, JetBrains, Obsidian).
+///
+/// This complements `inferTerminalApp(from:)` in the hook payload pipeline.
+/// Env-var inference is authoritative when `TERM_PROGRAM` (or the JetBrains
+/// `TERMINAL_EMULATOR` signal) is set, but plugins like Obsidian's terminal
+/// or any agent launched without inheriting those vars leave inference with
+/// nothing to go on. The process tree always knows.
+///
+/// The walk starts at `getppid()` (the agent process) and climbs upward via
+/// `ps -o ppid=` until it finds a process whose `ps -o command=` line points
+/// at a known IDE `.app` bundle path, or until the depth cap is hit.
+public enum EmbeddedTerminalResolver {
+
+    /// A single embedded host the resolver can recognize.
+    public enum EmbeddedHost: Sendable, Equatable {
+        case vscodeFamily(bundleID: String, displayName: String)
+        case jetbrains(bundleID: String, displayName: String)
+        case obsidian
+
+        public var bundleID: String {
+            switch self {
+            case let .vscodeFamily(bundleID, _), let .jetbrains(bundleID, _):
+                return bundleID
+            case .obsidian:
+                return "md.obsidian"
+            }
+        }
+
+        public var displayName: String {
+            switch self {
+            case let .vscodeFamily(_, displayName), let .jetbrains(_, displayName):
+                return displayName
+            case .obsidian:
+                return "Obsidian"
+            }
+        }
+    }
+
+    /// Identifies the embedded host found above the calling process.
+    public struct HostContext: Sendable, Equatable {
+        public let host: EmbeddedHost
+        /// PID of the host process (the IDE / editor itself).
+        public let hostPID: pid_t
+        /// PID of the direct child of the host. For most IDEs this is the
+        /// shell that owns the embedded terminal pane — useful later for
+        /// per-pane focus precision.
+        public let shellPID: pid_t
+
+        public init(host: EmbeddedHost, hostPID: pid_t, shellPID: pid_t) {
+            self.host = host
+            self.hostPID = hostPID
+            self.shellPID = shellPID
+        }
+    }
+
+    /// Resolves the embedded host of the calling process. Returns nil when
+    /// the process is not a descendant of any recognized IDE.
+    public static func resolveCurrentHostContext() -> HostContext? {
+        resolveCurrentHostContext(
+            parentPIDProvider: defaultParentPIDProvider,
+            commandProvider: defaultCommandProvider
+        )
+    }
+
+    /// Test-friendly overload that accepts injected providers.
+    public static func resolveCurrentHostContext(
+        parentPIDProvider: (pid_t) -> pid_t?,
+        commandProvider: (pid_t) -> String?
+    ) -> HostContext? {
+        resolveHostContext(
+            startingFrom: getppid(),
+            parentPIDProvider: parentPIDProvider,
+            commandProvider: commandProvider
+        )
+    }
+
+    /// Internal walker. Climbs the parent chain from `initial` looking for a
+    /// known IDE ancestor. The depth cap (24) is generous enough to cover
+    /// VS Code's helper-process tree (Code Helper (Plugin) → Code Helper →
+    /// Electron → outer app) plus several levels of shell/agent nesting,
+    /// while bounding the walk so a broken `ps` chain cannot loop forever.
+    static func resolveHostContext(
+        startingFrom initial: pid_t,
+        parentPIDProvider: (pid_t) -> pid_t?,
+        commandProvider: (pid_t) -> String?
+    ) -> HostContext? {
+        var current = initial
+        for _ in 0..<24 {
+            guard current > 1 else { return nil }
+            guard let parent = parentPIDProvider(current), parent > 1 else {
+                return nil
+            }
+            if let parentCommand = commandProvider(parent),
+               let host = classify(command: parentCommand) {
+                return HostContext(host: host, hostPID: parent, shellPID: current)
+            }
+            current = parent
+        }
+        return nil
+    }
+
+    /// Maps a `ps -o command=` line for a process to a known embedded host.
+    /// Match by `.app` path because VS Code forks (Cursor, Windsurf, Trae)
+    /// share Electron's `Code Helper` binary names — the bundle path is the
+    /// only reliable discriminator on macOS.
+    static func classify(command: String) -> EmbeddedHost? {
+        let lower = command.lowercased()
+
+        // VS Code family. Order matters: Insiders before generic VS Code,
+        // since Insiders contains "code.app" in some helper paths too.
+        if lower.contains("/visual studio code - insiders.app/") ||
+           lower.contains("/code - insiders.app/") {
+            return .vscodeFamily(
+                bundleID: "com.microsoft.VSCodeInsiders",
+                displayName: "VS Code Insiders"
+            )
+        }
+        if lower.contains("/visual studio code.app/") || lower.contains("/code.app/") {
+            return .vscodeFamily(bundleID: "com.microsoft.VSCode", displayName: "VS Code")
+        }
+        if lower.contains("/cursor.app/") {
+            return .vscodeFamily(
+                bundleID: "com.todesktop.230313mzl4w4u92",
+                displayName: "Cursor"
+            )
+        }
+        if lower.contains("/windsurf.app/") {
+            return .vscodeFamily(bundleID: "com.exafunction.windsurf", displayName: "Windsurf")
+        }
+        if lower.contains("/trae cn.app/") {
+            return .vscodeFamily(bundleID: "cn.trae.app", displayName: "Trae")
+        }
+        if lower.contains("/trae.app/") {
+            return .vscodeFamily(bundleID: "com.trae.app", displayName: "Trae")
+        }
+
+        // JetBrains family. Each IDE ships its own `.app`; the binary name
+        // inside Contents/MacOS matches the lowercased product name.
+        for entry in jetbrainsAppPathFragments {
+            if lower.contains(entry.fragment) {
+                return .jetbrains(bundleID: entry.bundleID, displayName: entry.displayName)
+            }
+        }
+
+        if lower.contains("/obsidian.app/") {
+            return .obsidian
+        }
+
+        return nil
+    }
+
+    private struct JetBrainsEntry {
+        let fragment: String
+        let bundleID: String
+        let displayName: String
+    }
+
+    /// Lowercased `.app/` path fragments that uniquely identify each
+    /// JetBrains IDE bundle. Kept in a single table so adding a new IDE is
+    /// one line. Must stay in sync with the descriptors in
+    /// `TerminalJumpService.knownApps`.
+    private static let jetbrainsAppPathFragments: [JetBrainsEntry] = [
+        JetBrainsEntry(fragment: "/intellij idea", bundleID: "com.jetbrains.intellij", displayName: "IntelliJ IDEA"),
+        JetBrainsEntry(fragment: "/webstorm.app/", bundleID: "com.jetbrains.WebStorm", displayName: "WebStorm"),
+        JetBrainsEntry(fragment: "/pycharm.app/", bundleID: "com.jetbrains.pycharm", displayName: "PyCharm"),
+        JetBrainsEntry(fragment: "/pycharm ce.app/", bundleID: "com.jetbrains.pycharm", displayName: "PyCharm"),
+        JetBrainsEntry(fragment: "/goland.app/", bundleID: "com.jetbrains.goland", displayName: "GoLand"),
+        JetBrainsEntry(fragment: "/clion.app/", bundleID: "com.jetbrains.CLion", displayName: "CLion"),
+        JetBrainsEntry(fragment: "/rubymine.app/", bundleID: "com.jetbrains.rubymine", displayName: "RubyMine"),
+        JetBrainsEntry(fragment: "/phpstorm.app/", bundleID: "com.jetbrains.PhpStorm", displayName: "PhpStorm"),
+        JetBrainsEntry(fragment: "/rider.app/", bundleID: "com.jetbrains.rider", displayName: "Rider"),
+        JetBrainsEntry(fragment: "/rustrover.app/", bundleID: "com.jetbrains.rustrover", displayName: "RustRover"),
+    ]
+
+    // MARK: - Default providers (production)
+
+    static let defaultParentPIDProvider: @Sendable (pid_t) -> pid_t? = { pid in
+        guard let output = runSubprocess(
+            executable: "/bin/ps",
+            arguments: ["-o", "ppid=", "-p", "\(pid)"]
+        ) else { return nil }
+        let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        return pid_t(trimmed)
+    }
+
+    static let defaultCommandProvider: @Sendable (pid_t) -> String? = { pid in
+        guard let output = runSubprocess(
+            executable: "/bin/ps",
+            arguments: ["-o", "command=", "-p", "\(pid)"]
+        ) else { return nil }
+        return output.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func runSubprocess(executable: String, arguments: [String]) -> String? {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: executable)
+        task.arguments = arguments
+        let stdout = Pipe()
+        task.standardOutput = stdout
+        task.standardError = Pipe()
+        do {
+            try task.run()
+            task.waitUntilExit()
+        } catch {
+            return nil
+        }
+        guard task.terminationStatus == 0 else { return nil }
+        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/Sources/OpenIslandCore/GeminiHooks.swift
+++ b/Sources/OpenIslandCore/GeminiHooks.swift
@@ -205,19 +205,29 @@ public extension GeminiHookPayload {
         withRuntimeContext(
             environment: environment,
             currentTTYProvider: { currentTTY() },
-            terminalLocatorProvider: { terminalLocator(for: $0) }
+            terminalLocatorProvider: { terminalLocator(for: $0) },
+            embeddedHostResolver: { EmbeddedTerminalResolver.resolveCurrentHostContext() }
         )
     }
 
     func withRuntimeContext(
         environment: [String: String],
         currentTTYProvider: () -> String?,
-        terminalLocatorProvider: (String) -> (sessionID: String?, tty: String?, title: String?)
+        terminalLocatorProvider: (String) -> (sessionID: String?, tty: String?, title: String?),
+        embeddedHostResolver: () -> EmbeddedTerminalResolver.HostContext? = {
+            EmbeddedTerminalResolver.resolveCurrentHostContext()
+        }
     ) -> GeminiHookPayload {
         var payload = self
 
         if payload.terminalApp == nil {
             payload.terminalApp = inferTerminalApp(from: environment)
+        }
+
+        // Process-tree fallback for hosts the env vars don't reach. See
+        // ClaudeHookPayload.withRuntimeContext.
+        if payload.terminalApp == nil, let host = embeddedHostResolver() {
+            payload.terminalApp = host.host.displayName
         }
 
         if payload.terminalTTY == nil {

--- a/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
@@ -208,12 +208,18 @@ struct ClaudeHooksTests {
 
     @Test
     func claudeDefaultJumpTargetUsesUnknownSentinelForUnrecognizedTerminal() {
+        // This test validates the env-only inference path. We inject a nil
+        // embedded-host resolver so the assertion doesn't fluctuate based
+        // on where the suite is being run from (e.g. VS Code's integrated
+        // terminal would otherwise have the process-tree fallback fill in
+        // "VS Code" and break the nil expectation).
         let payload = ClaudeHookPayload(
             cwd: "/tmp/demo", hookEventName: .sessionStart, sessionID: "s1"
         ).withRuntimeContext(
             environment: ["TERM_PROGRAM": "rio"],
             currentTTYProvider: { nil },
-            terminalLocatorProvider: { _ in (sessionID: nil, tty: nil, title: nil) }
+            terminalLocatorProvider: { _ in (sessionID: nil, tty: nil, title: nil) },
+            embeddedHostResolver: { nil }
         )
 
         #expect(payload.terminalApp == nil)

--- a/Tests/OpenIslandCoreTests/EmbeddedTerminalResolverTests.swift
+++ b/Tests/OpenIslandCoreTests/EmbeddedTerminalResolverTests.swift
@@ -1,0 +1,252 @@
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+struct EmbeddedTerminalResolverTests {
+
+    // MARK: - resolveHostContext
+
+    @Test
+    func detectsVSCodeAncestor() {
+        // hook CLI (1000) → claude (900) → zsh (500) →
+        // Code Helper (Plugin) (300) → Code Helper (250) →
+        // Electron (200) → Visual Studio Code (100).
+        let parents: [pid_t: pid_t] = [
+            900: 500,
+            500: 300,
+            300: 250,
+            250: 200,
+            200: 100,
+            100: 1,
+        ]
+        let commands: [pid_t: String] = [
+            900: "claude",
+            500: "-zsh",
+            300: "/Applications/Visual Studio Code.app/Contents/Frameworks/Code Helper (Plugin).app/Contents/MacOS/Code Helper (Plugin)",
+            250: "/Applications/Visual Studio Code.app/Contents/Frameworks/Code Helper.app/Contents/MacOS/Code Helper",
+            200: "/Applications/Visual Studio Code.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron",
+            100: "/Applications/Visual Studio Code.app/Contents/MacOS/Electron",
+            1: "launchd",
+        ]
+
+        let ctx = EmbeddedTerminalResolver.resolveHostContext(
+            startingFrom: 900,
+            parentPIDProvider: { parents[$0] },
+            commandProvider: { commands[$0] }
+        )
+
+        // The walker stops at the FIRST ancestor whose command classifies.
+        // For a tree where every helper carries the VS Code .app path,
+        // that's the immediate parent of zsh (300). The shellPID is the
+        // last pid before that — 500 (zsh).
+        #expect(ctx?.host == .vscodeFamily(bundleID: "com.microsoft.VSCode", displayName: "VS Code"))
+        #expect(ctx?.hostPID == 300)
+        #expect(ctx?.shellPID == 500)
+    }
+
+    @Test
+    func detectsCursorByBundlePathNotBinaryName() {
+        // Cursor's binary inside Contents/MacOS/ is also named "Cursor",
+        // but the discriminator that matters is the .app path — which is
+        // what classify() looks at. A naive binary-name match would
+        // confuse Cursor with VS Code (both ship Electron-based helpers
+        // named "Code Helper"). Pin the path-based dispatch.
+        let parents: [pid_t: pid_t] = [
+            900: 500,
+            500: 200,
+            200: 1,
+        ]
+        let commands: [pid_t: String] = [
+            900: "claude",
+            500: "-zsh",
+            200: "/Applications/Cursor.app/Contents/Frameworks/Code Helper.app/Contents/MacOS/Code Helper",
+            1: "launchd",
+        ]
+
+        let ctx = EmbeddedTerminalResolver.resolveHostContext(
+            startingFrom: 900,
+            parentPIDProvider: { parents[$0] },
+            commandProvider: { commands[$0] }
+        )
+
+        #expect(ctx?.host == .vscodeFamily(
+            bundleID: "com.todesktop.230313mzl4w4u92",
+            displayName: "Cursor"
+        ))
+    }
+
+    @Test
+    func detectsObsidianAncestor() {
+        // Obsidian is the case the resolver fundamentally exists to
+        // cover — its terminal plugin doesn't set TERM_PROGRAM, so
+        // env-var inference returns nil and the process tree is the
+        // only signal.
+        let parents: [pid_t: pid_t] = [
+            900: 500,
+            500: 200,
+            200: 1,
+        ]
+        let commands: [pid_t: String] = [
+            900: "claude",
+            500: "-zsh",
+            200: "/Applications/Obsidian.app/Contents/MacOS/Obsidian",
+            1: "launchd",
+        ]
+
+        let ctx = EmbeddedTerminalResolver.resolveHostContext(
+            startingFrom: 900,
+            parentPIDProvider: { parents[$0] },
+            commandProvider: { commands[$0] }
+        )
+
+        #expect(ctx?.host == .obsidian)
+        #expect(ctx?.hostPID == 200)
+        #expect(ctx?.shellPID == 500)
+    }
+
+    @Test
+    func detectsJetBrainsGoLand() {
+        let parents: [pid_t: pid_t] = [
+            900: 500,
+            500: 200,
+            200: 1,
+        ]
+        let commands: [pid_t: String] = [
+            900: "claude",
+            500: "-zsh",
+            200: "/Applications/GoLand.app/Contents/MacOS/goland",
+            1: "launchd",
+        ]
+
+        let ctx = EmbeddedTerminalResolver.resolveHostContext(
+            startingFrom: 900,
+            parentPIDProvider: { parents[$0] },
+            commandProvider: { commands[$0] }
+        )
+
+        #expect(ctx?.host == .jetbrains(bundleID: "com.jetbrains.goland", displayName: "GoLand"))
+    }
+
+    @Test
+    func returnsNilWhenAncestorChainIsAStandaloneTerminal() {
+        // Ghostty-hosted claude — must return nil so the env-var
+        // inference path stays in charge. The resolver is a fallback,
+        // not a competing classifier.
+        let parents: [pid_t: pid_t] = [
+            900: 500,
+            500: 150,
+            150: 1,
+        ]
+        let commands: [pid_t: String] = [
+            900: "claude",
+            500: "-zsh",
+            150: "/Applications/Ghostty.app/Contents/MacOS/ghostty",
+            1: "launchd",
+        ]
+
+        let ctx = EmbeddedTerminalResolver.resolveHostContext(
+            startingFrom: 900,
+            parentPIDProvider: { parents[$0] },
+            commandProvider: { commands[$0] }
+        )
+
+        #expect(ctx == nil)
+    }
+
+    @Test
+    func capsWalkDepthToPreventInfiniteLoops() {
+        // A broken `ps` chain that cycles forever must terminate the walk
+        // via the depth cap, not loop.
+        let parents: [pid_t: pid_t] = [100: 200, 200: 100]
+        let commands: [pid_t: String] = [:]
+
+        let ctx = EmbeddedTerminalResolver.resolveHostContext(
+            startingFrom: 100,
+            parentPIDProvider: { parents[$0] },
+            commandProvider: { commands[$0] }
+        )
+
+        #expect(ctx == nil)
+    }
+
+    @Test
+    func returnsNilWhenAncestorIsLaunchd() {
+        // Process inherited by launchd (e.g. backgrounded shell). No
+        // app ancestor exists — the walker must return nil rather than
+        // misclassifying.
+        let parents: [pid_t: pid_t] = [900: 1]
+        let commands: [pid_t: String] = [
+            900: "claude",
+            1: "launchd",
+        ]
+
+        let ctx = EmbeddedTerminalResolver.resolveHostContext(
+            startingFrom: 900,
+            parentPIDProvider: { parents[$0] },
+            commandProvider: { commands[$0] }
+        )
+
+        #expect(ctx == nil)
+    }
+
+    // MARK: - classify
+
+    @Test
+    func classifyDistinguishesVSCodeFromInsiders() {
+        // Insiders contains "code.app" in some helper paths but the
+        // outer `.app` is `Visual Studio Code - Insiders.app`. The
+        // Insiders check must run before the generic VS Code check.
+        #expect(
+            EmbeddedTerminalResolver.classify(
+                command: "/Applications/Visual Studio Code - Insiders.app/Contents/MacOS/Electron"
+            )
+            == .vscodeFamily(bundleID: "com.microsoft.VSCodeInsiders", displayName: "VS Code Insiders")
+        )
+    }
+
+    @Test
+    func classifyDistinguishesTraeFromTraeCN() {
+        #expect(
+            EmbeddedTerminalResolver.classify(
+                command: "/Applications/Trae CN.app/Contents/MacOS/Trae"
+            )
+            == .vscodeFamily(bundleID: "cn.trae.app", displayName: "Trae")
+        )
+        #expect(
+            EmbeddedTerminalResolver.classify(
+                command: "/Applications/Trae.app/Contents/MacOS/Trae"
+            )
+            == .vscodeFamily(bundleID: "com.trae.app", displayName: "Trae")
+        )
+    }
+
+    @Test
+    func classifyIgnoresStandaloneTerminals() {
+        // The resolver is intentionally narrow — terminals like Ghostty,
+        // Terminal.app, Warp, etc. must not be classified as embedded
+        // hosts even though they too are .app bundles. They're handled
+        // by the existing terminal-app dispatch path.
+        #expect(EmbeddedTerminalResolver.classify(
+            command: "/Applications/Ghostty.app/Contents/MacOS/ghostty"
+        ) == nil)
+        #expect(EmbeddedTerminalResolver.classify(
+            command: "/Applications/Warp.app/Contents/MacOS/stable"
+        ) == nil)
+        #expect(EmbeddedTerminalResolver.classify(
+            command: "/System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal"
+        ) == nil)
+    }
+
+    @Test
+    func classifyIsCaseInsensitive() {
+        // `ps` output is normally lowercase, but pin the case-insensitive
+        // match so a future capitalization change doesn't silently break
+        // detection.
+        #expect(
+            EmbeddedTerminalResolver.classify(
+                command: "/APPLICATIONS/CURSOR.APP/Contents/MacOS/Cursor"
+            )
+            == .vscodeFamily(bundleID: "com.todesktop.230313mzl4w4u92", displayName: "Cursor")
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Closes the "click-the-island opens a new Terminal/Ghostty window" bug from #173 for the case the existing env-var inference can't see — Obsidian's terminal plugin and any agent launched without inheriting `TERM_PROGRAM` / `TERMINAL_EMULATOR`.

- New `EmbeddedTerminalResolver` in `OpenIslandCore` mirrors `WarpProcessResolver`: ancestor walk from `getppid()` with injectable providers, capped at 24 levels to cover VS Code's helper-process nesting (Code Helper (Plugin) → Code Helper → Electron → outer app).
- Recognizes the **VS Code family** (VS Code, Insiders, Cursor, Windsurf, Trae / Trae CN), **JetBrains IDEs** (IntelliJ, WebStorm, PyCharm, GoLand, CLion, RubyMine, PhpStorm, Rider, RustRover), and **Obsidian** via `.app` path matching. Bundle path is the only reliable discriminator since Cursor/Windsurf/Trae all ship Electron's "Code Helper" binary.
- Wired into `Claude` / `Codex` / `Gemini` `withRuntimeContext` as a strict fallback: only fills in `terminalApp` when env-based inference returned `nil`, so a present `TERM_PROGRAM` stays in charge. This deliberately avoids regressing the Warp-vs-Ghostty env-leak handling that `inferTerminalApp` was carefully designed to protect.
- Added Obsidian to `TerminalJumpService.knownApps` with an activate-only branch — no working-directory arg, since Obsidian would treat the path as a vault import.

## Why this scope

Phase 1 is intentionally minimal: detect the embedded host, route to "activate the IDE/editor app" instead of spawning a new terminal. Per-pane focus precision (VS Code's terminal API, JetBrains tool windows, Obsidian's terminal plugin) is a separate per-IDE follow-up. The fail-open posture of hooks is preserved end-to-end.

## Tests

- `EmbeddedTerminalResolverTests` — 11 unit tests covering VS Code / Cursor / Insiders / Trae CN / JetBrains / Obsidian detection, the standalone-terminal negative path, depth-cap behavior, and case-insensitive matching.
- `claudeDefaultJumpTargetUsesUnknownSentinelForUnrecognizedTerminal` updated to inject `embeddedHostResolver: { nil }` so the assertion no longer depends on whether the suite runs from VS Code's integrated terminal.

## Verification

- [x] `swift build` clean
- [x] `swift test` — 234 tests passing
- [x] Manual: run an agent inside Obsidian's terminal plugin → click the island → Obsidian comes to front (vs. the previous behavior of spawning a new Terminal/Ghostty window)
- [x] Manual: run an agent inside VS Code's integrated terminal *with* `TERM_PROGRAM=vscode` → behavior unchanged (env-var inference still wins)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Obsidian as a recognized terminal application and will activate it when used as a jump target.
  * Improved terminal detection with a fallback to identify embedded hosts (VS Code family, JetBrains, Obsidian), improving runtime context and terminal selection.

* **Tests**
  * Added comprehensive tests covering embedded terminal detection and host classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->