### PR TITLE
fix(codex): choose hooks feature flag by Codex version

### DIFF
--- a/Sources/OpenIslandCore/CodexHookInstallationManager.swift
+++ b/Sources/OpenIslandCore/CodexHookInstallationManager.swift
@@ -35,15 +35,18 @@ public final class CodexHookInstallationManager: @unchecked Sendable {
     public let codexDirectory: URL
     public let managedHooksBinaryURL: URL
     private let fileManager: FileManager
+    private let featureKeyProvider: @Sendable () -> CodexHooksFeatureFlagKey
 
     public init(
         codexDirectory: URL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".codex", isDirectory: true),
         managedHooksBinaryURL: URL = ManagedHooksBinary.defaultURL(),
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        featureKeyProvider: @escaping @Sendable () -> CodexHooksFeatureFlagKey = CodexHookInstaller.preferredCodexHooksFeatureKey
     ) {
         self.codexDirectory = codexDirectory
         self.managedHooksBinaryURL = managedHooksBinaryURL.standardizedFileURL
         self.fileManager = fileManager
+        self.featureKeyProvider = featureKeyProvider
     }
 
     public func status(hooksBinaryURL: URL? = nil) throws -> CodexHookInstallationStatus {
@@ -91,7 +94,10 @@ public final class CodexHookInstallationManager: @unchecked Sendable {
         )
 
         let command = CodexHookInstaller.hookCommand(for: installedHooksBinaryURL.path)
-        let featureMutation = CodexHookInstaller.enableCodexHooksFeature(in: existingConfig)
+        let featureMutation = CodexHookInstaller.enableCodexHooksFeature(
+            in: existingConfig,
+            preferredKey: featureKeyProvider()
+        )
         let hooksMutation = try CodexHookInstaller.installHooksJSON(existingData: existingHooks, hookCommand: command)
 
         if featureMutation.changed, fileManager.fileExists(atPath: configURL.path) {

--- a/Sources/OpenIslandCore/CodexHookInstaller.swift
+++ b/Sources/OpenIslandCore/CodexHookInstaller.swift
@@ -43,6 +43,20 @@ public struct CodexHookFileMutation: Equatable, Sendable {
     }
 }
 
+public enum CodexHooksFeatureFlagKey: String, Equatable, Sendable {
+    case current = "hooks"
+    case legacy = "codex_hooks"
+
+    var alternate: CodexHooksFeatureFlagKey {
+        switch self {
+        case .current:
+            return .legacy
+        case .legacy:
+            return .current
+        }
+    }
+}
+
 public enum CodexHookInstallerError: Error, LocalizedError {
     case invalidHooksJSON
 
@@ -59,8 +73,8 @@ public enum CodexHookInstaller {
     public static let managedStatusMessage = "Managed by Open Island"
     public static let legacyManagedStatusMessage = "Managed by Vibe Island"
     public static let managedTimeout = 45
-    private static let currentFeatureKey = "hooks"
-    private static let legacyFeatureKey = "codex_hooks"
+    private static let currentFeatureKey = CodexHooksFeatureFlagKey.current.rawValue
+    private static let legacyFeatureKey = CodexHooksFeatureFlagKey.legacy.rawValue
 
     // Keep the managed Codex install aligned with the original app's low-noise footprint.
     // The bridge still understands richer hook events, but we do not install them by default
@@ -141,12 +155,18 @@ public enum CodexHookInstaller {
     }
 
     /// Enables the current Codex hooks feature flag and migrates the legacy flag when present.
-    public static func enableCodexHooksFeature(in contents: String) -> CodexFeatureMutation {
+    public static func enableCodexHooksFeature(
+        in contents: String,
+        preferredKey: CodexHooksFeatureFlagKey = .current
+    ) -> CodexFeatureMutation {
         var lines = contents.components(separatedBy: "\n")
+        let featureKey = preferredKey.rawValue
+        let alternateFeatureKey = preferredKey.alternate.rawValue
 
-        if let hooksIndex = lineIndex(ofKey: currentFeatureKey, inSection: "features", lines: lines) {
-            if featureValue(for: currentFeatureKey, lines: lines) == true {
-                removeFeatureLine(legacyFeatureKey, from: &lines)
+        if let hooksIndex = lineIndex(ofKey: featureKey, inSection: "features", lines: lines) {
+            let alternateWasEnabled = featureValue(for: alternateFeatureKey, lines: lines) == true
+            if featureValue(for: featureKey, lines: lines) == true {
+                removeFeatureLine(alternateFeatureKey, from: &lines)
                 let updatedContents = lines.joined(separator: "\n")
                 return CodexFeatureMutation(
                     contents: updatedContents,
@@ -155,18 +175,18 @@ public enum CodexHookInstaller {
                 )
             }
 
-            lines[hooksIndex] = "\(currentFeatureKey) = true"
-            removeFeatureLine(legacyFeatureKey, from: &lines)
+            lines[hooksIndex] = "\(featureKey) = true"
+            removeFeatureLine(alternateFeatureKey, from: &lines)
             return CodexFeatureMutation(
                 contents: lines.joined(separator: "\n"),
                 changed: true,
-                featureEnabledByInstaller: true
+                featureEnabledByInstaller: !alternateWasEnabled
             )
         }
 
-        if let legacyHookIndex = lineIndex(ofKey: legacyFeatureKey, inSection: "features", lines: lines) {
-            let legacyWasEnabled = featureValue(for: legacyFeatureKey, lines: lines) == true
-            lines[legacyHookIndex] = "\(currentFeatureKey) = true"
+        if let legacyHookIndex = lineIndex(ofKey: alternateFeatureKey, inSection: "features", lines: lines) {
+            let legacyWasEnabled = featureValue(for: alternateFeatureKey, lines: lines) == true
+            lines[legacyHookIndex] = "\(featureKey) = true"
             return CodexFeatureMutation(
                 contents: lines.joined(separator: "\n"),
                 changed: true,
@@ -176,7 +196,7 @@ public enum CodexHookInstaller {
 
         if let featuresRange = sectionRange(named: "features", lines: lines) {
             let insertIndex = featuresRange.upperBound
-            lines.insert("\(currentFeatureKey) = true", at: insertIndex)
+            lines.insert("\(featureKey) = true", at: insertIndex)
             return CodexFeatureMutation(
                 contents: lines.joined(separator: "\n"),
                 changed: true,
@@ -188,7 +208,7 @@ public enum CodexHookInstaller {
             lines.append("")
         }
         lines.append("[features]")
-        lines.append("\(currentFeatureKey) = true")
+        lines.append("\(featureKey) = true")
 
         return CodexFeatureMutation(
             contents: lines.joined(separator: "\n"),
@@ -239,6 +259,20 @@ public enum CodexHookInstaller {
         let lines = contents.components(separatedBy: "\n")
         return featureValue(for: currentFeatureKey, lines: lines) == true
             || featureValue(for: legacyFeatureKey, lines: lines) == true
+    }
+
+    public static func preferredCodexHooksFeatureKey() -> CodexHooksFeatureFlagKey {
+        if let featureKey = commandOutput(arguments: ["features", "list"])
+            .flatMap(preferredCodexHooksFeatureKey(fromFeatureList:)) {
+            return featureKey
+        }
+
+        if let featureKey = commandOutput(arguments: ["--version"])
+            .flatMap(preferredCodexHooksFeatureKey(fromVersionOutput:)) {
+            return featureKey
+        }
+
+        return .legacy
     }
 
     private static func loadRootObject(from data: Data?) throws -> [String: Any] {
@@ -421,7 +455,7 @@ public enum CodexHookInstaller {
             return nil
         }
 
-        switch assignment.value {
+        switch assignment.value.lowercased() {
         case "true":
             return true
         case "false":
@@ -445,6 +479,88 @@ public enum CodexHookInstaller {
         }
 
         return (key: parts[0], value: parts[1])
+    }
+
+    static func preferredCodexHooksFeatureKey(fromFeatureList output: String) -> CodexHooksFeatureFlagKey? {
+        let featureNames = Set(output.split(whereSeparator: \.isNewline).compactMap { line -> String? in
+            line.split(whereSeparator: \.isWhitespace).first.map(String.init)
+        })
+
+        if featureNames.contains(currentFeatureKey) {
+            return .current
+        }
+        if featureNames.contains(legacyFeatureKey) {
+            return .legacy
+        }
+        return nil
+    }
+
+    static func preferredCodexHooksFeatureKey(fromVersionOutput output: String) -> CodexHooksFeatureFlagKey? {
+        guard let versionToken = output.split(whereSeparator: \.isWhitespace).first(where: { token in
+            token.first?.isNumber == true
+        }) else {
+            return nil
+        }
+
+        let components = versionToken.split(separator: ".").compactMap { Int($0) }
+        guard components.count >= 2 else {
+            return nil
+        }
+
+        let major = components[0]
+        let minor = components[1]
+        return major > 0 || minor >= 130 ? .current : .legacy
+    }
+
+    private static func commandOutput(arguments: [String]) -> String? {
+        for command in codexCommandCandidates() {
+            if let output = runCommand(
+                executableURL: command.executableURL,
+                arguments: command.prefixArguments + arguments
+            ) {
+                return output
+            }
+        }
+
+        return nil
+    }
+
+    private static func codexCommandCandidates() -> [(executableURL: URL, prefixArguments: [String])] {
+        var candidates: [(executableURL: URL, prefixArguments: [String])] = [
+            (URL(fileURLWithPath: "/usr/bin/env"), ["codex"]),
+        ]
+
+        for path in ["/opt/homebrew/bin/codex", "/usr/local/bin/codex"] {
+            if FileManager.default.isExecutableFile(atPath: path) {
+                candidates.append((URL(fileURLWithPath: path), []))
+            }
+        }
+
+        return candidates
+    }
+
+    private static func runCommand(executableURL: URL, arguments: [String]) -> String? {
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = arguments
+
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return nil
+        }
+
+        guard process.terminationStatus == 0 else {
+            return nil
+        }
+
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)
     }
 
     private static func shellQuote(_ string: String) -> String {

--- a/Sources/OpenIslandSetup/OpenIslandSetupCLI.swift
+++ b/Sources/OpenIslandSetup/OpenIslandSetupCLI.swift
@@ -132,9 +132,9 @@ private struct SetupCommand {
         print("Codex dir: \(status.codexDirectory.path)")
         print("Hooks binary: \(hooksBinary.path)")
         if status.manifest?.enabledCodexHooksFeature == true {
-            print("Updated config.toml to enable [features].codex_hooks = true")
+            print("Updated config.toml to enable Codex hooks")
         } else {
-            print("config.toml already had codex_hooks enabled")
+            print("config.toml already had Codex hooks enabled")
         }
     }
 

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -853,6 +853,20 @@ struct SessionStateTests {
     }
 
     @Test
+    func codexHookInstallerCanUseLegacyFeatureFlagForOlderCodex() {
+        let initialConfig = """
+        model = "gpt-5-codex"
+        """
+
+        let enabled = CodexHookInstaller.enableCodexHooksFeature(in: initialConfig, preferredKey: .legacy)
+        #expect(enabled.changed)
+        #expect(enabled.featureEnabledByInstaller)
+        #expect(enabled.contents.contains("[features]"))
+        #expect(enabled.contents.contains("codex_hooks = true"))
+        #expect(!enabled.contents.contains("hooks = true"))
+    }
+
+    @Test
     func codexHookInstallerRemovesLegacyFlagWhenCurrentFlagExists() {
         let mixedConfig = """
         [features]
@@ -893,6 +907,23 @@ struct SessionStateTests {
         [features]
         hooks=false # disabled by user
         """))
+    }
+
+    @Test
+    func codexHookInstallerDetectsPreferredFeatureFlagFromCodexOutput() {
+        let currentFeatures = """
+        plugin_hooks  under development  false
+        hooks         stable             true
+        """
+        let legacyFeatures = """
+        codex_hooks   stable             true
+        shell_tool    stable             true
+        """
+
+        #expect(CodexHookInstaller.preferredCodexHooksFeatureKey(fromFeatureList: currentFeatures) == .current)
+        #expect(CodexHookInstaller.preferredCodexHooksFeatureKey(fromFeatureList: legacyFeatures) == .legacy)
+        #expect(CodexHookInstaller.preferredCodexHooksFeatureKey(fromVersionOutput: "codex-cli 0.130.0") == .current)
+        #expect(CodexHookInstaller.preferredCodexHooksFeatureKey(fromVersionOutput: "codex-cli 0.129.0") == .legacy)
     }
 
     @Test

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -862,8 +862,9 @@ struct SessionStateTests {
         #expect(enabled.changed)
         #expect(enabled.featureEnabledByInstaller)
         #expect(enabled.contents.contains("[features]"))
-        #expect(enabled.contents.contains("codex_hooks = true"))
-        #expect(!enabled.contents.contains("hooks = true"))
+        let enabledLines = enabled.contents.components(separatedBy: "\n")
+        #expect(enabledLines.contains("codex_hooks = true"))
+        #expect(!enabledLines.contains("hooks = true"))
     }
 
     @Test

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -45,7 +45,7 @@ Agent
 
 The managed Codex hook installer (`CodexHookInstaller`) installs only `SessionStart`, `UserPromptSubmit`, and `Stop` by default. This is intentional: per-command Bash hooks add terminal log noise, so the default set keeps the workflow low-noise while still providing session lifecycle and usage visibility.
 
-For Codex v0.130 and newer, the installer enables hooks with `[features].hooks = true` in `~/.codex/config.toml`. Older installs that still contain `[features].codex_hooks = true` are recognized as enabled and migrated on the next managed install.
+The installer chooses the Codex hook feature flag that the local Codex CLI advertises. Newer Codex builds use `[features].hooks = true`; older builds use the legacy `[features].codex_hooks = true`. Status checks recognize both keys, and managed installs migrate between them when the local Codex version changes.
 
 After hooks are installed or changed, Codex may require a manual trust review before running them. Open `/hooks` inside Codex CLI and approve the expected Open Island hook entries. This approval gate belongs to Codex and is not bypassed by Open Island.
 


### PR DESCRIPTION
## Summary
- Builds on community PR #463 for the Codex v0.130 hooks feature-flag rename.
- Keeps the #463 migration/status behavior, while choosing the install-time feature flag from the local Codex CLI.
- Writes `[features].hooks = true` for newer Codex builds that advertise `hooks`, and falls back to legacy `[features].codex_hooks = true` for older or undetectable Codex builds.
- Updates setup output and hook docs so they do not imply only one Codex version is supported.

## Root Cause
Codex v0.130 warns that `[features].codex_hooks` is deprecated in favor of `[features].hooks`, but older Codex builds and the currently published docs still reference the legacy key. The installer should avoid the new warning without dropping older CLI compatibility.

## Validation
- `git diff --check`
- `scripts/check-docs.sh`
- `swift build --product OpenIslandHooks`
- `swift build --product OpenIslandSetup`

## Verification Gap
- `swift test --filter codexHookInstaller` is blocked in this local environment because the test target cannot import Swift's `Testing` module (`no such module 'Testing'`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of the appropriate Codex hooks feature flag based on your installed Codex CLI version.
  * Support for both current and legacy Codex hooks feature flags with seamless compatibility.

* **Documentation**
  * Updated documentation describing how Codex hook feature flags are selected and managed during installation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Octane0411/open-vibe-island/pull/464)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->