### PR TITLE
fix: restore Codex.app sessions on startup

### DIFF
--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -111,7 +111,10 @@ extension AgentSession {
     }
 
     var spotlightTerminalBadge: String? {
-        jumpTarget?.terminalApp
+        if isCodexDesktopSession {
+            return nil
+        }
+        return jumpTarget?.terminalApp
     }
 
     var spotlightWorkspaceName: String {
@@ -182,9 +185,12 @@ extension AgentSession {
     }
 
     var spotlightHeadlinePromptText: String? {
+        if let codexDesktopTitle = codexDesktopHeadlineTitle {
+            return codexDesktopTitle
+        }
         // Headline shows the initial prompt (session topic), not the latest.
         // The latest prompt is shown separately in the "You:" line.
-        initialPromptText ?? latestPromptText
+        return initialPromptText ?? latestPromptText
     }
 
     var spotlightPromptText: String? {
@@ -435,8 +441,30 @@ extension AgentSession {
         return prompt
     }
 
+    private var codexDesktopHeadlineTitle: String? {
+        guard isCodexDesktopSession else {
+            return nil
+        }
+
+        let trimmedTitle = title.trimmedForSurface
+        guard !trimmedTitle.isEmpty else {
+            return nil
+        }
+
+        let workspace = jumpTarget?.workspaceName.trimmedForSurface ?? ""
+        guard trimmedTitle.localizedCaseInsensitiveCompare(workspace) != .orderedSame else {
+            return nil
+        }
+
+        return trimmedTitle
+    }
+
     private var prefersLivePromptHeadline: Bool {
         isProcessAlive || phase == .running || phase.requiresAttention
+    }
+
+    private var isCodexDesktopSession: Bool {
+        isCodexAppSession || jumpTarget?.terminalApp == "Codex.app"
     }
 }
 

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -687,6 +687,9 @@ final class AppModel {
                 self.codexAppServer.disconnect()
             }
         }
+        monitoring.onCodexAppRunningObserved = { [weak self] in
+            self?.discovery.rediscoverCodexAppSessionsIfNeeded()
+        }
         refreshOverlayDisplayConfiguration()
         hasFinishedInit = true
     }
@@ -1503,6 +1506,7 @@ final class AppModel {
                 switch event {
                 case let .sessionStarted(p): return p.sessionID
                 case let .activityUpdated(p): return p.sessionID
+                case let .sessionRefreshed(p): return p.sessionID
                 case let .permissionRequested(p): return p.sessionID
                 case let .questionAsked(p): return p.sessionID
                 case let .sessionCompleted(p): return p.sessionID
@@ -1755,6 +1759,8 @@ final class AppModel {
             return "Session started: \(payload.title)"
         case let .activityUpdated(payload):
             return payload.summary
+        case let .sessionRefreshed(payload):
+            return "Session refreshed: \(payload.title)"
         case let .permissionRequested(payload):
             return payload.request.summary
         case let .questionAsked(payload):

--- a/Sources/OpenIslandApp/CodexAppServerCoordinator.swift
+++ b/Sources/OpenIslandApp/CodexAppServerCoordinator.swift
@@ -95,7 +95,10 @@ final class CodexAppServerCoordinator {
     private func syncLoadedThreads() async {
         guard let client else { return }
         do {
-            let threads = try await client.listLoadedThreads()
+            var threads = try await client.listLoadedThreads()
+            if threads.isEmpty {
+                threads = try await client.listThreads(limit: 20)
+            }
             var created = 0
             for thread in threads where !thread.ephemeral {
                 // Skip threads already tracked — re-emitting sessionStarted

--- a/Sources/OpenIslandApp/CodexAppServerCoordinator.swift
+++ b/Sources/OpenIslandApp/CodexAppServerCoordinator.swift
@@ -100,16 +100,21 @@ final class CodexAppServerCoordinator {
                 threads = try await client.listThreads(limit: 20)
             }
             var created = 0
+            var refreshed = 0
             for thread in threads where !thread.ephemeral {
-                // Skip threads already tracked — re-emitting sessionStarted
-                // rebuilds the AgentSession and would wipe richer state
-                // already accumulated from hooks or rediscovery.
-                if isSessionTracked?(thread.id) == true { continue }
-                emitSessionStarted(from: thread)
-                created += 1
+                if isSessionTracked?(thread.id) == true {
+                    emitSessionRefreshed(from: thread)
+                    refreshed += 1
+                } else {
+                    emitSessionStarted(from: thread)
+                    created += 1
+                }
             }
             if created > 0 {
                 onStatusMessage?("Synced \(created) new Codex thread(s) from app-server.")
+            }
+            if refreshed > 0 {
+                onStatusMessage?("Refreshed \(refreshed) tracked Codex thread(s) from app-server.")
             }
         } catch {
             onStatusMessage?("Failed to list loaded Codex threads: \(error.localizedDescription)")
@@ -186,12 +191,8 @@ final class CodexAppServerCoordinator {
                 )
             ))
 
-        case .threadNameUpdated:
-            // Title updates don't have a dedicated AgentEvent and we can't
-            // safely overwrite phase/summary here (would clobber running or
-            // waiting-for-approval state).  Skip for now — the title is
-            // populated at sessionStarted time which is usually enough.
-            break
+        case .threadNameUpdated(let threadId, _):
+            refreshTrackedThread(threadID: threadId)
 
         case .turnStarted(let threadId, _):
             onEvent?(.activityUpdated(
@@ -232,6 +233,62 @@ final class CodexAppServerCoordinator {
     // MARK: - Helpers
 
     private func emitSessionStarted(from thread: CodexThread) {
+        let payload = threadPayload(from: thread)
+
+        onEvent?(.sessionStarted(
+            SessionStarted(
+                sessionID: thread.id,
+                title: payload.title,
+                tool: .codex,
+                origin: .live,
+                initialPhase: payload.phase,
+                summary: payload.summary,
+                timestamp: .now,
+                jumpTarget: payload.jumpTarget,
+                codexMetadata: CodexSessionMetadata(
+                    transcriptPath: thread.path,
+                    initialUserPrompt: thread.preview.isEmpty ? nil : thread.preview
+                )
+            )
+        ))
+    }
+
+    private func emitSessionRefreshed(from thread: CodexThread) {
+        let payload = threadPayload(from: thread)
+        onEvent?(.sessionRefreshed(
+            SessionRefreshed(
+                sessionID: thread.id,
+                title: payload.title,
+                summary: payload.summary,
+                phase: payload.phase,
+                timestamp: .now,
+                jumpTarget: payload.jumpTarget,
+                codexMetadata: CodexSessionMetadata(
+                    transcriptPath: thread.path,
+                    initialUserPrompt: thread.preview.isEmpty ? nil : thread.preview
+                )
+            )
+        ))
+    }
+
+    private func refreshTrackedThread(threadID: String) {
+        guard let client else { return }
+        Task { [weak self] in
+            guard let self else { return }
+            guard self.isSessionTracked?(threadID) == true else { return }
+            guard let thread = try? await client.readThread(threadID: threadID) else { return }
+            await MainActor.run {
+                self.emitSessionRefreshed(from: thread)
+            }
+        }
+    }
+
+    private func threadPayload(from thread: CodexThread) -> (
+        title: String,
+        summary: String,
+        phase: SessionPhase,
+        jumpTarget: JumpTarget
+    ) {
         let workspaceName = URL(fileURLWithPath: thread.cwd).lastPathComponent
         let title = thread.name ?? workspaceName
         let summary = thread.preview.isEmpty ? "Codex session." : String(thread.preview.prefix(120))
@@ -243,27 +300,14 @@ final class CodexAppServerCoordinator {
         case .notLoaded, .systemError: phase = .completed
         }
 
-        onEvent?(.sessionStarted(
-            SessionStarted(
-                sessionID: thread.id,
-                title: title,
-                tool: .codex,
-                origin: .live,
-                initialPhase: phase,
-                summary: summary,
-                timestamp: .now,
-                jumpTarget: JumpTarget(
-                    terminalApp: "Codex.app",
-                    workspaceName: workspaceName,
-                    paneTitle: title,
-                    workingDirectory: thread.cwd,
-                    codexThreadID: thread.id
-                ),
-                codexMetadata: CodexSessionMetadata(
-                    transcriptPath: thread.path,
-                    initialUserPrompt: thread.preview.isEmpty ? nil : thread.preview
-                )
-            )
-        ))
+        let jumpTarget = JumpTarget(
+            terminalApp: "Codex.app",
+            workspaceName: workspaceName,
+            paneTitle: title,
+            workingDirectory: thread.cwd,
+            codexThreadID: thread.id
+        )
+
+        return (title, summary, phase, jumpTarget)
     }
 }

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -29,6 +29,11 @@ final class ProcessMonitoringCoordinator {
     @ObservationIgnored
     var onCodexAppRunningChanged: ((_ isRunning: Bool) -> Void)?
 
+    /// Fires on each monitoring pass while Codex.app is running so fallback
+    /// rediscovery can keep recent desktop threads hydrated.
+    @ObservationIgnored
+    var onCodexAppRunningObserved: (() -> Void)?
+
     @ObservationIgnored
     let activeAgentProcessDiscovery = ActiveAgentProcessDiscovery()
 
@@ -125,6 +130,9 @@ final class ProcessMonitoringCoordinator {
         if isCodexAppRunning != wasCodexAppRunning {
             wasCodexAppRunning = isCodexAppRunning
             onCodexAppRunningChanged?(isCodexAppRunning)
+        }
+        if isCodexAppRunning {
+            onCodexAppRunningObserved?()
         }
         let sessions = local.sessions.filter(\.isTrackedLiveSession)
         guard !sessions.isEmpty else {
@@ -232,6 +240,8 @@ final class ProcessMonitoringCoordinator {
         case let .sessionStarted(payload):
             payload.sessionID
         case let .activityUpdated(payload):
+            payload.sessionID
+        case let .sessionRefreshed(payload):
             payload.sessionID
         case let .permissionRequested(payload):
             payload.sessionID

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1444,6 +1444,10 @@ private struct IslandSessionRow: View {
     }
 
     private var notificationWorkspaceHeadlineText: String {
+        if session.isCodexAppSession {
+            return session.spotlightHeadlineText.trimmedForNotificationCard
+        }
+
         let workspace = session.spotlightWorkspaceName.trimmedForNotificationCard
         let title = workspace.isEmpty ? session.tool.displayName : workspace
         guard let branch = session.spotlightWorktreeBranch?.trimmedForNotificationCard,

--- a/Sources/OpenIslandCore/AgentEvent.swift
+++ b/Sources/OpenIslandCore/AgentEvent.swift
@@ -68,6 +68,34 @@ public struct SessionActivityUpdated: Equatable, Codable, Sendable {
     }
 }
 
+public struct SessionRefreshed: Equatable, Codable, Sendable {
+    public var sessionID: String
+    public var title: String
+    public var summary: String
+    public var phase: SessionPhase
+    public var timestamp: Date
+    public var jumpTarget: JumpTarget?
+    public var codexMetadata: CodexSessionMetadata?
+
+    public init(
+        sessionID: String,
+        title: String,
+        summary: String,
+        phase: SessionPhase,
+        timestamp: Date,
+        jumpTarget: JumpTarget? = nil,
+        codexMetadata: CodexSessionMetadata? = nil
+    ) {
+        self.sessionID = sessionID
+        self.title = title
+        self.summary = summary
+        self.phase = phase
+        self.timestamp = timestamp
+        self.jumpTarget = jumpTarget
+        self.codexMetadata = codexMetadata
+    }
+}
+
 public struct PermissionRequested: Equatable, Codable, Sendable {
     public var sessionID: String
     public var request: PermissionRequest
@@ -241,6 +269,7 @@ public struct ActionableStateResolved: Equatable, Codable, Sendable {
 public enum AgentEvent: Equatable, Codable, Sendable {
     case sessionStarted(SessionStarted)
     case activityUpdated(SessionActivityUpdated)
+    case sessionRefreshed(SessionRefreshed)
     case permissionRequested(PermissionRequested)
     case questionAsked(QuestionAsked)
     case sessionCompleted(SessionCompleted)
@@ -256,6 +285,7 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case type
         case sessionStarted
         case activityUpdated
+        case sessionRefreshed
         case permissionRequested
         case questionAsked
         case sessionCompleted
@@ -271,6 +301,7 @@ public enum AgentEvent: Equatable, Codable, Sendable {
     private enum EventType: String, Codable {
         case sessionStarted
         case activityUpdated
+        case sessionRefreshed
         case permissionRequested
         case questionAsked
         case sessionCompleted
@@ -292,6 +323,8 @@ public enum AgentEvent: Equatable, Codable, Sendable {
             self = .sessionStarted(try container.decode(SessionStarted.self, forKey: .sessionStarted))
         case .activityUpdated:
             self = .activityUpdated(try container.decode(SessionActivityUpdated.self, forKey: .activityUpdated))
+        case .sessionRefreshed:
+            self = .sessionRefreshed(try container.decode(SessionRefreshed.self, forKey: .sessionRefreshed))
         case .permissionRequested:
             self = .permissionRequested(try container.decode(PermissionRequested.self, forKey: .permissionRequested))
         case .questionAsked:
@@ -335,6 +368,9 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case let .activityUpdated(payload):
             try container.encode(EventType.activityUpdated, forKey: .type)
             try container.encode(payload, forKey: .activityUpdated)
+        case let .sessionRefreshed(payload):
+            try container.encode(EventType.sessionRefreshed, forKey: .type)
+            try container.encode(payload, forKey: .sessionRefreshed)
         case let .permissionRequested(payload):
             try container.encode(EventType.permissionRequested, forKey: .type)
             try container.encode(payload, forKey: .permissionRequested)

--- a/Sources/OpenIslandCore/CodexAppServer.swift
+++ b/Sources/OpenIslandCore/CodexAppServer.swift
@@ -50,7 +50,11 @@ public enum CodexThreadSource: String, Codable, Sendable {
     case unknown
 
     public init(from decoder: Decoder) throws {
-        let value = try decoder.singleValueContainer().decode(String.self)
+        let container = try decoder.singleValueContainer()
+        guard let value = try? container.decode(String.self) else {
+            self = .unknown
+            return
+        }
         self = CodexThreadSource(rawValue: value) ?? .unknown
     }
 }
@@ -182,19 +186,50 @@ public final class CodexAppServerClient: @unchecked Sendable {
     /// List currently loaded threads from the app-server.
     public func listLoadedThreads() async throws -> [CodexThread] {
         struct Params: Encodable {}
-        struct Result: Decodable { let threads: [CodexThread] }
+        struct Result: Decodable {
+            let threads: [CodexThread]?
+            let data: [String]?
+        }
         let data = try await sendRequest(method: "thread/loaded/list", params: Params())
         let result = try JSONDecoder().decode(Result.self, from: data)
-        return result.threads
+        if let threads = result.threads {
+            return threads
+        }
+
+        var threads: [CodexThread] = []
+        for threadID in result.data ?? [] {
+            if let thread = try? await readThread(threadID: threadID) {
+                threads.append(thread)
+            }
+        }
+        return threads
     }
 
     /// List all threads (including not-loaded) from the app-server.
     public func listThreads(limit: Int? = nil) async throws -> [CodexThread] {
         struct Params: Encodable { let limit: Int? }
-        struct Result: Decodable { let threads: [CodexThread] }
+        struct Result: Decodable {
+            let threads: [CodexThread]?
+            let data: [CodexThread]?
+        }
         let data = try await sendRequest(method: "thread/list", params: Params(limit: limit))
         let result = try JSONDecoder().decode(Result.self, from: data)
-        return result.threads
+        return result.threads ?? result.data ?? []
+    }
+
+    /// Read a single thread by id from the app-server.
+    public func readThread(threadID: String) async throws -> CodexThread {
+        struct Params: Encodable {
+            let threadId: String
+            let includeTurns: Bool
+        }
+        struct Result: Decodable { let thread: CodexThread }
+        let data = try await sendRequest(
+            method: "thread/read",
+            params: Params(threadId: threadID, includeTurns: false)
+        )
+        let result = try JSONDecoder().decode(Result.self, from: data)
+        return result.thread
     }
 
     // MARK: - JSON-RPC transport

--- a/Sources/OpenIslandCore/CodexSessionTracking.swift
+++ b/Sources/OpenIslandCore/CodexSessionTracking.swift
@@ -229,6 +229,7 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
         var sessionID: String
         var cwd: String
         var timestamp: Date?
+        var isCodexDesktopApp: Bool
 
         var workspaceName: String {
             let workspace = URL(fileURLWithPath: cwd).lastPathComponent
@@ -389,6 +390,13 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             currentTool: snapshot.currentTool,
             currentCommandPreview: snapshot.currentCommandPreview
         )
+        let jumpTarget = sessionMeta.isCodexDesktopApp ? JumpTarget(
+            terminalApp: "Codex.app",
+            workspaceName: sessionMeta.workspaceName,
+            paneTitle: sessionMeta.sessionTitle,
+            workingDirectory: sessionMeta.cwd,
+            codexThreadID: sessionMeta.sessionID
+        ) : nil
 
         return CodexTrackedSessionRecord(
             sessionID: sessionMeta.sessionID,
@@ -398,6 +406,7 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             summary: summary,
             phase: snapshot.phase,
             updatedAt: updatedAt,
+            jumpTarget: jumpTarget,
             codexMetadata: metadata
         )
     }
@@ -423,7 +432,8 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             cwd: cwd,
             timestamp: codexRolloutParseTimestamp(
                 (payload["timestamp"] as? String) ?? (object["timestamp"] as? String)
-            )
+            ),
+            isCodexDesktopApp: (payload["originator"] as? String) == "Codex Desktop"
         )
     }
 

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -112,6 +112,28 @@ public struct SessionState: Equatable, Sendable {
             session.updatedAt = payload.timestamp
             upsert(session)
 
+        case let .sessionRefreshed(payload):
+            guard var session = sessionsByID[payload.sessionID] else {
+                return
+            }
+
+            session.title = payload.title
+            session.jumpTarget = payload.jumpTarget ?? session.jumpTarget
+            session.codexMetadata = payload.codexMetadata?.isEmpty == true ? nil : payload.codexMetadata
+            session.updatedAt = payload.timestamp
+            session.isSessionEnded = false
+            session.isProcessAlive = true
+            session.processNotSeenCount = 0
+            Self.refreshCodexAppClassification(for: &session)
+
+            let preservesActionableState = session.phase == .waitingForApproval || session.phase == .waitingForAnswer
+            if !preservesActionableState {
+                session.phase = payload.phase
+                session.summary = payload.summary
+            }
+
+            upsert(session)
+
         case let .permissionRequested(payload):
             guard var session = sessionsByID[payload.sessionID] else {
                 return

--- a/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
+++ b/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
@@ -333,4 +333,33 @@ struct AgentSessionPresentationTests {
         #expect(session.spotlightSecondaryText == "Running Search")
         #expect(session.displayCurrentToolName == "Search")
     }
+
+    @Test
+    func codexDesktopSessionUsesThreadTitleForHeadlineAndHidesTerminalBadge() {
+        let session = AgentSession(
+            id: "codex-app-session",
+            title: "Open Island issue check",
+            tool: .codex,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Thinking.",
+            updatedAt: Date(timeIntervalSince1970: 10_000),
+            jumpTarget: JumpTarget(
+                terminalApp: "Codex.app",
+                workspaceName: "lijie10",
+                paneTitle: "Open Island issue check",
+                workingDirectory: "/Users/lijie10",
+                codexThreadID: "codex-app-session"
+            ),
+            codexMetadata: CodexSessionMetadata(
+                initialUserPrompt: "https://vibeisland.app/zh/ 看看这个 app",
+                lastUserPrompt: "看看有没有现成 issue"
+            )
+        )
+
+        #expect(session.spotlightHeadlineText == "lijie10 · Open Island issue check")
+        #expect(session.spotlightPromptLineText == "You: 看看有没有现成 issue")
+        #expect(session.spotlightTerminalBadge == nil)
+    }
 }

--- a/Tests/OpenIslandCoreTests/CodexAppServerDecodingTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexAppServerDecodingTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+struct CodexAppServerDecodingTests {
+    @Test
+    func codexThreadDecodesObjectSourceAsUnknown() throws {
+        let json = Data(
+            """
+            {
+              "id": "019e6cb5-46dc-7e11-ad95-e1df0de7cdb7",
+              "cwd": "/Users/pojue/Documents/Codex",
+              "name": "Investigate Open Island",
+              "preview": "Looking at Codex app-server output.",
+              "modelProvider": "openai",
+              "createdAt": 1779940000000,
+              "updatedAt": 1779940300000,
+              "ephemeral": false,
+              "path": "/Users/pojue/.codex/sessions/2026/05/28/rollout.jsonl",
+              "status": {
+                "type": "notLoaded"
+              },
+              "source": {
+                "kind": "subagent",
+                "parentThreadId": "019e6cb5-46dc-7e11-ad95-e1df0de7cdb7"
+              },
+              "turns": []
+            }
+            """.utf8
+        )
+
+        let thread = try JSONDecoder().decode(CodexThread.self, from: json)
+
+        #expect(thread.source == .unknown)
+    }
+}

--- a/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
@@ -1093,6 +1093,56 @@ struct CodexSessionTrackingTests {
     }
 
     @Test
+    func codexRolloutDiscoveryMarksCodexDesktopSessionsWithAppJumpTarget() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-discovery-codex-app-\(UUID().uuidString)", isDirectory: true)
+        let rolloutDirectoryURL = rootURL.appendingPathComponent("2026/05/28", isDirectory: true)
+        let rolloutURL = rolloutDirectoryURL.appendingPathComponent("rollout-codex-app.jsonl")
+        let now = Date(timeIntervalSince1970: 1_779_940_000)
+
+        try FileManager.default.createDirectory(at: rolloutDirectoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let cwd = "/Users/pojue/Documents/Codex/2026-05-28/hatch-pet-users-pojue-codex-skills"
+        let lines = [
+            sessionMetaLine(
+                sessionID: "019e6cb5-46dc-7e11-ad95-e1df0de7cdb7",
+                timestamp: "2026-05-28T03:51:20.275Z",
+                cwd: cwd,
+                originator: "Codex Desktop",
+                source: "vscode"
+            ),
+            rolloutLine(
+                timestamp: "2026-05-28T03:51:22.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "turn_complete",
+                    "last_agent_message": "Turn completed.",
+                ]
+            ),
+        ]
+        try lines.joined(separator: "\n").appending("\n").write(to: rolloutURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.modificationDate: now], ofItemAtPath: rolloutURL.path)
+
+        let discovery = CodexRolloutDiscovery(
+            rootURL: rootURL,
+            fileManager: .default,
+            maxAge: 86_400,
+            maxFiles: 10
+        )
+
+        let records = discovery.discoverRecentSessions(now: now)
+        let record = records.first
+        let session = record?.session
+
+        #expect(records.count == 1)
+        #expect(record?.jumpTarget?.terminalApp == "Codex.app")
+        #expect(record?.jumpTarget?.workingDirectory == cwd)
+        #expect(record?.jumpTarget?.codexThreadID == "019e6cb5-46dc-7e11-ad95-e1df0de7cdb7")
+        #expect(session?.isCodexAppSession == true)
+    }
+
+    @Test
     func codexRolloutDiscoveryHandlesTrailingLineWithoutNewline() throws {
         // A rollout written by Codex while the process is mid-flush
         // can land on disk without a trailing newline. The streamed
@@ -1185,7 +1235,9 @@ private func rolloutLine(
 private func sessionMetaLine(
     sessionID: String,
     timestamp: String,
-    cwd: String
+    cwd: String,
+    originator: String = "codex-tui",
+    source: String = "cli"
 ) -> String {
     rolloutLine(
         timestamp: timestamp,
@@ -1194,8 +1246,8 @@ private func sessionMetaLine(
             "id": sessionID,
             "timestamp": timestamp,
             "cwd": cwd,
-            "originator": "codex-tui",
-            "source": "cli",
+            "originator": originator,
+            "source": source,
         ]
     )
 }

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -1357,6 +1357,69 @@ struct SessionStateTests {
         let legacyUpdated = ISO8601DateFormatter().date(from: "2026-01-01T00:00:00Z")
         #expect(legacy.session.firstSeenAt == legacyUpdated)
     }
+
+    @Test
+    func sessionRefreshedUpdatesCodexDesktopTitleAndPreservesApprovalState() {
+        let t0 = Date(timeIntervalSince1970: 10_000)
+        var state = SessionState()
+        state.apply(.sessionStarted(SessionStarted(
+            sessionID: "codex-app-1",
+            title: "Initial",
+            tool: .codex,
+            origin: .live,
+            initialPhase: .running,
+            summary: "Working",
+            timestamp: t0,
+            jumpTarget: JumpTarget(
+                terminalApp: "Codex.app",
+                workspaceName: "lijie10",
+                paneTitle: "Initial",
+                workingDirectory: "/Users/lijie10",
+                codexThreadID: "codex-app-1"
+            ),
+            codexMetadata: CodexSessionMetadata(
+                initialUserPrompt: "first prompt"
+            )
+        )))
+
+        state.apply(.permissionRequested(PermissionRequested(
+            sessionID: "codex-app-1",
+            request: PermissionRequest(
+                title: "Approval Required",
+                summary: "Codex is waiting for approval.",
+                affectedPath: ""
+            ),
+            timestamp: t0.addingTimeInterval(10)
+        )))
+
+        state.apply(.sessionRefreshed(SessionRefreshed(
+            sessionID: "codex-app-1",
+            title: "Open Island issue check",
+            summary: "Updated preview",
+            phase: .running,
+            timestamp: t0.addingTimeInterval(20),
+            jumpTarget: JumpTarget(
+                terminalApp: "Codex.app",
+                workspaceName: "lijie10",
+                paneTitle: "Open Island issue check",
+                workingDirectory: "/Users/lijie10",
+                codexThreadID: "codex-app-1"
+            ),
+            codexMetadata: CodexSessionMetadata(
+                transcriptPath: "/tmp/rollout.jsonl",
+                initialUserPrompt: "first prompt"
+            )
+        )))
+
+        let session = state.session(id: "codex-app-1")
+        #expect(session?.title == "Open Island issue check")
+        #expect(session?.jumpTarget?.paneTitle == "Open Island issue check")
+        #expect(session?.phase == .waitingForApproval)
+        #expect(session?.permissionRequest?.summary == "Codex is waiting for approval.")
+        #expect(session?.isProcessAlive == true)
+        #expect(session?.isCodexAppSession == true)
+        #expect(session?.codexMetadata?.transcriptPath == "/tmp/rollout.jsonl")
+    }
 }
 
 private enum SessionStateTestError: Error {


### PR DESCRIPTION
Closes #528

## Stack note
This is part of a fork-based stack because I cannot push feature branches to the upstream repository. Later PRs are opened against \, so their GitHub diff is cumulative; review focus for this PR is the commit listed below.

1. This PR: Codex.app startup live restore.



## Review focus
Restore current/recent Codex.app sessions during startup, preserve app-server titles, and improve liveness classification for Codex Desktop sessions.

## Main commit
- \

## Verification
swift test --filter CodexAppServerDecodingTests --filter CodexAppServerCoordinatorTests --filter CodexSessionTrackingTests --filter CodexUsageTests --filter AppModelSessionListTests --filter OverlayPanelControllerTests --filter IslandAnimationPolicyTests --filter IslandSessionRowInteractionTests --filter SessionStateTests\n\nResult from local verification: 175 tests passed in 9 suites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session refresh event notifications for real-time session updates.
  * Improved support for Codex Desktop app sessions with optimized notification headlines and badge display.
  * Added Codex app running state observation for automatic session discovery.

* **Bug Fixes**
  * Thread discovery now includes fallback mechanism when initial list is unavailable.
  * Thread name updates now properly trigger session refresh notifications.
  * Improved robustness of thread source data parsing.

* **Tests**
  * Added comprehensive test coverage for Codex Desktop session handling, session refresh events, and thread decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->