### PR TITLE
fix: allow subagent permission requests through bridge filter

### DIFF
--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -396,6 +396,10 @@ struct ActiveAgentProcessDiscovery {
             return "Ghostty"
         }
 
+        if lowered.contains("/kitty.app/contents/macos/kitty") || lowered.hasSuffix("/kitty") {
+            return "Kitty"
+        }
+
         if lowered.contains("/terminal.app/contents/macos/terminal") {
             return "Terminal"
         }

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -3,6 +3,7 @@ import Foundation
 import Observation
 import OpenIslandCore
 import SwiftUI
+import os
 
 extension Notification.Name {
     /// Posted by `AppModel.showOnboarding()` to ask `SettingsView` to
@@ -15,6 +16,7 @@ extension Notification.Name {
 @MainActor
 @Observable
 final class AppModel {
+    private static let ntfyLogger = Logger(subsystem: "app.openisland", category: "NtfyFlow")
     private static let soundMutedDefaultsKey = "overlay.sound.muted"
     private static let showDockIconDefaultsKey = "app.showDockIcon"
     private static let hapticFeedbackEnabledDefaultsKey = "app.hapticFeedbackEnabled"
@@ -497,6 +499,139 @@ final class AppModel {
         watchRelay = nil
     }
 
+    // MARK: - Ntfy Remote Notification (Away Detection)
+
+    private static let ntfyEnabledKey = "ntfy.enabled"
+    private static let ntfyAlwaysNotifyKey = "ntfy.alwaysNotify"
+
+    var ntfyEnabled: Bool = false {
+        didSet {
+            guard hasFinishedInit, ntfyEnabled != oldValue else { return }
+            UserDefaults.standard.set(ntfyEnabled, forKey: Self.ntfyEnabledKey)
+            if ntfyEnabled {
+                startNtfyMonitoring()
+            } else {
+                stopNtfyMonitoring()
+            }
+        }
+    }
+
+    var ntfyAlwaysNotify: Bool = false {
+        didSet {
+            guard hasFinishedInit, ntfyAlwaysNotify != oldValue else { return }
+            UserDefaults.standard.set(ntfyAlwaysNotify, forKey: Self.ntfyAlwaysNotifyKey)
+        }
+    }
+
+    @ObservationIgnored
+    private let idleMonitor = IdleActivityMonitor()
+    @ObservationIgnored
+    private let ntfyNotifier = NtfyRemoteNotifier()
+
+    var currentIdleSeconds: TimeInterval { idleMonitor.idleSeconds }
+    var isUserAway: Bool { idleMonitor.isUserAway }
+
+    private func startNtfyMonitoring() {
+        idleMonitor.start()
+        ntfyNotifier.onPermissionResponse = { [weak self] sessionID, approved in
+            Self.ntfyLogger.info("onPermissionResponse callback fired: sessionID=\(sessionID), approved=\(approved)")
+            self?.approvePermission(for: sessionID, approved: approved)
+        }
+        ntfyNotifier.onQuestionResponse = { [weak self] sessionID, answer in
+            Self.ntfyLogger.info("onQuestionResponse callback fired: sessionID=\(sessionID), answer=\(answer)")
+            self?.answerQuestion(
+                for: sessionID,
+                answer: QuestionPromptResponse(answer: answer)
+            )
+        }
+    }
+
+    // MARK: - Debug Session Logger
+
+    @ObservationIgnored
+    private var debugLogTimer: Timer?
+
+    func startDebugSessionLogger() {
+        debugLogTimer = Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.logSessionState()
+            }
+        }
+    }
+
+    private func logSessionState() {
+        let sessions = surfacedSessions
+        var lines: [String] = ["[SessionDebug] \(sessions.count) visible sessions:"]
+        for s in sessions {
+            let terminal = s.jumpTarget?.terminalApp ?? "nil"
+            let hookManaged = s.isHookManaged
+            let ended = s.isSessionEnded
+            let alive = s.isProcessAlive
+            let tty = s.jumpTarget?.terminalTTY ?? "nil"
+            let tmux = s.jumpTarget?.tmuxTarget ?? "nil"
+            let source = sessionDiscoverySource(s)
+            lines.append("  [\(s.id)] \(s.spotlightHeadlineText) | phase=\(s.phase) source=\(source) terminal=\(terminal) hookManaged=\(hookManaged) ended=\(ended) alive=\(alive) tty=\(tty) tmux=\(tmux)")
+        }
+        lines.append("[IdleDebug] ntfyEnabled=\(ntfyEnabled) isUserAway=\(idleMonitor.isUserAway) idleSeconds=\(Int(idleMonitor.idleSeconds))")
+        let output = lines.joined(separator: "\n")
+        try? output.write(toFile: "/tmp/open-island-debug.log", atomically: true, encoding: .utf8)
+    }
+
+    private func sessionDiscoverySource(_ session: AgentSession) -> String {
+        if session.isHookManaged {
+            return "hook"
+        }
+        if session.id.hasPrefix(Self.syntheticClaudeSessionPrefix) {
+            return "process-synthetic"
+        }
+        if session.origin == .live {
+            return "registry-restored"
+        }
+        if session.claudeMetadata?.transcriptPath != nil {
+            return "transcript"
+        }
+        return "unknown"
+    }
+
+    private func stopNtfyMonitoring() {
+        idleMonitor.stop()
+        ntfyNotifier.cancel()
+    }
+
+    private func sendNtfyIfAway(for event: AgentEvent) {
+        guard ntfyEnabled else {
+            Self.ntfyLogger.debug("sendNtfyIfAway: ntfy disabled")
+            return
+        }
+        guard ntfyAlwaysNotify || idleMonitor.isUserAway else {
+            Self.ntfyLogger.debug("sendNtfyIfAway: user not away (alwaysNotify=\(self.ntfyAlwaysNotify))")
+            return
+        }
+        guard ntfyNotifier.config.isConfigured else {
+            Self.ntfyLogger.warning("sendNtfyIfAway: ntfy not configured (server=\(self.ntfyNotifier.config.server), topic=\(self.ntfyNotifier.config.topic))")
+            return
+        }
+
+        switch event {
+        case let .permissionRequested(payload):
+            guard let session = state.session(id: payload.sessionID) else {
+                Self.ntfyLogger.warning("sendNtfyIfAway: session not found for permissionRequested, sessionID=\(payload.sessionID)")
+                return
+            }
+            Self.ntfyLogger.info("sendNtfyIfAway: dispatching permission notification for sessionID=\(payload.sessionID)")
+            ntfyNotifier.sendPermissionNotification(sessionID: payload.sessionID, session: session)
+        case let .questionAsked(payload):
+            guard let session = state.session(id: payload.sessionID) else {
+                Self.ntfyLogger.warning("sendNtfyIfAway: session not found for questionAsked, sessionID=\(payload.sessionID)")
+                return
+            }
+            Self.ntfyLogger.info("sendNtfyIfAway: dispatching question notification for sessionID=\(payload.sessionID)")
+            ntfyNotifier.sendQuestionNotification(sessionID: payload.sessionID, session: session)
+        default:
+            break
+        }
+    }
+
     var ignoresPointerExitDuringHarness = false
     var disablesOverlayEventMonitoringDuringHarness = false
 
@@ -615,6 +750,12 @@ final class AppModel {
         if watchNotificationEnabled {
             startWatchRelay()
         }
+        ntfyEnabled = UserDefaults.standard.bool(forKey: Self.ntfyEnabledKey)
+        ntfyAlwaysNotify = UserDefaults.standard.bool(forKey: Self.ntfyAlwaysNotifyKey)
+        if ntfyEnabled {
+            startNtfyMonitoring()
+        }
+        startDebugSessionLogger()
 
         overlay.appModel = self
         overlay.restoreDisplayPreference()
@@ -1344,7 +1485,9 @@ final class AppModel {
     }
 
     func approvePermission(for sessionID: String, approved: Bool) {
+        Self.ntfyLogger.info("approvePermission: sessionID=\(sessionID), approved=\(approved)")
         guard let session = state.session(id: sessionID) else {
+            Self.ntfyLogger.error("approvePermission: session not found for sessionID=\(sessionID)")
             return
         }
 
@@ -1354,6 +1497,7 @@ final class AppModel {
         synchronizeSelection()
         refreshOverlayPlacementIfVisible()
 
+        Self.ntfyLogger.info("approvePermission: sending bridge command resolvePermission for \(session.title)")
         send(
             .resolvePermission(sessionID: session.id, resolution: resolution),
             userMessage: approved
@@ -1444,7 +1588,9 @@ final class AppModel {
 
             do {
                 try await self.bridgeClient.send(command)
+                Self.ntfyLogger.info("send: bridge command sent successfully — \(userMessage)")
             } catch {
+                Self.ntfyLogger.error("send: bridge command failed — \(error.localizedDescription)")
                 self.lastActionMessage = "Failed to send bridge command: \(error.localizedDescription)"
             }
         }
@@ -1518,6 +1664,8 @@ final class AppModel {
             let session = eventSessionID.flatMap { state.session(id: $0) }
             relay.notifyEvent(event, session: session)
         }
+
+        sendNtfyIfAway(for: event)
 
         if updateLastActionMessage {
             lastActionMessage = describe(event)

--- a/Sources/OpenIslandApp/IdleActivityMonitor.swift
+++ b/Sources/OpenIslandApp/IdleActivityMonitor.swift
@@ -1,0 +1,34 @@
+import CoreGraphics
+import Foundation
+
+@MainActor
+final class IdleActivityMonitor {
+    private var timer: Timer?
+    private let idleThreshold: TimeInterval = 60
+
+    private(set) var isUserAway: Bool = false
+    private(set) var idleSeconds: TimeInterval = 0
+
+    func start() {
+        timer = Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.poll()
+            }
+        }
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+        idleSeconds = 0
+    }
+
+    private func poll() {
+        let seconds = CGEventSource.secondsSinceLastEventType(
+            .combinedSessionState,
+            eventType: .init(rawValue: ~0)!
+        )
+        idleSeconds = seconds
+        isUserAway = seconds >= idleThreshold
+    }
+}

--- a/Sources/OpenIslandApp/NtfyRemoteNotifier.swift
+++ b/Sources/OpenIslandApp/NtfyRemoteNotifier.swift
@@ -1,0 +1,256 @@
+import Foundation
+import OpenIslandCore
+import os
+
+@MainActor
+final class NtfyRemoteNotifier {
+    private nonisolated(unsafe) static let logger = Logger(subsystem: "app.openisland", category: "NtfyRemoteNotifier")
+
+    struct Config {
+        var server: String
+        var topic: String
+
+        var isConfigured: Bool {
+            !server.isEmpty && !topic.isEmpty
+        }
+
+        var responseTopic: String { "\(topic)-response" }
+    }
+
+    private var pendingTask: Task<Void, Never>?
+    private(set) var pendingRequestID: String?
+
+    var config: Config {
+        Config(
+            server: UserDefaults.standard.string(forKey: "ntfy.server") ?? "",
+            topic: UserDefaults.standard.string(forKey: "ntfy.topic") ?? ""
+        )
+    }
+
+    var onPermissionResponse: ((String, Bool) -> Void)?
+    var onQuestionResponse: ((String, String) -> Void)?
+
+    func sendPermissionNotification(sessionID: String, session: AgentSession) {
+        guard config.isConfigured,
+              let request = session.permissionRequest else {
+            Self.logger.warning("sendPermissionNotification skipped: configured=\(self.config.isConfigured), hasPermissionRequest=\(session.permissionRequest != nil)")
+            return
+        }
+
+        let requestID = UUID().uuidString
+        pendingRequestID = requestID
+
+        Self.logger.info("Sending permission notification: sessionID=\(sessionID), requestID=\(requestID), tool=\(request.toolName ?? "nil")")
+
+        let title = "Open Island: \(session.title) · \(request.toolName ?? "Permission")"
+        let message = request.summary.isEmpty ? request.title : request.summary
+
+        let responseURL = "\(config.server)/\(config.responseTopic)"
+        let actions: [[String: Any]] = [
+            [
+                "action": "http",
+                "label": "Approve",
+                "url": responseURL,
+                "method": "POST",
+                "body": "{\"requestId\":\"\(requestID)\",\"approved\":true}",
+            ],
+            [
+                "action": "http",
+                "label": "Deny",
+                "url": responseURL,
+                "method": "POST",
+                "body": "{\"requestId\":\"\(requestID)\",\"approved\":false}",
+            ],
+        ]
+
+        let body: [String: Any] = [
+            "topic": config.topic,
+            "title": title,
+            "message": String(message.prefix(1000)),
+            "actions": actions,
+        ]
+
+        Task {
+            await postNotification(body: body)
+        }
+
+        pendingTask = Task { [weak self] in
+            await self?.listenForResponse(requestID: requestID, sessionID: sessionID)
+        }
+    }
+
+    func sendQuestionNotification(sessionID: String, session: AgentSession) {
+        guard config.isConfigured,
+              let prompt = session.questionPrompt else {
+            Self.logger.warning("sendQuestionNotification skipped: configured=\(self.config.isConfigured), hasQuestionPrompt=\(session.questionPrompt != nil)")
+            return
+        }
+
+        let requestID = UUID().uuidString
+        pendingRequestID = requestID
+
+        Self.logger.info("Sending question notification: sessionID=\(sessionID), requestID=\(requestID)")
+
+        let title = "Open Island: \(session.title) · Question"
+        let questionText = prompt.questions.first?.question ?? prompt.title
+        let responseURL = "\(config.server)/\(config.responseTopic)"
+
+        var actions: [[String: Any]] = []
+        let options = prompt.questions.first?.options ?? []
+        for option in options.prefix(3) {
+            actions.append([
+                "action": "http",
+                "label": option.label,
+                "url": responseURL,
+                "method": "POST",
+                "body": "{\"requestId\":\"\(requestID)\",\"answer\":\"\(escapeJSON(option.label))\"}",
+            ])
+        }
+
+        let body: [String: Any] = [
+            "topic": config.topic,
+            "title": title,
+            "message": String(questionText.prefix(1000)),
+            "actions": actions,
+        ]
+
+        Task {
+            await postNotification(body: body)
+        }
+
+        pendingTask = Task { [weak self] in
+            await self?.listenForResponse(requestID: requestID, sessionID: sessionID)
+        }
+    }
+
+    func cancel() {
+        Self.logger.info("Cancelling pending ntfy listener, requestID=\(self.pendingRequestID ?? "nil")")
+        pendingTask?.cancel()
+        pendingTask = nil
+        pendingRequestID = nil
+    }
+
+    // MARK: - Private
+
+    private func postNotification(body: [String: Any]) async {
+        guard let url = URL(string: config.server) else {
+            Self.logger.error("postNotification: invalid server URL '\(self.config.server)'")
+            return
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            Self.logger.info("postNotification: HTTP \(statusCode) to \(url.absoluteString)")
+        } catch {
+            Self.logger.error("postNotification failed: \(error.localizedDescription)")
+        }
+    }
+
+    private nonisolated func listenForResponse(requestID: String, sessionID: String) async {
+        let config = await self.config
+        let streamURLString = "\(config.server)/\(config.responseTopic)/json?since=1s"
+        guard let streamURL = URL(string: streamURLString) else {
+            Self.logger.error("listenForResponse: invalid stream URL '\(streamURLString)'")
+            return
+        }
+
+        Self.logger.info("listenForResponse: starting stream at \(streamURLString), requestID=\(requestID), sessionID=\(sessionID)")
+
+        while !Task.isCancelled {
+            var request = URLRequest(url: streamURL)
+            request.timeoutInterval = .infinity
+
+            guard let (bytes, response) = try? await URLSession.shared.bytes(for: request) else {
+                Self.logger.error("listenForResponse: failed to open stream connection, retrying in 2s...")
+                try? await Task.sleep(for: .seconds(2))
+                continue
+            }
+
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            Self.logger.info("listenForResponse: stream connected, HTTP \(statusCode)")
+
+            if statusCode != 200 {
+                Self.logger.error("listenForResponse: unexpected status \(statusCode), retrying in 2s...")
+                try? await Task.sleep(for: .seconds(2))
+                continue
+            }
+
+            do {
+                for try await line in bytes.lines {
+                    guard !Task.isCancelled else {
+                        Self.logger.info("listenForResponse: task cancelled, stopping")
+                        return
+                    }
+
+                    let truncated = String(line.prefix(200))
+                    Self.logger.debug("listenForResponse: received line: \(truncated)")
+
+                    guard let data = line.data(using: .utf8) else {
+                        Self.logger.warning("listenForResponse: line not valid UTF-8")
+                        continue
+                    }
+
+                    guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                        Self.logger.debug("listenForResponse: line is not valid JSON object")
+                        continue
+                    }
+
+                    guard let messageStr = json["message"] as? String else {
+                        Self.logger.debug("listenForResponse: no 'message' field in event (type=\(json["event"] as? String ?? "unknown"))")
+                        continue
+                    }
+
+                    guard let messageData = messageStr.data(using: .utf8),
+                          let responsePayload = try? JSONSerialization.jsonObject(with: messageData) as? [String: Any] else {
+                        Self.logger.warning("listenForResponse: 'message' field is not valid JSON: \(String(messageStr.prefix(100)))")
+                        continue
+                    }
+
+                    guard let respRequestID = responsePayload["requestId"] as? String else {
+                        Self.logger.warning("listenForResponse: response has no 'requestId' field, keys=\(Array(responsePayload.keys))")
+                        continue
+                    }
+
+                    guard respRequestID == requestID else {
+                        Self.logger.info("listenForResponse: requestId mismatch, got=\(respRequestID), expected=\(requestID)")
+                        continue
+                    }
+
+                    Self.logger.info("listenForResponse: matched response! payload=\(String(messageStr.prefix(200)))")
+
+                    await MainActor.run { [responsePayload] in
+                        if let approved = responsePayload["approved"] as? Bool {
+                            Self.logger.info("listenForResponse: invoking onPermissionResponse(sessionID=\(sessionID), approved=\(approved)), callback set=\(self.onPermissionResponse != nil)")
+                            self.onPermissionResponse?(sessionID, approved)
+                        } else if let answer = responsePayload["answer"] as? String {
+                            Self.logger.info("listenForResponse: invoking onQuestionResponse(sessionID=\(sessionID), answer=\(answer)), callback set=\(self.onQuestionResponse != nil)")
+                            self.onQuestionResponse?(sessionID, answer)
+                        } else {
+                            Self.logger.warning("listenForResponse: matched requestId but no 'approved' or 'answer' field, keys=\(Array(responsePayload.keys))")
+                        }
+                        self.pendingRequestID = nil
+                        self.pendingTask = nil
+                    }
+                    return
+                }
+                Self.logger.info("listenForResponse: stream ended, reconnecting...")
+            } catch {
+                Self.logger.error("listenForResponse: stream error: \(error.localizedDescription), reconnecting...")
+            }
+
+            try? await Task.sleep(for: .seconds(1))
+        }
+    }
+
+    private func escapeJSON(_ string: String) -> String {
+        string
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+    }
+}

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -834,6 +834,13 @@ final class ProcessMonitoringCoordinator {
         if let terminalSessionID = jumpTarget.terminalSessionID?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !terminalSessionID.isEmpty {
+            // When inside tmux, multiple sessions may share the same
+            // terminalSessionID (e.g. KITTY_WINDOW_ID is per-OS-window,
+            // not per-pane). Prefer TTY for uniqueness in that case.
+            if jumpTarget.tmuxTarget != nil,
+               let terminalTTY = normalizedTTYForMatching(jumpTarget.terminalTTY) {
+                return "\(terminalApp.lowercased()):tty:\(terminalTTY.lowercased())"
+            }
             return "\(terminalApp.lowercased()):session:\(terminalSessionID.lowercased())"
         }
 

--- a/Sources/OpenIslandApp/TerminalJumpService.swift
+++ b/Sources/OpenIslandApp/TerminalJumpService.swift
@@ -59,6 +59,11 @@ struct TerminalJumpService {
             aliases: ["ghostty"]
         ),
         TerminalAppDescriptor(
+            displayName: "Kitty",
+            bundleIdentifier: "net.kovidgoyal.kitty",
+            aliases: ["kitty"]
+        ),
+        TerminalAppDescriptor(
             displayName: "Terminal",
             bundleIdentifier: "com.apple.Terminal",
             aliases: ["terminal", "apple_terminal"]
@@ -258,6 +263,10 @@ struct TerminalJumpService {
                     if try jumpToGhosttyTerminal(target) {
                         return "Focused the matching tmux pane in Ghostty."
                     }
+                case "net.kovidgoyal.kitty":
+                    if jumpToKittyWindow(target) {
+                        return "Focused the matching tmux pane in Kitty."
+                    }
                 case "com.googlecode.iterm2":
                     if try jumpToITermSession(target) {
                         return "Focused the matching tmux pane in iTerm."
@@ -349,6 +358,10 @@ struct TerminalJumpService {
             case "com.mitchellh.ghostty":
                 if try jumpToGhosttyTerminal(target) {
                     return "Focused the matching Ghostty terminal."
+                }
+            case "net.kovidgoyal.kitty":
+                if jumpToKittyWindow(target) {
+                    return "Focused the matching Kitty window."
                 }
             case "com.apple.Terminal":
                 if try jumpToTerminalTab(target) {
@@ -912,6 +925,68 @@ struct TerminalJumpService {
         end tell
         return ""
         """
+    }
+
+    // MARK: - Kitty CLI-based jump
+
+    private func resolveKittenPath() -> String? {
+        let candidates = [
+            "/Applications/kitty.app/Contents/MacOS/kitten",
+            NSHomeDirectory() + "/Applications/kitty.app/Contents/MacOS/kitten",
+            "/opt/homebrew/bin/kitten",
+            "/usr/local/bin/kitten",
+        ]
+        if let found = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) {
+            return found
+        }
+
+        let whichTask = Process()
+        whichTask.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        whichTask.arguments = ["kitten"]
+        let pipe = Pipe()
+        whichTask.standardOutput = pipe
+        whichTask.standardError = FileHandle.nullDevice
+        if let _ = try? whichTask.run() {
+            whichTask.waitUntilExit()
+            if whichTask.terminationStatus == 0 {
+                let path = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                if !path.isEmpty { return path }
+            }
+        }
+        return nil
+    }
+
+    private func runKittenCommand(kittenPath: String, args: [String]) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: kittenPath)
+        process.arguments = ["@"] + args
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0
+        } catch {
+            return false
+        }
+    }
+
+    private func jumpToKittyWindow(_ target: JumpTarget) -> Bool {
+        guard let kittenPath = resolveKittenPath() else {
+            try? openAction(["-b", "net.kovidgoyal.kitty"])
+            return true
+        }
+
+        if let windowID = target.terminalSessionID, !windowID.isEmpty {
+            _ = runKittenCommand(kittenPath: kittenPath, args: ["focus-window", "--match", "id:\(windowID)"])
+        } else if let cwd = target.workingDirectory, !cwd.isEmpty {
+            _ = runKittenCommand(kittenPath: kittenPath, args: ["focus-window", "--match", "cwd:\(cwd)"])
+        }
+
+        try? openAction(["-b", "net.kovidgoyal.kitty"])
+        return true
     }
 
     private func jumpToTerminalTab(_ target: JumpTarget) throws -> Bool {

--- a/Sources/OpenIslandApp/TerminalJumpTargetResolver.swift
+++ b/Sources/OpenIslandApp/TerminalJumpTargetResolver.swift
@@ -238,12 +238,16 @@ struct TerminalJumpTargetResolver {
         var assignments: [String: TmuxPaneSnapshot] = [:]
 
         for snapshot in snapshots {
-            // TTY match
-            if let session = sessions.first(where: {
+            // TTY match — assign to ALL sessions sharing this TTY (e.g. hook-managed
+            // session + synthetic discovery session in the same pane).
+            let ttyMatches = sessions.filter {
                 assignments[$0.id] == nil
                     && nonEmptyValue($0.jumpTarget?.terminalTTY) == snapshot.tty
-            }) {
-                assignments[session.id] = snapshot
+            }
+            if !ttyMatches.isEmpty {
+                for session in ttyMatches {
+                    assignments[session.id] = snapshot
+                }
                 continue
             }
 

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -11,6 +11,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     case sound
     case appearance
     case watch
+    case ntfy
     case shortcuts
     case lab
     case about
@@ -25,6 +26,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .display:    lang.t("settings.tab.display")
         case .sound:      lang.t("settings.tab.sound")
         case .watch:      "Watch"
+        case .ntfy:       "Ntfy"
         case .shortcuts:  lang.t("settings.tab.shortcuts")
         case .lab:        lang.t("settings.tab.lab")
         case .about:      lang.t("settings.tab.about")
@@ -39,6 +41,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .display:    "textformat.size"
         case .sound:      "speaker.wave.2.fill"
         case .watch:      "applewatch"
+        case .ntfy:       "bell.badge.fill"
         case .shortcuts:  "keyboard.fill"
         case .lab:        "flask.fill"
         case .about:      "info.circle.fill"
@@ -53,6 +56,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .display:    .blue
         case .sound:      .green
         case .watch:      .cyan
+        case .ntfy:       .orange
         case .shortcuts:  .gray
         case .lab:        .pink
         case .about:      .blue
@@ -61,7 +65,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
 
     var section: SettingsSection {
         switch self {
-        case .general, .setup, .display, .sound, .appearance, .watch: .system
+        case .general, .setup, .display, .sound, .appearance, .watch, .ntfy: .system
         case .shortcuts, .lab:                                        .advanced
         case .about:                                                  .app
         }
@@ -148,6 +152,8 @@ struct SettingsView: View {
                 SoundSettingsPane(model: model)
             case .watch:
                 WatchSettingsPane(model: model)
+            case .ntfy:
+                NtfySettingsPane(model: model)
             case .shortcuts:
                 PlaceholderSettingsPane(model: model, titleKey: "settings.tab.shortcuts", subtitleKey: "settings.shortcuts.comingSoon")
             case .lab:
@@ -1037,6 +1043,120 @@ struct WatchSettingsPane: View {
         .onAppear {
             pairingCode = model.watchPairingCode
         }
+    }
+}
+
+// MARK: - Ntfy
+
+struct NtfySettingsPane: View {
+    var model: AppModel
+
+    @State private var server: String = UserDefaults.standard.string(forKey: "ntfy.server") ?? "https://ntfy.sh"
+    @State private var topic: String = UserDefaults.standard.string(forKey: "ntfy.topic") ?? ""
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Enable ntfy notifications when away", isOn: Binding(
+                    get: { model.ntfyEnabled },
+                    set: { model.ntfyEnabled = $0 }
+                ))
+
+                if model.ntfyEnabled {
+                    Text("When you're away from the computer for 60+ seconds, permission requests and questions will be sent to your phone via ntfy.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    Toggle("Always notify (skip idle check)", isOn: Binding(
+                        get: { model.ntfyAlwaysNotify },
+                        set: { model.ntfyAlwaysNotify = $0 }
+                    ))
+
+                    Text("Send notifications immediately regardless of idle state. Useful for testing.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } header: {
+                Text("General")
+            }
+
+            Section("Configuration") {
+                TextField("Server", text: $server)
+                    .onSubmit { saveConfig() }
+                    .onChange(of: server) { _, _ in saveConfig() }
+
+                TextField("Topic", text: $topic)
+                    .onSubmit { saveConfig() }
+                    .onChange(of: topic) { _, _ in saveConfig() }
+
+                Text("Subscribe to this topic in the ntfy app on your phone to receive notifications.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if model.ntfyEnabled {
+                Section("Status") {
+                    TimelineView(.periodic(from: .now, by: 1)) { _ in
+                        let seconds = Int(model.currentIdleSeconds)
+                        let away = model.isUserAway
+                        HStack {
+                            Text("State")
+                            Spacer()
+                            Text(away ? "Away" : "Active")
+                                .foregroundStyle(away ? .orange : .green)
+                        }
+                        HStack {
+                            Text("Idle Duration")
+                            Spacer()
+                            Text(formattedIdleDuration(seconds))
+                                .monospacedDigit()
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+
+            Section("Test") {
+                Button("Send Test Notification") {
+                    sendTestNotification()
+                }
+                .disabled(server.isEmpty || topic.isEmpty)
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle("Ntfy")
+    }
+
+    private func saveConfig() {
+        UserDefaults.standard.set(server, forKey: "ntfy.server")
+        UserDefaults.standard.set(topic, forKey: "ntfy.topic")
+    }
+
+    private func formattedIdleDuration(_ totalSeconds: Int) -> String {
+        let m = totalSeconds / 60
+        let s = totalSeconds % 60
+        if m > 0 {
+            return "\(m)m \(s)s"
+        }
+        return "\(s)s"
+    }
+
+    private func sendTestNotification() {
+        let body: [String: Any] = [
+            "topic": topic,
+            "title": "Open Island: Test",
+            "message": "If you see this, ntfy is configured correctly!",
+        ]
+
+        guard let url = URL(string: server),
+              let jsonData = try? JSONSerialization.data(withJSONObject: body) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = jsonData
+
+        URLSession.shared.dataTask(with: request).resume()
     }
 }
 

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -560,9 +560,12 @@ public final class BridgeServer: @unchecked Sendable {
         // Subagent processes fire their own hooks with agentID set.
         // The parent session already receives SubagentStart/SubagentStop events,
         // so we suppress subagent hooks to avoid creating duplicate sessions.
+        // permissionRequest must pass through — it's interactive and the subagent
+        // is blocked until the user responds.
         if payload.agentID != nil,
            payload.hookEventName != .subagentStart,
-           payload.hookEventName != .subagentStop {
+           payload.hookEventName != .subagentStop,
+           payload.hookEventName != .permissionRequest {
             send(.response(.acknowledged), to: clientID)
             return
         }

--- a/Sources/OpenIslandCore/ClaudeHooks.swift
+++ b/Sources/OpenIslandCore/ClaudeHooks.swift
@@ -988,6 +988,13 @@ public extension ClaudeHookPayload {
             payload.warpPaneUUID = warpPaneResolver(payload.cwd)
         }
 
+        // For Kitty, use KITTY_WINDOW_ID as the terminal session identifier.
+        if payload.terminalApp == "Kitty" {
+            if payload.terminalSessionID == nil {
+                payload.terminalSessionID = environment["KITTY_WINDOW_ID"]
+            }
+        }
+
         // For cmux, use CMUX_SURFACE_ID as the terminal session identifier.
         if payload.terminalApp == "cmux" {
             if payload.terminalSessionID == nil {
@@ -1051,7 +1058,7 @@ public extension ClaudeHookPayload {
     }
 
     private static let noLocatorTerminalApps: Set<String> = [
-        "cmux", "kaku", "wezterm", "zellij",
+        "cmux", "kaku", "kitty", "wezterm", "zellij",
         "vs code", "vs code insiders", "cursor", "windsurf", "trae",
         "intellij idea", "webstorm", "pycharm", "goland", "clion",
         "rubymine", "phpstorm", "rider", "rustrover",
@@ -1190,6 +1197,8 @@ public extension ClaudeHookPayload {
                 return "Warp"
             case let value where value.contains("ghostty"):
                 return "Ghostty"
+            case "kitty":
+                return "Kitty"
             case "kaku":
                 return "Kaku"
             case "wezterm":
@@ -1226,6 +1235,9 @@ public extension ClaudeHookPayload {
         }
         if environment["GHOSTTY_RESOURCES_DIR"] != nil {
             return "Ghostty"
+        }
+        if environment["KITTY_WINDOW_ID"] != nil {
+            return "Kitty"
         }
 
         // JetBrains IDEs set TERMINAL_EMULATOR=JetBrains-JediTerm.

--- a/Sources/OpenIslandCore/ClaudeHooks.swift
+++ b/Sources/OpenIslandCore/ClaudeHooks.swift
@@ -898,16 +898,18 @@ public extension ClaudeHookPayload {
     }
 
     var permissionRequestTitle: String {
+        let base: String
         switch toolName {
         case "ExitPlanMode":
-            return "Exit plan mode"
+            base = "Exit plan mode"
         case "AskUserQuestion":
-            return "Answer Claude's questions"
+            base = "Answer Claude's questions"
         case let toolName?:
-            return "Allow \(toolName)"
+            base = "Allow \(toolName)"
         case nil:
-            return "Allow Claude tool"
+            base = "Allow Claude tool"
         }
+        return agentID != nil ? "\(base) (subagent)" : base
     }
 
     var permissionRequestSummary: String {


### PR DESCRIPTION
## Summary
- The subagent hook filter in `BridgeServer` silently dropped `permissionRequest` events from subagent processes (any hook with `agentID != nil`), leaving subagents permanently blocked waiting for a user response that never came.
- Added `.permissionRequest` to the filter's exception list so these interactive events pass through to the UI.
- Permission cards from subagents now show "(subagent)" suffix in the title for visual distinction.

## Test plan
- [x] `swift build` passes
- [x] `swift test` — no new failures (5 pre-existing failures on `main` confirmed unrelated)
- [ ] Manual: launch dev app, start a Claude Code session that spawns a subagent requiring permission (e.g., subagent runs Bash), verify permission card appears
- [ ] Verify "(subagent)" label visible on card
- [ ] Approve permission, confirm subagent resumes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Kitty terminal support: now recognizes and enables jumping to Kitty windows
  * Away-detection feature: monitors user idle time and sends remote notifications via Ntfy server when you're away
  * New "Ntfy" settings tab: configure remote notification server/topic, enable away-notifications, and send test notifications

* **Improvements**
  * Enhanced terminal session matching for better accuracy with multiple tmux sessions
  * Improved terminal identification logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Octane0411/open-vibe-island/pull/503?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->