### PR TITLE
[codex] restore Codex desktop sessions

### DIFF
--- a/Sources/OpenIslandApp/CodexAppServerCoordinator.swift
+++ b/Sources/OpenIslandApp/CodexAppServerCoordinator.swift
@@ -95,7 +95,10 @@ final class CodexAppServerCoordinator {
     private func syncLoadedThreads() async {
         guard let client else { return }
         do {
-            let threads = try await client.listLoadedThreads()
+            var threads = try await client.listLoadedThreads()
+            if threads.isEmpty {
+                threads = try await client.listThreads(limit: 20)
+            }
             var created = 0
             for thread in threads where !thread.ephemeral {
                 // Skip threads already tracked — re-emitting sessionStarted

--- a/Sources/OpenIslandCore/CodexAppServer.swift
+++ b/Sources/OpenIslandCore/CodexAppServer.swift
@@ -182,19 +182,33 @@ public final class CodexAppServerClient: @unchecked Sendable {
     /// List currently loaded threads from the app-server.
     public func listLoadedThreads() async throws -> [CodexThread] {
         struct Params: Encodable {}
-        struct Result: Decodable { let threads: [CodexThread] }
         let data = try await sendRequest(method: "thread/loaded/list", params: Params())
-        let result = try JSONDecoder().decode(Result.self, from: data)
+        let result = try JSONDecoder().decode(ThreadListResult.self, from: data)
         return result.threads
     }
 
     /// List all threads (including not-loaded) from the app-server.
     public func listThreads(limit: Int? = nil) async throws -> [CodexThread] {
         struct Params: Encodable { let limit: Int? }
-        struct Result: Decodable { let threads: [CodexThread] }
         let data = try await sendRequest(method: "thread/list", params: Params(limit: limit))
-        let result = try JSONDecoder().decode(Result.self, from: data)
+        let result = try JSONDecoder().decode(ThreadListResult.self, from: data)
         return result.threads
+    }
+
+    private struct ThreadListResult: Decodable {
+        let threads: [CodexThread]
+
+        private enum CodingKeys: String, CodingKey {
+            case threads
+            case data
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            threads = try container.decodeIfPresent([CodexThread].self, forKey: .threads)
+                ?? container.decodeIfPresent([CodexThread].self, forKey: .data)
+                ?? []
+        }
     }
 
     // MARK: - JSON-RPC transport

--- a/Sources/OpenIslandCore/CodexSessionTracking.swift
+++ b/Sources/OpenIslandCore/CodexSessionTracking.swift
@@ -398,6 +398,13 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             summary: summary,
             phase: snapshot.phase,
             updatedAt: updatedAt,
+            jumpTarget: JumpTarget(
+                terminalApp: "Codex.app",
+                workspaceName: sessionMeta.workspaceName,
+                paneTitle: sessionMeta.sessionTitle,
+                workingDirectory: sessionMeta.cwd,
+                codexThreadID: sessionMeta.sessionID
+            ),
             codexMetadata: metadata
         )
     }

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -360,7 +360,7 @@ public struct SessionState: Equatable, Sendable {
             // the rollout watcher / app-server notifications.
             if session.isCodexAppSession {
                 let wasAlive = session.isProcessAlive
-                session.isProcessAlive = aliveSessionIDs.contains(id)
+                session.isProcessAlive = isCodexAppRunning
                 if session.isProcessAlive != wasAlive {
                     changed.insert(id)
                 }


### PR DESCRIPTION
## Summary

- Decode Codex app-server thread list responses from both the old `threads` key and the current `data` key.
- Fall back from `thread/loaded/list` to `thread/list` when the loaded-thread list is empty, so current Codex Desktop sessions can still be discovered.
- Preserve Codex Desktop jump targets for rollout-discovered sessions and keep those sessions live while `Codex.app` is running.

## Root Cause

Current Codex app-server responses no longer match the shape Open Island expected. `thread/list` now returns records under `data`, while the previous Open Island decoder only accepted `threads`. In addition, a separate app-server process can return no loaded threads for Codex Desktop, so the app never reached the available thread records. Rollout-discovered Codex Desktop sessions also lost their `Codex.app` jump target and were marked dead by checking a thread id as if it were a process id.

## Impact

Open Island can show Codex Desktop conversations again after restart, including sessions restored from local rollout files. Existing callers that still return `threads` remain supported.

## Validation

- `git diff --check origin/main...HEAD`
- `swift build -c debug --product OpenIslandApp`
- Manual: built and ran `~/Applications/Open Island Dev.app`, then verified Codex Desktop sessions appeared in the island and the session cache contained records with `terminalApp: "Codex.app"`.

## Verification Gap

- `swift test --filter 'Codex(AppServer|SessionTracking)'` could not run in the local Command Line Tools Swift environment because the test target cannot import Swift `Testing` (`no such module 'Testing'`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved thread list loading with fallback mechanism when initial fetch returns empty
  * Enhanced session tracking and liveness detection accuracy for app sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->