### PR TITLE
fix: refresh overlay display picker on screen-parameters changes

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -618,6 +618,7 @@ final class AppModel {
 
         overlay.appModel = self
         overlay.restoreDisplayPreference()
+        overlay.startObservingDisplayChanges()
         overlay.onStatusMessage = { [weak self] message in
             self?.lastActionMessage = message
         }

--- a/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
+++ b/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
@@ -177,9 +177,16 @@ enum OverlayDisplayResolver {
         return fallbackScreenID(for: screen)
     }
 
+    /// Disambiguates identical displays (e.g. two AirPlay receivers with the
+    /// same model name and resolution) by appending the arrangement origin.
+    /// The origin is not stable across display rearrangement, but a mismatched
+    /// preference will self-heal through the existing
+    /// `validSelectionIDs.contains` check in `refreshOverlayDisplayConfiguration()`.
     private static func fallbackScreenID(for screen: NSScreen) -> String {
-        let width = Int(screen.frame.width)
-        let height = Int(screen.frame.height)
-        return "fallback-\(screen.localizedName)-\(width)x\(height)"
+        let width = Int(screen.frame.width.rounded())
+        let height = Int(screen.frame.height.rounded())
+        let originX = Int(screen.frame.origin.x.rounded())
+        let originY = Int(screen.frame.origin.y.rounded())
+        return "fallback-\(screen.localizedName)-\(width)x\(height)@\(originX),\(originY)"
     }
 }

--- a/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
+++ b/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
@@ -153,12 +153,33 @@ enum OverlayDisplayResolver {
         placementMode(for: screen) == .notch ? "Built-in notch" : "Top-bar fallback"
     }
 
-    private static func screenID(for screen: NSScreen) -> String {
+    /// Returns a string that identifies the physical display backing `screen`
+    /// stably across reconnects.
+    ///
+    /// Uses `CGDisplayCreateUUIDFromDisplayID` so the value survives the
+    /// `CGDirectDisplayID` churn that happens on hotplug / sleep / arrangement
+    /// changes — without this, a reassigned `CGDirectDisplayID` could silently
+    /// route the overlay to a different physical monitor than the one the user
+    /// picked. Falls back to a `localizedName + frame` composite when macOS
+    /// can't issue a UUID (some AirPlay / virtual displays).
+    static func screenID(for screen: NSScreen) -> String {
         let key = NSDeviceDescriptionKey("NSScreenNumber")
-        if let number = screen.deviceDescription[key] as? NSNumber {
-            return "display-\(number.uint32Value)"
+        guard let number = screen.deviceDescription[key] as? NSNumber else {
+            return fallbackScreenID(for: screen)
         }
 
-        return screen.localizedName
+        let displayID = number.uint32Value
+        if let uuid = CGDisplayCreateUUIDFromDisplayID(displayID)?.takeRetainedValue(),
+           let cfString = CFUUIDCreateString(nil, uuid) {
+            return cfString as String
+        }
+
+        return fallbackScreenID(for: screen)
+    }
+
+    private static func fallbackScreenID(for screen: NSScreen) -> String {
+        let width = Int(screen.frame.width)
+        let height = Int(screen.frame.height)
+        return "fallback-\(screen.localizedName)-\(width)x\(height)"
     }
 }

--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -198,6 +198,13 @@ final class OverlayPanelController {
         notchRect = NSRect(x: notchX, y: notchY, width: notchSize.width, height: notchSize.height)
     }
 
+    /// Picks the screen to anchor the overlay to.
+    ///
+    /// Priority: persisted manual preference (matched via the stable
+    /// `OverlayDisplayResolver.screenID` so a hotplug-reassigned
+    /// `CGDirectDisplayID` can't silently re-target the wrong monitor) →
+    /// first notched screen → `NSScreen.main` → first available screen.
+    /// Returns `nil` only when no displays are connected.
     private func resolveTargetScreen(preferredScreenID: String? = nil) -> NSScreen? {
         let screens = NSScreen.screens
         guard !screens.isEmpty else { return nil }

--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -203,7 +203,7 @@ final class OverlayPanelController {
         guard !screens.isEmpty else { return nil }
 
         if let preferredScreenID,
-           let screen = screens.first(where: { screenID(for: $0) == preferredScreenID }) {
+           let screen = screens.first(where: { OverlayDisplayResolver.screenID(for: $0) == preferredScreenID }) {
             return screen
         }
 
@@ -212,14 +212,6 @@ final class OverlayPanelController {
         }
 
         return NSScreen.main ?? screens[0]
-    }
-
-    private func screenID(for screen: NSScreen) -> String {
-        let key = NSDeviceDescriptionKey("NSScreenNumber")
-        if let number = screen.deviceDescription[key] as? NSNumber {
-            return "display-\(number.uint32Value)"
-        }
-        return screen.localizedName
     }
 
     // MARK: - Mouse event monitoring

--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -49,6 +49,9 @@ final class OverlayUICoordinator {
     let overlayPanelController = OverlayPanelController()
 
     @ObservationIgnored
+    private var screenParametersObserver: NSObjectProtocol?
+
+    @ObservationIgnored
     private var overlayTransitionGeneration: UInt64 = 0
 
     @ObservationIgnored
@@ -92,6 +95,25 @@ final class OverlayUICoordinator {
         overlayDisplaySelectionID = UserDefaults.standard.string(
             forKey: "overlay.display.preference"
         ) ?? OverlayDisplayOption.automaticID
+    }
+
+    /// Re-syncs the cached display options and the target panel placement
+    /// whenever macOS reports a screen configuration change (hotplug,
+    /// arrangement change, sleep/wake). Without this, the picker list keeps
+    /// stale entries after disconnect, and a saved preference whose
+    /// `CGDirectDisplayID` gets reused for a different physical display can
+    /// silently route the island to the wrong screen.
+    func startObservingDisplayChanges() {
+        guard screenParametersObserver == nil else { return }
+        screenParametersObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.refreshOverlayDisplayConfiguration()
+            }
+        }
     }
 
     // MARK: - Overlay transitions

--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -116,6 +116,12 @@ final class OverlayUICoordinator {
         }
     }
 
+    isolated deinit {
+        if let observer = screenParametersObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
     // MARK: - Overlay transitions
 
     func toggleOverlay() {

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -136,7 +136,7 @@ struct IslandPanelView: View {
 
     private var targetOverlayScreen: NSScreen? {
         if let targetScreenID = model.overlayPlacementDiagnostics?.targetScreenID,
-           let screen = NSScreen.screens.first(where: { screenID(for: $0) == targetScreenID }) {
+           let screen = NSScreen.screens.first(where: { OverlayDisplayResolver.screenID(for: $0) == targetScreenID }) {
             return screen
         }
 
@@ -1028,15 +1028,6 @@ struct IslandPanelView: View {
         }
         .lineLimit(1)
         .fixedSize(horizontal: true, vertical: false)
-    }
-
-    private func screenID(for screen: NSScreen) -> String {
-        let key = NSDeviceDescriptionKey("NSScreenNumber")
-        if let number = screen.deviceDescription[key] as? NSNumber {
-            return "display-\(number.uint32Value)"
-        }
-
-        return screen.localizedName
     }
 
     private func compactUsageChip(_ provider: UsageProviderPresentation, usesShortTitle: Bool) -> some View {


### PR DESCRIPTION
## Summary

Fixes #493.

Subscribe to `NSApplication.didChangeScreenParametersNotification` from `OverlayUICoordinator` and forward it to the existing `refreshOverlayDisplayConfiguration()`. This keeps the overlay display picker in sync with `NSScreen.screens` across display hotplug, arrangement changes, and sleep/wake.

While addressing review feedback, the screen-identity scheme also changed (see "Behavior changes" below).

## Root cause

`OverlayUICoordinator.overlayDisplayOptions` (the cached array the SwiftUI `Picker` in `SettingsView` reads from) was only rebuilt at two points: `AppModel.init()` and once during startup live-session resolution. After that, **nothing in the codebase observed screen-parameters changes**, so the picker list froze at boot-time state.

Two visible symptoms follow:

1. **Stale list.** Disconnecting a display does not remove its entry; reconnecting a different topology does not add new entries.
2. **Wrong-screen rendering.** `OverlayDisplayOption.id` encoded the `NSScreenNumber` (i.e. `CGDirectDisplayID`). When macOS reassigns that ID to a different physical display after a hotplug — which happens, especially around primary-display changes — the stale cached entry still matches a live `NSScreen`, just the wrong one. Selecting an entry labeled "DELL P2723QE" could then route the island to the HP screen because the cached ID was now bound to HP.

The existing `refreshOverlayDisplayConfiguration()` already handles list-staleness correctly: it rebuilds the options from `NSScreen.screens` and clears any saved selection that is no longer present (falling back to `automatic`). It was simply missing a trigger. Display-ID reuse, however, needed a separate fix at the identity layer.

## Fix

`Sources/OpenIslandApp/OverlayUICoordinator.swift`
- New `screenParametersObserver: NSObjectProtocol?` to hold the token.
- New `startObservingDisplayChanges()` that registers a one-shot observer on `NotificationCenter.default` for `NSApplication.didChangeScreenParametersNotification` (delivered on the main queue) and calls `refreshOverlayDisplayConfiguration()` inside `MainActor.assumeIsolated`.
- `isolated deinit` removes the observer (hygiene; `[weak self]` already prevents the leak).

`Sources/OpenIslandApp/OverlayDisplayConfiguration.swift`
- `OverlayDisplayResolver.screenID(for:)` now derives a stable per-physical-display key from `CGDisplayCreateUUIDFromDisplayID`, falling back to `localizedName + WxH @ originX,originY` for AirPlay / virtual displays that don't issue a CoreGraphics UUID. Origin is appended so two identical AirPlay receivers don't collide; the origin can shift on rearrangement, but a mismatched preference self-heals through the existing `validSelectionIDs.contains` check.

`Sources/OpenIslandApp/OverlayPanelController.swift` & `Sources/OpenIslandApp/Views/IslandPanelView.swift`
- Both call sites now route through the shared `OverlayDisplayResolver.screenID(for:)`. The local `screenID(for:)` helpers were deleted to keep there from being two competing identity formats. (The `IslandPanelView` helper was missed in the initial pass and added in a follow-up commit — without it, `targetOverlayScreen` always fell through to the `safeAreaInsets.top` heuristic, regressing multi-display layout for users who picked a non-notched display.)

`Sources/OpenIslandApp/AppModel.swift`
- One-line call: `overlay.startObservingDisplayChanges()` in `init()` right after `restoreDisplayPreference()`.

## Behavior changes

- **Saved display preferences from prior versions are silently invalidated on first launch.** `UserDefaults["overlay.display.preference"]` previously stored `"display-<CGDirectDisplayID>"`; the new resolver returns CFUUID strings (or the `fallback-…` composite). The legacy value will not match any current option, so `refreshOverlayDisplayConfiguration()` resets the selection to **Automatic** and removes the stale key. No explicit migration was added — re-resolving a `CGDirectDisplayID` against current screens at restore time would only kick in for users still on the same boot session, which is rarely true after an upgrade. A one-time degradation seems strictly better than carrying around a migration path that's mostly dead code.

  Affected users will see their previously selected non-default display revert to Automatic once after upgrading; re-selecting the desired display in Settings persists correctly under the new identity scheme and survives subsequent hotplug / sleep / wake cycles.

## Test plan

- [x] `swift build` clean.
- [x] `swift test` — 5 unrelated failures in `AppModelSessionListTests` / `AgentsGridRightSlotTests` are pre-existing on `origin/main` (verified by running the same tests against the unmodified branch base). They cover session-list grouping and grid layout, which this change does not touch.
- [ ] Manual hotplug check on a multi-display setup:
  - Disconnect an external → display picker shrinks accordingly.
  - Reconnect → picker reflects the new topology.
  - When the previously selected external is no longer present, selection auto-reverts to Automatic; the island does not silently render on a different physical display.
  - Selecting a non-notched display routes the island there (verifies `IslandPanelView.targetOverlayScreen` matches the resolver-produced ID).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Overlay now monitors screen configuration changes and automatically updates display settings and positioning when displays are connected, disconnected, or reconfigured.
  * Overlay begins observing display changes at startup so restored display preferences are applied immediately.
  * Display targets use stable per-physical-display identifiers, improving preservation of display preferences across hardware or arrangement changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Octane0411/open-vibe-island/pull/494)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Release notes

Per @Karl-Dai's review — flagging the user-visible preference reset so it makes the release notes verbatim.

- **Fixed**: Display picker now refreshes on hotplug, sleep/wake, and arrangement changes; selecting an external display routes the island correctly even after macOS reassigns `CGDirectDisplayID` values (#494).
  显示器选择器现在会在热插拔、睡眠/唤醒以及排列变更时刷新；即使 macOS 重新分配 `CGDirectDisplayID`，选中外接显示器也能正确把灵动岛投放到对应物理屏 (#494)。
- **Changed**: Overlay display preferences saved by earlier versions reset to **Automatic** on first launch after upgrade. If you had pinned a non-default display, re-select it once in Settings — the new identity scheme then persists across hotplug and sleep/wake (#494).
  升级后首次启动时，旧版本保存的灵动岛显示器偏好将重置为「自动」。如果之前固定了非默认显示器，请在设置中重新选择一次；新的识别方案会在之后的热插拔与睡眠/唤醒间保持稳定 (#494)。
