### PR TITLE
fix: rediscover active Codex CLI sessions

### DIFF
--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -225,7 +225,7 @@ struct ActiveAgentProcessDiscovery {
         processesByPID: [String: RunningProcess]
     ) -> ProcessSnapshot? {
         guard let lsofOutput = lsofOutput(pid: process.pid),
-              let transcriptPath = matchingPath(in: lsofOutput, containing: "/.codex/sessions/", suffix: ".jsonl"),
+              let transcriptPath = bestCodexTranscriptPath(in: lsofOutput),
               let sessionID = firstUUID(in: transcriptPath) else {
             return nil
         }
@@ -252,6 +252,21 @@ struct ActiveAgentProcessDiscovery {
         }
 
         return snapshot
+    }
+
+    private func bestCodexTranscriptPath(in lsofOutput: String) -> String? {
+        let paths = allMatchingPaths(in: lsofOutput, containing: "/.codex/sessions/", suffix: ".jsonl")
+        guard !paths.isEmpty else {
+            return nil
+        }
+
+        return paths.max {
+            codexRolloutSortKey(for: $0) < codexRolloutSortKey(for: $1)
+        }
+    }
+
+    private func codexRolloutSortKey(for path: String) -> String {
+        URL(fileURLWithPath: path).deletingPathExtension().lastPathComponent
     }
 
     private func isClaudeSubagentWorktree(_ path: String) -> Bool {
@@ -483,23 +498,6 @@ struct ActiveAgentProcessDiscovery {
             if value.hasPrefix("/") {
                 return value
             }
-        }
-
-        return nil
-    }
-
-    private func matchingPath(in lsofOutput: String, containing fragment: String, suffix: String) -> String? {
-        for line in lsofOutput.split(whereSeparator: \.isNewline) {
-            guard line.first == "n" else {
-                continue
-            }
-
-            let value = String(line.dropFirst()).trimmingCharacters(in: .whitespacesAndNewlines)
-            guard value.contains(fragment), value.hasSuffix(suffix) else {
-                continue
-            }
-
-            return value
         }
 
         return nil

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -685,6 +685,9 @@ final class AppModel {
                 self.codexAppServer.disconnect()
             }
         }
+        monitoring.onCodexCLIProcessesObserved = { [weak self] activeSessionIDs in
+            self?.discovery.rediscoverCodexCLISessionsIfNeeded(activeSessionIDs: activeSessionIDs)
+        }
 
         refreshOverlayDisplayConfiguration()
         hasFinishedInit = true

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -29,6 +29,11 @@ final class ProcessMonitoringCoordinator {
     @ObservationIgnored
     var onCodexAppRunningChanged: ((_ isRunning: Bool) -> Void)?
 
+    /// Fires when at least one interactive Codex CLI process is visible.
+    /// The app uses this to re-scan rollout files created after startup.
+    @ObservationIgnored
+    var onCodexCLIProcessesObserved: ((_ activeSessionIDs: Set<String>) -> Void)?
+
     @ObservationIgnored
     let activeAgentProcessDiscovery = ActiveAgentProcessDiscovery()
 
@@ -125,6 +130,14 @@ final class ProcessMonitoringCoordinator {
         if isCodexAppRunning != wasCodexAppRunning {
             wasCodexAppRunning = isCodexAppRunning
             onCodexAppRunningChanged?(isCodexAppRunning)
+        }
+        let activeCodexCLISessionIDs = Set(
+            activeProcesses
+                .filter { $0.tool == .codex }
+                .compactMap(\.sessionID)
+        )
+        if !activeCodexCLISessionIDs.isEmpty {
+            onCodexCLIProcessesObserved?(activeCodexCLISessionIDs)
         }
 
         let sessions = local.sessions.filter(\.isTrackedLiveSession)

--- a/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
+++ b/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
@@ -387,6 +387,9 @@ final class SessionDiscoveryCoordinator {
     @ObservationIgnored
     private var lastCodexAppRescanDate: Date = .distantPast
 
+    @ObservationIgnored
+    private var lastCodexCLIRescanDate: Date = .distantPast
+
     /// Re-scan `~/.codex/sessions/` for rollout files not yet tracked.
     /// Called periodically when Codex.app is running as a fallback when
     /// the app-server connection is unavailable.  Throttled to at most
@@ -404,6 +407,45 @@ final class SessionDiscoveryCoordinator {
                 self?.applyCodexAppRediscovery(discovered)
             }
         }
+    }
+
+    /// Re-scan `~/.codex/sessions/` for Codex CLI sessions created after app
+    /// startup. Codex can keep old rollout descriptors open after a thread is
+    /// completed, so process liveness alone cannot discover a newer session.
+    func rediscoverCodexCLISessionsIfNeeded(activeSessionIDs: Set<String>) {
+        guard !activeSessionIDs.isEmpty else { return }
+
+        let now = Date.now
+        guard now.timeIntervalSince(lastCodexCLIRescanDate) >= 10 else { return }
+        lastCodexCLIRescanDate = now
+
+        let discovery = codexRolloutDiscovery
+        Task.detached(priority: .utility) { [weak self] in
+            let discovered = discovery.discoverRecentSessions().filter {
+                activeSessionIDs.contains($0.sessionID)
+            }
+            guard !discovered.isEmpty else { return }
+            await MainActor.run { [weak self] in
+                self?.applyCodexCLIRediscovery(discovered)
+            }
+        }
+    }
+
+    private func applyCodexCLIRediscovery(_ records: [CodexTrackedSessionRecord]) {
+        let existingIDs = Set(state.sessions.filter { $0.tool == .codex }.map(\.id))
+        let existingPaths = Set(state.sessions.compactMap(\.codexMetadata?.transcriptPath))
+
+        let newRecords = records.filter { record in
+            !existingIDs.contains(record.sessionID)
+                && (record.codexMetadata?.transcriptPath).map { !existingPaths.contains($0) } ?? true
+        }
+        guard !newRecords.isEmpty else { return }
+
+        let merged = mergeDiscoveredSessions(newRecords.map(\.session))
+        state = SessionState(sessions: merged)
+        refreshCodexRolloutTracking()
+        scheduleCodexSessionPersistence()
+        onStatusMessage?("Discovered \(newRecords.count) new Codex CLI session(s) via rollout re-scan.")
     }
 
     private func applyCodexAppRediscovery(_ records: [CodexTrackedSessionRecord]) {

--- a/Tests/OpenIslandAppTests/ActiveAgentProcessDiscoveryTests.swift
+++ b/Tests/OpenIslandAppTests/ActiveAgentProcessDiscoveryTests.swift
@@ -95,6 +95,48 @@ struct ActiveAgentProcessDiscoveryTests {
         ])
     }
 
+    @Test
+    func codexDiscoveryUsesNewestOpenRolloutWhenProcessKeepsOldDescriptors() {
+        let discovery = ActiveAgentProcessDiscovery { executablePath, arguments in
+            if executablePath == "/bin/ps" {
+                return """
+                  202 401 ttys001 /opt/homebrew/bin/codex
+                  401 900 ttys001 -/opt/homebrew/bin/fish
+                  900 1 ?? /Applications/Ghostty.app/Contents/MacOS/ghostty
+                """
+            }
+
+            guard executablePath == "/usr/sbin/lsof",
+                  let pid = arguments.dropFirst(2).first else {
+                return nil
+            }
+
+            guard pid == "202" else {
+                Issue.record("unexpected lsof lookup for pid \(pid)")
+                return nil
+            }
+
+            return """
+            fcwd
+            n/tmp/open-island
+            n/Users/test/.codex/sessions/2026/05/10/rollout-2026-05-10T01-04-52-019e0db2-f3a5-7fe0-bea8-e63bd356c226.jsonl
+            n/Users/test/.codex/sessions/2026/05/10/rollout-2026-05-10T01-20-29-019e0dc1-3f8b-7eb0-ae8d-04a5911e95b9.jsonl
+            """
+        }
+
+        let snapshots = discovery.discover()
+
+        #expect(snapshots == [
+            .init(
+                tool: .codex,
+                sessionID: "019e0dc1-3f8b-7eb0-ae8d-04a5911e95b9",
+                workingDirectory: "/tmp/open-island",
+                terminalTTY: "/dev/ttys001",
+                terminalApp: "Ghostty"
+            ),
+        ])
+    }
+
     /// VS Code forks (Cursor, Windsurf, Trae, Qoder) bundle Electron's "Code
     /// Helper" inside their .app bundles. Their helper paths therefore contain
     /// both "/<fork>.app/" and "/code helper", and Open Island used to match

--- a/Tests/OpenIslandAppTests/ProcessMonitoringCoordinatorTests.swift
+++ b/Tests/OpenIslandAppTests/ProcessMonitoringCoordinatorTests.swift
@@ -1,0 +1,29 @@
+import Testing
+@testable import OpenIslandApp
+import OpenIslandCore
+
+@MainActor
+struct ProcessMonitoringCoordinatorTests {
+    @Test
+    func reconcileNotifiesObservedCodexCLISessionIDsEvenWhenStateIsEmpty() {
+        let coordinator = ProcessMonitoringCoordinator()
+        var observedIDs: Set<String>?
+        coordinator.stateAccessor = { SessionState() }
+        coordinator.stateUpdater = { _ in }
+        coordinator.onCodexCLIProcessesObserved = { ids in
+            observedIDs = ids
+        }
+
+        coordinator.reconcileSessionAttachments(activeProcesses: [
+            ActiveProcessSnapshot(
+                tool: .codex,
+                sessionID: "019e0dc1-3f8b-7eb0-ae8d-04a5911e95b9",
+                workingDirectory: "/tmp/open-island",
+                terminalTTY: "/dev/ttys001",
+                terminalApp: "Ghostty"
+            ),
+        ])
+
+        #expect(observedIDs == Set(["019e0dc1-3f8b-7eb0-ae8d-04a5911e95b9"]))
+    }
+}


### PR DESCRIPTION
## Summary
- choose the newest open Codex rollout when a CLI process still holds older rollout descriptors
- notify session discovery about active Codex CLI session IDs from process monitoring
- periodically re-scan rollout files for those active CLI IDs so sessions created after app startup appear in the island

## Root Cause
Some Codex CLI processes keep old completed rollout files open while also opening the current rollout. Open Island used the first matching `.jsonl` from `lsof`, so active processes could be attributed to old completed sessions and the actual running sessions never entered the visible state list.

## Validation
- `swift test --filter ActiveAgentProcessDiscoveryTests --filter ProcessMonitoringCoordinatorTests`

## Notes
- Existing unrelated warning remains: `SessionState.swift` has an unnecessary `@discardableResult` on a `Void` function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex CLI session detection to select the most appropriate transcript when multiple candidates are available.
  * Enhanced session rediscovery to automatically update when active processes change.

* **Tests**
  * Added test coverage for session detection and process monitoring logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Octane0411/open-vibe-island/pull/473)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->