### PR TITLE
[codex] fix claude away summary session completion

### DIFF
--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -783,7 +783,7 @@ public final class BridgeServer: @unchecked Sendable {
 
             let currentPhase = localState.session(id: payload.sessionID)?.phase ?? .completed
             let notificationPhase: SessionPhase
-            if payload.notificationType == "idle_prompt" {
+            if payload.isIdleNotification {
                 notificationPhase = .completed
             } else {
                 // Notifications are informational — never escalate phase to running.

--- a/Sources/OpenIslandCore/ClaudeHooks.swift
+++ b/Sources/OpenIslandCore/ClaudeHooks.swift
@@ -355,6 +355,7 @@ public struct ClaudeHookPayload: Equatable, Codable, Sendable {
     public var message: String?
     public var title: String?
     public var notificationType: String?
+    public var subtype: String?
     public var stopHookActive: Bool?
     public var lastAssistantMessage: String?
     public var error: String?
@@ -398,6 +399,7 @@ public struct ClaudeHookPayload: Equatable, Codable, Sendable {
         case message
         case title
         case notificationType = "notification_type"
+        case subtype
         case stopHookActive = "stop_hook_active"
         case lastAssistantMessage = "last_assistant_message"
         case error
@@ -431,6 +433,7 @@ public struct ClaudeHookPayload: Equatable, Codable, Sendable {
         message: String? = nil,
         title: String? = nil,
         notificationType: String? = nil,
+        subtype: String? = nil,
         stopHookActive: Bool? = nil,
         lastAssistantMessage: String? = nil,
         error: String? = nil,
@@ -462,6 +465,7 @@ public struct ClaudeHookPayload: Equatable, Codable, Sendable {
         self.message = message
         self.title = title
         self.notificationType = notificationType
+        self.subtype = subtype
         self.stopHookActive = stopHookActive
         self.lastAssistantMessage = lastAssistantMessage
         self.error = error
@@ -757,6 +761,12 @@ public extension ClaudeHookPayload {
         case .sessionEnd:
             return "\(agent) session ended in \(workspaceName)."
         }
+    }
+
+    var isIdleNotification: Bool {
+        let values = [notificationType, subtype]
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+        return values.contains("idle_prompt") || values.contains("away_summary")
     }
 
     var promptPreview: String? {

--- a/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
@@ -377,6 +377,59 @@ struct ClaudeHooksTests {
     }
 
     @Test
+    func claudeAwaySummaryNotificationCompletesRunningSessionWhenStopWasMissed() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let promptPayload = ClaudeHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .userPromptSubmit,
+            sessionID: "claude-away-summary",
+            transcriptPath: "/tmp/claude-away-summary.jsonl",
+            prompt: "Run the completion probe."
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(.processClaudeHook(promptPayload))
+
+        var iterator = stream.makeAsyncIterator()
+        let runningEvent = try await nextMatchingEvent(from: &iterator, maxEvents: 6) { event in
+            if case let .activityUpdated(payload) = event {
+                return payload.sessionID == "claude-away-summary" && payload.phase == .running
+            }
+            return false
+        }
+        if case let .activityUpdated(payload) = runningEvent {
+            #expect(payload.summary == "Prompt: Run the completion probe.")
+        }
+
+        let awaySummaryPayload = ClaudeHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .notification,
+            sessionID: "claude-away-summary",
+            transcriptPath: "/tmp/claude-away-summary.jsonl",
+            message: "Claude produced an away summary.",
+            notificationType: "away_summary"
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(.processClaudeHook(awaySummaryPayload))
+
+        let completedEvent = try await nextMatchingEvent(from: &iterator, maxEvents: 6) { event in
+            if case let .activityUpdated(payload) = event {
+                return payload.sessionID == "claude-away-summary" && payload.phase == .completed
+            }
+            return false
+        }
+        if case let .activityUpdated(payload) = completedEvent {
+            #expect(payload.summary == "Claude produced an away summary.")
+        }
+    }
+
+    @Test
     func questionPromptAlwaysAppendsOtherFreeformOption() throws {
         let payload = ClaudeHookPayload(
             cwd: "/tmp",
@@ -402,6 +455,24 @@ struct ClaudeHooksTests {
         #expect(options.map(\.label) == ["Production", "Staging", "Other"])
         #expect(options.last?.allowsFreeform == true)
         #expect(options.dropLast().allSatisfy { !$0.allowsFreeform })
+    }
+
+    @Test
+    func claudeNotificationSubtypeCanIdentifyAwaySummary() throws {
+        let data = Data("""
+        {
+          "cwd": "/tmp/worktree",
+          "hook_event_name": "Notification",
+          "session_id": "claude-away-summary",
+          "subtype": "away_summary",
+          "message": "Claude produced an away summary."
+        }
+        """.utf8)
+
+        let payload = try JSONDecoder().decode(ClaudeHookPayload.self, from: data)
+
+        #expect(payload.subtype == "away_summary")
+        #expect(payload.isIdleNotification)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fix Claude Code sessions that can remain shown as running after the turn has completed when Claude later emits an away-summary notification.

## Root Cause

Claude Code 2.1.108 introduced the recap / away-summary behavior. In local traces from Claude Code 2.1.138, an `away_summary` system event can appear after `Stop` / `turn_duration`. Open Island already treated `idle_prompt` notifications as idle/completed, but did not recognize the newer away-summary signal, so a missed or delayed `Stop` could leave the session phase as running when the later notification arrived.

## Changes

- Decode Claude hook `subtype` so internal notification subtypes such as `away_summary` can be recognized.
- Centralize idle notification detection for `idle_prompt` and `away_summary`.
- Treat those idle/away notifications as completed in the bridge.
- Add regression coverage for a running Claude session receiving `away_summary` after a missed `Stop`.

## Validation

- `swift test --filter ClaudeHooksTests`
- `swift test --filter OpenIslandCoreTests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced idle notification detection with improved classification mechanism for more reliable recognition.
  * Extended notification metadata structure to support additional field classifications.

* **Tests**
  * Added tests validating notification handling for idle and away scenarios.
  * Verified correct metadata preservation and classification during notification processing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Octane0411/open-vibe-island/pull/470)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->