### PR TITLE
fix(codex): update hooks feature flag (issues #460)

### DIFF
--- a/Sources/OpenIslandCore/CodexHookInstallationManager.swift
+++ b/Sources/OpenIslandCore/CodexHookInstallationManager.swift
@@ -67,7 +67,7 @@ public final class CodexHookInstallationManager: @unchecked Sendable {
             hooksURL: hooksURL,
             manifestURL: manifestURL,
             hooksBinaryURL: resolvedHooksBinaryURL,
-            featureFlagEnabled: configContents.contains("codex_hooks = true"),
+            featureFlagEnabled: CodexHookInstaller.isCodexHooksFeatureEnabled(in: configContents),
             managedHooksPresent: managedHooksPresent,
             manifest: manifest
         )

--- a/Sources/OpenIslandCore/CodexHookInstaller.swift
+++ b/Sources/OpenIslandCore/CodexHookInstaller.swift
@@ -59,6 +59,8 @@ public enum CodexHookInstaller {
     public static let managedStatusMessage = "Managed by Open Island"
     public static let legacyManagedStatusMessage = "Managed by Vibe Island"
     public static let managedTimeout = 45
+    private static let currentFeatureKey = "hooks"
+    private static let legacyFeatureKey = "codex_hooks"
 
     // Keep the managed Codex install aligned with the original app's low-noise footprint.
     // The bridge still understands richer hook events, but we do not install them by default
@@ -138,20 +140,23 @@ public enum CodexHookInstaller {
         return CodexHookFileMutation(contents: data, changed: mutated || data != existingData, hasRemainingHooks: true)
     }
 
+    /// Enables the current Codex hooks feature flag and migrates the legacy flag when present.
     public static func enableCodexHooksFeature(in contents: String) -> CodexFeatureMutation {
         var lines = contents.components(separatedBy: "\n")
 
-        if let codexHookIndex = lineIndex(ofKey: "codex_hooks", inSection: "features", lines: lines) {
-            let trimmed = lines[codexHookIndex].trimmingCharacters(in: .whitespaces)
-            if trimmed == "codex_hooks = true" {
+        if let hooksIndex = lineIndex(ofKey: currentFeatureKey, inSection: "features", lines: lines) {
+            if featureValue(for: currentFeatureKey, lines: lines) == true {
+                removeFeatureLine(legacyFeatureKey, from: &lines)
+                let updatedContents = lines.joined(separator: "\n")
                 return CodexFeatureMutation(
-                    contents: contents,
-                    changed: false,
+                    contents: updatedContents,
+                    changed: updatedContents != contents,
                     featureEnabledByInstaller: false
                 )
             }
 
-            lines[codexHookIndex] = "codex_hooks = true"
+            lines[hooksIndex] = "\(currentFeatureKey) = true"
+            removeFeatureLine(legacyFeatureKey, from: &lines)
             return CodexFeatureMutation(
                 contents: lines.joined(separator: "\n"),
                 changed: true,
@@ -159,9 +164,19 @@ public enum CodexHookInstaller {
             )
         }
 
+        if let legacyHookIndex = lineIndex(ofKey: legacyFeatureKey, inSection: "features", lines: lines) {
+            let legacyWasEnabled = featureValue(for: legacyFeatureKey, lines: lines) == true
+            lines[legacyHookIndex] = "\(currentFeatureKey) = true"
+            return CodexFeatureMutation(
+                contents: lines.joined(separator: "\n"),
+                changed: true,
+                featureEnabledByInstaller: !legacyWasEnabled
+            )
+        }
+
         if let featuresRange = sectionRange(named: "features", lines: lines) {
             let insertIndex = featuresRange.upperBound
-            lines.insert("codex_hooks = true", at: insertIndex)
+            lines.insert("\(currentFeatureKey) = true", at: insertIndex)
             return CodexFeatureMutation(
                 contents: lines.joined(separator: "\n"),
                 changed: true,
@@ -173,7 +188,7 @@ public enum CodexHookInstaller {
             lines.append("")
         }
         lines.append("[features]")
-        lines.append("codex_hooks = true")
+        lines.append("\(currentFeatureKey) = true")
 
         return CodexFeatureMutation(
             contents: lines.joined(separator: "\n"),
@@ -182,14 +197,23 @@ public enum CodexHookInstaller {
         )
     }
 
+    /// Removes hook feature flags that were previously enabled by the managed installer.
     public static func disableCodexHooksFeatureIfManaged(in contents: String) -> CodexFeatureMutation {
         var lines = contents.components(separatedBy: "\n")
-        guard let featuresRange = sectionRange(named: "features", lines: lines),
-              let codexHookIndex = lineIndex(ofKey: "codex_hooks", inSection: "features", lines: lines) else {
+        guard let featuresRange = sectionRange(named: "features", lines: lines) else {
             return CodexFeatureMutation(contents: contents, changed: false, featureEnabledByInstaller: false)
         }
 
-        lines.remove(at: codexHookIndex)
+        var removedFeatureFlag = false
+        for key in [currentFeatureKey, legacyFeatureKey] {
+            if let index = lineIndex(ofKey: key, inSection: "features", lines: lines) {
+                lines.remove(at: index)
+                removedFeatureFlag = true
+            }
+        }
+        guard removedFeatureFlag else {
+            return CodexFeatureMutation(contents: contents, changed: false, featureEnabledByInstaller: false)
+        }
 
         let updatedRange = sectionRange(named: "features", lines: lines) ?? featuresRange
         let remainingFeatureLines = lines[updatedRange.lowerBound + 1..<updatedRange.upperBound]
@@ -208,6 +232,13 @@ public enum CodexHookInstaller {
             changed: true,
             featureEnabledByInstaller: false
         )
+    }
+
+    /// Returns whether the config enables Codex hooks using either the current or legacy flag.
+    public static func isCodexHooksFeatureEnabled(in contents: String) -> Bool {
+        let lines = contents.components(separatedBy: "\n")
+        return featureValue(for: currentFeatureKey, lines: lines) == true
+            || featureValue(for: legacyFeatureKey, lines: lines) == true
     }
 
     private static func loadRootObject(from data: Data?) throws -> [String: Any] {
@@ -365,13 +396,55 @@ public enum CodexHookInstaller {
         }
 
         for index in (range.lowerBound + 1)..<range.upperBound {
-            let trimmed = lines[index].trimmingCharacters(in: .whitespaces)
-            if trimmed.hasPrefix("\(key) =") {
+            if featureAssignment(in: lines[index])?.key == key {
                 return index
             }
         }
 
         return nil
+    }
+
+    /// Removes a feature flag line from the `[features]` section if it exists.
+    private static func removeFeatureLine(_ key: String, from lines: inout [String]) {
+        if let index = lineIndex(ofKey: key, inSection: "features", lines: lines) {
+            lines.remove(at: index)
+        }
+    }
+
+    /// Reads a boolean value from a feature flag line in the `[features]` section.
+    private static func featureValue(for key: String, lines: [String]) -> Bool? {
+        guard let index = lineIndex(ofKey: key, inSection: "features", lines: lines) else {
+            return nil
+        }
+
+        guard let assignment = featureAssignment(in: lines[index]) else {
+            return nil
+        }
+
+        switch assignment.value {
+        case "true":
+            return true
+        case "false":
+            return false
+        default:
+            return nil
+        }
+    }
+
+    /// Parses a simple TOML-style key/value assignment and ignores trailing comments.
+    private static func featureAssignment(in line: String) -> (key: String, value: String)? {
+        let uncommented = line
+            .split(separator: "#", maxSplits: 1, omittingEmptySubsequences: false)
+            .first
+            .map(String.init) ?? line
+        let parts = uncommented.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false).map {
+            $0.trimmingCharacters(in: .whitespaces)
+        }
+        guard parts.count == 2, !parts[0].isEmpty else {
+            return nil
+        }
+
+        return (key: parts[0], value: parts[1])
     }
 
     private static func shellQuote(_ string: String) -> String {

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -830,11 +830,69 @@ struct SessionStateTests {
         #expect(enabled.changed)
         #expect(enabled.featureEnabledByInstaller)
         #expect(enabled.contents.contains("[features]"))
-        #expect(enabled.contents.contains("codex_hooks = true"))
+        #expect(enabled.contents.contains("hooks = true"))
+        #expect(!enabled.contents.contains("codex_hooks = true"))
 
         let removed = CodexHookInstaller.disableCodexHooksFeatureIfManaged(in: enabled.contents)
         #expect(removed.changed)
-        #expect(!removed.contents.contains("codex_hooks = true"))
+        #expect(!removed.contents.contains("hooks = true"))
+    }
+
+    @Test
+    func codexHookInstallerMigratesLegacyFeatureFlag() {
+        let legacyConfig = """
+        [features]
+        codex_hooks = true
+        """
+
+        let enabled = CodexHookInstaller.enableCodexHooksFeature(in: legacyConfig)
+        #expect(enabled.changed)
+        #expect(!enabled.featureEnabledByInstaller)
+        #expect(enabled.contents.contains("hooks = true"))
+        #expect(!enabled.contents.contains("codex_hooks = true"))
+    }
+
+    @Test
+    func codexHookInstallerRemovesLegacyFlagWhenCurrentFlagExists() {
+        let mixedConfig = """
+        [features]
+        hooks = true
+        codex_hooks = true
+        """
+
+        let enabled = CodexHookInstaller.enableCodexHooksFeature(in: mixedConfig)
+        #expect(enabled.changed)
+        #expect(!enabled.featureEnabledByInstaller)
+        #expect(enabled.contents.contains("hooks = true"))
+        #expect(!enabled.contents.contains("codex_hooks = true"))
+    }
+
+    @Test
+    func codexHookInstallerRecognizesCurrentAndLegacyFeatureFlags() {
+        #expect(CodexHookInstaller.isCodexHooksFeatureEnabled(in: """
+        [features]
+        hooks = true
+        """))
+
+        #expect(CodexHookInstaller.isCodexHooksFeatureEnabled(in: """
+        [features]
+        hooks=true # enabled by user
+        """))
+
+        #expect(CodexHookInstaller.isCodexHooksFeatureEnabled(in: """
+        [features]
+        codex_hooks = true
+        """))
+
+        #expect(CodexHookInstaller.isCodexHooksFeatureEnabled(in: """
+        [features]
+        codex_hooks=true # legacy enabled by user
+        """))
+
+        #expect(!CodexHookInstaller.isCodexHooksFeatureEnabled(in: """
+        [features]
+        hooks=false # disabled by user
+        """))
     }
 
     @Test

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -45,6 +45,10 @@ Agent
 
 The managed Codex hook installer (`CodexHookInstaller`) installs only `SessionStart`, `UserPromptSubmit`, and `Stop` by default. This is intentional: per-command Bash hooks add terminal log noise, so the default set keeps the workflow low-noise while still providing session lifecycle and usage visibility.
 
+For Codex v0.130 and newer, the installer enables hooks with `[features].hooks = true` in `~/.codex/config.toml`. Older installs that still contain `[features].codex_hooks = true` are recognized as enabled and migrated on the next managed install.
+
+After hooks are installed or changed, Codex may require a manual trust review before running them. Open `/hooks` inside Codex CLI and approve the expected Open Island hook entries. This approval gate belongs to Codex and is not bypassed by Open Island.
+
 The `CodexHookPayload` model and `BridgeServer` can parse richer events (`PreToolUse`, `PostToolUse`) when they are present in the hook payload, and will surface them in the UI if received. However, these richer events are **not** installed by the managed installer and must be configured manually if desired.
 
 > **Note on file-edit coverage**: Codex file edits may use internal apply-patch paths that do not emit `PreToolUse` events. File-edit approval should not be treated as guaranteed `PreToolUse` coverage; the current reliable coverage is command/shell-level events, depending on Codex hook configuration.


### PR DESCRIPTION
Fixes #460.

Codex v0.130 deprecated `[features].codex_hooks` in favor of `[features].hooks`.

This PR updates the managed Codex hook installer to use the current feature flag while keeping existing installs compatible.

Changes:

- write `[features].hooks = true` for new managed installs
- treat both `hooks = true` and legacy `codex_hooks = true` as enabled during status checks
- migrate legacy `codex_hooks = true` to `hooks = true` on managed install
- remove stale `codex_hooks = true` when both current and legacy flags are present, so Codex v0.130 no longer prints the deprecation warning
- keep uninstall conservative: only remove the feature flag when the manifest says Open Island enabled it
- document Codex's `/hooks` review step

Compatibility note:

This intentionally writes only the current `hooks = true` flag. Keeping `codex_hooks = true` would preserve compatibility with older Codex builds but would continue to trigger the v0.130 deprecation warning reported in this issue.

Existing installs are still recognized before migration because status checks accept both `hooks = true` and legacy `codex_hooks = true`.

The second warning in the issue:

> 3 hooks need review before they can run. Open /hooks to review them.

is Codex CLI's own trust gate. Open Island should not bypass it; users still need to approve the expected hooks in `/hooks`.

Validation:

- `git diff --check`
- `scripts/check-docs.sh`
- `swift build --product OpenIslandHooks`
- `swift build --product OpenIslandSetup`

Note: `swift test --filter 'SessionStateTests/codexHookInstaller'` is blocked in my local environment because the existing test target cannot import Swift's `Testing` module. The product builds pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable Codex hooks detection and management: legacy hook settings are migrated to the modern flag and the current hooks flag is ensured/removed as appropriate.

* **New Features**
  * Added explicit feature-detection logic so installs consistently recognize enabled hooks (including legacy variants).

* **Tests**
  * Expanded tests verifying migration, removal, and detection behavior.

* **Documentation**
  * Updated installation docs for v0.130+ and noted manual trust approval may still be required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->