### PR TITLE
fix: prevent Kimi hook placeholder TOML collisions

### DIFF
--- a/Sources/OpenIslandCore/KimiHookInstaller.swift
+++ b/Sources/OpenIslandCore/KimiHookInstaller.swift
@@ -57,7 +57,9 @@ public enum KimiHookInstaller {
         hookCommand: String
     ) -> KimiHookFileMutation {
         let original = existingContents ?? ""
-        let cleaned = stripManagedBlocks(from: original, managedCommand: hookCommand)
+        let cleaned = stripEmptyTopLevelHooksArray(
+            from: stripManagedBlocks(from: original, managedCommand: hookCommand)
+        )
 
         var output = cleaned
         if !output.isEmpty, !output.hasSuffix("\n") {
@@ -144,6 +146,44 @@ public enum KimiHookInstaller {
         }
 
         return result.joined(separator: "\n")
+    }
+
+    /// Kimi may seed config.toml with a top-level `hooks = []` placeholder.
+    /// Managed hooks use TOML array-of-tables syntax (`[[hooks]]`), so the
+    /// empty placeholder must be removed before appending managed blocks.
+    private static func stripEmptyTopLevelHooksArray(from contents: String) -> String {
+        let lines = contents.components(separatedBy: "\n")
+        var result: [String] = []
+        var hasEnteredTable = false
+
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            if !hasEnteredTable, isEmptyHooksArrayAssignment(trimmed) {
+                continue
+            }
+
+            if trimmed.hasPrefix("[") && trimmed.hasSuffix("]") {
+                hasEnteredTable = true
+            }
+
+            result.append(line)
+        }
+
+        return result.joined(separator: "\n")
+    }
+
+    private static func isEmptyHooksArrayAssignment(_ trimmedLine: String) -> Bool {
+        guard trimmedLine.hasPrefix("hooks") else { return false }
+        guard let equalsIndex = trimmedLine.firstIndex(of: "=") else { return false }
+
+        let key = trimmedLine[..<equalsIndex].trimmingCharacters(in: .whitespaces)
+        guard key == "hooks" else { return false }
+
+        let rhs = trimmedLine[trimmedLine.index(after: equalsIndex)...]
+        let value = rhs.split(separator: "#", maxSplits: 1, omittingEmptySubsequences: false)[0]
+            .trimmingCharacters(in: .whitespaces)
+        return value == "[]"
     }
 
     private static func isHooksHeader(_ line: String) -> Bool {

--- a/Tests/OpenIslandCoreTests/KimiHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/KimiHooksTests.swift
@@ -48,6 +48,53 @@ struct KimiHooksTests {
     }
 
     @Test
+    func installRemovesEmptyTopLevelHooksArrayPlaceholder() {
+        let userToml = """
+        default_model = "kimi-code/kimi-for-coding"
+        default_thinking = true
+        hooks = [] # Kimi may seed this placeholder
+
+        [models."kimi-code/kimi-for-coding"]
+        provider = "managed:kimi-code"
+
+        [[hooks]]
+        event = "PostToolUse"
+        command = "user-hook"
+
+        """
+        let command = KimiHookInstaller.hookCommand(for: "/opt/open-island/OpenIslandHooks")
+        let mutation = KimiHookInstaller.installConfigTOML(
+            existingContents: userToml,
+            hookCommand: command
+        )
+
+        let contents = try! #require(mutation.contents)
+        #expect(contents.contains("hooks = []") == false)
+        #expect(contents.contains("[models.\"kimi-code/kimi-for-coding\"]"))
+        #expect(contents.contains("command = \"user-hook\""))
+        #expect(contents.contains("event = \"SessionStart\""))
+    }
+
+    @Test
+    func installKeepsNonTopLevelHooksArrayAssignments() {
+        let userToml = """
+        [harness]
+        hooks = []
+        embedded = true
+
+        """
+        let command = KimiHookInstaller.hookCommand(for: "/opt/open-island/OpenIslandHooks")
+        let mutation = KimiHookInstaller.installConfigTOML(
+            existingContents: userToml,
+            hookCommand: command
+        )
+
+        let contents = try! #require(mutation.contents)
+        #expect(contents.contains("[harness]\nhooks = []\nembedded = true"))
+        #expect(contents.contains("event = \"SessionStart\""))
+    }
+
+    @Test
     func reinstallIsIdempotent() {
         let command = KimiHookInstaller.hookCommand(for: "/opt/open-island/OpenIslandHooks")
         let firstInstall = KimiHookInstaller.installConfigTOML(


### PR DESCRIPTION
## Summary

- Remove Kimi's empty top-level `hooks = []` placeholder before appending managed `[[hooks]]` entries.
- Keep the cleanup scoped to top-level placeholders before the first TOML table so embedded or scoped `hooks = []` settings are preserved.
- Add regression tests for the invalid TOML case and for preserving non-top-level harness-style hook arrays.

## Root Cause

Kimi can seed `~/.kimi/config.toml` with:

```toml
hooks = []
```

Open Island installs managed Kimi hooks as TOML array-of-tables:

```toml
[[hooks]]
event = "SessionStart"
```

Leaving both in the same file defines `hooks` as two different TOML shapes, so Kimi rejects the config with `Key "hooks" already exists`.

## Validation

- `swift test --filter KimiHooksTests`
- `swift test --filter Harness`

I also ran full `swift test`; the Kimi and Harness coverage passed, but the run hit an unrelated local-environment failure in `TerminalJumpServiceTests.testTraeJumpActivatesRunningTraeCNApp`.

Closes #498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration cleanup during re-installation to remove empty hooks placeholders, resulting in a cleaner configuration file without leftover placeholder entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Octane0411/open-vibe-island/pull/499?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->