### PR TITLE
fix: align Codex rollout statuses

### DIFF
--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -58,8 +58,7 @@ extension AgentSession {
             return request.affectedPath.isEmpty ? nil : request.affectedPath
         }
 
-        if let currentTool = currentToolName?.trimmedForSurface,
-           !currentTool.isEmpty {
+        if let currentTool = displayCurrentToolName {
             return phase == .completed
                 ? summary
                 : "Running \(currentTool)"
@@ -75,12 +74,7 @@ extension AgentSession {
     }
 
     var spotlightCurrentToolLabel: String? {
-        guard let currentTool = currentToolName?.trimmedForSurface,
-              !currentTool.isEmpty else {
-            return nil
-        }
-
-        return currentTool
+        displayCurrentToolName
     }
 
     var spotlightTrackingLabel: String? {
@@ -219,7 +213,7 @@ extension AgentSession {
             if let activity = spotlightRunningActivityText {
                 return activity
             }
-            return spotlightPromptLineText == nil ? "Running" : "Input"
+            return spotlightPromptLineText == nil ? "Running" : "Thinking"
         case .waitingForApproval:
             return permissionRequest?.summary.trimmedForSurface ?? "Approval needed"
         case .waitingForAnswer:
@@ -318,7 +312,7 @@ extension AgentSession {
             return nil
         }
 
-        let label = currentToolDisplayName(for: currentTool)
+        let label = Self.currentToolDisplayName(for: currentTool)
         guard let preview = currentCommandPreviewText?.trimmedForSurface,
               !preview.isEmpty else {
             return label
@@ -327,7 +321,16 @@ extension AgentSession {
         return "\(label) \(preview)"
     }
 
-    private func currentToolDisplayName(for toolName: String) -> String {
+    var displayCurrentToolName: String? {
+        guard let currentTool = currentToolName?.trimmedForSurface,
+              !currentTool.isEmpty else {
+            return nil
+        }
+
+        return Self.currentToolDisplayName(for: currentTool)
+    }
+
+    static func currentToolDisplayName(for toolName: String) -> String {
         switch toolName {
         case "exec_command":
             return "Bash"
@@ -341,9 +344,37 @@ extension AgentSession {
             return "Patch"
         case "write_stdin":
             return "Input"
+        case "web_search", "tool_search":
+            return "Search"
+        case "image_generation", "view_image":
+            return "Image"
+        case "context_compaction":
+            return "Compact"
+        case "update_plan":
+            return "Plan"
+        case "request_user_input":
+            return "Question"
+        case "spawn_agent":
+            return "Subagent"
         default:
-            return toolName
+            return humanizedToolName(toolName)
         }
+    }
+
+    private static func humanizedToolName(_ toolName: String) -> String {
+        let trimmed = toolName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let withoutPrivatePrefix = String(trimmed.drop(while: { $0 == "_" }))
+        let pieces = withoutPrivatePrefix
+            .split(separator: "_", omittingEmptySubsequences: true)
+            .map { piece -> String in
+                let upper = piece.uppercased()
+                if ["API", "CI", "ID", "PR", "URL"].contains(upper) {
+                    return upper
+                }
+                return piece.prefix(1).uppercased() + piece.dropFirst().lowercased()
+            }
+        let label = pieces.joined(separator: " ")
+        return label.isEmpty ? toolName : label
     }
 
     private var initialPromptText: String? {

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -855,7 +855,7 @@ final class AppModel {
             if !workspace.isEmpty { return workspace }
             return session.title.isEmpty ? session.tool.displayName : session.title
         case .agentAction:
-            let action = session.currentToolName?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let action = session.displayCurrentToolName
             if let action, !action.isEmpty {
                 return "\(session.tool.displayName) · \(action)"
             }

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1752,7 +1752,7 @@ private struct IslandSessionRow: View {
         case "ExitPlanMode": return "Plan"
         case "apply_patch": return "Patch"
         case "write_stdin": return "Input"
-        case let value?: return value.capitalized
+        case let value?: return AgentSession.currentToolDisplayName(for: value)
         case nil: return "Command"
         }
     }

--- a/Sources/OpenIslandCore/CodexSessionTracking.swift
+++ b/Sources/OpenIslandCore/CodexSessionTracking.swift
@@ -559,7 +559,7 @@ public enum CodexRolloutReducer {
         to snapshot: inout CodexRolloutSnapshot
     ) {
         switch payload["type"] as? String {
-        case "task_started":
+        case "task_started", "turn_started":
             snapshot.phase = .running
             snapshot.isCompleted = false
             snapshot.isInterrupted = false
@@ -578,7 +578,7 @@ public enum CodexRolloutReducer {
 
             applyAssistantMessage(message, timestamp: timestamp, to: &snapshot)
             return
-        case "task_complete":
+        case "task_complete", "turn_complete":
             snapshot.currentTool = nil
             snapshot.currentCommandPreview = nil
             snapshot.phase = .completed
@@ -598,20 +598,86 @@ public enum CodexRolloutReducer {
             snapshot.isCompleted = true
             snapshot.isInterrupted = true
             snapshot.summary = "Codex turn was interrupted."
+        case "agent_reasoning", "agent_reasoning_raw_content", "agent_reasoning_section_break":
+            applyThinking(to: &snapshot)
+        case "exec_command_begin":
+            applyToolActivity(
+                "exec_command",
+                preview: commandPreview(fromCommandValue: payload["command"]),
+                to: &snapshot
+            )
+        case "terminal_interaction":
+            applyToolActivity(
+                "write_stdin",
+                preview: clipped(payload["stdin"] as? String),
+                to: &snapshot
+            )
         case "exec_command_end":
-            snapshot.currentTool = nil
-            snapshot.currentCommandPreview = nil
-            if !snapshot.isCompleted {
-                snapshot.phase = .running
-            }
-            snapshot.summary = "Command finished."
+            applyThinking(to: &snapshot)
+        case "patch_apply_begin", "patch_apply_updated":
+            applyToolActivity(
+                "apply_patch",
+                preview: changesPreview(from: payload),
+                to: &snapshot
+            )
         case "patch_apply_end":
-            snapshot.currentTool = nil
-            snapshot.currentCommandPreview = nil
-            if !snapshot.isCompleted {
-                snapshot.phase = .running
+            applyThinking(to: &snapshot)
+        case "mcp_tool_call_begin":
+            if let toolName = mcpToolName(from: payload) {
+                applyToolActivity(
+                    toolName,
+                    preview: mcpToolPreview(from: payload),
+                    to: &snapshot
+                )
             }
-            snapshot.summary = "Patch applied."
+        case "mcp_tool_call_end", "dynamic_tool_call_response":
+            applyThinking(to: &snapshot)
+        case "dynamic_tool_call_request":
+            if let toolName = clipped(payload["tool"] as? String) {
+                applyToolActivity(
+                    toolName,
+                    preview: jsonPreview(from: payload["arguments"]),
+                    to: &snapshot
+                )
+            }
+        case "web_search_begin":
+            applyToolActivity("web_search", preview: nil, to: &snapshot)
+        case "web_search_end":
+            applyToolActivity(
+                "web_search",
+                preview: webSearchPreview(from: payload),
+                to: &snapshot
+            )
+        case "image_generation_begin":
+            applyToolActivity("image_generation", preview: nil, to: &snapshot)
+        case "image_generation_end":
+            applyToolActivity(
+                "image_generation",
+                preview: clipped(payload["revised_prompt"] as? String),
+                to: &snapshot
+            )
+        case "view_image_tool_call":
+            applyToolActivity(
+                "view_image",
+                preview: clipped(payload["path"] as? String),
+                to: &snapshot
+            )
+        case "plan_update":
+            applyToolActivity("update_plan", preview: nil, to: &snapshot)
+        case "request_user_input", "elicitation_request":
+            applyQuestionRequest(
+                summary: clipped(payload["prompt"] as? String)
+                    ?? clipped(payload["message"] as? String),
+                to: &snapshot
+            )
+        case "exec_approval_request", "apply_patch_approval_request", "request_permissions":
+            applyApprovalRequest(
+                summary: clipped(payload["reason"] as? String)
+                    ?? clipped(payload["message"] as? String),
+                to: &snapshot
+            )
+        case "context_compacted":
+            applyThinking(to: &snapshot)
         default:
             break
         }
@@ -626,8 +692,8 @@ public enum CodexRolloutReducer {
         timestamp: Date?,
         to snapshot: inout CodexRolloutSnapshot
     ) {
-        let itemType = payload["type"] as? String
-        if itemType == "message" {
+        switch payload["type"] as? String {
+        case "message":
             guard let role = payload["role"] as? String else {
                 return
             }
@@ -650,35 +716,112 @@ public enum CodexRolloutReducer {
             }
 
             return
-        }
-
-        guard itemType == "function_call" || itemType == "custom_tool_call" else {
-            return
-        }
-
-        guard let toolName = payload["name"] as? String, !toolName.isEmpty else {
-            return
-        }
-
-        // After task_complete, trailing response_item entries (function_call
-        // results still being flushed) should not reset the completion state.
-        guard !snapshot.isCompleted else {
-            if let timestamp {
-                snapshot.updatedAt = timestamp
+        case "reasoning":
+            applyThinking(to: &snapshot)
+        case "function_call", "custom_tool_call":
+            guard let toolName = payload["name"] as? String, !toolName.isEmpty else {
+                return
             }
+
+            applyToolActivity(
+                toolName,
+                preview: commandPreview(for: toolName, payload: payload),
+                to: &snapshot
+            )
+        case "local_shell_call":
+            applyToolActivity(
+                "exec_command",
+                preview: localShellCommandPreview(from: payload),
+                to: &snapshot
+            )
+        case "tool_search_call":
+            applyToolActivity(
+                "tool_search",
+                preview: toolSearchPreview(from: payload),
+                to: &snapshot
+            )
+        case "web_search_call":
+            applyToolActivity(
+                "web_search",
+                preview: webSearchPreview(from: payload),
+                to: &snapshot
+            )
+        case "image_generation_call":
+            applyToolActivity(
+                "image_generation",
+                preview: clipped(payload["revised_prompt"] as? String),
+                to: &snapshot
+            )
+        case "compaction", "compaction_summary", "context_compaction":
+            applyToolActivity("context_compaction", preview: nil, to: &snapshot)
+        case "function_call_output", "custom_tool_call_output", "tool_search_output":
+            applyThinking(to: &snapshot)
+        default:
             return
         }
-
-        snapshot.currentTool = toolName
-        snapshot.currentCommandPreview = commandPreview(for: toolName, payload: payload)
-        snapshot.phase = .running
-        snapshot.isCompleted = false
-        snapshot.isInterrupted = false
-        snapshot.summary = "Running \(displayName(for: toolName))."
 
         if let timestamp {
             snapshot.updatedAt = timestamp
         }
+    }
+
+    private static func applyToolActivity(
+        _ toolName: String,
+        preview: String?,
+        to snapshot: inout CodexRolloutSnapshot
+    ) {
+        // After task_complete, trailing tool lifecycle records can still be
+        // flushed into the JSONL. They may refresh updatedAt, but must not
+        // reopen the completed turn or replace the final assistant summary.
+        guard !snapshot.isCompleted else {
+            return
+        }
+
+        snapshot.currentTool = toolName
+        snapshot.currentCommandPreview = preview
+        snapshot.phase = .running
+        snapshot.isCompleted = false
+        snapshot.isInterrupted = false
+        snapshot.summary = "Running \(displayName(for: toolName))."
+    }
+
+    private static func applyThinking(to snapshot: inout CodexRolloutSnapshot) {
+        guard !snapshot.isCompleted else {
+            return
+        }
+
+        snapshot.currentTool = nil
+        snapshot.currentCommandPreview = nil
+        snapshot.phase = .running
+        snapshot.isCompleted = false
+        snapshot.isInterrupted = false
+        snapshot.summary = "Thinking."
+    }
+
+    private static func applyApprovalRequest(summary: String?, to snapshot: inout CodexRolloutSnapshot) {
+        guard !snapshot.isCompleted else {
+            return
+        }
+
+        snapshot.currentTool = nil
+        snapshot.currentCommandPreview = nil
+        snapshot.phase = .waitingForApproval
+        snapshot.isCompleted = false
+        snapshot.isInterrupted = false
+        snapshot.summary = summary ?? "Approval needed."
+    }
+
+    private static func applyQuestionRequest(summary: String?, to snapshot: inout CodexRolloutSnapshot) {
+        guard !snapshot.isCompleted else {
+            return
+        }
+
+        snapshot.currentTool = nil
+        snapshot.currentCommandPreview = nil
+        snapshot.phase = .waitingForAnswer
+        snapshot.isCompleted = false
+        snapshot.isInterrupted = false
+        snapshot.summary = summary ?? "Answer needed."
     }
 
     private static func applyUserMessage(
@@ -732,15 +875,27 @@ public enum CodexRolloutReducer {
             "patch"
         case "write_stdin":
             "input"
+        case "web_search":
+            "web search"
+        case "tool_search":
+            "tool search"
+        case "image_generation":
+            "image generation"
+        case "context_compaction":
+            "context compaction"
+        case "view_image":
+            "image"
+        case "update_plan":
+            "plan"
+        case "request_user_input":
+            "question"
         default:
-            toolName
+            readableToolName(toolName)
         }
     }
 
     private static func commandPreview(for toolName: String, payload: [String: Any]) -> String? {
-        guard let arguments = payload["arguments"] as? String,
-              let data = arguments.data(using: .utf8),
-              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        guard let object = decodedArguments(from: payload) else {
             return nil
         }
 
@@ -749,9 +904,166 @@ public enum CodexRolloutReducer {
             return clipped(object["cmd"] as? String)
         case "write_stdin":
             return clipped(object["chars"] as? String)
+        case "view_image":
+            return clipped(object["path"] as? String)
         default:
             return nil
         }
+    }
+
+    private static func decodedArguments(from payload: [String: Any]) -> [String: Any]? {
+        if let object = payload["arguments"] as? [String: Any] {
+            return object
+        }
+
+        guard let arguments = payload["arguments"] as? String,
+              let data = arguments.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+
+        return object
+    }
+
+    private static func localShellCommandPreview(from payload: [String: Any]) -> String? {
+        if let action = payload["action"] as? [String: Any] {
+            return commandPreview(fromCommandValue: action["command"])
+        }
+
+        return commandPreview(fromCommandValue: payload["command"])
+    }
+
+    private static func commandPreview(fromCommandValue value: Any?) -> String? {
+        if let command = value as? String {
+            return clipped(command)
+        }
+
+        if let command = value as? [String] {
+            if command.count >= 3, command[1] == "-lc" {
+                return clipped(command[2])
+            }
+            return clipped(command.joined(separator: " "))
+        }
+
+        if let command = value as? [Any] {
+            let pieces = command.compactMap { $0 as? String }
+            guard !pieces.isEmpty else {
+                return nil
+            }
+            if pieces.count >= 3, pieces[1] == "-lc" {
+                return clipped(pieces[2])
+            }
+            return clipped(pieces.joined(separator: " "))
+        }
+
+        return nil
+    }
+
+    private static func toolSearchPreview(from payload: [String: Any]) -> String? {
+        clipped(payload["execution"] as? String)
+            ?? jsonPreview(from: payload["arguments"])
+    }
+
+    private static func mcpToolName(from payload: [String: Any]) -> String? {
+        guard let invocation = payload["invocation"] as? [String: Any] else {
+            return nil
+        }
+
+        return clipped(invocation["tool"] as? String)
+    }
+
+    private static func mcpToolPreview(from payload: [String: Any]) -> String? {
+        guard let invocation = payload["invocation"] as? [String: Any] else {
+            return nil
+        }
+
+        return jsonPreview(from: invocation["arguments"])
+    }
+
+    private static func webSearchPreview(from payload: [String: Any]) -> String? {
+        if let action = payload["action"] as? [String: Any],
+           let detail = webSearchActionDetail(from: action) {
+            return detail
+        }
+
+        return clipped(payload["query"] as? String)
+    }
+
+    private static func webSearchActionDetail(from action: [String: Any]) -> String? {
+        switch action["type"] as? String {
+        case "search":
+            if let query = clipped(action["query"] as? String) {
+                return query
+            }
+
+            guard let queries = action["queries"] as? [String],
+                  let firstQuery = clipped(queries.first) else {
+                return nil
+            }
+
+            return queries.count > 1 ? "\(firstQuery) ..." : firstQuery
+        case "open_page", "openPage":
+            return clipped(action["url"] as? String)
+        case "find_in_page", "findInPage":
+            let pattern = clipped(action["pattern"] as? String)
+            let url = clipped(action["url"] as? String)
+
+            switch (pattern, url) {
+            case let (pattern?, url?):
+                return "'\(pattern)' in \(url)"
+            case let (pattern?, nil):
+                return pattern
+            case let (nil, url?):
+                return url
+            case (nil, nil):
+                return nil
+            }
+        default:
+            return nil
+        }
+    }
+
+    private static func changesPreview(from payload: [String: Any]) -> String? {
+        guard let changes = payload["changes"] as? [String: Any],
+              !changes.isEmpty else {
+            return nil
+        }
+
+        let visibleNames = changes.keys.sorted().prefix(3).map { path in
+            let lastPathComponent = URL(fileURLWithPath: path).lastPathComponent
+            return lastPathComponent.isEmpty ? path : lastPathComponent
+        }
+        let suffix = changes.count > visibleNames.count ? " ..." : ""
+        return clipped("\(visibleNames.joined(separator: ", "))\(suffix)")
+    }
+
+    private static func jsonPreview(from value: Any?) -> String? {
+        guard let value else {
+            return nil
+        }
+
+        if let string = value as? String {
+            return clipped(string)
+        }
+
+        if let number = value as? NSNumber {
+            return clipped(number.stringValue)
+        }
+
+        guard JSONSerialization.isValidJSONObject(value),
+              let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys]),
+              let string = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        return clipped(string)
+    }
+
+    private static func readableToolName(_ toolName: String) -> String {
+        let trimmed = toolName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let withoutPrivatePrefix = String(trimmed.drop(while: { $0 == "_" }))
+        let readable = withoutPrivatePrefix.replacingOccurrences(of: "_", with: " ")
+        return readable.isEmpty ? toolName : readable
     }
 
     private static func responseMessageText(

--- a/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
+++ b/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
@@ -235,4 +235,72 @@ struct AgentSessionPresentationTests {
         #expect(session.spotlightPromptLineText == "You: Also confirm the worktree status.")
         #expect(session.notificationHeaderPromptLineText == nil)
     }
+
+    @Test
+    func runningCodexSessionWithoutToolShowsThinkingBesidePrompt() {
+        let session = AgentSession(
+            id: "session-1",
+            title: "Codex · worktree",
+            tool: .codex,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Thinking.",
+            updatedAt: Date(timeIntervalSince1970: 10_000),
+            codexMetadata: CodexSessionMetadata(
+                lastUserPrompt: "Align the Codex statuses."
+            )
+        )
+
+        #expect(session.spotlightPromptLineText == "You: Align the Codex statuses.")
+        #expect(session.spotlightActivityLineText == "Thinking")
+        #expect(session.displayCurrentToolName == nil)
+    }
+
+    @Test
+    func runningCodexSessionKeepsWriteStdinAsInput() {
+        let session = AgentSession(
+            id: "session-1",
+            title: "Codex · worktree",
+            tool: .codex,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Running input.",
+            updatedAt: Date(timeIntervalSince1970: 10_000),
+            codexMetadata: CodexSessionMetadata(
+                lastUserPrompt: "Continue the command.",
+                currentTool: "write_stdin",
+                currentCommandPreview: "y"
+            )
+        )
+
+        #expect(session.spotlightActivityLineText == "Input y")
+        #expect(session.spotlightStatusLabel == "Live · Input")
+        #expect(session.displayCurrentToolName == "Input")
+    }
+
+    @Test
+    func runningCodexSessionDisplaysWebSearchAction() {
+        let session = AgentSession(
+            id: "session-1",
+            title: "Codex · worktree",
+            tool: .codex,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Running web search.",
+            updatedAt: Date(timeIntervalSince1970: 10_000),
+            codexMetadata: CodexSessionMetadata(
+                lastUserPrompt: "Check the Codex repo.",
+                currentTool: "web_search",
+                currentCommandPreview: "Codex rollout ResponseItem"
+            )
+        )
+
+        #expect(session.spotlightActivityLineText == "Search Codex rollout ResponseItem")
+        #expect(session.spotlightStatusLabel == "Live · Search")
+        #expect(session.spotlightSecondaryText == "Running Search")
+        #expect(session.displayCurrentToolName == "Search")
+    }
 }

--- a/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
@@ -222,6 +222,309 @@ struct CodexSessionTrackingTests {
     }
 
     @Test
+    func codexRolloutReducerAlignsCodexResponseItemStatuses() {
+        var snapshot = CodexRolloutSnapshot()
+
+        CodexRolloutReducer.apply(
+            line: rolloutLine(
+                timestamp: "2026-04-02T04:03:44.500Z",
+                type: "event_msg",
+                payload: [
+                    "type": "user_message",
+                    "message": "Check the Codex statuses.",
+                ]
+            ),
+            to: &snapshot
+        )
+        CodexRolloutReducer.apply(
+            line: rolloutLine(
+                timestamp: "2026-04-02T04:03:45.000Z",
+                type: "response_item",
+                payload: [
+                    "type": "reasoning",
+                    "summary": [],
+                ]
+            ),
+            to: &snapshot
+        )
+
+        #expect(snapshot.currentTool == nil)
+        #expect(snapshot.currentCommandPreview == nil)
+        #expect(snapshot.summary == "Thinking.")
+
+        CodexRolloutReducer.apply(
+            line: rolloutLine(
+                timestamp: "2026-04-02T04:03:46.000Z",
+                type: "response_item",
+                payload: [
+                    "type": "web_search_call",
+                    "status": "completed",
+                    "action": [
+                        "type": "search",
+                        "query": "Codex rollout ResponseItem",
+                    ],
+                ]
+            ),
+            to: &snapshot
+        )
+
+        #expect(snapshot.currentTool == "web_search")
+        #expect(snapshot.currentCommandPreview == "Codex rollout ResponseItem")
+        #expect(snapshot.summary == "Running web search.")
+
+        CodexRolloutReducer.apply(
+            line: rolloutLine(
+                timestamp: "2026-04-02T04:03:47.000Z",
+                type: "response_item",
+                payload: [
+                    "type": "function_call_output",
+                    "call_id": "call-1",
+                    "output": "done",
+                ]
+            ),
+            to: &snapshot
+        )
+
+        #expect(snapshot.currentTool == nil)
+        #expect(snapshot.currentCommandPreview == nil)
+        #expect(snapshot.summary == "Thinking.")
+
+        CodexRolloutReducer.apply(
+            line: rolloutLine(
+                timestamp: "2026-04-02T04:03:48.000Z",
+                type: "response_item",
+                payload: [
+                    "type": "image_generation_call",
+                    "id": "ig-1",
+                    "status": "completed",
+                    "revised_prompt": "A status diagram",
+                    "result": "base64",
+                ]
+            ),
+            to: &snapshot
+        )
+
+        #expect(snapshot.currentTool == "image_generation")
+        #expect(snapshot.currentCommandPreview == "A status diagram")
+        #expect(snapshot.summary == "Running image generation.")
+
+        CodexRolloutReducer.apply(
+            line: rolloutLine(
+                timestamp: "2026-04-02T04:03:49.000Z",
+                type: "response_item",
+                payload: [
+                    "type": "local_shell_call",
+                    "status": "in_progress",
+                    "action": [
+                        "type": "exec",
+                        "command": ["zsh", "-lc", "swift test --filter CodexSessionTrackingTests"],
+                    ],
+                ]
+            ),
+            to: &snapshot
+        )
+
+        #expect(snapshot.currentTool == "exec_command")
+        #expect(snapshot.currentCommandPreview == "swift test --filter CodexSessionTrackingTests")
+        #expect(snapshot.summary == "Running command.")
+
+        CodexRolloutReducer.apply(
+            line: rolloutLine(
+                timestamp: "2026-04-02T04:03:50.000Z",
+                type: "response_item",
+                payload: [
+                    "type": "tool_search_call",
+                    "execution": "search docs",
+                    "arguments": [
+                        "query": "Codex EventMsg",
+                    ],
+                ]
+            ),
+            to: &snapshot
+        )
+
+        #expect(snapshot.currentTool == "tool_search")
+        #expect(snapshot.currentCommandPreview == "search docs")
+        #expect(snapshot.summary == "Running tool search.")
+    }
+
+    @Test
+    func codexRolloutReducerAlignsCodexEventMessageStatuses() {
+        var snapshot = CodexRolloutSnapshot()
+
+        CodexRolloutReducer.apply(
+            line: rolloutLine(
+                timestamp: "2026-04-02T04:03:44.500Z",
+                type: "event_msg",
+                payload: [
+                    "type": "exec_command_begin",
+                    "command": ["zsh", "-lc", "git status -sb"],
+                ]
+            ),
+            to: &snapshot
+        )
+
+        #expect(snapshot.currentTool == "exec_command")
+        #expect(snapshot.currentCommandPreview == "git status -sb")
+        #expect(snapshot.summary == "Running command.")
+
+        CodexRolloutReducer.apply(
+            line: rolloutLine(
+                timestamp: "2026-04-02T04:03:45.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "exec_command_end",
+                    "command": ["zsh", "-lc", "git status -sb"],
+                    "stdout": "",
+                    "stderr": "",
+                    "exit_code": 0,
+                    "status": "completed",
+                ]
+            ),
+            to: &snapshot
+        )
+
+        #expect(snapshot.currentTool == nil)
+        #expect(snapshot.currentCommandPreview == nil)
+        #expect(snapshot.summary == "Thinking.")
+
+        CodexRolloutReducer.apply(
+            line: rolloutLine(
+                timestamp: "2026-04-02T04:03:46.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "terminal_interaction",
+                    "stdin": "y\n",
+                ]
+            ),
+            to: &snapshot
+        )
+
+        #expect(snapshot.currentTool == "write_stdin")
+        #expect(snapshot.currentCommandPreview == "y")
+        #expect(snapshot.summary == "Running input.")
+
+        CodexRolloutReducer.apply(
+            line: rolloutLine(
+                timestamp: "2026-04-02T04:03:47.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "patch_apply_begin",
+                    "changes": [
+                        "Sources/OpenIslandCore/CodexSessionTracking.swift": [:],
+                    ],
+                ]
+            ),
+            to: &snapshot
+        )
+
+        #expect(snapshot.currentTool == "apply_patch")
+        #expect(snapshot.currentCommandPreview == "CodexSessionTracking.swift")
+        #expect(snapshot.summary == "Running patch.")
+
+        CodexRolloutReducer.apply(
+            line: rolloutLine(
+                timestamp: "2026-04-02T04:03:48.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "patch_apply_end",
+                    "success": true,
+                    "changes": [
+                        "Sources/OpenIslandCore/CodexSessionTracking.swift": [:],
+                    ],
+                    "status": "completed",
+                ]
+            ),
+            to: &snapshot
+        )
+
+        #expect(snapshot.currentTool == nil)
+        #expect(snapshot.summary == "Thinking.")
+
+        CodexRolloutReducer.apply(
+            line: rolloutLine(
+                timestamp: "2026-04-02T04:03:49.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "web_search_end",
+                    "query": "Codex statuses",
+                    "action": [
+                        "type": "find_in_page",
+                        "pattern": "ResponseItem",
+                        "url": "https://github.com/openai/codex",
+                    ],
+                ]
+            ),
+            to: &snapshot
+        )
+
+        #expect(snapshot.currentTool == "web_search")
+        #expect(snapshot.currentCommandPreview == "'ResponseItem' in https://github.com/openai/codex")
+        #expect(snapshot.summary == "Running web search.")
+    }
+
+    @Test
+    func codexRolloutReducerKeepsCompletionAfterTrailingToolEvents() {
+        let snapshot = CodexRolloutReducer.snapshot(for: [
+            rolloutLine(
+                timestamp: "2026-04-02T04:03:44.500Z",
+                type: "event_msg",
+                payload: [
+                    "type": "user_message",
+                    "message": "Finish this turn.",
+                ]
+            ),
+            rolloutLine(
+                timestamp: "2026-04-02T04:03:45.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "task_complete",
+                    "last_agent_message": "Final answer stays visible.",
+                ]
+            ),
+            rolloutLine(
+                timestamp: "2026-04-02T04:03:46.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "exec_command_end",
+                    "command": ["zsh", "-lc", "git status -sb"],
+                    "stdout": "",
+                    "stderr": "",
+                    "exit_code": 0,
+                    "status": "completed",
+                ]
+            ),
+            rolloutLine(
+                timestamp: "2026-04-02T04:03:47.000Z",
+                type: "response_item",
+                payload: [
+                    "type": "function_call_output",
+                    "call_id": "call-1",
+                    "output": "done",
+                ]
+            ),
+            rolloutLine(
+                timestamp: "2026-04-02T04:03:48.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "patch_apply_end",
+                    "success": true,
+                    "changes": [:],
+                    "status": "completed",
+                ]
+            ),
+        ])
+
+        #expect(snapshot.phase == .completed)
+        #expect(snapshot.isCompleted)
+        #expect(!snapshot.isInterrupted)
+        #expect(snapshot.currentTool == nil)
+        #expect(snapshot.currentCommandPreview == nil)
+        #expect(snapshot.summary == "Final answer stays visible.")
+        #expect(snapshot.updatedAt == Date(timeIntervalSince1970: 1_775_102_628))
+    }
+
+    @Test
     func codexRolloutReducerMarksTurnAbortedAsInterruptedCompletion() {
         let initialSnapshot = CodexRolloutReducer.snapshot(for: [
             rolloutLine(


### PR DESCRIPTION
## Summary

Align Codex rollout status parsing and presentation with the current Codex protocol surface.

- Map Codex response items and event messages for reasoning, shell commands, patch apply, MCP/dynamic tools, web search, image generation, compaction, and approval/question states.
- Show `Thinking` in the session list when Codex is running without an active tool instead of falling back to `Input`.
- Keep real stdin writes (`write_stdin` / terminal interaction) displayed as `Input`.
- Reuse normalized tool display names across the session list, notification card, and closed island agent-action label.
- Preserve completed turn summaries when trailing tool end/output events arrive after `task_complete`.

## Root Cause

The session list fallback treated any running Codex session with no active tool as `Input`, and the rollout reducer only understood a narrow subset of Codex tool events. That made reasoning or post-tool work look like input even when Codex was actively thinking or doing other work.

## Validation

- `swift test --filter CodexSessionTrackingTests`
- `swift test --filter AgentSessionPresentationTests`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tool display labeling across the interface for consistent, clearer identification
  * Activity status now shows "Thinking" when the agent is processing without active tools
  * Expanded support for displaying various tool types with better recognition

* **Tests**
  * Added coverage for activity status display and session tracking behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Octane0411/open-vibe-island/pull/474)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->