### PR TITLE
fix(hooks): support per-process skip environment

### DIFF
--- a/Sources/OpenIslandCore/HookSkipConfiguration.swift
+++ b/Sources/OpenIslandCore/HookSkipConfiguration.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Centralizes the per-process hook skip environment contract.
+/// 集中管理“单次子进程跳过 hook”的环境变量协议。
+public enum HookSkipConfiguration {
+    /// Preferred Open Island environment key for disabling hooks in this process.
+    /// Open Island 推荐使用的当前进程 hook 跳过开关。
+    public static let openIslandSkipKey = "OPEN_ISLAND_SKIP_HOOKS"
+    /// Compatibility alias used by existing Vibe Island integrations.
+    /// 兼容已有 Vibe Island 集成使用的旧开关。
+    public static let legacyVibeIslandSkipKey = "VIBE_ISLAND_SKIP"
+
+    /// Returns true when the provided environment explicitly requests hook no-op mode.
+    /// 当传入环境显式要求跳过 hook 时返回 true。
+    public static func shouldSkipHooks(environment: [String: String]) -> Bool {
+        isTruthy(environment[openIslandSkipKey])
+            || isTruthy(environment[legacyVibeIslandSkipKey])
+    }
+
+    /// Interprets common shell-friendly truthy values and treats everything else as false.
+    /// 只接受常见 shell 友好的真值，其它值都按 false 处理。
+    private static func isTruthy(_ value: String?) -> Bool {
+        guard let value else { return false }
+        switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "1", "true", "yes", "on":
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
+++ b/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
@@ -29,6 +29,12 @@ struct OpenIslandHooksCLI {
 
     static func main() {
         do {
+            // Allow wrappers to delegate one child process away from Open Island without changing global hook installation.
+            // 允许外部控制器只让当前子进程跳过 Open Island hook，不影响全局安装状态。
+            if HookSkipConfiguration.shouldSkipHooks(environment: ProcessInfo.processInfo.environment) {
+                return
+            }
+
             let input = FileHandle.standardInput.readDataToEndOfFile()
             guard !input.isEmpty else {
                 return

--- a/Tests/OpenIslandCoreTests/HookSkipConfigurationTests.swift
+++ b/Tests/OpenIslandCoreTests/HookSkipConfigurationTests.swift
@@ -1,0 +1,39 @@
+import Testing
+@testable import OpenIslandCore
+
+/// Verifies the per-process hook skip environment contract.
+/// 验证单次子进程 hook 跳过环境变量协议。
+struct HookSkipConfigurationTests {
+    /// Accepts common truthy spellings for the preferred Open Island key.
+    /// 推荐的新环境变量接受常见真值写法。
+    @Test
+    func openIslandSkipHooksAcceptsTruthyValues() {
+        for value in ["1", "true", "TRUE", "yes", "on", " 1 "] {
+            #expect(HookSkipConfiguration.shouldSkipHooks(environment: [
+                HookSkipConfiguration.openIslandSkipKey: value,
+            ]))
+        }
+    }
+
+    /// Keeps compatibility with existing Vibe Island-based wrappers.
+    /// 保留对已有 Vibe Island wrapper 的兼容。
+    @Test
+    func legacyVibeIslandSkipAliasIsSupported() {
+        #expect(HookSkipConfiguration.shouldSkipHooks(environment: [
+            HookSkipConfiguration.legacyVibeIslandSkipKey: "1",
+        ]))
+    }
+
+    /// Rejects unset or non-truthy values so hooks remain enabled by default.
+    /// 未设置或非真值时保持默认启用 hook。
+    @Test
+    func skipHooksRejectsFalsyOrMissingValues() {
+        for value in ["", "0", "false", "no", "off", "random"] {
+            #expect(!HookSkipConfiguration.shouldSkipHooks(environment: [
+                HookSkipConfiguration.openIslandSkipKey: value,
+            ]))
+        }
+
+        #expect(!HookSkipConfiguration.shouldSkipHooks(environment: [:]))
+    }
+}

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -22,6 +22,14 @@ Agent
 
 **Fail-open principle**: if the bridge is unavailable the hook process exits silently without writing to stdout, so the agent continues running unaffected.
 
+## Skip Hooks For Delegated Control
+
+Set `OPEN_ISLAND_SKIP_HOOKS=1` on a child agent process when another local controller intentionally owns permission handling for that run. The hook CLI exits immediately without reading or forwarding the payload, so the agent continues without Open Island UI intervention.
+
+`VIBE_ISLAND_SKIP=1` is also recognized as a legacy compatibility alias.
+
+This is meant for per-process launches. Do not set it globally unless you want Open Island hooks disabled for every agent started from that environment.
+
 **Entry point**: [`Sources/OpenIslandHooks/main.swift`](../Sources/OpenIslandHooks/main.swift)
 
 ---


### PR DESCRIPTION
This PR adds a real integration escape hatch for hook delegation, without changing the default behavior.

In some setups, an external controller or wrapper owns the permission policy for a specific agent run. For example, it may launch a child agent process in a delegated-control mode and intentionally handle permissions outside of Open Island. In that case, Open Island hooks should not read the payload, forward it to the bridge, or show UI for that child process.

This PR adds a per-process skip environment variable:

- `OPEN_ISLAND_SKIP_HOOKS=1`
- `VIBE_ISLAND_SKIP=1` as a compatibility alias

When either variable is set, `OpenIslandHooks` exits immediately as a no-op. It does not read stdin, forward the payload, or write stdout. This only affects child processes launched with the env var, so existing installation and default hook behavior remain unchanged.

Validation:

- `swift build --product OpenIslandHooks`
- `git diff --check`
- `scripts/check-docs.sh`
- Direct CLI smoke:
  - invalid JSON + `OPEN_ISLAND_SKIP_HOOKS=1` exits cleanly with empty stdout/stderr
  - invalid JSON + `VIBE_ISLAND_SKIP=1` exits cleanly with empty stdout/stderr
  - invalid JSON without skip env still reaches decoding and logs `hook failed`

Note: `swift test --filter HookSkipConfigurationTests` is currently blocked in my local environment because the existing test target cannot import Swift's `Testing` module. The targeted product build and direct hook smoke both pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-process hook control: set environment variables `OPEN_ISLAND_SKIP_HOOKS` or `VIBE_ISLAND_SKIP` (legacy) to disable hook forwarding for specific processes without affecting global hook settings.

* **Documentation**
  * Updated documentation with instructions on using environment variables to skip hooks for individual processes.

* **Tests**
  * Added test coverage for hook skip configuration, including backward compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->