### PR TITLE
[codex] fix Claude subagent stop completion regression

### DIFF
--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -892,10 +892,18 @@ public final class BridgeServer: @unchecked Sendable {
         case .subagentStop:
             ensureClaudeSessionExists(for: payload)
             synchronizeClaudeJumpTarget(for: payload)
-            synchronizeClaudeMetadata(for: payload)
+            let sessionWasAlreadyCompleted = localState.session(id: payload.sessionID)?.phase == .completed
+            if !sessionWasAlreadyCompleted {
+                synchronizeClaudeMetadata(for: payload)
+            }
 
             if let agentID = payload.agentID {
                 removeSubagent(agentID: agentID, fromSession: payload.sessionID)
+            }
+
+            if sessionWasAlreadyCompleted {
+                send(.response(.acknowledged), to: clientID)
+                return
             }
 
             let summary = payload.lastAssistantMessage ?? payload.assistantMessagePreview
@@ -2014,8 +2022,12 @@ public final class BridgeServer: @unchecked Sendable {
             model: update.model ?? existing?.model,
             startupSource: update.startupSource ?? existing?.startupSource,
             permissionMode: update.permissionMode ?? existing?.permissionMode,
-            agentID: update.agentID ?? existing?.agentID,
-            agentType: update.agentType ?? existing?.agentType,
+            agentID: hookEventName.isSubagentLifecycle
+                ? existing?.agentID
+                : update.agentID ?? existing?.agentID,
+            agentType: hookEventName.isSubagentLifecycle
+                ? existing?.agentType
+                : update.agentType ?? existing?.agentType,
             worktreeBranch: update.worktreeBranch ?? existing?.worktreeBranch,
             activeSubagents: existing?.activeSubagents ?? [],
             activeTasks: existing?.activeTasks ?? []
@@ -2046,7 +2058,11 @@ public final class BridgeServer: @unchecked Sendable {
             return
         }
 
+        let previousCount = metadata.activeSubagents.count
         metadata.activeSubagents.removeAll { $0.agentID == agentID }
+        guard metadata.activeSubagents.count != previousCount else {
+            return
+        }
 
         emit(
             .claudeSessionMetadataUpdated(
@@ -2581,5 +2597,11 @@ public final class BridgeServer: @unchecked Sendable {
         }
 
         client.readSource.cancel()
+    }
+}
+
+private extension ClaudeHookEventName {
+    var isSubagentLifecycle: Bool {
+        self == .subagentStart || self == .subagentStop
     }
 }

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -947,10 +947,18 @@ public final class BridgeServer: @unchecked Sendable {
         case .subagentStop:
             ensureClaudeSessionExists(for: payload)
             synchronizeClaudeJumpTarget(for: payload)
-            synchronizeClaudeMetadata(for: payload)
+            let sessionWasAlreadyCompleted = localState.session(id: payload.sessionID)?.phase == .completed
+            if !sessionWasAlreadyCompleted {
+                synchronizeClaudeMetadata(for: payload)
+            }
 
             if let agentID = payload.agentID {
                 removeSubagent(agentID: agentID, fromSession: payload.sessionID)
+            }
+
+            if sessionWasAlreadyCompleted {
+                send(.response(.acknowledged), to: clientID)
+                return
             }
 
             let summary = payload.lastAssistantMessage ?? payload.assistantMessagePreview
@@ -2069,8 +2077,12 @@ public final class BridgeServer: @unchecked Sendable {
             model: update.model ?? existing?.model,
             startupSource: update.startupSource ?? existing?.startupSource,
             permissionMode: update.permissionMode ?? existing?.permissionMode,
-            agentID: update.agentID ?? existing?.agentID,
-            agentType: update.agentType ?? existing?.agentType,
+            agentID: hookEventName.isSubagentLifecycle
+                ? existing?.agentID
+                : update.agentID ?? existing?.agentID,
+            agentType: hookEventName.isSubagentLifecycle
+                ? existing?.agentType
+                : update.agentType ?? existing?.agentType,
             worktreeBranch: update.worktreeBranch ?? existing?.worktreeBranch,
             activeSubagents: existing?.activeSubagents ?? [],
             activeTasks: existing?.activeTasks ?? []
@@ -2101,7 +2113,11 @@ public final class BridgeServer: @unchecked Sendable {
             return
         }
 
+        let previousCount = metadata.activeSubagents.count
         metadata.activeSubagents.removeAll { $0.agentID == agentID }
+        guard metadata.activeSubagents.count != previousCount else {
+            return
+        }
 
         emit(
             .claudeSessionMetadataUpdated(
@@ -2655,5 +2671,11 @@ public final class BridgeServer: @unchecked Sendable {
         }
 
         client.readSource.cancel()
+    }
+}
+
+private extension ClaudeHookEventName {
+    var isSubagentLifecycle: Bool {
+        self == .subagentStart || self == .subagentStop
     }
 }

--- a/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
@@ -526,6 +526,88 @@ struct ClaudeHooksTests {
     }
 
     @Test
+    func claudeSubagentStopAfterStopDoesNotReopenCompletedSession() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+
+        let collector = AgentEventCollector()
+        let collectionTask = Task {
+            do {
+                for try await event in stream {
+                    await collector.append(event)
+                }
+            } catch {}
+        }
+        defer { collectionTask.cancel() }
+
+        try await observer.send(.registerClient(role: .observer))
+
+        let sessionID = "claude-subagent-stop-after-stop"
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processClaudeHook(
+                ClaudeHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .userPromptSubmit,
+                    sessionID: sessionID,
+                    transcriptPath: "/tmp/claude-subagent-stop-after-stop.jsonl",
+                    prompt: "Reply with exactly OK."
+                )
+            )
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processClaudeHook(
+                ClaudeHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .stop,
+                    sessionID: sessionID,
+                    transcriptPath: "/tmp/claude-subagent-stop-after-stop.jsonl",
+                    lastAssistantMessage: "OK"
+                )
+            )
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processClaudeHook(
+                ClaudeHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .subagentStop,
+                    sessionID: sessionID,
+                    transcriptPath: "/tmp/claude-subagent-stop-after-stop.jsonl",
+                    agentID: "statusline-agent",
+                    agentType: "",
+                    lastAssistantMessage: "(silence)"
+                )
+            )
+        )
+
+        try await Task.sleep(for: .milliseconds(250))
+
+        let events = await collector.snapshot()
+        var state = SessionState()
+        for event in events {
+            state.apply(event)
+        }
+
+        let session = try #require(state.session(id: sessionID))
+        #expect(session.phase == .completed)
+        #expect(session.summary == "OK")
+        #expect(session.claudeMetadata?.agentID == nil)
+        #expect(!events.contains { event in
+            if case let .activityUpdated(payload) = event {
+                return payload.sessionID == sessionID
+                    && payload.phase == .running
+                    && payload.summary == "(silence)"
+            }
+            return false
+        })
+    }
+
+    @Test
     func questionPromptAlwaysAppendsOtherFreeformOption() throws {
         let payload = ClaudeHookPayload(
             cwd: "/tmp",
@@ -630,6 +712,18 @@ struct ClaudeHooksTests {
 private enum ClaudeHooksTestError: Error {
     case streamEnded
     case noMatchingEvent
+}
+
+private actor AgentEventCollector {
+    private var events: [AgentEvent] = []
+
+    func append(_ event: AgentEvent) {
+        events.append(event)
+    }
+
+    func snapshot() -> [AgentEvent] {
+        events
+    }
 }
 
 private func nextEvent(

--- a/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
@@ -585,9 +585,17 @@ struct ClaudeHooksTests {
             )
         )
 
-        try await Task.sleep(for: .milliseconds(250))
-
-        let events = await collector.snapshot()
+        let events = await collector.snapshot(
+            waitingUntil: { events in
+                events.contains { event in
+                    if case let .sessionCompleted(payload) = event {
+                        return payload.sessionID == sessionID && payload.summary == "OK"
+                    }
+                    return false
+                }
+            },
+            timeout: .seconds(1)
+        )
         var state = SessionState()
         for event in events {
             state.apply(event)
@@ -721,7 +729,15 @@ private actor AgentEventCollector {
         events.append(event)
     }
 
-    func snapshot() -> [AgentEvent] {
+    func snapshot(
+        waitingUntil predicate: ([AgentEvent]) -> Bool = { _ in true },
+        timeout: Duration = .zero
+    ) async -> [AgentEvent] {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while !predicate(events), clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
         events
     }
 }


### PR DESCRIPTION
## Summary
- Keep completed Claude sessions completed when a late `SubagentStop` hook arrives after `Stop`.
- Prevent subagent lifecycle `agent_id` / `agent_type` values from being persisted onto the parent Claude session metadata.
- Add a regression test for `UserPromptSubmit -> Stop -> SubagentStop(agent_id, agent_type: "")`.

## Root Cause
Claude Code can emit a normal `Stop` hook for the parent turn and then emit a later `SubagentStop` payload with an `agent_id` and empty `agent_type`. The bridge previously handled every `SubagentStop` by emitting `activityUpdated(... phase: .running)`, which could reopen an already completed parent session and leave it stuck as running.

## Validation
- `swift test --filter ClaudeHooksTests`
- `swift test` before rebasing this branch
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented reopening or further updates to a session after it has completed when a subagent stops.
  * Avoided emitting redundant metadata updates and preserved subagent identity during lifecycle changes.

* **Tests**
  * Added an integration test to validate session remains completed when a subagent stops, and a safe async event collector for the test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->