### PR TITLE
fix: strip markdown syntax from preview text and completion card

### DIFF
--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -442,6 +442,19 @@ extension AgentSession {
 
 private extension String {
     var trimmedForSurface: String {
-        trimmingCharacters(in: .whitespacesAndNewlines)
+        strippingMarkdown.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var strippingMarkdown: String {
+        var s = self
+        s = s.replacingOccurrences(of: "```[\\s\\S]*?```", with: "", options: .regularExpression)
+        s = s.replacingOccurrences(of: "`([^`]+)`", with: "$1", options: .regularExpression)
+        s = s.replacingOccurrences(of: "\\*{1,3}(.+?)\\*{1,3}", with: "$1", options: .regularExpression)
+        s = s.replacingOccurrences(of: "(?<![\\w])_{1,3}(.+?)_{1,3}(?![\\w])", with: "$1", options: .regularExpression)
+        s = s.replacingOccurrences(of: "(?m)^#{1,6}\\s+", with: "", options: .regularExpression)
+        s = s.replacingOccurrences(of: "\\[([^\\]]+)\\]\\([^)]+\\)", with: "$1", options: .regularExpression)
+        s = s.replacingOccurrences(of: "^[\\-*>+]\\s+", with: "", options: .regularExpression)
+        s = s.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+        return s
     }
 }

--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -453,7 +453,7 @@ private extension String {
         s = s.replacingOccurrences(of: "(?<![\\w])_{1,3}(.+?)_{1,3}(?![\\w])", with: "$1", options: .regularExpression)
         s = s.replacingOccurrences(of: "(?m)^#{1,6}\\s+", with: "", options: .regularExpression)
         s = s.replacingOccurrences(of: "\\[([^\\]]+)\\]\\([^)]+\\)", with: "$1", options: .regularExpression)
-        s = s.replacingOccurrences(of: "^[\\-*>+]\\s+", with: "", options: .regularExpression)
+        s = s.replacingOccurrences(of: "(?m)^[\\-*>+]\\s+", with: "", options: .regularExpression)
         s = s.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
         return s
     }

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -2739,7 +2739,7 @@ private extension String {
         s = s.replacingOccurrences(of: "(?<![\\w])_{1,3}(.+?)_{1,3}(?![\\w])", with: "$1", options: .regularExpression)
         s = s.replacingOccurrences(of: "(?m)^#{1,6}\\s+", with: "", options: .regularExpression)
         s = s.replacingOccurrences(of: "\\[([^\\]]+)\\]\\([^)]+\\)", with: "$1", options: .regularExpression)
-        s = s.replacingOccurrences(of: "^[\\-*>+]\\s+", with: "", options: .regularExpression)
+        s = s.replacingOccurrences(of: "(?m)^[\\-*>+]\\s+", with: "", options: .regularExpression)
         return s
     }
 }

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1706,8 +1706,9 @@ private struct IslandSessionRow: View {
         VStack(alignment: .leading, spacing: 0) {
             if !completionMessageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 AutoHeightScrollView(maxHeight: 160) {
-                    Markdown(completionMessageText)
-                        .markdownTheme(.completionCard)
+                    Text(completionMessageText.strippingMarkdownForCard)
+                        .font(.system(size: 13.5, weight: .medium))
+                        .foregroundStyle(.white.opacity(0.88))
                         .frame(maxWidth: .infinity, alignment: .topLeading)
                         .padding(.horizontal, 14)
                         .padding(.vertical, 9)
@@ -2726,5 +2727,19 @@ private struct DismissButton: View {
         }
         .buttonStyle(.plain)
         .onHover { isHovered = $0 }
+    }
+}
+
+private extension String {
+    var strippingMarkdownForCard: String {
+        var s = self
+        s = s.replacingOccurrences(of: "```[\\s\\S]*?```", with: "", options: .regularExpression)
+        s = s.replacingOccurrences(of: "`([^`]+)`", with: "$1", options: .regularExpression)
+        s = s.replacingOccurrences(of: "\\*{1,3}(.+?)\\*{1,3}", with: "$1", options: .regularExpression)
+        s = s.replacingOccurrences(of: "(?<![\\w])_{1,3}(.+?)_{1,3}(?![\\w])", with: "$1", options: .regularExpression)
+        s = s.replacingOccurrences(of: "(?m)^#{1,6}\\s+", with: "", options: .regularExpression)
+        s = s.replacingOccurrences(of: "\\[([^\\]]+)\\]\\([^)]+\\)", with: "$1", options: .regularExpression)
+        s = s.replacingOccurrences(of: "^[\\-*>+]\\s+", with: "", options: .regularExpression)
+        return s
     }
 }


### PR DESCRIPTION
## Summary

- Replace `MarkdownUI` rendering in the completion card with plain `Text`, stripping markdown syntax before display
- Strip markdown from all surface preview text (`trimmedForSurface`) so island spotlight shows clean text instead of raw markdown markers
- Two stripping variants: `strippingMarkdown` (collapses whitespace, for single-line previews) and `strippingMarkdownForCard` (preserves newlines, for card body)

Closes #58

## Changes

- `AgentSession+Presentation.swift`: `trimmedForSurface` now calls `strippingMarkdown` before trimming, removing code blocks, inline code, bold/italic, headings, links, and list markers
- `IslandPanelView.swift`: Completion card body uses `Text(completionMessageText.strippingMarkdownForCard)` instead of `Markdown(completionMessageText).markdownTheme(.completionCard)`

## Test plan

- [x] `swift build` passes
- [x] `swift test` - no regressions (5 pre-existing failures on base branch)
- [ ] Visual verification via harness: `OPEN_ISLAND_HARNESS_SCENARIO=longCompletionCard OPEN_ISLAND_HARNESS_PRESENT_OVERLAY=1 swift run OpenIslandApp`
- [ ] Manual test with live agent session via dev app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session spotlight text now has Markdown formatting removed before display, preventing raw markup from appearing in UI.
  * Completion messages are shown as sanitized plain text (Markdown stripped) so cards render cleanly and consistently without formatting artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Octane0411/open-vibe-island/pull/496?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->