### PR TITLE
feat: support Codex PermissionRequest hooks

### DIFF
--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -13,6 +13,7 @@ public final class BridgeServer: @unchecked Sendable {
 
     private struct PendingApproval {
         let clientID: UUID
+        let hookEventName: CodexHookEventName
     }
 
     private struct PendingClaudeToolContext {
@@ -378,13 +379,25 @@ public final class BridgeServer: @unchecked Sendable {
                 return
             }
 
+            let pendingApproval = pendingApprovals[sessionID]
+            let approvedSummary = pendingApproval?.hookEventName == .permissionRequest
+                ? "Permission approved. Codex continued the tool."
+                : "Permission approved. Codex continued the command."
+            let deniedSummary: String = {
+                if case let .deny(message, _) = resolution {
+                    return message ?? "Permission denied in Open Island."
+                }
+
+                return "Permission denied in Open Island."
+            }()
+
             localState.resolvePermission(sessionID: sessionID, resolution: resolution)
             broadcast([.event(
                 resolution.isApproved
                     ? .activityUpdated(
                         SessionActivityUpdated(
                             sessionID: sessionID,
-                            summary: "Permission approved. Codex continued the command.",
+                            summary: approvedSummary,
                             phase: .running,
                             timestamp: .now
                         )
@@ -392,12 +405,12 @@ public final class BridgeServer: @unchecked Sendable {
                     : .sessionCompleted(
                         SessionCompleted(
                             sessionID: sessionID,
-                            summary: "Permission denied in Open Island.",
+                            summary: deniedSummary,
                             timestamp: .now
                         )
                     )
             )])
-            resolvePendingApproval(sessionID: sessionID, approved: resolution.isApproved)
+            resolvePendingApproval(sessionID: sessionID, resolution: resolution)
             send(.response(.acknowledged), to: clientID)
 
         case let .answerQuestion(sessionID, response):
@@ -514,7 +527,36 @@ public final class BridgeServer: @unchecked Sendable {
             emit(approvalEvent)
 
             pendingApprovals[payload.sessionID] = PendingApproval(
-                clientID: clientID
+                clientID: clientID,
+                hookEventName: .preToolUse
+            )
+
+        case .permissionRequest:
+            ensureSessionExists(for: payload)
+            synchronizeJumpTarget(for: payload)
+            synchronizeCodexMetadata(for: payload)
+
+            emit(
+                .permissionRequested(
+                    PermissionRequested(
+                        sessionID: payload.sessionID,
+                        request: PermissionRequest(
+                            title: payload.permissionRequestTitle,
+                            summary: payload.permissionRequestSummary,
+                            affectedPath: payload.permissionRequestAffectedPath,
+                            primaryActionTitle: "Allow",
+                            secondaryActionTitle: "Deny",
+                            toolName: payload.toolName,
+                            toolUseID: payload.toolUseID
+                        ),
+                        timestamp: .now
+                    )
+                )
+            )
+
+            pendingApprovals[payload.sessionID] = PendingApproval(
+                clientID: clientID,
+                hookEventName: .permissionRequest
             )
 
         case .postToolUse:
@@ -1986,7 +2028,7 @@ public final class BridgeServer: @unchecked Sendable {
         switch hookEventName {
         case .userPromptSubmit, .postToolUse, .stop:
             return nil
-        case .sessionStart, .preToolUse:
+        case .sessionStart, .preToolUse, .permissionRequest:
             return existing
         }
     }
@@ -2298,21 +2340,31 @@ public final class BridgeServer: @unchecked Sendable {
         switch hookEventName {
         case .userPromptSubmit, .postToolUse, .stop:
             return nil
-        case .sessionStart, .preToolUse:
+        case .sessionStart, .preToolUse, .permissionRequest:
             return existing
         }
     }
 
-    private func resolvePendingApproval(sessionID: String, approved: Bool) {
+    private func resolvePendingApproval(sessionID: String, resolution: PermissionResolution) {
         guard let pendingApproval = pendingApprovals.removeValue(forKey: sessionID) else {
             return
         }
 
         let response: BridgeResponse
-        if approved {
+        switch (pendingApproval.hookEventName, resolution) {
+        case (.preToolUse, .allowOnce):
             response = .acknowledged
-        } else {
-            response = .codexHookDirective(.deny(reason: "Permission denied in Open Island."))
+        case let (.preToolUse, .deny(message, _)):
+            response = .codexHookDirective(.deny(reason: message ?? "Permission denied in Open Island."))
+        case (.permissionRequest, .allowOnce):
+            response = .codexHookDirective(.permissionRequest(.allow))
+        case let (.permissionRequest, .deny(message, _)):
+            response = .codexHookDirective(
+                .permissionRequest(.deny(message: message ?? "Permission denied in Open Island."))
+            )
+        case (.sessionStart, _), (.postToolUse, _), (.userPromptSubmit, _), (.stop, _):
+            assertionFailure("Unexpected Codex hook waiting for permission.")
+            response = .acknowledged
         }
 
         send(.response(response), to: pendingApproval.clientID)

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -13,6 +13,7 @@ public final class BridgeServer: @unchecked Sendable {
 
     private struct PendingApproval {
         let clientID: UUID
+        let hookEventName: CodexHookEventName
     }
 
     private struct PendingClaudeToolContext {
@@ -370,13 +371,25 @@ public final class BridgeServer: @unchecked Sendable {
                 return
             }
 
+            let pendingApproval = pendingApprovals[sessionID]
+            let approvedSummary = pendingApproval?.hookEventName == .permissionRequest
+                ? "Permission approved. Codex continued the tool."
+                : "Permission approved. Codex continued the command."
+            let deniedSummary: String = {
+                if case let .deny(message, _) = resolution {
+                    return message ?? "Permission denied in Open Island."
+                }
+
+                return "Permission denied in Open Island."
+            }()
+
             localState.resolvePermission(sessionID: sessionID, resolution: resolution)
             broadcast([.event(
                 resolution.isApproved
                     ? .activityUpdated(
                         SessionActivityUpdated(
                             sessionID: sessionID,
-                            summary: "Permission approved. Codex continued the command.",
+                            summary: approvedSummary,
                             phase: .running,
                             timestamp: .now
                         )
@@ -384,12 +397,12 @@ public final class BridgeServer: @unchecked Sendable {
                     : .sessionCompleted(
                         SessionCompleted(
                             sessionID: sessionID,
-                            summary: "Permission denied in Open Island.",
+                            summary: deniedSummary,
                             timestamp: .now
                         )
                     )
             )])
-            resolvePendingApproval(sessionID: sessionID, approved: resolution.isApproved)
+            resolvePendingApproval(sessionID: sessionID, resolution: resolution)
             send(.response(.acknowledged), to: clientID)
 
         case let .answerQuestion(sessionID, response):
@@ -506,7 +519,36 @@ public final class BridgeServer: @unchecked Sendable {
             emit(approvalEvent)
 
             pendingApprovals[payload.sessionID] = PendingApproval(
-                clientID: clientID
+                clientID: clientID,
+                hookEventName: .preToolUse
+            )
+
+        case .permissionRequest:
+            ensureSessionExists(for: payload)
+            synchronizeJumpTarget(for: payload)
+            synchronizeCodexMetadata(for: payload)
+
+            emit(
+                .permissionRequested(
+                    PermissionRequested(
+                        sessionID: payload.sessionID,
+                        request: PermissionRequest(
+                            title: payload.permissionRequestTitle,
+                            summary: payload.permissionRequestSummary,
+                            affectedPath: payload.permissionRequestAffectedPath,
+                            primaryActionTitle: "Allow",
+                            secondaryActionTitle: "Deny",
+                            toolName: payload.toolName,
+                            toolUseID: payload.toolUseID
+                        ),
+                        timestamp: .now
+                    )
+                )
+            )
+
+            pendingApprovals[payload.sessionID] = PendingApproval(
+                clientID: clientID,
+                hookEventName: .permissionRequest
             )
 
         case .postToolUse:
@@ -1971,7 +2013,7 @@ public final class BridgeServer: @unchecked Sendable {
         switch hookEventName {
         case .userPromptSubmit, .postToolUse, .stop:
             return nil
-        case .sessionStart, .preToolUse:
+        case .sessionStart, .preToolUse, .permissionRequest:
             return existing
         }
     }
@@ -2243,21 +2285,31 @@ public final class BridgeServer: @unchecked Sendable {
         switch hookEventName {
         case .userPromptSubmit, .postToolUse, .stop:
             return nil
-        case .sessionStart, .preToolUse:
+        case .sessionStart, .preToolUse, .permissionRequest:
             return existing
         }
     }
 
-    private func resolvePendingApproval(sessionID: String, approved: Bool) {
+    private func resolvePendingApproval(sessionID: String, resolution: PermissionResolution) {
         guard let pendingApproval = pendingApprovals.removeValue(forKey: sessionID) else {
             return
         }
 
         let response: BridgeResponse
-        if approved {
+        switch (pendingApproval.hookEventName, resolution) {
+        case (.preToolUse, .allowOnce):
             response = .acknowledged
-        } else {
-            response = .codexHookDirective(.deny(reason: "Permission denied in Open Island."))
+        case let (.preToolUse, .deny(message, _)):
+            response = .codexHookDirective(.deny(reason: message ?? "Permission denied in Open Island."))
+        case (.permissionRequest, .allowOnce):
+            response = .codexHookDirective(.permissionRequest(.allow))
+        case let (.permissionRequest, .deny(message, _)):
+            response = .codexHookDirective(
+                .permissionRequest(.deny(message: message ?? "Permission denied in Open Island."))
+            )
+        case (.sessionStart, _), (.postToolUse, _), (.userPromptSubmit, _), (.stop, _):
+            assertionFailure("Unexpected Codex hook waiting for permission.")
+            response = .acknowledged
         }
 
         send(.response(response), to: pendingApproval.clientID)

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -379,8 +379,21 @@ public final class BridgeServer: @unchecked Sendable {
                 return
             }
 
-            let pendingApproval = pendingApprovals[sessionID]
-            let approvedSummary = pendingApproval?.hookEventName == .permissionRequest
+            guard let pendingApproval = pendingApprovals[sessionID] else {
+                emit(
+                    .actionableStateResolved(
+                        ActionableStateResolved(
+                            sessionID: sessionID,
+                            summary: "Permission request is no longer active.",
+                            timestamp: .now
+                        )
+                    )
+                )
+                send(.response(.acknowledged), to: clientID)
+                return
+            }
+
+            let approvedSummary = pendingApproval.hookEventName == .permissionRequest
                 ? "Permission approved. Codex continued the tool."
                 : "Permission approved. Codex continued the command."
             let deniedSummary: String = {
@@ -2576,6 +2589,15 @@ public final class BridgeServer: @unchecked Sendable {
 
         for sessionID in pendingSessionIDs {
             pendingApprovals.removeValue(forKey: sessionID)
+            emit(
+                .actionableStateResolved(
+                    ActionableStateResolved(
+                        sessionID: sessionID,
+                        summary: "Hook process disconnected.",
+                        timestamp: .now
+                    )
+                )
+            )
         }
 
         let pendingClaudeSessionIDs = pendingClaudeInteractions.compactMap { entry -> String? in

--- a/Sources/OpenIslandCore/CodexHookInstaller.swift
+++ b/Sources/OpenIslandCore/CodexHookInstaller.swift
@@ -73,16 +73,18 @@ public enum CodexHookInstaller {
     public static let managedStatusMessage = "Managed by Open Island"
     public static let legacyManagedStatusMessage = "Managed by Vibe Island"
     public static let managedTimeout = 45
+    public static let managedInteractiveTimeout = 60 * 60
     private static let currentFeatureKey = CodexHooksFeatureFlagKey.current.rawValue
     private static let legacyFeatureKey = CodexHooksFeatureFlagKey.legacy.rawValue
 
     // Keep the managed Codex install aligned with the original app's low-noise footprint.
     // The bridge still understands richer hook events, but we do not install them by default
     // because per-command Bash hooks produce a large amount of terminal log spam.
-    private static let eventSpecs: [(name: String, matcher: String?)] = [
-        ("SessionStart", "startup|resume"),
-        ("UserPromptSubmit", nil),
-        ("Stop", nil),
+    private static let eventSpecs: [(name: String, matcher: String?, timeout: Int)] = [
+        ("SessionStart", "startup|resume", managedTimeout),
+        ("UserPromptSubmit", nil, managedTimeout),
+        ("PermissionRequest", nil, managedInteractiveTimeout),
+        ("Stop", nil, managedTimeout),
     ]
 
     public static func hookCommand(for binaryPath: String) -> String {
@@ -109,7 +111,9 @@ public enum CodexHookInstaller {
         for spec in eventSpecs {
             let existingGroups = hooksObject[spec.name] as? [Any] ?? []
             let cleanedGroups = sanitizeForInstall(groups: existingGroups, replacingCommand: hookCommand)
-            hooksObject[spec.name] = cleanedGroups + [managedGroup(matcher: spec.matcher, hookCommand: hookCommand)]
+            hooksObject[spec.name] = cleanedGroups + [
+                managedGroup(matcher: spec.matcher, hookCommand: hookCommand, timeout: spec.timeout)
+            ]
         }
 
         rootObject["hooks"] = hooksObject
@@ -357,12 +361,12 @@ public enum CodexHookInstaller {
         }
     }
 
-    private static func managedGroup(matcher: String?, hookCommand: String) -> [String: Any] {
+    private static func managedGroup(matcher: String?, hookCommand: String, timeout: Int) -> [String: Any] {
         var group: [String: Any] = [
             "hooks": [[
                 "type": "command",
                 "command": hookCommand,
-                "timeout": managedTimeout,
+                "timeout": timeout,
             ]]
         ]
 

--- a/Sources/OpenIslandCore/CodexHooks.swift
+++ b/Sources/OpenIslandCore/CodexHooks.swift
@@ -3,6 +3,7 @@ import Foundation
 public enum CodexHookEventName: String, Codable, Sendable {
     case sessionStart = "SessionStart"
     case preToolUse = "PreToolUse"
+    case permissionRequest = "PermissionRequest"
     case postToolUse = "PostToolUse"
     case userPromptSubmit = "UserPromptSubmit"
     case stop = "Stop"
@@ -14,16 +15,6 @@ public enum CodexPermissionMode: String, Codable, Sendable {
     case plan
     case dontAsk
     case bypassPermissions
-}
-
-
-
-public struct CodexHookToolInput: Equatable, Codable, Sendable {
-    public var command: String
-
-    public init(command: String) {
-        self.command = command
-    }
 }
 
 public enum CodexHookJSONValue: Equatable, Codable, Sendable {
@@ -71,6 +62,58 @@ public enum CodexHookJSONValue: Equatable, Codable, Sendable {
         case .null:
             try container.encodeNil()
         }
+    }
+}
+
+public struct CodexHookToolInput: Equatable, Codable, Sendable {
+    public var command: String?
+    public var description: String?
+    public var rawValue: CodexHookJSONValue?
+
+    private enum CodingKeys: String, CodingKey {
+        case command
+        case description
+    }
+
+    public init(command: String? = nil, description: String? = nil) {
+        self.command = command
+        self.description = description
+        rawValue = nil
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let rawValue = try CodexHookJSONValue(from: decoder)
+        self.rawValue = rawValue
+
+        guard case let .object(object) = rawValue else {
+            command = nil
+            description = nil
+            return
+        }
+
+        command = object["command"]?.stringScalar
+        description = object["description"]?.stringScalar
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        if let rawValue {
+            try rawValue.encode(to: encoder)
+            return
+        }
+
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(command, forKey: .command)
+        try container.encodeIfPresent(description, forKey: .description)
+    }
+}
+
+private extension CodexHookJSONValue {
+    var stringScalar: String? {
+        if case let .string(value) = self {
+            return value
+        }
+
+        return nil
     }
 }
 
@@ -191,16 +234,58 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
     }
 }
 
+public enum CodexPermissionRequestDecision: Equatable, Codable, Sendable {
+    case allow
+    case deny(message: String? = nil)
+
+    private enum CodingKeys: String, CodingKey {
+        case behavior
+        case message
+    }
+
+    private enum Behavior: String, Codable {
+        case allow
+        case deny
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let behavior = try container.decode(Behavior.self, forKey: .behavior)
+
+        switch behavior {
+        case .allow:
+            self = .allow
+        case .deny:
+            self = .deny(message: try container.decodeIfPresent(String.self, forKey: .message))
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        switch self {
+        case .allow:
+            try container.encode(Behavior.allow, forKey: .behavior)
+        case let .deny(message):
+            try container.encode(Behavior.deny, forKey: .behavior)
+            try container.encodeIfPresent(message, forKey: .message)
+        }
+    }
+}
+
 public enum CodexHookDirective: Equatable, Codable, Sendable {
     case deny(reason: String)
+    case permissionRequest(CodexPermissionRequestDecision)
 
     private enum CodingKeys: String, CodingKey {
         case type
         case reason
+        case decision
     }
 
     private enum DirectiveType: String, Codable {
         case deny
+        case permissionRequest
     }
 
     public init(from decoder: any Decoder) throws {
@@ -210,6 +295,8 @@ public enum CodexHookDirective: Equatable, Codable, Sendable {
         switch type {
         case .deny:
             self = .deny(reason: try container.decode(String.self, forKey: .reason))
+        case .permissionRequest:
+            self = .permissionRequest(try container.decode(CodexPermissionRequestDecision.self, forKey: .decision))
         }
     }
 
@@ -220,6 +307,9 @@ public enum CodexHookDirective: Equatable, Codable, Sendable {
         case let .deny(reason):
             try container.encode(DirectiveType.deny, forKey: .type)
             try container.encode(reason, forKey: .reason)
+        case let .permissionRequest(decision):
+            try container.encode(DirectiveType.permissionRequest, forKey: .type)
+            try container.encode(decision, forKey: .decision)
         }
     }
 }
@@ -228,6 +318,21 @@ public enum CodexHookOutputEncoder {
     private struct LegacyBlockOutput: Codable {
         var decision = "block"
         var reason: String
+    }
+
+    private struct PermissionRequestOutput: Codable {
+        var continueProcessing = true
+        var hookSpecificOutput: HookSpecificOutput
+
+        private enum CodingKeys: String, CodingKey {
+            case continueProcessing = "continue"
+            case hookSpecificOutput
+        }
+
+        struct HookSpecificOutput: Codable {
+            var hookEventName = CodexHookEventName.permissionRequest
+            var decision: CodexPermissionRequestDecision
+        }
     }
 
     public static func standardOutput(for response: BridgeResponse) throws -> Data? {
@@ -243,6 +348,12 @@ public enum CodexHookOutputEncoder {
             switch directive {
             case let .deny(reason):
                 data = try encoder.encode(LegacyBlockOutput(reason: reason))
+            case let .permissionRequest(decision):
+                data = try encoder.encode(
+                    PermissionRequestOutput(
+                        hookSpecificOutput: PermissionRequestOutput.HookSpecificOutput(decision: decision)
+                    )
+                )
             }
 
             var line = data
@@ -307,6 +418,8 @@ public extension CodexHookPayload {
             return "Started Codex session in \(workspaceName)."
         case .preToolUse:
             return "Codex is preparing a Bash command in \(workspaceName)."
+        case .permissionRequest:
+            return "Codex is waiting for permission approval in \(workspaceName)."
         case .postToolUse:
             return "Codex reported a Bash result in \(workspaceName)."
         case .userPromptSubmit:
@@ -324,6 +437,42 @@ public extension CodexHookPayload {
         clipped(commandText)
     }
 
+    var permissionRequestTitle: String {
+        guard let toolName, !toolName.isEmpty else {
+            return "Approve Codex action"
+        }
+
+        if isBashToolName(toolName) {
+            return "Run Bash command"
+        }
+
+        if toolName == "apply_patch" {
+            return "Apply code patch"
+        }
+
+        return "Approve \(toolName)"
+    }
+
+    var permissionRequestSummary: String {
+        if let description = clipped(toolInput?.description), !description.isEmpty {
+            return description
+        }
+
+        if let commandPreview {
+            return "Codex wants to run: \(commandPreview)"
+        }
+
+        if let toolName, !toolName.isEmpty {
+            return "Codex wants to use \(toolName)."
+        }
+
+        return "Codex is requesting permission."
+    }
+
+    var permissionRequestAffectedPath: String {
+        commandText ?? toolInput?.description ?? toolName ?? "Permission request"
+    }
+
     var promptPreview: String? {
         clipped(prompt)
     }
@@ -338,6 +487,11 @@ public extension CodexHookPayload {
         }
 
         return clipped(stringValue(for: toolResponse))
+    }
+
+    private func isBashToolName(_ toolName: String) -> Bool {
+        let normalized = toolName.lowercased()
+        return normalized == "bash" || normalized == "shell"
     }
 
     private func clipped(_ value: String?, limit: Int = 110) -> String? {

--- a/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
+++ b/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
@@ -4,6 +4,7 @@ import OpenIslandCore
 @main
 struct OpenIslandHooksCLI {
     private static let interactiveClaudeHookTimeout: TimeInterval = 24 * 60 * 60
+    private static let interactiveCodexHookTimeout: TimeInterval = 55 * 60
 
     private enum HookSource: String {
         case codex
@@ -52,8 +53,12 @@ struct OpenIslandHooksCLI {
                     .decode(CodexHookPayload.self, from: input)
                     .withRuntimeContext(environment: ProcessInfo.processInfo.environment)
 
-                guard let response = try? client.send(.processCodexHook(payload)) else {
-                    logStderr("bridge unavailable for codex hook")
+                let timeout = payload.hookEventName == .permissionRequest
+                    ? interactiveCodexHookTimeout
+                    : 45
+
+                guard let response = try? client.send(.processCodexHook(payload), timeout: timeout) else {
+                    logStderr("bridge unavailable for codex hook (\(payload.hookEventName.rawValue))")
                     return
                 }
 

--- a/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
+++ b/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
@@ -4,7 +4,8 @@ import OpenIslandCore
 @main
 struct OpenIslandHooksCLI {
     private static let interactiveClaudeHookTimeout: TimeInterval = 24 * 60 * 60
-    private static let interactiveCodexHookTimeout: TimeInterval = 55 * 60
+    private static let interactiveCodexHookTimeout =
+        TimeInterval(CodexHookInstaller.managedInteractiveTimeout)
 
     private enum HookSource: String {
         case codex

--- a/Tests/OpenIslandCoreTests/CodexHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexHooksTests.swift
@@ -86,4 +86,69 @@ struct CodexHooksTests {
         #expect(payload.warpPaneUUID == nil)
     }
 
+    @Test
+    func codexPermissionRequestPayloadAcceptsDescriptionOnlyToolInput() throws {
+        let data = """
+        {
+          "cwd": "/tmp/demo",
+          "hook_event_name": "PermissionRequest",
+          "model": "gpt-5-codex",
+          "permission_mode": "default",
+          "session_id": "s1",
+          "tool_name": "apply_patch",
+          "tool_input": {
+            "description": "Apply a focused patch to Sources/App.swift",
+            "path": "Sources/App.swift"
+          },
+          "transcript_path": null,
+          "turn_id": "turn-1"
+        }
+        """.data(using: .utf8)!
+
+        let payload = try JSONDecoder().decode(CodexHookPayload.self, from: data)
+
+        #expect(payload.hookEventName == .permissionRequest)
+        #expect(payload.toolInput?.command == nil)
+        #expect(payload.toolInput?.description == "Apply a focused patch to Sources/App.swift")
+        #expect(payload.permissionRequestTitle == "Apply code patch")
+        #expect(payload.permissionRequestSummary == "Apply a focused patch to Sources/App.swift")
+    }
+
+    @Test
+    func codexHookOutputEncoderEncodesPermissionRequestAllowDecision() throws {
+        let output = try CodexHookOutputEncoder.standardOutput(
+            for: .codexHookDirective(.permissionRequest(.allow))
+        )
+
+        let payload = try #require(output)
+        let object = try jsonObject(from: payload)
+        let hookSpecificOutput = object["hookSpecificOutput"] as? [String: Any]
+        let decision = hookSpecificOutput?["decision"] as? [String: Any]
+
+        #expect(object["continue"] as? Bool == true)
+        #expect(hookSpecificOutput?["hookEventName"] as? String == "PermissionRequest")
+        #expect(decision?["behavior"] as? String == "allow")
+    }
+
+    @Test
+    func codexHookOutputEncoderEncodesPermissionRequestDenyDecision() throws {
+        let output = try CodexHookOutputEncoder.standardOutput(
+            for: .codexHookDirective(.permissionRequest(.deny(message: "Use a narrower patch.")))
+        )
+
+        let payload = try #require(output)
+        let object = try jsonObject(from: payload)
+        let hookSpecificOutput = object["hookSpecificOutput"] as? [String: Any]
+        let decision = hookSpecificOutput?["decision"] as? [String: Any]
+
+        #expect(hookSpecificOutput?["hookEventName"] as? String == "PermissionRequest")
+        #expect(decision?["behavior"] as? String == "deny")
+        #expect(decision?["message"] as? String == "Use a narrower patch.")
+    }
+
+}
+
+private func jsonObject(from data: Data) throws -> [String: Any] {
+    let object = try JSONSerialization.jsonObject(with: data)
+    return object as? [String: Any] ?? [:]
 }

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -516,10 +516,129 @@ struct SessionStateTests {
         #expect(startedEvent.isSessionStarted)
         #expect(permissionEvent.isPermissionRequested)
 
-        try await observer.send(.resolvePermission(sessionID: "codex-session-1", resolution: .deny()))
+        try await observer.send(
+            .resolvePermission(
+                sessionID: "codex-session-1",
+                resolution: .deny(message: "Use the project cleanup script instead.")
+            )
+        )
 
         let response = try await responseTask
-        #expect(response == .codexHookDirective(.deny(reason: "Permission denied in Open Island.")))
+        #expect(response == .codexHookDirective(.deny(reason: "Use the project cleanup script instead.")))
+    }
+
+    @Test
+    func codexPermissionRequestReturnsAllowDirectiveAfterApproval() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let payload = CodexHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .permissionRequest,
+            model: "gpt-5-codex",
+            permissionMode: .default,
+            sessionID: "codex-permission-allow",
+            transcriptPath: nil,
+            turnID: "turn-1",
+            toolName: "apply_patch",
+            toolUseID: "tool-use-1",
+            toolInput: CodexHookToolInput(description: "Apply a focused patch to Sources/App.swift")
+        )
+
+        async let responseTask = sendOnGCDThread(.processCodexHook(payload), socketURL: socketURL)
+
+        var iterator = stream.makeAsyncIterator()
+        let startedEvent = try await nextEvent(from: &iterator)
+        let permissionEvent = try await nextEvent(from: &iterator)
+
+        #expect(startedEvent.isSessionStarted)
+        guard case let .permissionRequested(permission) = permissionEvent else {
+            Issue.record("Expected Codex permission request")
+            return
+        }
+        #expect(permission.request.title == "Apply code patch")
+        #expect(permission.request.summary == "Apply a focused patch to Sources/App.swift")
+        #expect(permission.request.toolName == "apply_patch")
+        #expect(permission.request.toolUseID == "tool-use-1")
+
+        try await observer.send(.resolvePermission(sessionID: "codex-permission-allow", resolution: .allowOnce()))
+
+        let activityEvent = try await nextEvent(from: &iterator)
+        let response = try await responseTask
+
+        #expect(activityEvent.activityUpdate?.summary == "Permission approved. Codex continued the tool.")
+        #expect(response == .codexHookDirective(.permissionRequest(.allow)))
+    }
+
+    @Test
+    func codexPermissionRequestReturnsDenyDirectiveAfterRejection() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let payload = CodexHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .permissionRequest,
+            model: "gpt-5-codex",
+            permissionMode: .default,
+            sessionID: "codex-permission-deny",
+            transcriptPath: nil,
+            turnID: "turn-1",
+            toolName: "Bash",
+            toolUseID: "tool-use-2",
+            toolInput: CodexHookToolInput(
+                command: "rm -rf build",
+                description: "Run a cleanup command"
+            )
+        )
+
+        async let responseTask = sendOnGCDThread(.processCodexHook(payload), socketURL: socketURL)
+
+        var iterator = stream.makeAsyncIterator()
+        _ = try await nextEvent(from: &iterator)
+        let permissionEvent = try await nextEvent(from: &iterator)
+
+        guard case let .permissionRequested(permission) = permissionEvent else {
+            Issue.record("Expected Codex permission request")
+            return
+        }
+        #expect(permission.request.title == "Run Bash command")
+        #expect(permission.request.summary == "Run a cleanup command")
+        #expect(permission.request.affectedPath == "rm -rf build")
+
+        try await observer.send(
+            .resolvePermission(
+                sessionID: "codex-permission-deny",
+                resolution: .deny(message: "Use the project cleanup script instead.")
+            )
+        )
+
+        let completedEvent = try await nextEvent(from: &iterator)
+        let response = try await responseTask
+
+        guard case let .sessionCompleted(completed) = completedEvent else {
+            Issue.record("Expected Codex completion after denial")
+            return
+        }
+        #expect(completed.summary == "Use the project cleanup script instead.")
+        #expect(
+            response == .codexHookDirective(
+                .permissionRequest(.deny(message: "Use the project cleanup script instead."))
+            )
+        )
     }
 
     @Test
@@ -759,7 +878,13 @@ struct SessionStateTests {
         #expect(managedStopHook?["statusMessage"] == nil)
 
         let sessionStartGroups = hooks?["SessionStart"] as? [[String: Any]]
+        let permissionGroups = hooks?["PermissionRequest"] as? [[String: Any]]
+        let managedPermissionHook = permissionGroups?
+            .compactMap { $0["hooks"] as? [[String: Any]] }
+            .flatMap { $0 }
+            .first(where: { $0["command"] as? String == "'/tmp/OpenIslandHooks'" })
         #expect(sessionStartGroups?.contains(where: { $0["matcher"] as? String == "startup|resume" }) == true)
+        #expect(managedPermissionHook?["timeout"] as? Int == CodexHookInstaller.managedInteractiveTimeout)
         #expect(hooks?["PreToolUse"] == nil)
         #expect(hooks?["PostToolUse"] == nil)
     }
@@ -825,8 +950,14 @@ struct SessionStateTests {
             .compactMap { $0["hooks"] as? [[String: Any]] }
             .flatMap { $0 }
             .compactMap { $0["command"] as? String } ?? []
+        let permissionGroups = hooks?["PermissionRequest"] as? [[String: Any]]
+        let permissionCommands = permissionGroups?
+            .compactMap { $0["hooks"] as? [[String: Any]] }
+            .flatMap { $0 }
+            .compactMap { $0["command"] as? String } ?? []
 
         #expect(preToolCommands == ["/usr/bin/printf"])
+        #expect(permissionCommands == ["'/tmp/new-release/OpenIslandHooks'"])
         #expect(hooks?["PostToolUse"] == nil)
         #expect(stopCommands.contains("/usr/bin/true"))
         #expect(stopCommands.contains("'/tmp/new-release/OpenIslandHooks'"))

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -45,19 +45,20 @@ This is meant for per-process launches. Do not set it globally unless you want O
 |---|---|---|
 | `SessionStart` | Session starts or resumes (`source: "resume"` on resume) | `prompt`, `source` |
 | `PreToolUse` | Before a shell command executes | `tool_name`, `tool_input.command`, `turn_id`, `tool_use_id` |
+| `PermissionRequest` | Codex requests permission for a tool/action | `tool_name`, `tool_input`, `turn_id` |
 | `PostToolUse` | After a shell command completes | `tool_name`, `tool_input`, `tool_response`, `turn_id` |
 | `UserPromptSubmit` | User submits a new prompt | `prompt` |
 | `Stop` | A turn completes | `last_assistant_message`, `stop_hook_active` |
 
 ### Default managed installation
 
-The managed Codex hook installer (`CodexHookInstaller`) installs only `SessionStart`, `UserPromptSubmit`, and `Stop` by default. This is intentional: per-command Bash hooks add terminal log noise, so the default set keeps the workflow low-noise while still providing session lifecycle and usage visibility.
+The managed Codex hook installer (`CodexHookInstaller`) installs `SessionStart`, `UserPromptSubmit`, `PermissionRequest`, and `Stop` by default. This keeps the lifecycle hooks low-noise while still allowing OpenIsland to broker Codex's first-class approval requests. Per-command `PreToolUse` / `PostToolUse` hooks remain opt-in because they can add terminal log noise.
 
 The installer chooses the Codex hook feature flag that the local Codex CLI advertises. Newer Codex builds use `[features].hooks = true`; older builds use the legacy `[features].codex_hooks = true`. Status checks recognize both keys, and managed installs migrate between them when the local Codex version changes.
 
 After hooks are installed or changed, Codex may require a manual trust review before running them. Open `/hooks` inside Codex CLI and approve the expected Open Island hook entries. This approval gate belongs to Codex and is not bypassed by Open Island.
 
-The `CodexHookPayload` model and `BridgeServer` can parse richer events (`PreToolUse`, `PostToolUse`) when they are present in the hook payload, and will surface them in the UI if received. However, these richer events are **not** installed by the managed installer and must be configured manually if desired.
+The `CodexHookPayload` model and `BridgeServer` can parse richer events (`PreToolUse`, `PostToolUse`) when they are present in the hook payload, and will surface them in the UI if received. However, these per-tool lifecycle events are **not** installed by the managed installer and must be configured manually if desired.
 
 > **Note on file-edit coverage**: Codex file edits may use internal apply-patch paths that do not emit `PreToolUse` events. File-edit approval should not be treated as guaranteed `PreToolUse` coverage; the current reliable coverage is command/shell-level events, depending on Codex hook configuration.
 
@@ -78,13 +79,15 @@ The `CodexHookPayload` model and `BridgeServer` can parse richer events (`PreToo
 | `turn_id` | `turnID` | Current turn ID |
 | `tool_name` | `toolName` | Tool name (e.g. `shell`) |
 | `tool_use_id` | `toolUseID` | Tool-use call ID |
-| `tool_input` | `toolInput` | Tool input (contains `command`) |
+| `tool_input` | `toolInput` | Tool input (commonly includes `command` and/or `description`) |
 | `tool_response` | `toolResponse` | Tool output (JSON) |
 | `prompt` | `prompt` | User prompt text |
 | `last_assistant_message` | `lastAssistantMessage` | Last assistant message |
 | `stop_hook_active` | `stopHookActive` | Whether the stop hook is active |
 
-### Directive response (PreToolUse only)
+### Directive responses
+
+#### `PreToolUse`
 
 The app can block a command by writing this to stdout:
 
@@ -92,7 +95,40 @@ The app can block a command by writing this to stdout:
 {"decision": "block", "reason": "Blocked by Open Island"}
 ```
 
-All other events require no stdout response.
+#### `PermissionRequest`
+
+The managed `PermissionRequest` hook has a 1-hour timeout so the user can approve or deny from the UI.
+
+Allow:
+
+```json
+{
+  "continue": true,
+  "hookSpecificOutput": {
+    "hookEventName": "PermissionRequest",
+    "decision": {
+      "behavior": "allow"
+    }
+  }
+}
+```
+
+Deny:
+
+```json
+{
+  "continue": true,
+  "hookSpecificOutput": {
+    "hookEventName": "PermissionRequest",
+    "decision": {
+      "behavior": "deny",
+      "message": "User denied the permission request"
+    }
+  }
+}
+```
+
+All other Codex events require no stdout response.
 
 ---
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -311,7 +311,8 @@ Setting `interrupt: true` terminates the current agent turn immediately.
 
 | Source | Event | Timeout |
 |---|---|---|
-| Codex | All events | Bridge default |
+| Codex | `PermissionRequest` | **1 hour** (awaits human approval) |
+| Codex | All other managed events | **45 seconds** |
 | Claude Code | `PermissionRequest` | **24 hours** (awaits human approval) |
 | Claude Code | All other events | **45 seconds** |
 | Gemini CLI | All events | Bridge default |


### PR DESCRIPTION
## Summary

Adds focused Codex `PermissionRequest` hook support without expanding the default Codex install to `PreToolUse` or `PostToolUse`.

This supersedes the useful direction from #386 with a fresh branch on current `main` and a narrower implementation.

## What changed

- Add `CodexHookEventName.permissionRequest` and Codex permission allow/deny directive encoding.
- Decode flexible Codex `tool_input` payloads while extracting common `command` and `description` fields for UI display.
- Handle Codex `PermissionRequest` in `BridgeServer`, including custom deny messages and non-Bash tool names such as `apply_patch`.
- Install managed Codex `PermissionRequest` hooks by default with a 1-hour timeout while keeping `PreToolUse`/`PostToolUse` opt-in.
- Extend hook CLI timeout handling, docs, and tests.

## Notes

The output shape follows the current upstream Codex generated schema for `permission-request.command.output`:
https://raw.githubusercontent.com/openai/codex/main/codex-rs/hooks/schema/generated/permission-request.command.output.schema.json

## Verification

- `git diff --check`
- `swift test --filter CodexHooksTests --filter SessionStateTests`
- `swift test`

The first full `swift test` run exposed a transient `AppModelSessionListTests/islandAppearancePreferencesPersistPerDisplayProfile` failure; that test passed in isolation and the subsequent full `swift test` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Codex permission-request hooks with tailored user-facing summaries and responses.
  * Per-event timeouts including a 1-hour interactive timeout for permission requests.
  * Permission decisions now propagate denial messages and preserve current tool/command previews during resolution.

* **Bug Fixes**
  * Graceful handling when a pending permission is missing and when a client disconnects.

* **Documentation**
  * Updated hooks docs to describe the permission-request lifecycle and timeouts.

* **Tests**
  * Added tests covering permission-request encoding/decoding and resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->