### PR TITLE
fix: keep completion cards visible while hovered

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1203,6 +1203,7 @@ final class AppModel {
     var autoCollapseOnMouseLeaveRequiresPriorSurfaceEntry: Bool { overlay.autoCollapseOnMouseLeaveRequiresPriorSurfaceEntry }
     var showsNotificationCard: Bool { overlay.showsNotificationCard }
     var shouldDeferTimedNotificationAutoCollapse: Bool { overlay.shouldDeferTimedNotificationAutoCollapse }
+    var hasPendingNotificationAutoCollapse: Bool { overlay.hasPendingNotificationAutoCollapse }
 
     func loadDebugSnapshot(
         _ snapshot: IslandDebugSnapshot,

--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -54,6 +54,10 @@ final class OverlayUICoordinator {
     @ObservationIgnored
     private var notificationAutoCollapseTask: Task<Void, Never>?
 
+    var hasPendingNotificationAutoCollapse: Bool {
+        notificationAutoCollapseTask != nil
+    }
+
     @ObservationIgnored
     private var autoCollapseSurfaceHasBeenEntered = false
 
@@ -286,6 +290,11 @@ final class OverlayUICoordinator {
 
         isPointerInsideIslandSurface = true
         autoCollapseSurfaceHasBeenEntered = true
+
+        if notchOpenReason == .notification {
+            notificationAutoCollapseTask?.cancel()
+            notificationAutoCollapseTask = nil
+        }
     }
 
     func handlePointerExitedIslandSurface() {
@@ -356,6 +365,11 @@ final class OverlayUICoordinator {
         guard notchStatus == .opened,
               notchOpenReason == .notification,
               islandSurface.autoDismissesWhenPresentedAsNotification(session: activeIslandCardSession) else {
+            return
+        }
+
+        if overlayPanelController.isPointInExpandedArea(NSEvent.mouseLocation) {
+            notePointerInsideIslandSurface()
             return
         }
 

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -493,6 +493,13 @@ struct IslandPanelView: View {
                 // Notification mode: NO ScrollView — content sizes naturally
                 sessionListContent(referenceDate: referenceDate)
                     .padding(.vertical, 2)
+                    .onHover { hovering in
+                        if hovering {
+                            model.notePointerInsideIslandSurface()
+                        } else {
+                            model.handlePointerExitedIslandSurface()
+                        }
+                    }
                     .background(
                         GeometryReader { geo in
                             Color.clear.preference(

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -741,6 +741,35 @@ struct AppModelSessionListTests {
     }
 
     @Test
+    func completionNotificationHoverCancelsPendingTimedCollapse() {
+        let model = AppModel()
+        model.state = SessionState(
+            sessions: [
+                AgentSession(
+                    id: "session-1",
+                    title: "Test",
+                    tool: .codex,
+                    attachmentState: .attached,
+                    phase: .completed,
+                    summary: "Done",
+                    updatedAt: .now
+                )
+            ]
+        )
+
+        model.notchOpen(reason: .notification, surface: .sessionList(actionableSessionID: "session-1"))
+
+        #expect(model.hasPendingNotificationAutoCollapse)
+
+        model.notePointerInsideIslandSurface()
+
+        #expect(!model.hasPendingNotificationAutoCollapse)
+        #expect(model.shouldDeferTimedNotificationAutoCollapse)
+        #expect(model.notchStatus == .opened)
+        #expect(model.notchOpenReason == .notification)
+    }
+
+    @Test
     func mergeDiscoveredClaudeSessionsPreservesRegistryJumpTargetAndAddsTranscriptMetadata() {
         let now = Date(timeIntervalSince1970: 2_000)
         let model = AppModel()


### PR DESCRIPTION
## Summary
- Cancel the completion-card timed auto-collapse when the pointer enters the notification surface.
- Add SwiftUI hover tracking on notification-mode content so a stationary hover is observed reliably.
- Cover the behavior with an AppModel regression test.

## Root Cause
Completion notification cards still owned a 10-second auto-collapse task. The previous hover guard deferred collapse at the deadline, but it did not cancel the pending task when hover was detected, and static hover could rely too much on global mouse-move tracking.

## Impact
Completed cards stay visible while the user is hovering them, instead of disappearing and falling back into the session list.

## Verification
- `swift test --filter AppModelSessionListTests --filter IslandSurfaceTests`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Enhanced notification handling: Notifications now intelligently respond to your pointer interactions. When you hover over a notification or move your cursor into the notification area, any pending auto-collapse is cancelled, ensuring the notification remains visible while you're actively interacting with it.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Octane0411/open-vibe-island/pull/471)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->