### PR TITLE
Fix Codex permission request hooks

### DIFF
--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -13,6 +13,7 @@ public final class BridgeServer: @unchecked Sendable {
 
     private struct PendingApproval {
         let clientID: UUID
+        let hookEventName: CodexHookEventName
     }
 
     private struct PendingClaudeToolContext {
@@ -490,22 +491,22 @@ public final class BridgeServer: @unchecked Sendable {
             )
             send(.response(.acknowledged), to: clientID)
 
-        case .preToolUse:
+        case .preToolUse, .permissionRequest:
             ensureSessionExists(for: payload)
             synchronizeJumpTarget(for: payload)
             synchronizeCodexMetadata(for: payload)
-
-            let command = payload.commandPreview ?? "Bash command"
 
             let approvalEvent = AgentEvent.permissionRequested(
                 PermissionRequested(
                     sessionID: payload.sessionID,
                     request: PermissionRequest(
-                        title: "Run Bash command",
-                        summary: "Codex wants to run a shell command.",
-                        affectedPath: payload.commandText ?? command,
+                        title: payload.permissionRequestTitle,
+                        summary: payload.permissionRequestSummary,
+                        affectedPath: payload.permissionAffectedPath,
                         primaryActionTitle: "Allow",
-                        secondaryActionTitle: "Deny"
+                        secondaryActionTitle: "Deny",
+                        toolName: payload.toolName,
+                        toolUseID: payload.toolUseID
                     ),
                     timestamp: .now
                 )
@@ -514,7 +515,8 @@ public final class BridgeServer: @unchecked Sendable {
             emit(approvalEvent)
 
             pendingApprovals[payload.sessionID] = PendingApproval(
-                clientID: clientID
+                clientID: clientID,
+                hookEventName: payload.hookEventName
             )
 
         case .postToolUse:
@@ -1986,7 +1988,7 @@ public final class BridgeServer: @unchecked Sendable {
         switch hookEventName {
         case .userPromptSubmit, .postToolUse, .stop:
             return nil
-        case .sessionStart, .preToolUse:
+        case .sessionStart, .preToolUse, .permissionRequest:
             return existing
         }
     }
@@ -2298,7 +2300,7 @@ public final class BridgeServer: @unchecked Sendable {
         switch hookEventName {
         case .userPromptSubmit, .postToolUse, .stop:
             return nil
-        case .sessionStart, .preToolUse:
+        case .sessionStart, .preToolUse, .permissionRequest:
             return existing
         }
     }
@@ -2309,9 +2311,14 @@ public final class BridgeServer: @unchecked Sendable {
         }
 
         let response: BridgeResponse
-        if approved {
+        switch (pendingApproval.hookEventName, approved) {
+        case (.permissionRequest, true):
+            response = .codexHookDirective(.permissionRequest(.allow))
+        case (.permissionRequest, false):
+            response = .codexHookDirective(.permissionRequest(.deny(message: "Permission denied in Open Island.")))
+        case (_, true):
             response = .acknowledged
-        } else {
+        case (_, false):
             response = .codexHookDirective(.deny(reason: "Permission denied in Open Island."))
         }
 

--- a/Sources/OpenIslandCore/CodexHookInstaller.swift
+++ b/Sources/OpenIslandCore/CodexHookInstaller.swift
@@ -73,16 +73,17 @@ public enum CodexHookInstaller {
     public static let managedStatusMessage = "Managed by Open Island"
     public static let legacyManagedStatusMessage = "Managed by Vibe Island"
     public static let managedTimeout = 45
+    public static let managedPermissionTimeout = 86_400
     private static let currentFeatureKey = CodexHooksFeatureFlagKey.current.rawValue
     private static let legacyFeatureKey = CodexHooksFeatureFlagKey.legacy.rawValue
 
-    // Keep the managed Codex install aligned with the original app's low-noise footprint.
-    // The bridge still understands richer hook events, but we do not install them by default
-    // because per-command Bash hooks produce a large amount of terminal log spam.
-    private static let eventSpecs: [(name: String, matcher: String?)] = [
-        ("SessionStart", "startup|resume"),
-        ("UserPromptSubmit", nil),
-        ("Stop", nil),
+    // Keep the managed Codex install low-noise. PermissionRequest is installed
+    // because it only fires when Codex is already waiting on user approval.
+    private static let eventSpecs: [(name: String, matcher: String?, timeout: Int)] = [
+        ("SessionStart", "startup|resume", managedTimeout),
+        ("UserPromptSubmit", nil, managedTimeout),
+        ("PermissionRequest", nil, managedPermissionTimeout),
+        ("Stop", nil, managedTimeout),
     ]
 
     public static func hookCommand(for binaryPath: String) -> String {
@@ -109,7 +110,13 @@ public enum CodexHookInstaller {
         for spec in eventSpecs {
             let existingGroups = hooksObject[spec.name] as? [Any] ?? []
             let cleanedGroups = sanitizeForInstall(groups: existingGroups, replacingCommand: hookCommand)
-            hooksObject[spec.name] = cleanedGroups + [managedGroup(matcher: spec.matcher, hookCommand: hookCommand)]
+            hooksObject[spec.name] = cleanedGroups + [
+                managedGroup(
+                    matcher: spec.matcher,
+                    timeout: spec.timeout,
+                    hookCommand: hookCommand
+                )
+            ]
         }
 
         rootObject["hooks"] = hooksObject
@@ -357,12 +364,12 @@ public enum CodexHookInstaller {
         }
     }
 
-    private static func managedGroup(matcher: String?, hookCommand: String) -> [String: Any] {
+    private static func managedGroup(matcher: String?, timeout: Int, hookCommand: String) -> [String: Any] {
         var group: [String: Any] = [
             "hooks": [[
                 "type": "command",
                 "command": hookCommand,
-                "timeout": managedTimeout,
+                "timeout": timeout,
             ]]
         ]
 

--- a/Sources/OpenIslandCore/CodexHooks.swift
+++ b/Sources/OpenIslandCore/CodexHooks.swift
@@ -4,6 +4,7 @@ public enum CodexHookEventName: String, Codable, Sendable {
     case sessionStart = "SessionStart"
     case preToolUse = "PreToolUse"
     case postToolUse = "PostToolUse"
+    case permissionRequest = "PermissionRequest"
     case userPromptSubmit = "UserPromptSubmit"
     case stop = "Stop"
 }
@@ -19,10 +20,37 @@ public enum CodexPermissionMode: String, Codable, Sendable {
 
 
 public struct CodexHookToolInput: Equatable, Codable, Sendable {
-    public var command: String
+    public var command: String?
+    public var rawValue: CodexHookJSONValue
 
     public init(command: String) {
         self.command = command
+        rawValue = .object(["command": .string(command)])
+    }
+
+    public init(rawValue: CodexHookJSONValue) {
+        self.rawValue = rawValue
+        command = Self.command(from: rawValue)
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let rawValue = try CodexHookJSONValue(from: decoder)
+        self.rawValue = rawValue
+        command = Self.command(from: rawValue)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        try rawValue.encode(to: encoder)
+    }
+
+    private static func command(from value: CodexHookJSONValue) -> String? {
+        guard case let .object(object) = value,
+              case let .string(command) = object["command"],
+              !command.isEmpty else {
+            return nil
+        }
+
+        return command
     }
 }
 
@@ -191,16 +219,58 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
     }
 }
 
+public enum CodexPermissionRequestDecision: Equatable, Codable, Sendable {
+    case allow
+    case deny(message: String? = nil)
+
+    private enum CodingKeys: String, CodingKey {
+        case behavior
+        case message
+    }
+
+    private enum Behavior: String, Codable {
+        case allow
+        case deny
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let behavior = try container.decode(Behavior.self, forKey: .behavior)
+
+        switch behavior {
+        case .allow:
+            self = .allow
+        case .deny:
+            self = .deny(message: try container.decodeIfPresent(String.self, forKey: .message))
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        switch self {
+        case .allow:
+            try container.encode(Behavior.allow, forKey: .behavior)
+        case let .deny(message):
+            try container.encode(Behavior.deny, forKey: .behavior)
+            try container.encodeIfPresent(message, forKey: .message)
+        }
+    }
+}
+
 public enum CodexHookDirective: Equatable, Codable, Sendable {
     case deny(reason: String)
+    case permissionRequest(CodexPermissionRequestDecision)
 
     private enum CodingKeys: String, CodingKey {
         case type
         case reason
+        case directive
     }
 
     private enum DirectiveType: String, Codable {
         case deny
+        case permissionRequest
     }
 
     public init(from decoder: any Decoder) throws {
@@ -210,6 +280,8 @@ public enum CodexHookDirective: Equatable, Codable, Sendable {
         switch type {
         case .deny:
             self = .deny(reason: try container.decode(String.self, forKey: .reason))
+        case .permissionRequest:
+            self = .permissionRequest(try container.decode(CodexPermissionRequestDecision.self, forKey: .directive))
         }
     }
 
@@ -220,6 +292,9 @@ public enum CodexHookDirective: Equatable, Codable, Sendable {
         case let .deny(reason):
             try container.encode(DirectiveType.deny, forKey: .type)
             try container.encode(reason, forKey: .reason)
+        case let .permissionRequest(decision):
+            try container.encode(DirectiveType.permissionRequest, forKey: .type)
+            try container.encode(decision, forKey: .directive)
         }
     }
 }
@@ -228,6 +303,15 @@ public enum CodexHookOutputEncoder {
     private struct LegacyBlockOutput: Codable {
         var decision = "block"
         var reason: String
+    }
+
+    private struct PermissionRequestOutput: Encodable {
+        struct HookSpecificOutput: Encodable {
+            var hookEventName = CodexHookEventName.permissionRequest.rawValue
+            var decision: CodexPermissionRequestDecision
+        }
+
+        var hookSpecificOutput: HookSpecificOutput
     }
 
     public static func standardOutput(for response: BridgeResponse) throws -> Data? {
@@ -243,6 +327,12 @@ public enum CodexHookOutputEncoder {
             switch directive {
             case let .deny(reason):
                 data = try encoder.encode(LegacyBlockOutput(reason: reason))
+            case let .permissionRequest(decision):
+                data = try encoder.encode(
+                    PermissionRequestOutput(
+                        hookSpecificOutput: PermissionRequestOutput.HookSpecificOutput(decision: decision)
+                    )
+                )
             }
 
             var line = data
@@ -309,6 +399,8 @@ public extension CodexHookPayload {
             return "Codex is preparing a Bash command in \(workspaceName)."
         case .postToolUse:
             return "Codex reported a Bash result in \(workspaceName)."
+        case .permissionRequest:
+            return "Codex is requesting permission in \(workspaceName)."
         case .userPromptSubmit:
             return "Codex received a new prompt in \(workspaceName)."
         case .stop:
@@ -322,6 +414,43 @@ public extension CodexHookPayload {
 
     var commandPreview: String? {
         clipped(commandText)
+    }
+
+    var toolInputPreview: String? {
+        guard let toolInput else {
+            return nil
+        }
+
+        return clipped(stringValue(for: toolInput.rawValue))
+    }
+
+    var permissionRequestTitle: String {
+        if toolName == "Bash" {
+            return "Run Bash command"
+        }
+
+        return toolName.map { "Allow \($0)" } ?? "Allow Codex action"
+    }
+
+    var permissionRequestSummary: String {
+        if toolName == "Bash" {
+            return "Codex wants to run a shell command."
+        }
+
+        return "Codex needs permission to continue."
+    }
+
+    var permissionAffectedPath: String {
+        commandText ?? toolInputPreview ?? cwd
+    }
+
+    var bridgeResponseTimeout: TimeInterval {
+        switch hookEventName {
+        case .permissionRequest:
+            return TimeInterval(CodexHookInstaller.managedPermissionTimeout)
+        case .sessionStart, .preToolUse, .postToolUse, .userPromptSubmit, .stop:
+            return TimeInterval(CodexHookInstaller.managedTimeout)
+        }
     }
 
     var promptPreview: String? {

--- a/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
+++ b/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
@@ -52,7 +52,10 @@ struct OpenIslandHooksCLI {
                     .decode(CodexHookPayload.self, from: input)
                     .withRuntimeContext(environment: ProcessInfo.processInfo.environment)
 
-                guard let response = try? client.send(.processCodexHook(payload)) else {
+                guard let response = try? client.send(
+                    .processCodexHook(payload),
+                    timeout: payload.bridgeResponseTimeout
+                ) else {
                     logStderr("bridge unavailable for codex hook")
                     return
                 }

--- a/Tests/OpenIslandCoreTests/CodexHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexHooksTests.swift
@@ -4,6 +4,74 @@ import Testing
 
 struct CodexHooksTests {
     @Test
+    func codexPermissionRequestPayloadDecodesArbitraryToolInput() throws {
+        let data = """
+        {
+          "cwd": "/tmp/worktree",
+          "hook_event_name": "PermissionRequest",
+          "model": "gpt-5-codex",
+          "permission_mode": "default",
+          "session_id": "codex-permission-1",
+          "turn_id": "turn-1",
+          "tool_name": "mcp__filesystem__write_file",
+          "tool_input": {
+            "path": "/tmp/worktree/Sources/App.swift",
+            "reason": "write change"
+          }
+        }
+        """.data(using: .utf8)!
+
+        let payload = try JSONDecoder().decode(CodexHookPayload.self, from: data)
+
+        #expect(payload.hookEventName.rawValue == "PermissionRequest")
+        #expect(payload.toolName == "mcp__filesystem__write_file")
+        #expect(payload.toolInput?.command == nil)
+    }
+
+    @Test
+    func codexPermissionRequestUsesInteractiveBridgeTimeout() {
+        let payload = CodexHookPayload(
+            cwd: "/tmp/demo",
+            hookEventName: .permissionRequest,
+            model: "gpt-5-codex",
+            permissionMode: .default,
+            sessionID: "s1",
+            transcriptPath: nil
+        )
+
+        #expect(payload.bridgeResponseTimeout == 86_400)
+    }
+
+    @Test
+    func codexPermissionRequestOutputEncoderEmitsAllowDecision() throws {
+        let maybeOutput = try CodexHookOutputEncoder.standardOutput(
+            for: .codexHookDirective(.permissionRequest(.allow))
+        )
+        let output = try #require(maybeOutput)
+        let object = try JSONSerialization.jsonObject(with: output) as? [String: Any]
+        let hookSpecificOutput = object?["hookSpecificOutput"] as? [String: Any]
+        let decision = hookSpecificOutput?["decision"] as? [String: Any]
+
+        #expect(hookSpecificOutput?["hookEventName"] as? String == "PermissionRequest")
+        #expect(decision?["behavior"] as? String == "allow")
+    }
+
+    @Test
+    func codexPermissionRequestOutputEncoderEmitsDenyDecision() throws {
+        let maybeOutput = try CodexHookOutputEncoder.standardOutput(
+            for: .codexHookDirective(.permissionRequest(.deny(message: "Blocked")))
+        )
+        let output = try #require(maybeOutput)
+        let object = try JSONSerialization.jsonObject(with: output) as? [String: Any]
+        let hookSpecificOutput = object?["hookSpecificOutput"] as? [String: Any]
+        let decision = hookSpecificOutput?["decision"] as? [String: Any]
+
+        #expect(hookSpecificOutput?["hookEventName"] as? String == "PermissionRequest")
+        #expect(decision?["behavior"] as? String == "deny")
+        #expect(decision?["message"] as? String == "Blocked")
+    }
+
+    @Test
     func codexDefaultJumpTargetForwardsWarpPaneUUID() {
         var payload = CodexHookPayload(
             cwd: "/tmp/demo",

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -568,6 +568,101 @@ struct SessionStateTests {
     }
 
     @Test
+    func codexPermissionRequestWaitsForApprovalAndSurfacesToolInput() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let data = """
+        {
+          "cwd": "/tmp/worktree",
+          "hook_event_name": "PermissionRequest",
+          "model": "gpt-5-codex",
+          "permission_mode": "default",
+          "session_id": "codex-permission-1",
+          "turn_id": "turn-1",
+          "tool_name": "mcp__filesystem__write_file",
+          "tool_input": {
+            "path": "/tmp/worktree/Sources/App.swift",
+            "reason": "write change"
+          }
+        }
+        """.data(using: .utf8)!
+        let payload = try JSONDecoder().decode(CodexHookPayload.self, from: data)
+
+        async let responseTask = sendOnGCDThread(.processCodexHook(payload), socketURL: socketURL)
+
+        var iterator = stream.makeAsyncIterator()
+        let startedEvent = try await nextEvent(from: &iterator)
+        let permissionEvent = try await nextEvent(from: &iterator)
+
+        #expect(startedEvent.isSessionStarted)
+        if case let .permissionRequested(payload) = permissionEvent {
+            #expect(payload.request.title == "Allow mcp__filesystem__write_file")
+            #expect(payload.request.summary == "Codex needs permission to continue.")
+            #expect(payload.request.affectedPath == "{path: /tmp/worktree/Sources/App.swift, reason: write change}")
+            #expect(payload.request.toolName == "mcp__filesystem__write_file")
+        } else {
+            Issue.record("Expected a Codex permission request event")
+        }
+
+        try await observer.send(.resolvePermission(sessionID: "codex-permission-1", resolution: .allowOnce()))
+
+        let activityEvent = try await nextEvent(from: &iterator)
+        let response = try await responseTask
+
+        #expect(activityEvent.activityUpdate?.summary == "Permission approved. Codex continued the command.")
+        #expect(response == .codexHookDirective(.permissionRequest(.allow)))
+    }
+
+    @Test
+    func codexPermissionRequestReturnsDenyDirectiveAfterDenial() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let payload = CodexHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .permissionRequest,
+            model: "gpt-5-codex",
+            permissionMode: .default,
+            sessionID: "codex-permission-deny",
+            transcriptPath: nil,
+            turnID: "turn-1",
+            toolName: "Bash",
+            toolUseID: "tool-use-1",
+            toolInput: CodexHookToolInput(command: "sudo make install")
+        )
+
+        async let responseTask = sendOnGCDThread(.processCodexHook(payload), socketURL: socketURL)
+
+        var iterator = stream.makeAsyncIterator()
+        _ = try await nextEvent(from: &iterator)
+        let permissionEvent = try await nextEvent(from: &iterator)
+        #expect(permissionEvent.isPermissionRequested)
+
+        try await observer.send(.resolvePermission(sessionID: "codex-permission-deny", resolution: .deny()))
+
+        let completedEvent = try await nextEvent(from: &iterator)
+        let response = try await responseTask
+
+        #expect(completedEvent.sessionCompleted?.summary == "Permission denied in Open Island.")
+        #expect(response == .codexHookDirective(.permissionRequest(.deny(message: "Permission denied in Open Island."))))
+    }
+
+    @Test
     func codexHookUpdatesJumpTargetWhenLaterHooksLearnMoreAboutTheTerminal() async throws {
         let socketURL = BridgeSocketLocation.uniqueTestURL()
         let server = BridgeServer(socketURL: socketURL)
@@ -759,7 +854,14 @@ struct SessionStateTests {
         #expect(managedStopHook?["statusMessage"] == nil)
 
         let sessionStartGroups = hooks?["SessionStart"] as? [[String: Any]]
+        let permissionGroups = hooks?["PermissionRequest"] as? [[String: Any]]
+        let permissionHook = permissionGroups?
+            .compactMap { $0["hooks"] as? [[String: Any]] }
+            .flatMap { $0 }
+            .first(where: { $0["command"] as? String == "'/tmp/OpenIslandHooks'" })
         #expect(sessionStartGroups?.contains(where: { $0["matcher"] as? String == "startup|resume" }) == true)
+        #expect(hooks?["PermissionRequest"] != nil)
+        #expect(permissionHook?["timeout"] as? Int == 86_400)
         #expect(hooks?["PreToolUse"] == nil)
         #expect(hooks?["PostToolUse"] == nil)
     }

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -46,20 +46,21 @@ This is meant for per-process launches. Do not set it globally unless you want O
 | `SessionStart` | Session starts or resumes (`source: "resume"` on resume) | `prompt`, `source` |
 | `PreToolUse` | Before a shell command executes | `tool_name`, `tool_input.command`, `turn_id`, `tool_use_id` |
 | `PostToolUse` | After a shell command completes | `tool_name`, `tool_input`, `tool_response`, `turn_id` |
+| `PermissionRequest` | Codex requests user approval | `tool_name`, `tool_input`, `turn_id`, `tool_use_id` |
 | `UserPromptSubmit` | User submits a new prompt | `prompt` |
 | `Stop` | A turn completes | `last_assistant_message`, `stop_hook_active` |
 
 ### Default managed installation
 
-The managed Codex hook installer (`CodexHookInstaller`) installs only `SessionStart`, `UserPromptSubmit`, and `Stop` by default. This is intentional: per-command Bash hooks add terminal log noise, so the default set keeps the workflow low-noise while still providing session lifecycle and usage visibility.
+The managed Codex hook installer (`CodexHookInstaller`) installs `SessionStart`, `UserPromptSubmit`, `PermissionRequest`, and `Stop` by default. This keeps per-command Bash hooks out of the default set while still surfacing Codex approval prompts in the island. `PermissionRequest` uses a 24-hour hook timeout so the app can wait for a human approval decision.
 
 The installer chooses the Codex hook feature flag that the local Codex CLI advertises. Newer Codex builds use `[features].hooks = true`; older builds use the legacy `[features].codex_hooks = true`. Status checks recognize both keys, and managed installs migrate between them when the local Codex version changes.
 
 After hooks are installed or changed, Codex may require a manual trust review before running them. Open `/hooks` inside Codex CLI and approve the expected Open Island hook entries. This approval gate belongs to Codex and is not bypassed by Open Island.
 
-The `CodexHookPayload` model and `BridgeServer` can parse richer events (`PreToolUse`, `PostToolUse`) when they are present in the hook payload, and will surface them in the UI if received. However, these richer events are **not** installed by the managed installer and must be configured manually if desired.
+The `CodexHookPayload` model and `BridgeServer` can parse richer events (`PreToolUse`, `PostToolUse`) when they are present in the hook payload, and will surface them in the UI if received. However, these richer per-command events are **not** installed by the managed installer and must be configured manually if desired.
 
-> **Note on file-edit coverage**: Codex file edits may use internal apply-patch paths that do not emit `PreToolUse` events. File-edit approval should not be treated as guaranteed `PreToolUse` coverage; the current reliable coverage is command/shell-level events, depending on Codex hook configuration.
+> **Note on file-edit coverage**: Codex file edits may use internal apply-patch paths that do not emit `PreToolUse` events. File-edit approval should be handled through `PermissionRequest`, not treated as guaranteed `PreToolUse` coverage.
 
 ### Common payload fields
 
@@ -78,21 +79,48 @@ The `CodexHookPayload` model and `BridgeServer` can parse richer events (`PreToo
 | `turn_id` | `turnID` | Current turn ID |
 | `tool_name` | `toolName` | Tool name (e.g. `shell`) |
 | `tool_use_id` | `toolUseID` | Tool-use call ID |
-| `tool_input` | `toolInput` | Tool input (contains `command`) |
+| `tool_input` | `toolInput` | Tool input (may contain `command` for shell tools or arbitrary JSON for other tools) |
 | `tool_response` | `toolResponse` | Tool output (JSON) |
 | `prompt` | `prompt` | User prompt text |
 | `last_assistant_message` | `lastAssistantMessage` | Last assistant message |
 | `stop_hook_active` | `stopHookActive` | Whether the stop hook is active |
 
-### Directive response (PreToolUse only)
+### Directive response
 
-The app can block a command by writing this to stdout:
+The app can block a `PreToolUse` command by writing this legacy block shape to stdout:
 
 ```json
 {"decision": "block", "reason": "Blocked by Open Island"}
 ```
 
-All other events require no stdout response.
+For `PermissionRequest`, the app approves the request with this hook-specific shape:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PermissionRequest",
+    "decision": {
+      "behavior": "allow"
+    }
+  }
+}
+```
+
+It denies the request with:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PermissionRequest",
+    "decision": {
+      "behavior": "deny",
+      "message": "Permission denied in Open Island."
+    }
+  }
+}
+```
+
+All other Codex events require no stdout response.
 
 ---
 
@@ -275,7 +303,8 @@ Setting `interrupt: true` terminates the current agent turn immediately.
 
 | Source | Event | Timeout |
 |---|---|---|
-| Codex | All events | Bridge default |
+| Codex | `PermissionRequest` | **24 hours** (awaits human approval) |
+| Codex | All other managed events | **45 seconds** |
 | Claude Code | `PermissionRequest` | **24 hours** (awaits human approval) |
 | Claude Code | All other events | **45 seconds** |
 | Gemini CLI | All events | Bridge default |


### PR DESCRIPTION
## Summary
- Add Codex `PermissionRequest` parsing, approval bridging, and hook-specific allow/deny stdout output.
- Install Codex `PermissionRequest` by default with a 24-hour approval timeout while keeping noisy per-command hooks out of the default set.
- Preserve arbitrary Codex `tool_input` JSON so non-Bash approval prompts can be displayed in Open Island.

## Test Plan
- [x] `swift test`

Fixes #520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added permission request event handling for Codex hooks, enabling users to approve or deny tool execution requests with a 24-hour approval window.

* **Documentation**
  * Updated documentation to clarify permission request flow and timeout policies for hook events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->