### PR TITLE
fix: show Codex thinking status

### DIFF
--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -208,7 +208,7 @@ extension AgentSession {
             if let activity = spotlightRunningActivityText {
                 return activity
             }
-            return spotlightPromptLineText == nil ? "Running" : "Input"
+            return spotlightPromptLineText == nil ? "Running" : "Thinking"
         case .waitingForApproval:
             return permissionRequest?.summary.trimmedForSurface ?? "Approval needed"
         case .waitingForAnswer:

--- a/Sources/OpenIslandCore/CodexSessionTracking.swift
+++ b/Sources/OpenIslandCore/CodexSessionTracking.swift
@@ -604,14 +604,14 @@ public enum CodexRolloutReducer {
             if !snapshot.isCompleted {
                 snapshot.phase = .running
             }
-            snapshot.summary = "Command finished."
+            snapshot.summary = "Thinking."
         case "patch_apply_end":
             snapshot.currentTool = nil
             snapshot.currentCommandPreview = nil
             if !snapshot.isCompleted {
                 snapshot.phase = .running
             }
-            snapshot.summary = "Patch applied."
+            snapshot.summary = "Thinking."
         default:
             break
         }
@@ -627,6 +627,11 @@ public enum CodexRolloutReducer {
         to snapshot: inout CodexRolloutSnapshot
     ) {
         let itemType = payload["type"] as? String
+        if itemType == "reasoning" {
+            applyReasoning(timestamp: timestamp, to: &snapshot)
+            return
+        }
+
         if itemType == "message" {
             guard let role = payload["role"] as? String else {
                 return
@@ -717,6 +722,23 @@ public enum CodexRolloutReducer {
             snapshot.currentCommandPreview = nil
             snapshot.phase = .running
             snapshot.isInterrupted = false
+        }
+
+        if let timestamp {
+            snapshot.updatedAt = timestamp
+        }
+    }
+
+    private static func applyReasoning(
+        timestamp: Date?,
+        to snapshot: inout CodexRolloutSnapshot
+    ) {
+        if !snapshot.isCompleted {
+            snapshot.currentTool = nil
+            snapshot.currentCommandPreview = nil
+            snapshot.phase = .running
+            snapshot.isInterrupted = false
+            snapshot.summary = "Thinking."
         }
 
         if let timestamp {

--- a/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
+++ b/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
@@ -129,6 +129,48 @@ struct AgentSessionPresentationTests {
     }
 
     @Test
+    func runningCodexSessionWithoutToolShowsThinkingActivity() {
+        let session = AgentSession(
+            id: "session-1",
+            title: "Codex · worktree",
+            tool: .codex,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Thinking.",
+            updatedAt: Date(timeIntervalSince1970: 10_000),
+            codexMetadata: CodexSessionMetadata(
+                initialUserPrompt: "Start by fixing the island hover behavior.",
+                lastUserPrompt: "Now make the overlay height fit the content."
+            )
+        )
+
+        #expect(session.spotlightPromptLineText == "You: Now make the overlay height fit the content.")
+        #expect(session.spotlightActivityLineText == "Thinking")
+    }
+
+    @Test
+    func writeStdinStillShowsInputActivity() {
+        let session = AgentSession(
+            id: "session-1",
+            title: "Codex · worktree",
+            tool: .codex,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Running input.",
+            updatedAt: Date(timeIntervalSince1970: 10_000),
+            codexMetadata: CodexSessionMetadata(
+                lastUserPrompt: "Continue the command.",
+                currentTool: "write_stdin",
+                currentCommandPreview: "y"
+            )
+        )
+
+        #expect(session.spotlightActivityLineText == "Input y")
+    }
+
+    @Test
     func detachedSessionHeadlineShowsInitialPrompt() {
         let session = AgentSession(
             id: "session-1",

--- a/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
@@ -222,6 +222,51 @@ struct CodexSessionTrackingTests {
     }
 
     @Test
+    func codexRolloutReducerMarksReasoningAsThinking() {
+        let snapshot = CodexRolloutReducer.snapshot(for: [
+            rolloutLine(
+                timestamp: "2026-04-02T04:03:44.500Z",
+                type: "event_msg",
+                payload: [
+                    "type": "user_message",
+                    "message": "Inspect the current status label.",
+                ]
+            ),
+            rolloutLine(
+                timestamp: "2026-04-02T04:03:44.894Z",
+                type: "response_item",
+                payload: [
+                    "type": "function_call",
+                    "name": "exec_command",
+                    "arguments": "{\"cmd\":\"git status -sb\"}",
+                ]
+            ),
+            rolloutLine(
+                timestamp: "2026-04-02T04:03:45.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "exec_command_end",
+                    "call_id": "call-1",
+                ]
+            ),
+            rolloutLine(
+                timestamp: "2026-04-02T04:03:45.200Z",
+                type: "response_item",
+                payload: [
+                    "type": "reasoning",
+                    "summary": [],
+                ]
+            ),
+        ])
+
+        #expect(snapshot.phase == .running)
+        #expect(snapshot.summary == "Thinking.")
+        #expect(snapshot.currentTool == nil)
+        #expect(snapshot.currentCommandPreview == nil)
+        #expect(snapshot.isCompleted == false)
+    }
+
+    @Test
     func codexRolloutReducerMarksTurnAbortedAsInterruptedCompletion() {
         let initialSnapshot = CodexRolloutReducer.snapshot(for: [
             rolloutLine(


### PR DESCRIPTION
## Summary
- Treat Codex rollout `reasoning` items as a running Thinking state
- Show `Thinking` instead of the misleading `Input` fallback when a running Codex session has no active tool
- Keep real `write_stdin` activity labeled as `Input`

## Verification
- `swift test --filter AgentSessionPresentationTests`
- `swift test --filter CodexSessionTrackingTests`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activity labels now display "Thinking" instead of "Input" when the agent is in a thinking state with an active prompt line.
  * Reasoning steps are now properly recognized and tracked during session execution, maintaining appropriate running state indicators.

* **Tests**
  * Added comprehensive test coverage for thinking activity display and reasoning state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->