### PR TITLE
[codex] preserve hovered notification cards

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1557,6 +1557,7 @@ final class AppModel {
 
         return (ingress == .bridge || !isResolvingInitialLiveSessions)
             && (notchStatus == .closed || notchOpenReason == .notification)
+            && !overlay.shouldPreserveCurrentNotificationSurface(against: surface)
             && surface.matchesCurrentState(of: session)
     }
 

--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -249,7 +249,11 @@ final class OverlayPanelController {
             cancelHoverOpen()
         }
 
-        if model.shouldAutoCollapseOnMouseLeave {
+        let shouldTrackNotificationPointer = model.notchStatus == .opened
+            && model.notchOpenReason == .notification
+            && model.showsNotificationCard
+
+        if shouldTrackNotificationPointer || model.shouldAutoCollapseOnMouseLeave {
             if isPointInExpandedArea(screenLocation) {
                 model.notePointerInsideIslandSurface()
             } else {

--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -280,20 +280,29 @@ final class OverlayUICoordinator {
     }
 
     func notePointerInsideIslandSurface() {
-        guard shouldAutoCollapseOnMouseLeave else {
+        guard shouldTrackPointerInsideIslandSurface else {
             return
         }
 
         isPointerInsideIslandSurface = true
         autoCollapseSurfaceHasBeenEntered = true
+
+        if notchOpenReason == .notification {
+            notificationAutoCollapseTask?.cancel()
+            notificationAutoCollapseTask = nil
+        }
     }
 
     func handlePointerExitedIslandSurface() {
-        guard shouldAutoCollapseOnMouseLeave else {
+        guard shouldTrackPointerInsideIslandSurface else {
             return
         }
 
         isPointerInsideIslandSurface = false
+
+        guard shouldAutoCollapseOnMouseLeave else {
+            return
+        }
 
         guard !autoCollapseOnMouseLeaveRequiresPriorSurfaceEntry
                 || autoCollapseSurfaceHasBeenEntered else {
@@ -310,8 +319,25 @@ final class OverlayUICoordinator {
             return
         }
 
+        guard !shouldPreserveCurrentNotificationSurface(against: surface) else {
+            return
+        }
+
+        appModel?.measuredNotificationContentHeight = 0
         NotificationSoundService.playNotification(isMuted: isSoundMuted)
         notchOpen(reason: .notification, surface: surface)
+    }
+
+    func shouldPreserveCurrentNotificationSurface(against candidate: IslandSurface) -> Bool {
+        guard candidate.isNotificationCard,
+              notchStatus == .opened,
+              notchOpenReason == .notification,
+              islandSurface.isNotificationCard,
+              islandSurface != candidate else {
+            return false
+        }
+
+        return isPointerInsideCurrentNotificationCard
     }
 
     func reconcileIslandSurfaceAfterStateChange() {
@@ -359,6 +385,11 @@ final class OverlayUICoordinator {
             return
         }
 
+        if overlayPanelController.isPointInExpandedArea(NSEvent.mouseLocation) {
+            notePointerInsideIslandSurface()
+            return
+        }
+
         notificationAutoCollapseTask = Task { @MainActor [weak self] in
             do {
                 try await Task.sleep(for: .seconds(Self.notificationSurfaceAutoCollapseDelay))
@@ -384,6 +415,16 @@ final class OverlayUICoordinator {
     }
 
     var shouldDeferTimedNotificationAutoCollapse: Bool {
+        isPointerInsideIslandSurface
+            || overlayPanelController.isPointInExpandedArea(NSEvent.mouseLocation)
+    }
+
+    private var shouldTrackPointerInsideIslandSurface: Bool {
+        shouldAutoCollapseOnMouseLeave
+            || (notchStatus == .opened && notchOpenReason == .notification && islandSurface.isNotificationCard)
+    }
+
+    private var isPointerInsideCurrentNotificationCard: Bool {
         isPointerInsideIslandSurface
             || overlayPanelController.isPointInExpandedArea(NSEvent.mouseLocation)
     }

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -548,6 +548,7 @@ struct IslandPanelView: View {
                         ? { model.replyToSession(session, text: $0) } : nil,
                     onJump: { model.jumpToSession(session) }
                 )
+                .id(notificationCardIdentity(for: session))
 
                 if model.allSessions.count > 1 {
                     Button {
@@ -597,6 +598,19 @@ struct IslandPanelView: View {
             if !isNotificationMode {
                 sessionPanelFooter
             }
+        }
+    }
+
+    private func notificationCardIdentity(for session: AgentSession) -> String {
+        switch session.phase {
+        case .waitingForApproval:
+            return "\(session.id)|approval|\(session.permissionRequest?.id.uuidString ?? "none")"
+        case .waitingForAnswer:
+            return "\(session.id)|question|\(session.questionPrompt?.id.uuidString ?? "none")"
+        case .completed:
+            return "\(session.id)|completed|\(session.updatedAt.timeIntervalSinceReferenceDate)"
+        case .running:
+            return "\(session.id)|running"
         }
     }
 

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -24,6 +24,9 @@ struct AppModelSessionListTests {
             "appearance.island.v8.topBar.sessionGroup",
             "appearance.island.v8.topBar.sessionSort",
             "appearance.island.v8.topBar.completedStaleThreshold",
+            "app.suppressFrontmostNotifications",
+            "feature.completionReply.enabled",
+            "overlay.sound.muted",
         ].forEach(UserDefaults.standard.removeObject(forKey:))
     }
 
@@ -992,6 +995,114 @@ struct AppModelSessionListTests {
             model.measuredNotificationContentHeight == 0,
             "Switching to a different session's card must clear the stale measurement from the previous session to prevent wrong initial panel sizing."
         )
+    }
+
+    @Test
+    @MainActor
+    func notificationMeasuredHeightClearedWhenSameSessionCardContentChanges() {
+        let model = AppModel()
+        model.isSoundMuted = true
+
+        var session = AgentSession(
+            id: "same-session",
+            title: "Codex · proj",
+            tool: .codex,
+            attachmentState: .attached,
+            phase: .waitingForApproval,
+            summary: "Approve edit",
+            updatedAt: .now,
+            permissionRequest: PermissionRequest(
+                title: "Edit",
+                summary: "A longer approval card",
+                affectedPath: "/tmp/long-file-name.swift"
+            )
+        )
+        session.isProcessAlive = true
+        session.phase = .completed
+        session.permissionRequest = nil
+        session.summary = "Done"
+        model.state = SessionState(sessions: [session])
+
+        let surface = IslandSurface.sessionList(actionableSessionID: "same-session")
+        model.notchStatus = .opened
+        model.notchOpenReason = .notification
+        model.islandSurface = surface
+        model.measuredNotificationContentHeight = 360
+
+        model.overlay.presentNotificationSurface(surface)
+
+        #expect(model.notchStatus == .opened)
+        #expect(model.notchOpenReason == .notification)
+        #expect(model.islandSurface == surface)
+        #expect(model.activeIslandCardSession?.phase == .completed)
+        #expect(
+            model.measuredNotificationContentHeight == 0,
+            "Replacing a notification with different content for the same session must discard the previous card's measured height."
+        )
+    }
+
+    @Test
+    @MainActor
+    func hoveredNotificationCardIsNotReplacedByAnotherNotification() {
+        let model = AppModel()
+        model.isSoundMuted = true
+
+        var currentSession = AgentSession(
+            id: "current-session",
+            title: "Claude · current",
+            tool: .claudeCode,
+            attachmentState: .attached,
+            phase: .waitingForApproval,
+            summary: "Approve current edit",
+            updatedAt: .now,
+            permissionRequest: PermissionRequest(
+                title: "Edit",
+                summary: "current.swift",
+                affectedPath: "/tmp/current.swift"
+            )
+        )
+        currentSession.isProcessAlive = true
+
+        var incomingSession = AgentSession(
+            id: "incoming-session",
+            title: "Codex · incoming",
+            tool: .codex,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Working",
+            updatedAt: .now
+        )
+        incomingSession.isProcessAlive = true
+
+        let currentSurface = IslandSurface.sessionList(actionableSessionID: "current-session")
+        model.state = SessionState(sessions: [currentSession, incomingSession])
+        model.notchStatus = .opened
+        model.notchOpenReason = .notification
+        model.islandSurface = currentSurface
+        model.measuredNotificationContentHeight = 280
+
+        model.notePointerInsideIslandSurface()
+
+        model.applyTrackedEvent(
+            .permissionRequested(PermissionRequested(
+                sessionID: "incoming-session",
+                request: PermissionRequest(
+                    title: "Edit",
+                    summary: "incoming.swift",
+                    affectedPath: "/tmp/incoming.swift"
+                ),
+                timestamp: .now
+            )),
+            updateLastActionMessage: false,
+            ingress: .bridge
+        )
+
+        #expect(model.state.session(id: "incoming-session")?.phase == .waitingForApproval)
+        #expect(model.notchStatus == .opened)
+        #expect(model.notchOpenReason == .notification)
+        #expect(model.islandSurface == currentSurface)
+        #expect(model.activeIslandCardSession?.id == "current-session")
+        #expect(model.measuredNotificationContentHeight == 280)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Keep the currently hovered notification card from being replaced by a different incoming notification.
- Reset notification height measurements whenever a notification surface is presented, including same-session content changes.
- Add a notification card view identity so SwiftUI does not reuse stale internal layout state across card content changes.

## Root Cause
The overlay tracked hover state primarily for auto-collapse decisions. A new notification could still replace the current notification while the pointer was inside it, and the panel could reuse the previous card's measured content height when the next card was shorter.

## Impact
Users can safely interact with the current notification without it being covered by another one, and shorter replacement cards resize to their actual content height.

## Validation
- `swift test --filter AppModelSessionListTests`
- `swift test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved notification surface preservation to prevent unintended presentation changes
  * Enhanced mouse pointer tracking behavior when notifications are active
  * Fixed notification card state management during phase transitions

* **Tests**
  * Added test coverage for notification overlay behavior and card preservation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Octane0411/open-vibe-island/pull/475)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->