### PR TITLE
[codex] fix completion reply placeholder agent name

### DIFF
--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -195,12 +195,24 @@ extension AgentSession {
         switch tool {
         case .claudeCode:
             return "Claude"
+        case .codex:
+            return "Codex"
         case .geminiCLI:
             return "Gemini"
+        case .openCode:
+            return "OpenCode"
+        case .qoder:
+            return "Qoder"
+        case .qwenCode:
+            return "Qwen Code"
+        case .factory:
+            return "Factory"
+        case .codebuddy:
+            return "CodeBuddy"
+        case .cursor:
+            return "Cursor"
         case .kimiCLI:
             return "Kimi"
-        default:
-            return tool.displayName
         }
     }
 

--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -191,6 +191,19 @@ extension AgentSession {
         return "You: \(prompt)"
     }
 
+    var completionReplyRecipientName: String {
+        switch tool {
+        case .claudeCode:
+            return "Claude"
+        case .geminiCLI:
+            return "Gemini"
+        case .kimiCLI:
+            return "Kimi"
+        default:
+            return tool.displayName
+        }
+    }
+
     var notificationHeaderPromptLineText: String? {
         guard phase != .completed else {
             return nil

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -221,7 +221,7 @@
 
 /* Island Panel - Completion */
 "completion.done" = "Done";
-"completion.replyPlaceholder" = "Reply to Claude…";
+"completion.replyPlaceholder" = "Reply to %@…";
 
 /* Window Titles */
 "window.settings" = "Open Island Settings";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -221,7 +221,7 @@
 
 /* Island Panel - Completion */
 "completion.done" = "完成";
-"completion.replyPlaceholder" = "回复 Claude…";
+"completion.replyPlaceholder" = "回复 %@…";
 
 /* Window Titles */
 "window.settings" = "Open Island 设置";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -220,7 +220,7 @@
 
 /* Island Panel - Completion */
 "completion.done" = "完成";
-"completion.replyPlaceholder" = "回覆 Claude…";
+"completion.replyPlaceholder" = "回覆 %@…";
 
 /* Window Titles */
 "window.settings" = "Open Island 設定";

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1707,7 +1707,7 @@ private struct IslandSessionRow: View {
     private var completionReplyInput: some View {
         HStack(spacing: 8) {
             ReplyTextField(
-                placeholder: lang.t("completion.replyPlaceholder"),
+                placeholder: lang.t("completion.replyPlaceholder", session.completionReplyRecipientName),
                 text: $replyText,
                 onSubmit: { submitReply() }
             )

--- a/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
+++ b/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
@@ -99,35 +99,33 @@ struct AgentSessionPresentationTests {
     }
 
     @Test
-    func completionReplyRecipientUsesSessionToolName() {
-        let codex = AgentSession(
-            id: "codex-session",
-            title: "Codex · worktree",
-            tool: .codex,
-            phase: .completed,
-            summary: "Ready",
-            updatedAt: .now
-        )
-        let claude = AgentSession(
-            id: "claude-session",
-            title: "Claude · worktree",
-            tool: .claudeCode,
-            phase: .completed,
-            summary: "Ready",
-            updatedAt: .now
-        )
-        let gemini = AgentSession(
-            id: "gemini-session",
-            title: "Gemini CLI · worktree",
-            tool: .geminiCLI,
-            phase: .completed,
-            summary: "Ready",
-            updatedAt: .now
-        )
+    func completionReplyRecipientCoversEveryAgentTool() {
+        let expectedNames: [(AgentTool, String)] = [
+            (.claudeCode, "Claude"),
+            (.codex, "Codex"),
+            (.geminiCLI, "Gemini"),
+            (.openCode, "OpenCode"),
+            (.qoder, "Qoder"),
+            (.qwenCode, "Qwen Code"),
+            (.factory, "Factory"),
+            (.codebuddy, "CodeBuddy"),
+            (.cursor, "Cursor"),
+            (.kimiCLI, "Kimi"),
+        ]
+        #expect(expectedNames.map { $0.0.rawValue }.sorted() == AgentTool.allCases.map(\.rawValue).sorted())
 
-        #expect(codex.completionReplyRecipientName == "Codex")
-        #expect(claude.completionReplyRecipientName == "Claude")
-        #expect(gemini.completionReplyRecipientName == "Gemini")
+        for (tool, expectedName) in expectedNames {
+            let session = AgentSession(
+                id: "\(tool.rawValue)-session",
+                title: "\(expectedName) · worktree",
+                tool: tool,
+                phase: .completed,
+                summary: "Ready",
+                updatedAt: .now
+            )
+
+            #expect(session.completionReplyRecipientName == expectedName)
+        }
     }
 
     @Test

--- a/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
+++ b/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
@@ -99,6 +99,38 @@ struct AgentSessionPresentationTests {
     }
 
     @Test
+    func completionReplyRecipientUsesSessionToolName() {
+        let codex = AgentSession(
+            id: "codex-session",
+            title: "Codex · worktree",
+            tool: .codex,
+            phase: .completed,
+            summary: "Ready",
+            updatedAt: .now
+        )
+        let claude = AgentSession(
+            id: "claude-session",
+            title: "Claude · worktree",
+            tool: .claudeCode,
+            phase: .completed,
+            summary: "Ready",
+            updatedAt: .now
+        )
+        let gemini = AgentSession(
+            id: "gemini-session",
+            title: "Gemini CLI · worktree",
+            tool: .geminiCLI,
+            phase: .completed,
+            summary: "Ready",
+            updatedAt: .now
+        )
+
+        #expect(codex.completionReplyRecipientName == "Codex")
+        #expect(claude.completionReplyRecipientName == "Claude")
+        #expect(gemini.completionReplyRecipientName == "Gemini")
+    }
+
+    @Test
     func completedSessionBecomesV8StaleAfterFiveMinutes() {
         let referenceDate = Date(timeIntervalSince1970: 10_000)
         let session = AgentSession(


### PR DESCRIPTION
## Summary

Fix the completion-card reply placeholder so it names the current session's agent/tool instead of always saying Claude.

## Details

- Add a presentation helper that derives the reply recipient from `AgentSession.tool`.
- Explicitly cover every `AgentTool` case so new agents must update the reply label mapping.
- Use a parameterized localized placeholder for English, Simplified Chinese, and Traditional Chinese.
- Add full agent coverage for completion reply recipient names.

## Root Cause

The completion reply placeholder was a static localized string (`Reply to Claude…` / `回复 Claude…`), so Codex completion cards could display a Claude-specific prompt.

## Validation

- `swift test --filter AgentSessionPresentationTests`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reply input now shows a specific recipient name per AI tool (e.g., Claude, Gemini, Kimi) instead of a fixed reference.

* **Internationalization**
  * Updated reply placeholder strings in English, Simplified Chinese, and Traditional Chinese to accept and display a dynamic recipient name.

* **Tests**
  * Added tests ensuring each AI tool maps to the correct reply recipient name.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Octane0411/open-vibe-island/pull/472)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->