### PR TITLE
docs: update Homebrew cask install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ Grab the latest DMG from [GitHub Releases](https://github.com/Octane0411/open-vi
 ### Option 2: Homebrew
 
 ```bash
-brew install --cask octane0411/tap/openisland
+brew install --cask open-island
 ```
 
-Upgrade later with `brew upgrade --cask openisland`.
+Upgrade later with `brew upgrade --cask open-island`.
 
 ### Option 3: Build from source
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -116,10 +116,10 @@ Open Island 驻留在 Mac 的**刘海区域**（或顶部栏），为你的 AI c
 ### 方式二：Homebrew
 
 ```bash
-brew install --cask octane0411/tap/openisland
+brew install --cask open-island
 ```
 
-后续升级用 `brew upgrade --cask openisland`。
+后续升级用 `brew upgrade --cask open-island`。
 
 ### 方式三：从源码构建
 


### PR DESCRIPTION
## Summary
- Update Homebrew install instructions to use the official `open-island` cask
- Update upgrade commands in English and Simplified Chinese READMEs

## Verification
- `git diff --check`

The cask was added to Homebrew/homebrew-cask, so users no longer need the custom tap install command.

## Related:
https://github.com/Homebrew/homebrew-cask/pull/267086

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Homebrew installation instructions to use the official cask (`brew install --cask open-island`) instead of the previous custom tap method.
  * Updated installation and upgrade guidance in both English and Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->