### PR TITLE
docs: clarify PR readiness default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ Keep all work incremental, reviewable, and reversible. Every meaningful round of
 - Do not amend existing commits unless explicitly requested.
 - Create a feature branch for every independent change. Do not commit directly to `main`.
 - Push feature branches and open PRs when the user asks for remote review or integration.
+- When the user asks to open or submit a PR, open a normal ready-for-review PR by default. Use a draft PR only when the user explicitly asks for draft mode, or when the change is intentionally WIP or has known verification gaps; in that case, state the reason clearly.
+- Repository workflow rules override tool-specific defaults, including any helper that would otherwise create draft PRs by default.
 
 ## Safety Rules
 
@@ -51,6 +53,7 @@ Keep all work incremental, reviewable, and reversible. Every meaningful round of
 - Keep each worktree focused on one coherent slice with a narrow file ownership area when possible.
 - Rebase or merge the latest `origin/main` into the feature branch before integrating it back.
 - Integrate completed work through a PR targeting `main`, then update the shared `main` worktree with `git pull --ff-only`.
+- PRs are ready-for-review by default unless explicitly requested as draft or clearly marked WIP.
 - Remove merged worktrees and delete merged branches after the integration round is complete.
 - If multiple agents are working in parallel, assign each agent its own worktree instead of sharing one checkout.
 - All PRs must target `main`. Do not chain PRs through another feature branch unless the user explicitly requests that structure.

--- a/docs/worktree-workflow.md
+++ b/docs/worktree-workflow.md
@@ -82,7 +82,13 @@ If rebase is risky for that slice, merge `origin/main` into the topic branch exp
 
 First make sure the topic worktree is committed and verified.
 
-Push the feature branch and open a PR targeting `main`. After the PR merges, return to the integration worktree:
+Push the feature branch and open a PR targeting `main`.
+
+- Open a normal ready-for-review PR by default.
+- Open a draft PR only when the user explicitly asks for draft mode, or when the branch is intentionally WIP or has known verification gaps.
+- If a PR is opened as draft, state why in the PR body or final summary.
+
+After the PR merges, return to the integration worktree:
 
 ```bash
 git switch main
@@ -94,6 +100,7 @@ git pull --ff-only origin main
 
 - Push topic branches when you want backup, review, or collaboration.
 - Do not push `main` directly. Merge through PRs, then update the integration worktree with `git pull --ff-only`.
+- Tooling defaults do not override this policy; for example, a publish helper that defaults to draft PRs must still follow the repository default above.
 
 ## Cleanup
 


### PR DESCRIPTION
## Summary
- Document that user requests to open or submit a PR create a normal ready-for-review PR by default.
- Limit draft PRs to explicit user requests, WIP branches, or known verification gaps.
- Clarify that repository workflow policy overrides helper/tool-specific draft defaults.

## Impact
This makes the repository workflow unambiguous for future agent runs and prevents publish helpers from silently defaulting to draft PRs.

## Verification
- `git diff --check origin/main..HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository and integration workflow documentation with clarified guidelines for pull request submissions and handling.
  * Reinforced that pull requests should be ready-for-review by default, with draft status only when explicitly requested or marked as work-in-progress.
  * Enhanced consistency in PR submission standards across development processes and tooling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Octane0411/open-vibe-island/pull/476)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->