### PR TITLE
test: simplify Claude subagent completion wait

### DIFF
--- a/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
@@ -585,16 +585,9 @@ struct ClaudeHooksTests {
             )
         )
 
-        let events = await collector.snapshot(
-            waitingUntil: { events in
-                events.contains { event in
-                    if case let .sessionCompleted(payload) = event {
-                        return payload.sessionID == sessionID && payload.summary == "OK"
-                    }
-                    return false
-                }
-            },
-            timeout: .seconds(1)
+        let events = await waitForCompletedSessionEvent(
+            sessionID: sessionID,
+            collector: collector
         )
         var state = SessionState()
         for event in events {
@@ -729,17 +722,30 @@ private actor AgentEventCollector {
         events.append(event)
     }
 
-    func snapshot(
-        waitingUntil predicate: ([AgentEvent]) -> Bool = { _ in true },
-        timeout: Duration = .zero
-    ) async -> [AgentEvent] {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: timeout)
-        while !predicate(events), clock.now < deadline {
-            try? await Task.sleep(for: .milliseconds(10))
-        }
+    func snapshot() -> [AgentEvent] {
         events
     }
+}
+
+private func waitForCompletedSessionEvent(
+    sessionID: String,
+    collector: AgentEventCollector
+) async -> [AgentEvent] {
+    for _ in 0..<100 {
+        let events = await collector.snapshot()
+        if events.contains(where: { event in
+            if case let .sessionCompleted(payload) = event {
+                return payload.sessionID == sessionID && payload.summary == "OK"
+            }
+            return false
+        }) {
+            return events
+        }
+
+        try? await Task.sleep(for: .milliseconds(10))
+    }
+
+    return await collector.snapshot()
 }
 
 private func nextEvent(


### PR DESCRIPTION
## Summary
- Replace the `AgentEventCollector.snapshot` default closure/`Duration` helper with a plain bounded polling helper.
- Keep the Claude subagent-stop regression coverage while avoiding a Swift Testing macro compile failure seen on the macOS 26 CI runner.

## Validation
- `git diff --check`
- `swift build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced testing infrastructure for session event handling with improved asynchronous polling mechanisms to better validate completion states.

* **Refactor**
  * Streamlined event collection architecture to provide simpler, more intuitive snapshot access patterns for test validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->