### PR TITLE
Fix Codex Desktop session discovery with current app-server protocol

### DIFF
--- a/Sources/OpenIslandApp/CodexAppServerCoordinator.swift
+++ b/Sources/OpenIslandApp/CodexAppServerCoordinator.swift
@@ -95,7 +95,10 @@ final class CodexAppServerCoordinator {
     private func syncLoadedThreads() async {
         guard let client else { return }
         do {
-            let threads = try await client.listLoadedThreads()
+            var threads = try await client.listLoadedThreads()
+            if threads.isEmpty {
+                threads = try await client.listThreads(limit: 20)
+            }
             var created = 0
             for thread in threads where !thread.ephemeral {
                 // Skip threads already tracked — re-emitting sessionStarted

--- a/Sources/OpenIslandCore/CodexAppServer.swift
+++ b/Sources/OpenIslandCore/CodexAppServer.swift
@@ -50,7 +50,11 @@ public enum CodexThreadSource: String, Codable, Sendable {
     case unknown
 
     public init(from decoder: Decoder) throws {
-        let value = try decoder.singleValueContainer().decode(String.self)
+        let container = try decoder.singleValueContainer()
+        guard let value = try? container.decode(String.self) else {
+            self = .unknown
+            return
+        }
         self = CodexThreadSource(rawValue: value) ?? .unknown
     }
 }
@@ -182,19 +186,50 @@ public final class CodexAppServerClient: @unchecked Sendable {
     /// List currently loaded threads from the app-server.
     public func listLoadedThreads() async throws -> [CodexThread] {
         struct Params: Encodable {}
-        struct Result: Decodable { let threads: [CodexThread] }
+        struct Result: Decodable {
+            let threads: [CodexThread]?
+            let data: [String]?
+        }
         let data = try await sendRequest(method: "thread/loaded/list", params: Params())
         let result = try JSONDecoder().decode(Result.self, from: data)
-        return result.threads
+        if let threads = result.threads {
+            return threads
+        }
+
+        var threads: [CodexThread] = []
+        for threadID in result.data ?? [] {
+            if let thread = try? await readThread(threadID: threadID) {
+                threads.append(thread)
+            }
+        }
+        return threads
     }
 
     /// List all threads (including not-loaded) from the app-server.
     public func listThreads(limit: Int? = nil) async throws -> [CodexThread] {
         struct Params: Encodable { let limit: Int? }
-        struct Result: Decodable { let threads: [CodexThread] }
+        struct Result: Decodable {
+            let threads: [CodexThread]?
+            let data: [CodexThread]?
+        }
         let data = try await sendRequest(method: "thread/list", params: Params(limit: limit))
         let result = try JSONDecoder().decode(Result.self, from: data)
-        return result.threads
+        return result.threads ?? result.data ?? []
+    }
+
+    /// Read a single thread by id from the app-server.
+    public func readThread(threadID: String) async throws -> CodexThread {
+        struct Params: Encodable {
+            let threadId: String
+            let includeTurns: Bool
+        }
+        struct Result: Decodable { let thread: CodexThread }
+        let data = try await sendRequest(
+            method: "thread/read",
+            params: Params(threadId: threadID, includeTurns: false)
+        )
+        let result = try JSONDecoder().decode(Result.self, from: data)
+        return result.thread
     }
 
     // MARK: - JSON-RPC transport

--- a/Sources/OpenIslandCore/CodexSessionTracking.swift
+++ b/Sources/OpenIslandCore/CodexSessionTracking.swift
@@ -229,6 +229,7 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
         var sessionID: String
         var cwd: String
         var timestamp: Date?
+        var isCodexDesktopApp: Bool
 
         var workspaceName: String {
             let workspace = URL(fileURLWithPath: cwd).lastPathComponent
@@ -389,6 +390,13 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             currentTool: snapshot.currentTool,
             currentCommandPreview: snapshot.currentCommandPreview
         )
+        let jumpTarget = sessionMeta.isCodexDesktopApp ? JumpTarget(
+            terminalApp: "Codex.app",
+            workspaceName: sessionMeta.workspaceName,
+            paneTitle: sessionMeta.sessionTitle,
+            workingDirectory: sessionMeta.cwd,
+            codexThreadID: sessionMeta.sessionID
+        ) : nil
 
         return CodexTrackedSessionRecord(
             sessionID: sessionMeta.sessionID,
@@ -398,6 +406,7 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             summary: summary,
             phase: snapshot.phase,
             updatedAt: updatedAt,
+            jumpTarget: jumpTarget,
             codexMetadata: metadata
         )
     }
@@ -423,7 +432,8 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             cwd: cwd,
             timestamp: codexRolloutParseTimestamp(
                 (payload["timestamp"] as? String) ?? (object["timestamp"] as? String)
-            )
+            ),
+            isCodexDesktopApp: (payload["originator"] as? String) == "Codex Desktop"
         )
     }
 

--- a/Tests/OpenIslandCoreTests/CodexAppServerDecodingTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexAppServerDecodingTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+struct CodexAppServerDecodingTests {
+    @Test
+    func codexThreadDecodesObjectSourceAsUnknown() throws {
+        let json = Data(
+            """
+            {
+              "id": "019e6cb5-46dc-7e11-ad95-e1df0de7cdb7",
+              "cwd": "/Users/pojue/Documents/Codex",
+              "name": "Investigate Open Island",
+              "preview": "Looking at Codex app-server output.",
+              "modelProvider": "openai",
+              "createdAt": 1779940000000,
+              "updatedAt": 1779940300000,
+              "ephemeral": false,
+              "path": "/Users/pojue/.codex/sessions/2026/05/28/rollout.jsonl",
+              "status": {
+                "type": "notLoaded"
+              },
+              "source": {
+                "kind": "subagent",
+                "parentThreadId": "019e6cb5-46dc-7e11-ad95-e1df0de7cdb7"
+              },
+              "turns": []
+            }
+            """.utf8
+        )
+
+        let thread = try JSONDecoder().decode(CodexThread.self, from: json)
+
+        #expect(thread.source == .unknown)
+    }
+}

--- a/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
@@ -1093,6 +1093,56 @@ struct CodexSessionTrackingTests {
     }
 
     @Test
+    func codexRolloutDiscoveryMarksCodexDesktopSessionsWithAppJumpTarget() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-discovery-codex-app-\(UUID().uuidString)", isDirectory: true)
+        let rolloutDirectoryURL = rootURL.appendingPathComponent("2026/05/28", isDirectory: true)
+        let rolloutURL = rolloutDirectoryURL.appendingPathComponent("rollout-codex-app.jsonl")
+        let now = Date(timeIntervalSince1970: 1_779_940_000)
+
+        try FileManager.default.createDirectory(at: rolloutDirectoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let cwd = "/Users/pojue/Documents/Codex/2026-05-28/hatch-pet-users-pojue-codex-skills"
+        let lines = [
+            sessionMetaLine(
+                sessionID: "019e6cb5-46dc-7e11-ad95-e1df0de7cdb7",
+                timestamp: "2026-05-28T03:51:20.275Z",
+                cwd: cwd,
+                originator: "Codex Desktop",
+                source: "vscode"
+            ),
+            rolloutLine(
+                timestamp: "2026-05-28T03:51:22.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "turn_complete",
+                    "last_agent_message": "Turn completed.",
+                ]
+            ),
+        ]
+        try lines.joined(separator: "\n").appending("\n").write(to: rolloutURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.modificationDate: now], ofItemAtPath: rolloutURL.path)
+
+        let discovery = CodexRolloutDiscovery(
+            rootURL: rootURL,
+            fileManager: .default,
+            maxAge: 86_400,
+            maxFiles: 10
+        )
+
+        let records = discovery.discoverRecentSessions(now: now)
+        let record = records.first
+        let session = record?.session
+
+        #expect(records.count == 1)
+        #expect(record?.jumpTarget?.terminalApp == "Codex.app")
+        #expect(record?.jumpTarget?.workingDirectory == cwd)
+        #expect(record?.jumpTarget?.codexThreadID == "019e6cb5-46dc-7e11-ad95-e1df0de7cdb7")
+        #expect(session?.isCodexAppSession == true)
+    }
+
+    @Test
     func codexRolloutDiscoveryHandlesTrailingLineWithoutNewline() throws {
         // A rollout written by Codex while the process is mid-flush
         // can land on disk without a trailing newline. The streamed
@@ -1185,7 +1235,9 @@ private func rolloutLine(
 private func sessionMetaLine(
     sessionID: String,
     timestamp: String,
-    cwd: String
+    cwd: String,
+    originator: String = "codex-tui",
+    source: String = "cli"
 ) -> String {
     rolloutLine(
         timestamp: timestamp,
@@ -1194,8 +1246,8 @@ private func sessionMetaLine(
             "id": sessionID,
             "timestamp": timestamp,
             "cwd": cwd,
-            "originator": "codex-tui",
-            "source": "cli",
+            "originator": originator,
+            "source": source,
         ]
     )
 }


### PR DESCRIPTION
## Summary

Fixes Codex Desktop sessions not appearing in Open Island.

Current Codex app-server responses use `data` for `thread/loaded/list` and `thread/list`, while Open Island expected `threads`. Also, rollout-discovered Codex Desktop sessions were not classified as `Codex.app` sessions, so they could be treated as stale CLI sessions and disappear even while Codex Desktop is running.

## Changes

- Decode both legacy `threads` and current `data` app-server responses.
- Fall back from empty `thread/loaded/list` to `thread/list`.
- Add `thread/read` support for loaded thread IDs.
- Tolerate non-string Codex thread `source` values.
- Mark Codex Desktop rollout sessions with a `Codex.app` jump target and `codexThreadID`.
- Add regression tests.

## Verification

- `swift build`
- Codex-related core tests: 24 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread discovery with automatic fallback mechanism when initial load is unavailable.
  * Enhanced compatibility with multiple API response formats for thread operations.
  * Strengthened error handling and data parsing resilience.

* **Tests**
  * Added comprehensive tests for thread data decoding scenarios.
  * Added tests for Codex Desktop session recognition and configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Octane0411/open-vibe-island/pull/513?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->