### PR TITLE
fix: recover Codex sessions from index and rollouts

### DIFF
--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -26,6 +26,9 @@ extension AgentSession {
     /// Note: `claudeMetadata.agentID` is NOT a reliable signal here because
     /// SubagentStart hooks set `agent_id` on the *parent* session's metadata.
     var isSubagentSession: Bool {
+        if codexMetadata?.isSubagentSession == true {
+            return true
+        }
         if let path = claudeMetadata?.transcriptPath, path.contains("/subagents/") {
             return true
         }
@@ -179,6 +182,10 @@ extension AgentSession {
 
         guard let prompt = spotlightHeadlinePromptText else {
             return headline
+        }
+
+        if isCodexDesktopSession {
+            return "\(headline)：\(prompt)"
         }
 
         return "\(headline) · \(prompt)"
@@ -387,7 +394,7 @@ extension AgentSession {
         case "ExitPlanMode":
             return "Plan"
         case "apply_patch":
-            return "Patch"
+            return "Editing"
         case "write_stdin":
             return "Input"
         case "web_search", "tool_search":
@@ -454,6 +461,16 @@ extension AgentSession {
         let workspace = jumpTarget?.workspaceName.trimmedForSurface ?? ""
         guard trimmedTitle.localizedCaseInsensitiveCompare(workspace) != .orderedSame else {
             return nil
+        }
+
+        let codexPrefix = "Codex · "
+        if trimmedTitle.range(of: codexPrefix, options: [.caseInsensitive, .anchored]) != nil {
+            let strippedTitle = String(trimmedTitle.dropFirst(codexPrefix.count)).trimmedForSurface
+            guard !strippedTitle.isEmpty,
+                  strippedTitle.localizedCaseInsensitiveCompare(workspace) != .orderedSame else {
+                return nil
+            }
+            return strippedTitle
         }
 
         return trimmedTitle

--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -111,7 +111,10 @@ extension AgentSession {
     }
 
     var spotlightTerminalBadge: String? {
-        jumpTarget?.terminalApp
+        if isCodexDesktopSession {
+            return nil
+        }
+        return jumpTarget?.terminalApp
     }
 
     var spotlightWorkspaceName: String {
@@ -182,9 +185,12 @@ extension AgentSession {
     }
 
     var spotlightHeadlinePromptText: String? {
+        if let codexDesktopTitle = codexDesktopHeadlineTitle {
+            return codexDesktopTitle
+        }
         // Headline shows the initial prompt (session topic), not the latest.
         // The latest prompt is shown separately in the "You:" line.
-        initialPromptText ?? latestPromptText
+        return initialPromptText ?? latestPromptText
     }
 
     var spotlightPromptText: String? {
@@ -435,8 +441,30 @@ extension AgentSession {
         return prompt
     }
 
+    private var codexDesktopHeadlineTitle: String? {
+        guard isCodexDesktopSession else {
+            return nil
+        }
+
+        let trimmedTitle = title.trimmedForSurface
+        guard !trimmedTitle.isEmpty else {
+            return nil
+        }
+
+        let workspace = jumpTarget?.workspaceName.trimmedForSurface ?? ""
+        guard trimmedTitle.localizedCaseInsensitiveCompare(workspace) != .orderedSame else {
+            return nil
+        }
+
+        return trimmedTitle
+    }
+
     private var prefersLivePromptHeadline: Bool {
         isProcessAlive || phase == .running || phase.requiresAttention
+    }
+
+    private var isCodexDesktopSession: Bool {
+        isCodexAppSession || jumpTarget?.terminalApp == "Codex.app"
     }
 }
 

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -687,6 +687,9 @@ final class AppModel {
                 self.codexAppServer.disconnect()
             }
         }
+        monitoring.onCodexAppRunningObserved = { [weak self] in
+            self?.discovery.rediscoverCodexAppSessionsIfNeeded()
+        }
         refreshOverlayDisplayConfiguration()
         hasFinishedInit = true
     }
@@ -1503,6 +1506,7 @@ final class AppModel {
                 switch event {
                 case let .sessionStarted(p): return p.sessionID
                 case let .activityUpdated(p): return p.sessionID
+                case let .sessionRefreshed(p): return p.sessionID
                 case let .permissionRequested(p): return p.sessionID
                 case let .questionAsked(p): return p.sessionID
                 case let .sessionCompleted(p): return p.sessionID
@@ -1755,6 +1759,8 @@ final class AppModel {
             return "Session started: \(payload.title)"
         case let .activityUpdated(payload):
             return payload.summary
+        case let .sessionRefreshed(payload):
+            return "Session refreshed: \(payload.title)"
         case let .permissionRequested(payload):
             return payload.request.summary
         case let .questionAsked(payload):

--- a/Sources/OpenIslandApp/CodexAppServerCoordinator.swift
+++ b/Sources/OpenIslandApp/CodexAppServerCoordinator.swift
@@ -95,7 +95,10 @@ final class CodexAppServerCoordinator {
     private func syncLoadedThreads() async {
         guard let client else { return }
         do {
-            let threads = try await client.listLoadedThreads()
+            var threads = try await client.listLoadedThreads()
+            if threads.isEmpty {
+                threads = try await client.listThreads(limit: 20)
+            }
             var created = 0
             for thread in threads where !thread.ephemeral {
                 // Skip threads already tracked — re-emitting sessionStarted

--- a/Sources/OpenIslandApp/CodexAppServerCoordinator.swift
+++ b/Sources/OpenIslandApp/CodexAppServerCoordinator.swift
@@ -100,16 +100,21 @@ final class CodexAppServerCoordinator {
                 threads = try await client.listThreads(limit: 20)
             }
             var created = 0
+            var refreshed = 0
             for thread in threads where !thread.ephemeral {
-                // Skip threads already tracked — re-emitting sessionStarted
-                // rebuilds the AgentSession and would wipe richer state
-                // already accumulated from hooks or rediscovery.
-                if isSessionTracked?(thread.id) == true { continue }
-                emitSessionStarted(from: thread)
-                created += 1
+                if isSessionTracked?(thread.id) == true {
+                    emitSessionRefreshed(from: thread)
+                    refreshed += 1
+                } else {
+                    emitSessionStarted(from: thread)
+                    created += 1
+                }
             }
             if created > 0 {
                 onStatusMessage?("Synced \(created) new Codex thread(s) from app-server.")
+            }
+            if refreshed > 0 {
+                onStatusMessage?("Refreshed \(refreshed) tracked Codex thread(s) from app-server.")
             }
         } catch {
             onStatusMessage?("Failed to list loaded Codex threads: \(error.localizedDescription)")
@@ -186,12 +191,8 @@ final class CodexAppServerCoordinator {
                 )
             ))
 
-        case .threadNameUpdated:
-            // Title updates don't have a dedicated AgentEvent and we can't
-            // safely overwrite phase/summary here (would clobber running or
-            // waiting-for-approval state).  Skip for now — the title is
-            // populated at sessionStarted time which is usually enough.
-            break
+        case .threadNameUpdated(let threadId, _):
+            refreshTrackedThread(threadID: threadId)
 
         case .turnStarted(let threadId, _):
             onEvent?(.activityUpdated(
@@ -232,6 +233,62 @@ final class CodexAppServerCoordinator {
     // MARK: - Helpers
 
     private func emitSessionStarted(from thread: CodexThread) {
+        let payload = threadPayload(from: thread)
+
+        onEvent?(.sessionStarted(
+            SessionStarted(
+                sessionID: thread.id,
+                title: payload.title,
+                tool: .codex,
+                origin: .live,
+                initialPhase: payload.phase,
+                summary: payload.summary,
+                timestamp: .now,
+                jumpTarget: payload.jumpTarget,
+                codexMetadata: CodexSessionMetadata(
+                    transcriptPath: thread.path,
+                    initialUserPrompt: thread.preview.isEmpty ? nil : thread.preview
+                )
+            )
+        ))
+    }
+
+    private func emitSessionRefreshed(from thread: CodexThread) {
+        let payload = threadPayload(from: thread)
+        onEvent?(.sessionRefreshed(
+            SessionRefreshed(
+                sessionID: thread.id,
+                title: payload.title,
+                summary: payload.summary,
+                phase: payload.phase,
+                timestamp: .now,
+                jumpTarget: payload.jumpTarget,
+                codexMetadata: CodexSessionMetadata(
+                    transcriptPath: thread.path,
+                    initialUserPrompt: thread.preview.isEmpty ? nil : thread.preview
+                )
+            )
+        ))
+    }
+
+    private func refreshTrackedThread(threadID: String) {
+        guard let client else { return }
+        Task { [weak self] in
+            guard let self else { return }
+            guard self.isSessionTracked?(threadID) == true else { return }
+            guard let thread = try? await client.readThread(threadID: threadID) else { return }
+            await MainActor.run {
+                self.emitSessionRefreshed(from: thread)
+            }
+        }
+    }
+
+    private func threadPayload(from thread: CodexThread) -> (
+        title: String,
+        summary: String,
+        phase: SessionPhase,
+        jumpTarget: JumpTarget
+    ) {
         let workspaceName = URL(fileURLWithPath: thread.cwd).lastPathComponent
         let title = thread.name ?? workspaceName
         let summary = thread.preview.isEmpty ? "Codex session." : String(thread.preview.prefix(120))
@@ -243,27 +300,14 @@ final class CodexAppServerCoordinator {
         case .notLoaded, .systemError: phase = .completed
         }
 
-        onEvent?(.sessionStarted(
-            SessionStarted(
-                sessionID: thread.id,
-                title: title,
-                tool: .codex,
-                origin: .live,
-                initialPhase: phase,
-                summary: summary,
-                timestamp: .now,
-                jumpTarget: JumpTarget(
-                    terminalApp: "Codex.app",
-                    workspaceName: workspaceName,
-                    paneTitle: title,
-                    workingDirectory: thread.cwd,
-                    codexThreadID: thread.id
-                ),
-                codexMetadata: CodexSessionMetadata(
-                    transcriptPath: thread.path,
-                    initialUserPrompt: thread.preview.isEmpty ? nil : thread.preview
-                )
-            )
-        ))
+        let jumpTarget = JumpTarget(
+            terminalApp: "Codex.app",
+            workspaceName: workspaceName,
+            paneTitle: title,
+            workingDirectory: thread.cwd,
+            codexThreadID: thread.id
+        )
+
+        return (title, summary, phase, jumpTarget)
     }
 }

--- a/Sources/OpenIslandApp/CodexAppServerCoordinator.swift
+++ b/Sources/OpenIslandApp/CodexAppServerCoordinator.swift
@@ -17,6 +17,9 @@ final class CodexAppServerCoordinator {
     @ObservationIgnored
     private var connectTask: Task<Void, Never>?
 
+    @ObservationIgnored
+    private var pendingApprovalRequests: [String: CodexAppServerApprovalRequest] = [:]
+
     /// Callback to emit AgentEvents into AppModel.
     @ObservationIgnored
     var onEvent: ((AgentEvent) -> Void)?
@@ -25,13 +28,26 @@ final class CodexAppServerCoordinator {
     @ObservationIgnored
     var onStatusMessage: ((String) -> Void)?
 
+    /// Callback to publish authoritative Codex usage snapshots from app-server.
+    @ObservationIgnored
+    var onUsageSnapshot: ((CodexUsageSnapshot) -> Void)?
+
     /// Returns `true` if a session with the given id is already tracked.
     /// Used to avoid re-emitting `sessionStarted` (which rebuilds the
     /// session and wipes richer state from hooks/rediscovery).
     @ObservationIgnored
     var isSessionTracked: ((String) -> Bool)?
 
+    /// Returns the currently stored Codex metadata for a tracked session.
+    /// App-server item notifications only carry tool deltas, so this keeps
+    /// transcript/title/user-message fields intact while updating tool state.
+    @ObservationIgnored
+    var codexMetadataForSession: ((String) -> CodexSessionMetadata?)?
+
     private(set) var isConnected = false
+    var isConnecting: Bool {
+        connectTask != nil
+    }
 
     // MARK: - Public API
 
@@ -73,7 +89,9 @@ final class CodexAppServerCoordinator {
                 self.onStatusMessage?("Connected to Codex app-server.")
 
                 // Fetch currently loaded threads and create sessions.
+                await self.refreshUsageFromAppServer()
                 await self.syncLoadedThreads()
+                MemoryPressureRelief.releaseEmptyMallocPages()
             } catch {
                 self.connectTask = nil
                 self.onStatusMessage?("Failed to connect to Codex app-server: \(error.localizedDescription)")
@@ -87,7 +105,25 @@ final class CodexAppServerCoordinator {
         connectTask = nil
         client?.stop()
         client = nil
+        pendingApprovalRequests.removeAll()
         isConnected = false
+    }
+
+    @discardableResult
+    func resolvePermission(sessionID: String, resolution: PermissionResolution) -> Bool {
+        guard let client,
+              let request = pendingApprovalRequests.removeValue(forKey: sessionID) else {
+            return false
+        }
+
+        do {
+            try client.resolveApprovalRequest(request, resolution: resolution)
+            return true
+        } catch {
+            pendingApprovalRequests[sessionID] = request
+            onStatusMessage?("Failed to resolve Codex app-server approval: \(error.localizedDescription)")
+            return false
+        }
     }
 
     // MARK: - Thread sync
@@ -95,10 +131,9 @@ final class CodexAppServerCoordinator {
     private func syncLoadedThreads() async {
         guard let client else { return }
         do {
-            var threads = try await client.listLoadedThreads()
-            if threads.isEmpty {
-                threads = try await client.listThreads(limit: 20)
-            }
+            let loadedThreads = try await client.listLoadedThreads()
+            let recentThreads = try await client.listThreads(limit: 20)
+            let threads = Self.mergedThreadSyncList(loadedThreads: loadedThreads, recentThreads: recentThreads)
             var created = 0
             var refreshed = 0
             for thread in threads where !thread.ephemeral {
@@ -121,6 +156,48 @@ final class CodexAppServerCoordinator {
         }
     }
 
+    static func mergedThreadSyncList(
+        loadedThreads: [CodexThread],
+        recentThreads: [CodexThread]
+    ) -> [CodexThread] {
+        var seenIDs: Set<String> = []
+        var merged: [CodexThread] = []
+
+        for thread in loadedThreads + recentThreads {
+            guard seenIDs.insert(thread.id).inserted else { continue }
+            merged.append(thread)
+        }
+
+        return merged
+    }
+
+    nonisolated static func fetchThreadTitles(
+        codexPath: String = "/Applications/Codex.app/Contents/Resources/codex",
+        limit: Int = 40
+    ) async -> [String: String] {
+        guard FileManager.default.isExecutableFile(atPath: codexPath) else {
+            return [:]
+        }
+
+        let client = CodexAppServerClient(codexPath: codexPath)
+        do {
+            try await client.start()
+            defer { client.stop() }
+
+            let threads = try await client.listThreads(limit: limit)
+            return Dictionary(uniqueKeysWithValues: threads.compactMap { thread in
+                guard let title = thread.name?.trimmedForCodexSurface,
+                      !title.isEmpty else {
+                    return nil
+                }
+                return (thread.id, title)
+            })
+        } catch {
+            client.stop()
+            return [:]
+        }
+    }
+
     // MARK: - Notification handling
 
     private func handleNotification(_ notification: CodexAppServerNotification) {
@@ -131,54 +208,8 @@ final class CodexAppServerCoordinator {
             emitSessionStarted(from: thread)
 
         case .threadStatusChanged(let threadId, let status):
-            switch status.type {
-            case .active:
-                if status.isWaitingOnApproval {
-                    onEvent?(.permissionRequested(
-                        PermissionRequested(
-                            sessionID: threadId,
-                            request: PermissionRequest(
-                                title: "Approval Required",
-                                summary: "Codex is waiting for approval.",
-                                affectedPath: ""
-                            ),
-                            timestamp: .now
-                        )
-                    ))
-                } else if status.isWaitingOnUserInput {
-                    onEvent?(.questionAsked(
-                        QuestionAsked(
-                            sessionID: threadId,
-                            prompt: QuestionPrompt(
-                                title: "Codex is waiting for input.",
-                                options: []
-                            ),
-                            timestamp: .now
-                        )
-                    ))
-                } else {
-                    onEvent?(.activityUpdated(
-                        SessionActivityUpdated(
-                            sessionID: threadId,
-                            summary: "Codex is working…",
-                            phase: .running,
-                            timestamp: .now
-                        )
-                    ))
-                }
-            case .idle:
-                // Idle means "between turns" in the same thread — the thread
-                // is still open.  Only `thread/closed` truly ends a session.
-                onEvent?(.activityUpdated(
-                    SessionActivityUpdated(
-                        sessionID: threadId,
-                        summary: "Idle.",
-                        phase: .completed,
-                        timestamp: .now
-                    )
-                ))
-            case .notLoaded, .systemError:
-                break
+            if let event = Self.eventForThreadStatusChanged(threadId: threadId, status: status) {
+                onEvent?(event)
             }
 
         case .threadClosed(let threadId):
@@ -224,16 +255,343 @@ final class CodexAppServerCoordinator {
                     timestamp: .now
                 )
             ))
+            emitCodexMetadataUpdate(
+                sessionID: threadId,
+                metadata: Self.codexMetadataClearingTool(
+                    existing: codexMetadataForSession?(threadId)
+                )
+            )
+
+        case .itemStarted(let activity):
+            emitCodexMetadataUpdate(
+                sessionID: activity.threadID,
+                metadata: Self.codexMetadata(
+                    existing: codexMetadataForSession?(activity.threadID),
+                    activity: activity
+                )
+            )
+            onEvent?(.activityUpdated(
+                SessionActivityUpdated(
+                    sessionID: activity.threadID,
+                    summary: Self.itemActivitySummary(activity),
+                    phase: .running,
+                    timestamp: .now
+                )
+            ))
+
+        case .itemCompleted(let activity):
+            emitCodexMetadataUpdate(
+                sessionID: activity.threadID,
+                metadata: Self.codexMetadata(
+                    existing: codexMetadataForSession?(activity.threadID),
+                    activity: activity
+                )
+            )
+            onEvent?(.activityUpdated(
+                SessionActivityUpdated(
+                    sessionID: activity.threadID,
+                    summary: Self.itemActivitySummary(activity),
+                    phase: .running,
+                    timestamp: .now
+                )
+            ))
+
+        case .itemOutputDelta(let activity):
+            emitCodexMetadataUpdate(
+                sessionID: activity.threadID,
+                metadata: Self.codexMetadataForOutputDelta(
+                    existing: codexMetadataForSession?(activity.threadID),
+                    activity: activity
+                )
+            )
+            onEvent?(.activityUpdated(
+                SessionActivityUpdated(
+                    sessionID: activity.threadID,
+                    summary: Self.itemActivitySummary(activity),
+                    phase: .running,
+                    timestamp: .now
+                )
+            ))
+
+        case .itemPatchUpdated(let activity):
+            emitCodexMetadataUpdate(
+                sessionID: activity.threadID,
+                metadata: Self.codexMetadata(
+                    existing: codexMetadataForSession?(activity.threadID),
+                    activity: activity
+                )
+            )
+            onEvent?(.activityUpdated(
+                SessionActivityUpdated(
+                    sessionID: activity.threadID,
+                    summary: Self.itemActivitySummary(activity),
+                    phase: .running,
+                    timestamp: .now
+                )
+            ))
+
+        case .agentMessageDelta(let delta):
+            emitCodexMetadataUpdate(
+                sessionID: delta.threadID,
+                metadata: Self.codexMetadataForAgentMessageDelta(
+                    existing: codexMetadataForSession?(delta.threadID),
+                    delta: delta
+                )
+            )
+            onEvent?(.activityUpdated(
+                SessionActivityUpdated(
+                    sessionID: delta.threadID,
+                    summary: delta.text,
+                    phase: .running,
+                    timestamp: .now
+                )
+            ))
+
+        case .rawResponseItemCompleted(let item):
+            emitCodexMetadataUpdate(
+                sessionID: item.threadID,
+                metadata: Self.codexMetadataForRawResponseItem(
+                    existing: codexMetadataForSession?(item.threadID),
+                    item: item
+                )
+            )
+            if let summary = Self.summary(for: item) {
+                onEvent?(.activityUpdated(
+                    SessionActivityUpdated(
+                        sessionID: item.threadID,
+                        summary: summary,
+                        phase: .running,
+                        timestamp: .now
+                    )
+                ))
+            }
+
+        case .approvalRequested(let request):
+            pendingApprovalRequests[request.threadID] = request
+            onEvent?(.permissionRequested(
+                PermissionRequested(
+                    sessionID: request.threadID,
+                    request: Self.permissionRequest(from: request),
+                    timestamp: .now
+                )
+            ))
+
+        case .serverRequestResolved(let threadId, let requestId):
+            guard let request = pendingApprovalRequests[threadId],
+                  requestId == nil || request.requestID == requestId else {
+                return
+            }
+            pendingApprovalRequests.removeValue(forKey: threadId)
+            onEvent?(.actionableStateResolved(
+                ActionableStateResolved(
+                    sessionID: threadId,
+                    summary: "Permission request is no longer active.",
+                    timestamp: .now
+                )
+            ))
+
+        case .accountRateLimitsUpdated(let snapshot):
+            onUsageSnapshot?(snapshot)
 
         case .unknown:
             break
         }
     }
 
+    private func emitCodexMetadataUpdate(sessionID: String, metadata: CodexSessionMetadata) {
+        guard !metadata.isEmpty else { return }
+        onEvent?(.sessionMetadataUpdated(
+            SessionMetadataUpdated(
+                sessionID: sessionID,
+                codexMetadata: metadata,
+                timestamp: .now
+            )
+        ))
+    }
+
+    func refreshUsageFromAppServer() async {
+        guard let client else { return }
+        do {
+            guard let snapshot = try await client.readAccountRateLimits() else { return }
+            onUsageSnapshot?(snapshot)
+        } catch {
+            onStatusMessage?("Failed to read Codex app-server rate limits: \(error.localizedDescription)")
+        }
+    }
+
+    private static func itemActivitySummary(_ activity: CodexAppServerItemActivity) -> String {
+        let displayName = AgentSession.currentToolDisplayName(for: activity.toolName)
+        guard let preview = activity.preview?.trimmedForCodexSurface,
+              !preview.isEmpty else {
+            return "Running \(displayName)."
+        }
+        return "\(displayName) \(preview)"
+    }
+
+    static func codexMetadata(
+        existing: CodexSessionMetadata?,
+        activity: CodexAppServerItemActivity
+    ) -> CodexSessionMetadata {
+        var metadata = existing ?? CodexSessionMetadata()
+        metadata.currentTool = activity.toolName
+        metadata.currentCommandPreview = activity.preview?.trimmedForCodexSurface
+        return metadata
+    }
+
+    static func codexMetadataForOutputDelta(
+        existing: CodexSessionMetadata?,
+        activity: CodexAppServerItemActivity
+    ) -> CodexSessionMetadata {
+        var metadata = existing ?? CodexSessionMetadata()
+        if metadata.currentTool?.trimmedForCodexSurface.isEmpty != false {
+            metadata.currentTool = activity.toolName
+        }
+        if metadata.currentCommandPreview?.trimmedForCodexSurface.isEmpty != false {
+            metadata.currentCommandPreview = activity.preview?.trimmedForCodexSurface
+        }
+        return metadata
+    }
+
+    static func codexMetadataForRawResponseItem(
+        existing: CodexSessionMetadata?,
+        item: CodexAppServerRawResponseItem
+    ) -> CodexSessionMetadata {
+        var metadata = existing ?? CodexSessionMetadata()
+        if let toolName = item.toolName?.trimmedForCodexSurface, !toolName.isEmpty {
+            metadata.currentTool = toolName
+            metadata.currentCommandPreview = item.preview?.trimmedForCodexSurface
+        }
+        if let assistantText = item.assistantText?.trimmedForCodexSurface, !assistantText.isEmpty {
+            metadata.lastAssistantMessage = assistantText
+        }
+        return metadata
+    }
+
+    private static func summary(for item: CodexAppServerRawResponseItem) -> String? {
+        if let assistantText = item.assistantText?.trimmedForCodexSurface, !assistantText.isEmpty {
+            return assistantText
+        }
+        guard let toolName = item.toolName?.trimmedForCodexSurface, !toolName.isEmpty else {
+            return nil
+        }
+        return itemActivitySummary(CodexAppServerItemActivity(
+            threadID: item.threadID,
+            turnID: item.turnID,
+            itemID: item.itemID,
+            toolName: toolName,
+            preview: item.preview
+        ))
+    }
+
+    static func codexMetadataForAgentMessageDelta(
+        existing: CodexSessionMetadata?,
+        delta: CodexAppServerAgentMessageDelta
+    ) -> CodexSessionMetadata {
+        var metadata = existing ?? CodexSessionMetadata()
+        metadata.lastAssistantMessage = delta.text.trimmedForCodexSurface
+        return metadata
+    }
+
+    static func codexMetadataClearingTool(existing: CodexSessionMetadata?) -> CodexSessionMetadata {
+        var metadata = existing ?? CodexSessionMetadata()
+        metadata.currentTool = nil
+        metadata.currentCommandPreview = nil
+        return metadata
+    }
+
+    static func permissionRequest(from request: CodexAppServerApprovalRequest) -> PermissionRequest {
+        let title: String
+        let summary: String
+        let affectedPath: String
+        let toolName: String?
+
+        switch request.kind {
+        case .commandExecution:
+            let command = request.command.joined(separator: " ")
+            title = "Command approval"
+            summary = command.isEmpty
+                ? (request.reason?.trimmedForCodexSurface ?? "Codex wants to run a command.")
+                : command
+            affectedPath = request.cwd ?? ""
+            toolName = "command"
+
+        case .fileChange:
+            title = "File change approval"
+            summary = request.reason?.trimmedForCodexSurface ?? "Codex wants to modify files."
+            affectedPath = request.cwd ?? ""
+            toolName = "file change"
+
+        case .permissions:
+            title = "Permission approval"
+            summary = request.reason?.trimmedForCodexSurface ?? "Codex is requesting additional permissions."
+            affectedPath = request.cwd ?? ""
+            toolName = "permissions"
+        }
+
+        return PermissionRequest(
+            title: title,
+            summary: summary,
+            affectedPath: affectedPath,
+            primaryActionTitle: "Allow",
+            secondaryActionTitle: "Deny",
+            toolName: toolName
+        )
+    }
+
+    static func eventForThreadStatusChanged(
+        threadId: String,
+        status: CodexThreadStatus,
+        timestamp: Date = .now
+    ) -> AgentEvent? {
+        switch status.type {
+        case .active:
+            if status.isWaitingOnUserInput {
+                return .questionAsked(
+                    QuestionAsked(
+                        sessionID: threadId,
+                        prompt: QuestionPrompt(
+                            title: "Codex is waiting for input.",
+                            options: []
+                        ),
+                        timestamp: timestamp
+                    )
+                )
+            }
+
+            // `waitingOnApproval` is only a status hint. Real app-server
+            // approvals arrive as server-initiated `item/*/requestApproval`
+            // requests with an id we can answer. Rendering a permission card
+            // from the hint alone creates a fake, unresolvable approval flash.
+            return .activityUpdated(
+                SessionActivityUpdated(
+                    sessionID: threadId,
+                    summary: status.isWaitingOnApproval ? "Codex is waiting for approval." : "Codex is working…",
+                    phase: .running,
+                    timestamp: timestamp
+                )
+            )
+
+        case .idle:
+            // Idle means "between turns" in the same thread — the thread
+            // is still open.  Only `thread/closed` truly ends a session.
+            return .activityUpdated(
+                SessionActivityUpdated(
+                    sessionID: threadId,
+                    summary: "Idle.",
+                    phase: .completed,
+                    timestamp: timestamp
+                )
+            )
+
+        case .notLoaded, .systemError:
+            return nil
+        }
+    }
+
     // MARK: - Helpers
 
     private func emitSessionStarted(from thread: CodexThread) {
-        let payload = threadPayload(from: thread)
+        let payload = Self.threadPayload(from: thread)
 
         onEvent?(.sessionStarted(
             SessionStarted(
@@ -243,30 +601,24 @@ final class CodexAppServerCoordinator {
                 origin: .live,
                 initialPhase: payload.phase,
                 summary: payload.summary,
-                timestamp: .now,
+                timestamp: payload.timestamp,
                 jumpTarget: payload.jumpTarget,
-                codexMetadata: CodexSessionMetadata(
-                    transcriptPath: thread.path,
-                    initialUserPrompt: thread.preview.isEmpty ? nil : thread.preview
-                )
+                codexMetadata: payload.codexMetadata
             )
         ))
     }
 
     private func emitSessionRefreshed(from thread: CodexThread) {
-        let payload = threadPayload(from: thread)
+        let payload = Self.threadPayload(from: thread)
         onEvent?(.sessionRefreshed(
             SessionRefreshed(
                 sessionID: thread.id,
                 title: payload.title,
                 summary: payload.summary,
                 phase: payload.phase,
-                timestamp: .now,
+                timestamp: payload.timestamp,
                 jumpTarget: payload.jumpTarget,
-                codexMetadata: CodexSessionMetadata(
-                    transcriptPath: thread.path,
-                    initialUserPrompt: thread.preview.isEmpty ? nil : thread.preview
-                )
+                codexMetadata: payload.codexMetadata
             )
         ))
     }
@@ -283,22 +635,40 @@ final class CodexAppServerCoordinator {
         }
     }
 
-    private func threadPayload(from thread: CodexThread) -> (
+    static func threadPayload(
+        from thread: CodexThread,
+        now: Date = .now
+    ) -> (
         title: String,
         summary: String,
         phase: SessionPhase,
-        jumpTarget: JumpTarget
+        timestamp: Date,
+        jumpTarget: JumpTarget,
+        codexMetadata: CodexSessionMetadata
     ) {
         let workspaceName = URL(fileURLWithPath: thread.cwd).lastPathComponent
-        let title = thread.name ?? workspaceName
-        let summary = thread.preview.isEmpty ? "Codex session." : String(thread.preview.prefix(120))
+        let rolloutSnapshot = Self.rolloutSnapshot(atPath: thread.path)
+        let isSubagentSession = Self.rolloutIsSubagentSession(atPath: thread.path)
+        let title = Self.threadTitle(
+            rawName: thread.name,
+            workspaceName: workspaceName,
+            rolloutSnapshot: rolloutSnapshot
+        )
+        let summary = Self.threadSummary(from: thread, rolloutSnapshot: rolloutSnapshot)
+        let threadUpdatedAt = Self.threadUpdatedAtDate(from: thread.updatedAt)
+        let timestamp = Self.latestDate(
+            rolloutSnapshot?.updatedAt,
+            Self.rolloutActivityDate(atPath: thread.path),
+            threadUpdatedAt
+        )
+            ?? .now
 
-        let phase: SessionPhase
-        switch thread.status.type {
-        case .active: phase = .running
-        case .idle: phase = .completed
-        case .notLoaded, .systemError: phase = .completed
-        }
+        let phase = Self.threadPhase(
+            from: thread.status,
+            rolloutSnapshot: rolloutSnapshot,
+            threadUpdatedAt: threadUpdatedAt,
+            now: now
+        )
 
         let jumpTarget = JumpTarget(
             terminalApp: "Codex.app",
@@ -308,6 +678,330 @@ final class CodexAppServerCoordinator {
             codexThreadID: thread.id
         )
 
-        return (title, summary, phase, jumpTarget)
+        let metadata = CodexSessionMetadata(
+            transcriptPath: thread.path,
+            initialUserPrompt: rolloutSnapshot?.initialUserPrompt,
+            lastUserPrompt: rolloutSnapshot?.lastUserPrompt,
+            lastAssistantMessage: rolloutSnapshot?.lastAssistantMessage,
+            currentTool: rolloutSnapshot?.currentTool,
+            currentCommandPreview: rolloutSnapshot?.currentCommandPreview,
+            isSubagentSession: isSubagentSession
+        )
+
+        return (title, summary, phase, timestamp, jumpTarget, metadata)
+    }
+
+    static func threadTitle(
+        rawName: String?,
+        workspaceName: String,
+        rolloutSnapshot: CodexRolloutSnapshot?
+    ) -> String {
+        if let rawName = rawName?.trimmedForCodexSurface,
+           !rawName.isEmpty,
+           !Self.isWorkspaceFallbackTitle(rawName, workspaceName: workspaceName) {
+            return rawName
+        }
+
+        if let prompt = rolloutSnapshot?.initialUserPrompt?.trimmedForCodexSurface,
+           !prompt.isEmpty {
+            return Self.promptTitle(prompt)
+        }
+
+        if let prompt = rolloutSnapshot?.lastUserPrompt?.trimmedForCodexSurface,
+           !prompt.isEmpty {
+            return Self.promptTitle(prompt)
+        }
+
+        return workspaceName
+    }
+
+    static func threadSummary(
+        from thread: CodexThread,
+        rolloutSnapshot: CodexRolloutSnapshot?
+    ) -> String {
+        if let summary = rolloutSnapshot?.summary?.trimmedForCodexSurface, !summary.isEmpty {
+            return summary
+        }
+
+        return thread.preview.isEmpty ? "Codex session." : String(thread.preview.prefix(120))
+    }
+
+    static func threadPhase(
+        from status: CodexThreadStatus,
+        rolloutSnapshot: CodexRolloutSnapshot?,
+        threadUpdatedAt: Date? = nil,
+        now: Date = .now
+    ) -> SessionPhase {
+        switch status.type {
+        case .active:
+            if status.isWaitingOnApproval {
+                return .waitingForApproval
+            }
+            if status.isWaitingOnUserInput {
+                return .waitingForAnswer
+            }
+            return .running
+        case .idle:
+            guard let rolloutSnapshot else {
+                return .completed
+            }
+            if rolloutSnapshot.isCompleted {
+                return .completed
+            }
+            if let updatedAt = rolloutSnapshot.updatedAt,
+               now.timeIntervalSince(updatedAt) <= 10 * 60 {
+                return rolloutSnapshot.phase
+            }
+            if Self.isRecentThreadActivity(threadUpdatedAt, now: now) {
+                return .running
+            }
+            return .completed
+        case .notLoaded, .systemError:
+            if let rolloutSnapshot,
+               !rolloutSnapshot.isCompleted,
+               let updatedAt = rolloutSnapshot.updatedAt,
+               now.timeIntervalSince(updatedAt) <= 10 * 60 {
+                return rolloutSnapshot.phase
+            }
+            if let rolloutSnapshot, rolloutSnapshot.isCompleted {
+                return .completed
+            }
+            if Self.isRecentThreadActivity(threadUpdatedAt, now: now) {
+                return .running
+            }
+            return .completed
+        }
+    }
+
+    private static func isRecentThreadActivity(_ threadUpdatedAt: Date?, now: Date) -> Bool {
+        guard let threadUpdatedAt else { return false }
+        let age = now.timeIntervalSince(threadUpdatedAt)
+        return age >= 0 && age <= 10 * 60
+    }
+
+    private static func latestDate(_ dates: Date?...) -> Date? {
+        dates.compactMap { $0 }.max()
+    }
+
+    static func rolloutSnapshot(atPath path: String?) -> CodexRolloutSnapshot? {
+        guard let path,
+              !path.isEmpty,
+              FileManager.default.fileExists(atPath: path),
+              let handle = try? FileHandle(forReadingFrom: URL(fileURLWithPath: path)) else {
+            return nil
+        }
+        defer { try? handle.close() }
+
+        do {
+            let fileSize = try handle.seekToEnd()
+            guard fileSize > 0 else { return nil }
+
+            let headLimit = min(fileSize, 256 * 1_024)
+            try handle.seek(toOffset: 0)
+            var headBuffer = try handle.read(upToCount: Int(headLimit)) ?? Data()
+            var snapshot = CodexRolloutSnapshot()
+            consumeCompleteRolloutLines(from: &headBuffer) { line in
+                CodexRolloutReducer.apply(line: String(decoding: line, as: UTF8.self), to: &snapshot)
+            }
+
+            let tailLimit = min(fileSize, 512 * 1_024)
+            if fileSize > headLimit {
+                try handle.seek(toOffset: fileSize - tailLimit)
+                var tailBuffer = try handle.readToEnd() ?? Data()
+                if fileSize > tailLimit {
+                    trimLeadingPartialRolloutLine(from: &tailBuffer)
+                }
+                consumeCompleteRolloutLines(from: &tailBuffer) { line in
+                    CodexRolloutReducer.apply(line: String(decoding: line, as: UTF8.self), to: &snapshot)
+                }
+            }
+
+            guard snapshot.updatedAt != nil
+                || snapshot.initialUserPrompt != nil
+                || snapshot.lastUserPrompt != nil
+                || snapshot.lastAssistantMessage != nil else {
+                return nil
+            }
+            return snapshot
+        } catch {
+            return nil
+        }
+    }
+
+    static func rolloutIsSubagentSession(atPath path: String?) -> Bool {
+        guard let path,
+              !path.isEmpty,
+              FileManager.default.fileExists(atPath: path),
+              let handle = try? FileHandle(forReadingFrom: URL(fileURLWithPath: path)) else {
+            return false
+        }
+        defer { try? handle.close() }
+
+        var buffer = Data()
+        let newline = UInt8(ascii: "\n")
+        while let chunk = try? handle.read(upToCount: 64 * 1_024), !chunk.isEmpty {
+            buffer.append(chunk)
+            while let newlineIndex = buffer.firstIndex(of: newline) {
+                let line = buffer.prefix(upTo: newlineIndex)
+                buffer.removeSubrange(...newlineIndex)
+                if let result = Self.rolloutLineIsSubagentSession(line) {
+                    return result
+                }
+            }
+        }
+
+        if !buffer.isEmpty, let result = Self.rolloutLineIsSubagentSession(buffer) {
+            return result
+        }
+
+        return false
+    }
+
+    private static func rolloutLineIsSubagentSession(_ line: Data) -> Bool? {
+        autoreleasepool {
+            guard let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
+                  object["type"] as? String == "session_meta" else {
+                return nil
+            }
+
+            let payload = object["payload"] as? [String: Any] ?? [:]
+            return (payload["thread_source"] as? String) == "subagent"
+        }
+    }
+
+    static func isWorkspaceFallbackTitle(_ title: String, workspaceName: String) -> Bool {
+        if title.localizedCaseInsensitiveCompare(workspaceName) == .orderedSame {
+            return true
+        }
+
+        let codexDotPrefix = "Codex · "
+        if title.range(of: codexDotPrefix, options: [.caseInsensitive, .anchored]) != nil {
+            let stripped = String(title.dropFirst(codexDotPrefix.count)).trimmedForCodexSurface
+            return stripped.localizedCaseInsensitiveCompare(workspaceName) == .orderedSame
+        }
+
+        if title.range(of: "Codex ", options: [.caseInsensitive, .anchored]) != nil {
+            return true
+        }
+
+        return false
+    }
+
+    static func promptTitle(_ prompt: String) -> String {
+        var title = prompt
+            .split(whereSeparator: \.isNewline)
+            .first
+            .map(String.init)?
+            .trimmedForCodexSurface ?? prompt.trimmedForCodexSurface
+
+        while let range = title.range(of: #"^https?://\S+\s*"#, options: .regularExpression) {
+            title.removeSubrange(range)
+            title = title.trimmedForCodexSurface
+        }
+
+        guard title.count > 40 else {
+            return title
+        }
+        let endIndex = title.index(title.startIndex, offsetBy: 39)
+        return "\(title[..<endIndex])…"
+    }
+
+    static func threadUpdatedAtDate(from rawValue: Int) -> Date? {
+        guard rawValue > 0 else { return nil }
+
+        let seconds: TimeInterval
+        if rawValue > 10_000_000_000 {
+            seconds = TimeInterval(rawValue) / 1_000
+        } else {
+            seconds = TimeInterval(rawValue)
+        }
+
+        let date = Date(timeIntervalSince1970: seconds)
+        guard date.timeIntervalSince1970 > 0 else { return nil }
+        return date
+    }
+
+    static func rolloutActivityDate(atPath path: String?) -> Date? {
+        guard let path,
+              !path.isEmpty,
+              FileManager.default.fileExists(atPath: path),
+              let handle = try? FileHandle(forReadingFrom: URL(fileURLWithPath: path)) else {
+            return nil
+        }
+        defer { try? handle.close() }
+
+        do {
+            let fileSize = try handle.seekToEnd()
+            guard fileSize > 0 else { return nil }
+
+            let tailLimit = min(fileSize, 512 * 1_024)
+            try handle.seek(toOffset: fileSize - tailLimit)
+            var buffer = try handle.readToEnd() ?? Data()
+            if fileSize > tailLimit {
+                trimLeadingPartialRolloutLine(from: &buffer)
+            }
+
+            var latest: Date?
+            consumeCompleteRolloutLines(from: &buffer) { line in
+                if let date = Self.rolloutLineTimestamp(line) {
+                    latest = max(latest ?? date, date)
+                }
+            }
+            if !buffer.isEmpty, let date = Self.rolloutLineTimestamp(buffer) {
+                latest = max(latest ?? date, date)
+            }
+
+            return latest
+        } catch {
+            return nil
+        }
+    }
+
+    private static func rolloutLineTimestamp(_ lineData: Data) -> Date? {
+        autoreleasepool {
+            guard !lineData.isEmpty,
+                  let object = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any] else {
+                return nil
+            }
+
+            let rawTimestamp = (object["timestamp"] as? String)
+                ?? ((object["payload"] as? [String: Any])?["timestamp"] as? String)
+            guard let rawTimestamp else { return nil }
+
+            let fractionalFormatter = ISO8601DateFormatter()
+            fractionalFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let date = fractionalFormatter.date(from: rawTimestamp) {
+                return date
+            }
+
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime]
+            return formatter.date(from: rawTimestamp)
+        }
+    }
+
+    private static func consumeCompleteRolloutLines(from buffer: inout Data, _ consume: (Data) -> Void) {
+        let newline = UInt8(ascii: "\n")
+        while let newlineIndex = buffer.firstIndex(of: newline) {
+            let line = buffer.prefix(upTo: newlineIndex)
+            buffer.removeSubrange(...newlineIndex)
+            guard !line.isEmpty else { continue }
+            consume(Data(line))
+        }
+    }
+
+    private static func trimLeadingPartialRolloutLine(from buffer: inout Data) {
+        let newline = UInt8(ascii: "\n")
+        guard let newlineIndex = buffer.firstIndex(of: newline) else {
+            buffer.removeAll(keepingCapacity: false)
+            return
+        }
+        buffer.removeSubrange(...newlineIndex)
+    }
+}
+
+private extension String {
+    var trimmedForCodexSurface: String {
+        trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -29,6 +29,11 @@ final class ProcessMonitoringCoordinator {
     @ObservationIgnored
     var onCodexAppRunningChanged: ((_ isRunning: Bool) -> Void)?
 
+    /// Fires on each monitoring pass while Codex.app is running so fallback
+    /// rediscovery can keep recent desktop threads hydrated.
+    @ObservationIgnored
+    var onCodexAppRunningObserved: (() -> Void)?
+
     @ObservationIgnored
     let activeAgentProcessDiscovery = ActiveAgentProcessDiscovery()
 
@@ -125,6 +130,9 @@ final class ProcessMonitoringCoordinator {
         if isCodexAppRunning != wasCodexAppRunning {
             wasCodexAppRunning = isCodexAppRunning
             onCodexAppRunningChanged?(isCodexAppRunning)
+        }
+        if isCodexAppRunning {
+            onCodexAppRunningObserved?()
         }
         let sessions = local.sessions.filter(\.isTrackedLiveSession)
         guard !sessions.isEmpty else {
@@ -232,6 +240,8 @@ final class ProcessMonitoringCoordinator {
         case let .sessionStarted(payload):
             payload.sessionID
         case let .activityUpdated(payload):
+            payload.sessionID
+        case let .sessionRefreshed(payload):
             payload.sessionID
         case let .permissionRequested(payload):
             payload.sessionID

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -50,6 +50,8 @@ final class ProcessMonitoringCoordinator {
     private var wasCodexAppRunning = false
 
     private static let cursorStalenessTimeout: TimeInterval = 600  // 10 minutes
+    private static let codexRunningCacheTTL: TimeInterval = 1
+    private static var codexRunningCache: (checkedAt: Date, isRunning: Bool)?
 
     private var state: SessionState {
         get { stateAccessor?() ?? SessionState() }
@@ -58,7 +60,7 @@ final class ProcessMonitoringCoordinator {
 
     // MARK: - Monitoring lifecycle
 
-    func startMonitoringIfNeeded() {
+    func startMonitoringIfNeeded(initialDelay: Duration = .zero) {
         guard sessionAttachmentMonitorTask == nil else {
             return
         }
@@ -68,6 +70,10 @@ final class ProcessMonitoringCoordinator {
                 return
             }
 
+            if initialDelay > .zero {
+                try? await Task.sleep(for: initialDelay)
+            }
+
             while !Task.isCancelled {
                 let discovery = self.activeAgentProcessDiscovery
                 let probe = self.terminalSessionAttachmentProbe
@@ -75,8 +81,14 @@ final class ProcessMonitoringCoordinator {
                 let liveSessions = self.state.sessions.filter(\.isTrackedLiveSession)
                 let (snapshots, ghosttyAvail, terminalAvail, jumpTargets) = await Task.detached(priority: .utility) {
                     let s = discovery.discover()
-                    let g = probe.ghosttySnapshotAvailability()
-                    let t = probe.terminalSnapshotAvailability()
+                    let g: TerminalSessionAttachmentProbe.SnapshotAvailability<TerminalSessionAttachmentProbe.GhosttyTerminalSnapshot> =
+                        Self.needsGhosttySnapshots(for: liveSessions)
+                            ? probe.ghosttySnapshotAvailability()
+                            : .available([], appIsRunning: false)
+                    let t: TerminalSessionAttachmentProbe.SnapshotAvailability<TerminalSessionAttachmentProbe.TerminalTabSnapshot> =
+                        Self.needsAppleTerminalSnapshots(for: liveSessions)
+                            ? probe.terminalSnapshotAvailability()
+                            : .available([], appIsRunning: false)
                     let j = resolver.resolveJumpTargets(for: liveSessions, activeProcesses: s)
                     return (s, g, t, j)
                 }.value
@@ -86,8 +98,39 @@ final class ProcessMonitoringCoordinator {
                     terminalAvailability: terminalAvail,
                     preResolvedJumpTargets: jumpTargets
                 )
+                MemoryPressureRelief.releaseEmptyMallocPages()
                 try? await Task.sleep(for: .seconds(2))
             }
+        }
+    }
+
+    nonisolated private static func needsGhosttySnapshots(for sessions: [AgentSession]) -> Bool {
+        sessions.contains { session in
+            guard !session.isCodexAppSession else {
+                return false
+            }
+            let terminalApp = session.jumpTarget?.terminalApp
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased() ?? ""
+            return terminalApp.isEmpty
+                || terminalApp == "unknown"
+                || terminalApp.contains("ghostty")
+        }
+    }
+
+    nonisolated private static func needsAppleTerminalSnapshots(for sessions: [AgentSession]) -> Bool {
+        sessions.contains { session in
+            guard !session.isCodexAppSession else {
+                return false
+            }
+            let terminalApp = session.jumpTarget?.terminalApp
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased() ?? ""
+            return terminalApp.isEmpty
+                || terminalApp == "unknown"
+                || terminalApp == "terminal"
+                || terminalApp == "apple_terminal"
+                || terminalApp.contains("terminal.app")
         }
     }
 
@@ -172,7 +215,10 @@ final class ProcessMonitoringCoordinator {
         _ = local.reconcileJumpTargets(jumpTargetUpdates)
 
         // Phase 1: populate isProcessAlive in parallel with existing system.
-        let aliveIDs = sessionIDsWithAliveProcesses(activeProcesses: activeProcesses)
+        let aliveIDs = sessionIDsWithAliveProcesses(
+            activeProcesses: activeProcesses,
+            isCodexAppRunning: isCodexAppRunning
+        )
         _ = local.markProcessLiveness(
             aliveSessionIDs: aliveIDs,
             isCodexAppRunning: isCodexAppRunning
@@ -273,7 +319,8 @@ final class ProcessMonitoringCoordinator {
     /// heuristics (e.g. bundle-ID liveness for Cursor, PID matching for
     /// Codex/Claude/Gemini).
     func sessionIDsWithAliveProcesses(
-        activeProcesses: [ActiveProcessSnapshot]
+        activeProcesses: [ActiveProcessSnapshot],
+        isCodexAppRunning: Bool? = nil
     ) -> Set<String> {
         var aliveIDs: Set<String> = []
         let sessions = state.sessions
@@ -285,7 +332,7 @@ final class ProcessMonitoringCoordinator {
                 .compactMap(\.sessionID)
         )
         // Codex.app sessions: keep alive while the desktop app is running.
-        let isCodexAppRunning = Self.isCodexDesktopAppRunning()
+        let isCodexAppRunning = isCodexAppRunning ?? Self.isCodexDesktopAppRunning()
         for session in sessions where session.tool == .codex && !session.isDemoSession {
             if session.isCodexAppSession {
                 if isCodexAppRunning { aliveIDs.insert(session.id) }
@@ -866,17 +913,24 @@ final class ProcessMonitoringCoordinator {
 
     // MARK: - Utilities
 
-    /// Check whether Codex.app is currently running.  Uses
-    /// `NSWorkspace.shared.runningApplications` directly because
-    /// `NSRunningApplication.runningApplications(withBundleIdentifier:)`
-    /// has been observed to intermittently return an empty array even
-    /// when the app is running (likely a brief indexing window after
-    /// app launch / conversation switch), which would cause Open Island
-    /// to incorrectly kill visible Codex sessions.
+    /// Check whether Codex.app is currently running. Prefer LaunchServices'
+    /// bundle-id lookup so startup monitoring does not enumerate every running
+    /// app and synchronously resolve each bundle id. Keep the full Workspace
+    /// scan as a short-cached fallback because the bundle-id lookup has been
+    /// observed to briefly return empty during Codex launch / thread switches.
     static func isCodexDesktopAppRunning() -> Bool {
-        NSWorkspace.shared.runningApplications.contains { app in
-            app.bundleIdentifier == "com.openai.codex"
+        let now = Date.now
+        if let cached = codexRunningCache,
+           now.timeIntervalSince(cached.checkedAt) < codexRunningCacheTTL {
+            return cached.isRunning
         }
+
+        let isRunning = !NSRunningApplication.runningApplications(withBundleIdentifier: "com.openai.codex").isEmpty
+            || NSWorkspace.shared.runningApplications.contains { app in
+                app.bundleIdentifier == "com.openai.codex"
+            }
+        codexRunningCache = (now, isRunning)
+        return isRunning
     }
 
     private func processIdentityKey(_ process: ActiveProcessSnapshot) -> String {

--- a/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
+++ b/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
@@ -37,16 +37,16 @@ final class SessionDiscoveryCoordinator {
     var onStateChanged: (() -> Void)?
 
     @ObservationIgnored
-    private let codexSessionStore = CodexSessionStore()
+    private let codexSessionStore: CodexSessionStore
 
     @ObservationIgnored
-    private let claudeSessionRegistry = ClaudeSessionRegistry()
+    private let claudeSessionRegistry: ClaudeSessionRegistry
 
     @ObservationIgnored
-    private let openCodeSessionRegistry = OpenCodeSessionRegistry()
+    private let openCodeSessionRegistry: OpenCodeSessionRegistry
 
     @ObservationIgnored
-    private let cursorSessionRegistry = CursorSessionRegistry()
+    private let cursorSessionRegistry: CursorSessionRegistry
 
     @ObservationIgnored
     let codexRolloutWatcher = CodexRolloutWatcher()
@@ -77,7 +77,57 @@ final class SessionDiscoveryCoordinator {
         }
     }
 
+    init(
+        codexSessionStore: CodexSessionStore = CodexSessionStore(),
+        claudeSessionRegistry: ClaudeSessionRegistry = ClaudeSessionRegistry(),
+        openCodeSessionRegistry: OpenCodeSessionRegistry = OpenCodeSessionRegistry(),
+        cursorSessionRegistry: CursorSessionRegistry = CursorSessionRegistry()
+    ) {
+        self.codexSessionStore = codexSessionStore
+        self.claudeSessionRegistry = claudeSessionRegistry
+        self.openCodeSessionRegistry = openCodeSessionRegistry
+        self.cursorSessionRegistry = cursorSessionRegistry
+    }
+
     // MARK: - Startup discovery
+
+    /// Restores the last persisted UI snapshot synchronously so the first
+    /// opened island frame is not empty while slower rollout/app-server
+    /// discovery runs in the background.
+    @discardableResult
+    func restorePersistedSessionsImmediately(now: Date = .now) -> Int {
+        let cutoff = now.addingTimeInterval(-86_400)
+        let codexRecords = ((try? codexSessionStore.load()) ?? [])
+            .filter { $0.updatedAt >= cutoff && $0.shouldRestoreToLiveState }
+        let claudeRecords = ((try? claudeSessionRegistry.load()) ?? [])
+            .filter { $0.updatedAt >= cutoff && $0.shouldRestoreToLiveState }
+        let openCodeRecords = ((try? openCodeSessionRegistry.load()) ?? [])
+            .filter { $0.updatedAt >= cutoff }
+        let cursorRecords = ((try? cursorSessionRegistry.load()) ?? [])
+            .filter { $0.updatedAt >= cutoff && $0.shouldRestoreToLiveState }
+
+        var restoredSessions: [AgentSession] = []
+        restoredSessions.append(contentsOf: codexRecords.map(coldStartCodexSession(from:)))
+        restoredSessions.append(contentsOf: claudeRecords.map(\.restorableSession))
+        restoredSessions.append(contentsOf: openCodeRecords.map(\.restorableSession))
+        restoredSessions.append(contentsOf: cursorRecords.map(\.restorableSession))
+
+        guard !restoredSessions.isEmpty else {
+            return 0
+        }
+
+        state = SessionState(sessions: mergeDiscoveredSessions(restoredSessions))
+        onStatusMessage?("Restored \(restoredSessions.count) recent session(s) from local cache.")
+        return restoredSessions.count
+    }
+
+    private func coldStartCodexSession(from record: CodexTrackedSessionRecord) -> AgentSession {
+        var session = record.restorableSession
+        if session.isCodexAppSession {
+            session.isProcessAlive = true
+        }
+        return session
+    }
 
     /// Performs all startup file I/O off the main thread and returns the raw results.
     nonisolated func loadStartupDiscoveryPayload() -> StartupDiscoveryPayload {
@@ -95,7 +145,7 @@ final class SessionDiscoveryCoordinator {
         let allCursor = (try? cursorSessionRegistry.load()) ?? []
         let cursorRecords = allCursor.filter { $0.updatedAt >= cutoff && $0.shouldRestoreToLiveState }
 
-        let discoveredCodex = codexRolloutDiscovery.discoverRecentSessions()
+        let discoveredCodex = codexRecords.isEmpty ? codexRolloutDiscovery.discoverRecentSessions() : []
         let discoveredClaude = claudeTranscriptDiscovery.discoverRecentSessions()
 
         return StartupDiscoveryPayload(
@@ -134,7 +184,8 @@ final class SessionDiscoveryCoordinator {
 
         // Restore persisted Codex sessions.
         if !payload.codexRecords.isEmpty {
-            state = SessionState(sessions: payload.codexRecords.map(\.restorableSession))
+            let restoredSessions = payload.codexRecords.map(\.restorableSession)
+            state = SessionState(sessions: mergeDiscoveredSessions(restoredSessions))
             onStatusMessage?("Restored \(payload.codexRecords.count) recent Codex session(s) from local cache.")
         }
 
@@ -161,7 +212,7 @@ final class SessionDiscoveryCoordinator {
 
         // Merge discovered Codex sessions.
         if !payload.discoveredCodexRecords.isEmpty {
-            let mergedSessions = mergeDiscoveredSessions(payload.discoveredCodexRecords.map(\.session))
+            let mergedSessions = mergeDiscoveredSessions(payload.discoveredCodexRecords.map(codexAppSession))
             state = SessionState(sessions: mergedSessions)
             scheduleCodexSessionPersistence()
             onStatusMessage?("Discovered \(payload.discoveredCodexRecords.count) recent Codex session(s) from local rollouts.")
@@ -177,6 +228,7 @@ final class SessionDiscoveryCoordinator {
 
         // Sync rollout tracking with current sessions.
         refreshCodexRolloutTracking()
+        MemoryPressureRelief.releaseEmptyMallocPages()
     }
 
     // MARK: - Merge & discovery
@@ -216,7 +268,9 @@ final class SessionDiscoveryCoordinator {
         let discoveredIsNewer = discovered.updatedAt >= existing.updatedAt
 
         if discoveredIsNewer {
-            merged.title = discovered.title
+            if shouldUseDiscoveredTitle(discovered.title, over: existing.title, workspaceName: existing.jumpTarget?.workspaceName ?? discovered.jumpTarget?.workspaceName) {
+                merged.title = discovered.title
+            }
             merged.phase = discovered.phase
             merged.summary = discovered.summary
             merged.updatedAt = discovered.updatedAt
@@ -235,8 +289,49 @@ final class SessionDiscoveryCoordinator {
         // (hook or rediscovery), preserve that flag so liveness uses the
         // app-level check instead of subprocess polling.
         merged.isCodexAppSession = existing.isCodexAppSession || discovered.isCodexAppSession
+        if discovered.isProcessAlive {
+            merged.isProcessAlive = true
+            merged.processNotSeenCount = 0
+        }
 
         return merged
+    }
+
+    private func shouldUseDiscoveredTitle(
+        _ discoveredTitle: String,
+        over existingTitle: String,
+        workspaceName: String?
+    ) -> Bool {
+        let discoveredIsFallback = isCodexWorkspaceFallbackTitle(discoveredTitle, workspaceName: workspaceName)
+        let existingIsFallback = isCodexWorkspaceFallbackTitle(existingTitle, workspaceName: workspaceName)
+
+        if discoveredIsFallback && !existingIsFallback {
+            return false
+        }
+
+        return true
+    }
+
+    private func isCodexWorkspaceFallbackTitle(_ title: String, workspaceName: String?) -> Bool {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTitle.isEmpty else {
+            return true
+        }
+
+        let workspace = workspaceName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !workspace.isEmpty,
+           trimmedTitle.localizedCaseInsensitiveCompare(workspace) == .orderedSame {
+            return true
+        }
+
+        let codexPrefix = "Codex · "
+        if trimmedTitle.range(of: codexPrefix, options: [.caseInsensitive, .anchored]) != nil {
+            let stripped = String(trimmedTitle.dropFirst(codexPrefix.count))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return workspace.isEmpty || stripped.localizedCaseInsensitiveCompare(workspace) == .orderedSame
+        }
+
+        return false
     }
 
     private func mergeOpenCodeMetadata(
@@ -322,7 +417,8 @@ final class SessionDiscoveryCoordinator {
             lastUserPrompt: discovered.lastUserPrompt ?? existing.lastUserPrompt,
             lastAssistantMessage: discovered.lastAssistantMessage ?? existing.lastAssistantMessage,
             currentTool: discovered.currentTool ?? existing.currentTool,
-            currentCommandPreview: discovered.currentCommandPreview ?? existing.currentCommandPreview
+            currentCommandPreview: discovered.currentCommandPreview ?? existing.currentCommandPreview,
+            isSubagentSession: existing.isSubagentSession || discovered.isSubagentSession
         )
         return merged.isEmpty ? nil : merged
     }
@@ -387,26 +483,58 @@ final class SessionDiscoveryCoordinator {
     @ObservationIgnored
     private var lastCodexAppRescanDate: Date = .distantPast
 
+    @ObservationIgnored
+    private var codexAppRediscoveryTask: Task<Void, Never>?
+
     /// Re-scan `~/.codex/sessions/` for rollout files not yet tracked.
     /// Called periodically when Codex.app is running as a fallback when
     /// the app-server connection is unavailable.  Throttled to at most
     /// once per 10 seconds.
     func rediscoverCodexAppSessionsIfNeeded() {
+        guard codexAppRediscoveryTask == nil else { return }
+
         let now = Date.now
         guard now.timeIntervalSince(lastCodexAppRescanDate) >= 10 else { return }
         lastCodexAppRescanDate = now
 
         let discovery = codexRolloutDiscovery
-        Task.detached(priority: .utility) { [weak self] in
+        codexAppRediscoveryTask = Task.detached(priority: .utility) { [weak self] in
             let discovered = discovery.discoverRecentSessions()
-            guard !discovered.isEmpty else { return }
+            let enriched: [CodexTrackedSessionRecord]
+            if discovered.isEmpty {
+                enriched = []
+            } else {
+                let titleBySessionID = await CodexAppServerCoordinator.fetchThreadTitles(limit: 40)
+                enriched = Self.enrichCodexRecords(discovered, titleBySessionID: titleBySessionID)
+            }
             await MainActor.run { [weak self] in
-                self?.applyCodexAppRediscovery(discovered)
+                if !enriched.isEmpty {
+                    self?.applyCodexAppRediscovery(enriched)
+                }
+                self?.codexAppRediscoveryTask = nil
+                MemoryPressureRelief.releaseEmptyMallocPages()
             }
         }
     }
 
-    private func applyCodexAppRediscovery(_ records: [CodexTrackedSessionRecord]) {
+    nonisolated static func enrichCodexRecords(
+        _ records: [CodexTrackedSessionRecord],
+        titleBySessionID: [String: String]
+    ) -> [CodexTrackedSessionRecord] {
+        records.map { record in
+            guard let title = titleBySessionID[record.sessionID]?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !title.isEmpty else {
+                return record
+            }
+
+            var enriched = record
+            enriched.title = title
+            enriched.jumpTarget?.paneTitle = title
+            return enriched
+        }
+    }
+
+    func applyCodexAppRediscovery(_ records: [CodexTrackedSessionRecord]) {
         let existingIDs = Set(state.sessions.filter { $0.tool == .codex }.map(\.id))
         let existingPaths = Set(state.sessions.compactMap(\.codexMetadata?.transcriptPath))
 
@@ -414,35 +542,46 @@ final class SessionDiscoveryCoordinator {
             !existingIDs.contains(record.sessionID)
                 && (record.codexMetadata?.transcriptPath).map { !existingPaths.contains($0) } ?? true
         }
-        guard !newRecords.isEmpty else { return }
-
-        let newSessions = newRecords.map { record -> AgentSession in
-            var session = record.session
-            session.isCodexAppSession = true
-            session.isProcessAlive = true
-            // Prefer the discovered record's cwd (sourced from the rollout
-            // file's session_meta) over an empty fallback.
-            let cwd = record.jumpTarget?.workingDirectory ?? ""
-            if session.jumpTarget == nil {
-                session.jumpTarget = JumpTarget(
-                    terminalApp: "Codex.app",
-                    workspaceName: URL(fileURLWithPath: cwd).lastPathComponent,
-                    paneTitle: session.title,
-                    workingDirectory: cwd.isEmpty ? nil : cwd,
-                    codexThreadID: session.id
-                )
-            } else {
-                session.jumpTarget?.terminalApp = "Codex.app"
-                session.jumpTarget?.codexThreadID = session.id
-            }
-            return session
+        let refreshRecords = records.filter { record in
+            existingIDs.contains(record.sessionID)
+                || (record.codexMetadata?.transcriptPath).map { existingPaths.contains($0) } ?? false
         }
+        guard !newRecords.isEmpty || !refreshRecords.isEmpty else { return }
 
-        let merged = mergeDiscoveredSessions(newSessions)
+        let refreshedSessions = (newRecords + refreshRecords).map(codexAppSession)
+
+        let merged = mergeDiscoveredSessions(refreshedSessions)
         state = SessionState(sessions: merged)
         refreshCodexRolloutTracking()
         scheduleCodexSessionPersistence()
-        onStatusMessage?("Discovered \(newRecords.count) new Codex.app session(s) via rollout re-scan.")
+        if !newRecords.isEmpty {
+            onStatusMessage?("Discovered \(newRecords.count) new Codex.app session(s) via rollout re-scan.")
+        }
+        if !refreshRecords.isEmpty {
+            onStatusMessage?("Refreshed \(refreshRecords.count) Codex.app session(s) via rollout re-scan.")
+        }
+    }
+
+    private func codexAppSession(from record: CodexTrackedSessionRecord) -> AgentSession {
+        var session = record.session
+        session.isCodexAppSession = true
+        session.isProcessAlive = true
+        // Prefer the discovered record's cwd (sourced from the rollout
+        // file's session_meta) over an empty fallback.
+        let cwd = record.jumpTarget?.workingDirectory ?? ""
+        if session.jumpTarget == nil {
+            session.jumpTarget = JumpTarget(
+                terminalApp: "Codex.app",
+                workspaceName: URL(fileURLWithPath: cwd).lastPathComponent,
+                paneTitle: session.title,
+                workingDirectory: cwd.isEmpty ? nil : cwd,
+                codexThreadID: session.id
+            )
+        } else {
+            session.jumpTarget?.terminalApp = "Codex.app"
+            session.jumpTarget?.codexThreadID = session.id
+        }
+        return session
     }
 
     // MARK: - Persistence scheduling

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1444,6 +1444,10 @@ private struct IslandSessionRow: View {
     }
 
     private var notificationWorkspaceHeadlineText: String {
+        if session.isCodexAppSession {
+            return session.spotlightHeadlineText.trimmedForNotificationCard
+        }
+
         let workspace = session.spotlightWorkspaceName.trimmedForNotificationCard
         let title = workspace.isEmpty ? session.tool.displayName : workspace
         guard let branch = session.spotlightWorktreeBranch?.trimmedForNotificationCard,

--- a/Sources/OpenIslandCore/AgentEvent.swift
+++ b/Sources/OpenIslandCore/AgentEvent.swift
@@ -68,6 +68,34 @@ public struct SessionActivityUpdated: Equatable, Codable, Sendable {
     }
 }
 
+public struct SessionRefreshed: Equatable, Codable, Sendable {
+    public var sessionID: String
+    public var title: String
+    public var summary: String
+    public var phase: SessionPhase
+    public var timestamp: Date
+    public var jumpTarget: JumpTarget?
+    public var codexMetadata: CodexSessionMetadata?
+
+    public init(
+        sessionID: String,
+        title: String,
+        summary: String,
+        phase: SessionPhase,
+        timestamp: Date,
+        jumpTarget: JumpTarget? = nil,
+        codexMetadata: CodexSessionMetadata? = nil
+    ) {
+        self.sessionID = sessionID
+        self.title = title
+        self.summary = summary
+        self.phase = phase
+        self.timestamp = timestamp
+        self.jumpTarget = jumpTarget
+        self.codexMetadata = codexMetadata
+    }
+}
+
 public struct PermissionRequested: Equatable, Codable, Sendable {
     public var sessionID: String
     public var request: PermissionRequest
@@ -241,6 +269,7 @@ public struct ActionableStateResolved: Equatable, Codable, Sendable {
 public enum AgentEvent: Equatable, Codable, Sendable {
     case sessionStarted(SessionStarted)
     case activityUpdated(SessionActivityUpdated)
+    case sessionRefreshed(SessionRefreshed)
     case permissionRequested(PermissionRequested)
     case questionAsked(QuestionAsked)
     case sessionCompleted(SessionCompleted)
@@ -256,6 +285,7 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case type
         case sessionStarted
         case activityUpdated
+        case sessionRefreshed
         case permissionRequested
         case questionAsked
         case sessionCompleted
@@ -271,6 +301,7 @@ public enum AgentEvent: Equatable, Codable, Sendable {
     private enum EventType: String, Codable {
         case sessionStarted
         case activityUpdated
+        case sessionRefreshed
         case permissionRequested
         case questionAsked
         case sessionCompleted
@@ -292,6 +323,8 @@ public enum AgentEvent: Equatable, Codable, Sendable {
             self = .sessionStarted(try container.decode(SessionStarted.self, forKey: .sessionStarted))
         case .activityUpdated:
             self = .activityUpdated(try container.decode(SessionActivityUpdated.self, forKey: .activityUpdated))
+        case .sessionRefreshed:
+            self = .sessionRefreshed(try container.decode(SessionRefreshed.self, forKey: .sessionRefreshed))
         case .permissionRequested:
             self = .permissionRequested(try container.decode(PermissionRequested.self, forKey: .permissionRequested))
         case .questionAsked:
@@ -335,6 +368,9 @@ public enum AgentEvent: Equatable, Codable, Sendable {
         case let .activityUpdated(payload):
             try container.encode(EventType.activityUpdated, forKey: .type)
             try container.encode(payload, forKey: .activityUpdated)
+        case let .sessionRefreshed(payload):
+            try container.encode(EventType.sessionRefreshed, forKey: .type)
+            try container.encode(payload, forKey: .sessionRefreshed)
         case let .permissionRequested(payload):
             try container.encode(EventType.permissionRequested, forKey: .type)
             try container.encode(payload, forKey: .permissionRequested)

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -16,6 +16,12 @@ public final class BridgeServer: @unchecked Sendable {
         let hookEventName: CodexHookEventName
     }
 
+    private struct PendingCodexQuestion {
+        let clientID: UUID
+        let payload: CodexHookPayload
+        let prompt: QuestionPrompt
+    }
+
     private struct PendingClaudeToolContext {
         let sessionID: String
         let toolUseID: String?
@@ -66,6 +72,7 @@ public final class BridgeServer: @unchecked Sendable {
     private var listeners: [Listener] = []
     private var clients: [UUID: ClientConnection] = [:]
     private var pendingApprovals: [String: PendingApproval] = [:]
+    private var pendingCodexQuestions: [String: PendingCodexQuestion] = [:]
     private var pendingClaudeToolContexts: [String: PendingClaudeToolContext] = [:]
     private var pendingClaudeInteractions: [String: PendingClaudeInteraction] = [:]
     private var pendingOpenCodeInteractions: [String: PendingOpenCodeInteraction] = [:]
@@ -180,6 +187,7 @@ public final class BridgeServer: @unchecked Sendable {
 
     private func stopLocked() {
         pendingApprovals.removeAll()
+        pendingCodexQuestions.removeAll()
         pendingClaudeInteractions.removeAll()
         pendingClaudeToolContexts.removeAll()
         pendingAgentDescriptions.removeAll()
@@ -427,6 +435,12 @@ public final class BridgeServer: @unchecked Sendable {
             send(.response(.acknowledged), to: clientID)
 
         case let .answerQuestion(sessionID, response):
+            if pendingCodexQuestions[sessionID] != nil {
+                resolvePendingCodexQuestion(sessionID: sessionID, response: response)
+                send(.response(.acknowledged), to: clientID)
+                return
+            }
+
             if pendingClaudeInteractions[sessionID] != nil {
                 resolvePendingClaudeQuestion(sessionID: sessionID, response: response)
                 send(.response(.acknowledged), to: clientID)
@@ -521,33 +535,41 @@ public final class BridgeServer: @unchecked Sendable {
             synchronizeJumpTarget(for: payload)
             synchronizeCodexMetadata(for: payload)
 
-            let command = payload.commandPreview ?? "Bash command"
-
-            let approvalEvent = AgentEvent.permissionRequested(
-                PermissionRequested(
-                    sessionID: payload.sessionID,
-                    request: PermissionRequest(
-                        title: "Run Bash command",
-                        summary: "Codex wants to run a shell command.",
-                        affectedPath: payload.commandText ?? command,
-                        primaryActionTitle: "Allow",
-                        secondaryActionTitle: "Deny"
-                    ),
-                    timestamp: .now
+            emit(
+                .activityUpdated(
+                    SessionActivityUpdated(
+                        sessionID: payload.sessionID,
+                        summary: payload.toolActivitySummary,
+                        phase: .running,
+                        timestamp: .now
+                    )
                 )
             )
-
-            emit(approvalEvent)
-
-            pendingApprovals[payload.sessionID] = PendingApproval(
-                clientID: clientID,
-                hookEventName: .preToolUse
-            )
+            send(.response(.acknowledged), to: clientID)
 
         case .permissionRequest:
             ensureSessionExists(for: payload)
             synchronizeJumpTarget(for: payload)
             synchronizeCodexMetadata(for: payload)
+
+            if payload.toolName == "AskUserQuestion",
+               let prompt = codexQuestionPrompt(from: payload) {
+                emit(
+                    .questionAsked(
+                        QuestionAsked(
+                            sessionID: payload.sessionID,
+                            prompt: prompt,
+                            timestamp: .now
+                        )
+                    )
+                )
+                pendingCodexQuestions[payload.sessionID] = PendingCodexQuestion(
+                    clientID: clientID,
+                    payload: payload,
+                    prompt: prompt
+                )
+                return
+            }
 
             emit(
                 .permissionRequested(
@@ -1874,7 +1896,7 @@ public final class BridgeServer: @unchecked Sendable {
             update: payload.defaultCodexMetadata,
             hookEventName: payload.hookEventName
         )
-        guard !mergedMetadata.isEmpty else {
+        guard existingSession.codexMetadata != nil || !mergedMetadata.isEmpty else {
             return
         }
 
@@ -2033,7 +2055,8 @@ public final class BridgeServer: @unchecked Sendable {
                 existing: existing?.currentCommandPreview,
                 update: update.currentCommandPreview,
                 hookEventName: hookEventName
-            )
+            ),
+            isSubagentSession: existing?.isSubagentSession == true || update.isSubagentSession
         )
     }
 
@@ -2042,16 +2065,18 @@ public final class BridgeServer: @unchecked Sendable {
         update: String?,
         hookEventName: CodexHookEventName
     ) -> String? {
-        if let update {
-            return update
-        }
-
         switch hookEventName {
         case .userPromptSubmit, .postToolUse, .stop:
             return nil
         case .sessionStart, .preToolUse, .permissionRequest:
-            return existing
+            break
         }
+
+        if let update {
+            return update
+        }
+
+        return existing
     }
 
     private func mergedClaudeMetadata(
@@ -2362,16 +2387,18 @@ public final class BridgeServer: @unchecked Sendable {
         update: String?,
         hookEventName: CodexHookEventName
     ) -> String? {
-        if let update {
-            return update
-        }
-
         switch hookEventName {
         case .userPromptSubmit, .postToolUse, .stop:
             return nil
         case .sessionStart, .preToolUse, .permissionRequest:
-            return existing
+            break
         }
+
+        if let update {
+            return update
+        }
+
+        return existing
     }
 
     private func resolvePendingApproval(sessionID: String, resolution: PermissionResolution) {
@@ -2386,7 +2413,7 @@ public final class BridgeServer: @unchecked Sendable {
         case let (.preToolUse, .deny(message, _)):
             response = .codexHookDirective(.deny(reason: message ?? "Permission denied in Open Island."))
         case (.permissionRequest, .allowOnce):
-            response = .codexHookDirective(.permissionRequest(.allow))
+            response = .codexHookDirective(.permissionRequest(.allow()))
         case let (.permissionRequest, .deny(message, _)):
             response = .codexHookDirective(
                 .permissionRequest(.deny(message: message ?? "Permission denied in Open Island."))
@@ -2397,6 +2424,40 @@ public final class BridgeServer: @unchecked Sendable {
         }
 
         send(.response(response), to: pendingApproval.clientID)
+    }
+
+    private func resolvePendingCodexQuestion(
+        sessionID: String,
+        response: QuestionPromptResponse
+    ) {
+        guard let pendingQuestion = pendingCodexQuestions.removeValue(forKey: sessionID) else {
+            return
+        }
+
+        let updatedInput = mergedCodexQuestionInput(
+            payload: pendingQuestion.payload,
+            prompt: pendingQuestion.prompt,
+            response: response
+        )
+        let summary = response.displaySummary.isEmpty
+            ? "Answered Codex's questions."
+            : "Answered: \(response.displaySummary)"
+
+        emit(
+            .activityUpdated(
+                SessionActivityUpdated(
+                    sessionID: sessionID,
+                    summary: summary,
+                    phase: .running,
+                    timestamp: .now
+                )
+            )
+        )
+
+        send(
+            .response(.codexHookDirective(.permissionRequest(.allow(updatedInput: updatedInput)))),
+            to: pendingQuestion.clientID
+        )
     }
 
     private func resolvePendingClaudeInteraction(
@@ -2510,6 +2571,112 @@ public final class BridgeServer: @unchecked Sendable {
 
     private func claudeToolUseID(for payload: ClaudeHookPayload) -> String? {
         payload.toolUseID ?? pendingClaudeToolContexts[payload.permissionCorrelationKey]?.toolUseID
+    }
+
+    private func codexQuestionPrompt(from payload: CodexHookPayload) -> QuestionPrompt? {
+        guard case let .object(root)? = payload.toolInput?.rawValue else {
+            return nil
+        }
+
+        let questions: [QuestionPromptItem]
+        if case let .array(questionValues)? = root["questions"] {
+            questions = questionValues.compactMap { value in
+                guard case let .object(questionObject) = value else {
+                    return nil
+                }
+
+                let id = codexString(questionObject["id"])
+                    ?? codexString(questionObject["key"])
+                    ?? codexString(questionObject["name"])
+                    ?? UUID().uuidString
+                let question = codexString(questionObject["question"])
+                    ?? codexString(questionObject["prompt"])
+                    ?? codexString(questionObject["label"])
+                    ?? id
+                let options = codexQuestionOptions(from: questionObject["options"])
+
+                return QuestionPromptItem(
+                    question: question,
+                    header: id,
+                    options: options
+                )
+            }
+        } else if let question = codexString(root["question"]) ?? codexString(root["prompt"]) {
+            let id = codexString(root["id"]) ?? "answer"
+            questions = [
+                QuestionPromptItem(
+                    question: question,
+                    header: id,
+                    options: codexQuestionOptions(from: root["options"])
+                ),
+            ]
+        } else {
+            questions = []
+        }
+
+        guard !questions.isEmpty else {
+            return nil
+        }
+
+        return QuestionPrompt(
+            title: "Codex is asking a question.",
+            questions: questions
+        )
+    }
+
+    private func mergedCodexQuestionInput(
+        payload: CodexHookPayload,
+        prompt: QuestionPrompt,
+        response: QuestionPromptResponse
+    ) -> CodexHookJSONValue {
+        var answers = response.answers
+        if answers.isEmpty,
+           let rawAnswer = response.rawAnswer,
+           !rawAnswer.isEmpty,
+           let fallbackQuestionID = prompt.questions.first?.header {
+            answers[fallbackQuestionID] = rawAnswer
+        }
+
+        guard case let .object(existingObject)? = payload.toolInput?.rawValue else {
+            return .object([
+                "answers": .object(answers.mapValues { .string($0) }),
+            ])
+        }
+
+        var updatedObject = existingObject
+        updatedObject["answers"] = .object(answers.mapValues { .string($0) })
+        return .object(updatedObject)
+    }
+
+    private func codexQuestionOptions(from value: CodexHookJSONValue?) -> [QuestionOption] {
+        guard case let .array(values)? = value else {
+            return []
+        }
+
+        return values.compactMap { value in
+            switch value {
+            case let .string(label):
+                return QuestionOption(label: label)
+            case let .object(object):
+                guard let label = codexString(object["label"]) ?? codexString(object["value"]) else {
+                    return nil
+                }
+                return QuestionOption(
+                    label: label,
+                    description: codexString(object["description"]) ?? ""
+                )
+            default:
+                return nil
+            }
+        }
+    }
+
+    private func codexString(_ value: CodexHookJSONValue?) -> String? {
+        guard case let .string(string)? = value,
+              !string.isEmpty else {
+            return nil
+        }
+        return string
     }
 
     private func mergedClaudeQuestionInput(

--- a/Sources/OpenIslandCore/CodexAppServer.swift
+++ b/Sources/OpenIslandCore/CodexAppServer.swift
@@ -80,7 +80,125 @@ public enum CodexAppServerNotification: Sendable {
     case threadNameUpdated(threadId: String, name: String?)
     case turnStarted(threadId: String, turn: CodexTurn)
     case turnCompleted(threadId: String, turn: CodexTurn)
+    case itemStarted(CodexAppServerItemActivity)
+    case itemCompleted(CodexAppServerItemActivity)
+    case itemOutputDelta(CodexAppServerItemActivity)
+    case itemPatchUpdated(CodexAppServerItemActivity)
+    case agentMessageDelta(CodexAppServerAgentMessageDelta)
+    case rawResponseItemCompleted(CodexAppServerRawResponseItem)
+    case approvalRequested(CodexAppServerApprovalRequest)
+    case serverRequestResolved(threadId: String, requestId: Int?)
+    case accountRateLimitsUpdated(CodexUsageSnapshot)
     case unknown(method: String)
+}
+
+public struct CodexAppServerItemActivity: Equatable, Sendable {
+    public var threadID: String
+    public var turnID: String?
+    public var itemID: String?
+    public var toolName: String
+    public var preview: String?
+
+    public init(
+        threadID: String,
+        turnID: String? = nil,
+        itemID: String? = nil,
+        toolName: String,
+        preview: String? = nil
+    ) {
+        self.threadID = threadID
+        self.turnID = turnID
+        self.itemID = itemID
+        self.toolName = toolName
+        self.preview = preview
+    }
+}
+
+public struct CodexAppServerAgentMessageDelta: Equatable, Sendable {
+    public var threadID: String
+    public var turnID: String?
+    public var itemID: String?
+    public var text: String
+
+    public init(
+        threadID: String,
+        turnID: String? = nil,
+        itemID: String? = nil,
+        text: String
+    ) {
+        self.threadID = threadID
+        self.turnID = turnID
+        self.itemID = itemID
+        self.text = text
+    }
+}
+
+public struct CodexAppServerRawResponseItem: Equatable, Sendable {
+    public var threadID: String
+    public var turnID: String?
+    public var itemID: String?
+    public var toolName: String?
+    public var preview: String?
+    public var assistantText: String?
+
+    public init(
+        threadID: String,
+        turnID: String? = nil,
+        itemID: String? = nil,
+        toolName: String? = nil,
+        preview: String? = nil,
+        assistantText: String? = nil
+    ) {
+        self.threadID = threadID
+        self.turnID = turnID
+        self.itemID = itemID
+        self.toolName = toolName
+        self.preview = preview
+        self.assistantText = assistantText
+    }
+}
+
+public enum CodexAppServerApprovalKind: Equatable, Sendable {
+    case commandExecution
+    case fileChange
+    case permissions
+}
+
+public struct CodexAppServerApprovalRequest: Equatable, Sendable {
+    public var requestID: Int
+    public var kind: CodexAppServerApprovalKind
+    public var threadID: String
+    public var turnID: String?
+    public var itemID: String?
+    public var approvalID: String?
+    public var reason: String?
+    public var command: [String]
+    public var cwd: String?
+    public var permissions: CodexHookJSONValue?
+
+    public init(
+        requestID: Int,
+        kind: CodexAppServerApprovalKind,
+        threadID: String,
+        turnID: String? = nil,
+        itemID: String? = nil,
+        approvalID: String? = nil,
+        reason: String? = nil,
+        command: [String] = [],
+        cwd: String? = nil,
+        permissions: CodexHookJSONValue? = nil
+    ) {
+        self.requestID = requestID
+        self.kind = kind
+        self.threadID = threadID
+        self.turnID = turnID
+        self.itemID = itemID
+        self.approvalID = approvalID
+        self.reason = reason
+        self.command = command
+        self.cwd = cwd
+        self.permissions = permissions
+    }
 }
 
 // MARK: - JSON-RPC transport
@@ -232,6 +350,36 @@ public final class CodexAppServerClient: @unchecked Sendable {
         return result.thread
     }
 
+    /// Read account-level Codex rate limits from the app-server. This is the
+    /// same authoritative source Codex.app uses, and is preferred over passive
+    /// JSONL `token_count.rate_limits` observations.
+    public func readAccountRateLimits() async throws -> CodexUsageSnapshot? {
+        struct Params: Encodable {}
+        let data = try await sendRequest(method: "account/rateLimits/read", params: Params())
+        let result = try JSONDecoder().decode(AccountRateLimitsReadResult.self, from: data)
+        return result.rateLimits?.usageSnapshot(source: "codex-app-server")
+    }
+
+    public func resolveApprovalRequest(
+        _ request: CodexAppServerApprovalRequest,
+        resolution: PermissionResolution
+    ) throws {
+        switch request.kind {
+        case .commandExecution, .fileChange:
+            let decision = Self.approvalDecision(for: resolution)
+            try sendResponse(id: request.requestID, result: ["decision": decision])
+
+        case .permissions:
+            let permissions = resolution.isApproved ? request.permissions?.jsonObject : [:]
+            try sendResponse(
+                id: request.requestID,
+                result: [
+                    "permissions": permissions ?? [:],
+                ]
+            )
+        }
+    }
+
     // MARK: - JSON-RPC transport
 
     /// Returns raw JSON `result` bytes from the response.
@@ -299,6 +447,30 @@ public final class CodexAppServerClient: @unchecked Sendable {
         continuation?.resume(throwing: error)
     }
 
+    private func sendResponse(id: Int, result: [String: Any]) throws {
+        guard let stdin else {
+            throw CodexAppServerError.notConnected
+        }
+
+        let envelope: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": result,
+        ]
+        var line = try JSONSerialization.data(withJSONObject: envelope)
+        line.append(contentsOf: [UInt8(ascii: "\n")])
+        stdin.write(line)
+    }
+
+    private static func approvalDecision(for resolution: PermissionResolution) -> String {
+        switch resolution {
+        case .allowOnce:
+            "accept"
+        case .deny:
+            "decline"
+        }
+    }
+
     // MARK: - Incoming data
 
     /// Maximum bytes we will accumulate without seeing a newline. Codex
@@ -325,7 +497,10 @@ public final class CodexAppServerClient: @unchecked Sendable {
                   let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any]
             else { continue }
 
-            if let id = json["id"] as? Int {
+            if let id = json["id"] as? Int,
+               json["method"] is String {
+                handleServerRequest(id: id, json: json)
+            } else if let id = json["id"] as? Int {
                 handleResponse(id: id, json: json)
             } else if let method = json["method"] as? String {
                 handleNotification(method: method, json: json)
@@ -355,6 +530,30 @@ public final class CodexAppServerClient: @unchecked Sendable {
         }
     }
 
+    private func handleServerRequest(id: Int, json: [String: Any]) {
+        guard let method = json["method"] as? String,
+              let params = json["params"] as? [String: Any] else {
+            return
+        }
+
+        switch method {
+        case "item/commandExecution/requestApproval":
+            guard let request = Self.commandExecutionApprovalRequest(id: id, params: params) else { return }
+            onNotification?(.approvalRequested(request))
+
+        case "item/fileChange/requestApproval":
+            guard let request = Self.fileChangeApprovalRequest(id: id, params: params) else { return }
+            onNotification?(.approvalRequested(request))
+
+        case "item/permissions/requestApproval":
+            guard let request = Self.permissionsApprovalRequest(id: id, params: params) else { return }
+            onNotification?(.approvalRequested(request))
+
+        default:
+            onNotification?(.unknown(method: method))
+        }
+    }
+
     private func handleNotification(method: String, json: [String: Any]) {
         guard let params = json["params"] else { return }
         let paramsData = (try? JSONSerialization.data(withJSONObject: params)) ?? Data()
@@ -380,11 +579,352 @@ public final class CodexAppServerClient: @unchecked Sendable {
         case "turn/completed":
             guard let n = try? decoder.decode(TurnNotificationParams.self, from: paramsData) else { return }
             notification = .turnCompleted(threadId: n.threadId, turn: n.turn)
+        case "item/started":
+            guard let activity = Self.itemActivity(from: params) else { return }
+            notification = .itemStarted(activity)
+        case "item/completed":
+            guard let activity = Self.itemActivity(from: params) else { return }
+            notification = .itemCompleted(activity)
+        case "item/commandExecution/outputDelta":
+            guard let activity = Self.commandOutputActivity(from: params) else { return }
+            notification = .itemOutputDelta(activity)
+        case "item/fileChange/patchUpdated":
+            guard let activity = Self.fileChangePatchActivity(from: params) else { return }
+            notification = .itemPatchUpdated(activity)
+        case "item/agentMessage/delta":
+            guard let delta = Self.agentMessageDelta(from: params) else { return }
+            notification = .agentMessageDelta(delta)
+        case "rawResponseItem/completed":
+            guard let item = Self.rawResponseItem(from: params) else { return }
+            notification = .rawResponseItemCompleted(item)
+        case "serverRequest/resolved":
+            guard let n = try? decoder.decode(ServerRequestResolvedParams.self, from: paramsData) else { return }
+            notification = .serverRequestResolved(threadId: n.threadId, requestId: n.requestId)
+        case "account/rateLimits/updated":
+            guard let n = try? decoder.decode(AccountRateLimitsUpdatedParams.self, from: paramsData),
+                  let snapshot = n.rateLimits.usageSnapshot(source: "codex-app-server-notification") else { return }
+            notification = .accountRateLimitsUpdated(snapshot)
         default:
             notification = .unknown(method: method)
         }
 
         onNotification?(notification)
+    }
+
+    private static func commandExecutionApprovalRequest(
+        id: Int,
+        params: [String: Any]
+    ) -> CodexAppServerApprovalRequest? {
+        guard let threadID = params["threadId"] as? String else { return nil }
+        return CodexAppServerApprovalRequest(
+            requestID: id,
+            kind: .commandExecution,
+            threadID: threadID,
+            turnID: params["turnId"] as? String,
+            itemID: params["itemId"] as? String,
+            approvalID: params["approvalId"] as? String,
+            reason: params["reason"] as? String,
+            command: commandParts(from: params["command"]),
+            cwd: params["cwd"] as? String
+        )
+    }
+
+    private static func fileChangeApprovalRequest(
+        id: Int,
+        params: [String: Any]
+    ) -> CodexAppServerApprovalRequest? {
+        guard let threadID = params["threadId"] as? String else { return nil }
+        return CodexAppServerApprovalRequest(
+            requestID: id,
+            kind: .fileChange,
+            threadID: threadID,
+            turnID: params["turnId"] as? String,
+            itemID: params["itemId"] as? String,
+            approvalID: params["approvalId"] as? String,
+            reason: params["reason"] as? String,
+            cwd: params["cwd"] as? String
+        )
+    }
+
+    private static func permissionsApprovalRequest(
+        id: Int,
+        params: [String: Any]
+    ) -> CodexAppServerApprovalRequest? {
+        guard let threadID = params["threadId"] as? String else { return nil }
+        let permissions = params["permissions"].flatMap(CodexHookJSONValue.init(jsonObject:))
+        return CodexAppServerApprovalRequest(
+            requestID: id,
+            kind: .permissions,
+            threadID: threadID,
+            turnID: params["turnId"] as? String,
+            itemID: params["itemId"] as? String,
+            reason: params["reason"] as? String,
+            cwd: params["cwd"] as? String,
+            permissions: permissions
+        )
+    }
+
+    private static func itemActivity(from params: Any) -> CodexAppServerItemActivity? {
+        guard let params = params as? [String: Any],
+              let threadID = params["threadId"] as? String else {
+            return nil
+        }
+
+        let item = params["item"] as? [String: Any] ?? params
+        let rawType = item["type"] as? String
+        let toolName: String
+        let preview: String?
+
+        switch rawType {
+        case "commandExecution", "command_execution", "local_shell_call":
+            toolName = "exec_command"
+            preview = commandPreview(from: item["command"] ?? item["cmd"])
+        case "fileChange", "file_change":
+            toolName = "apply_patch"
+            preview = fileChangePreview(from: item)
+        case "dynamicToolCall", "dynamic_tool_call", "mcpToolCall", "mcp_tool_call":
+            toolName = [
+                item["namespace"] as? String,
+                item["tool"] as? String ?? item["name"] as? String,
+            ]
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: ".")
+            preview = jsonPreview(from: item["arguments"] ?? item["input"])
+        default:
+            return nil
+        }
+
+        guard !toolName.isEmpty else { return nil }
+        return CodexAppServerItemActivity(
+            threadID: threadID,
+            turnID: params["turnId"] as? String,
+            itemID: item["id"] as? String ?? params["itemId"] as? String,
+            toolName: toolName,
+            preview: preview
+        )
+    }
+
+    private static func commandOutputActivity(from params: Any) -> CodexAppServerItemActivity? {
+        guard let params = params as? [String: Any],
+              let threadID = params["threadId"] as? String else {
+            return nil
+        }
+
+        return CodexAppServerItemActivity(
+            threadID: threadID,
+            turnID: params["turnId"] as? String,
+            itemID: params["itemId"] as? String,
+            toolName: "exec_command",
+            preview: outputDeltaPreview(from: params)
+        )
+    }
+
+    private static func fileChangePatchActivity(from params: Any) -> CodexAppServerItemActivity? {
+        guard let params = params as? [String: Any],
+              let threadID = params["threadId"] as? String else {
+            return nil
+        }
+
+        return CodexAppServerItemActivity(
+            threadID: threadID,
+            turnID: params["turnId"] as? String,
+            itemID: params["itemId"] as? String,
+            toolName: "apply_patch",
+            preview: fileChangePreview(from: params)
+        )
+    }
+
+    private static func agentMessageDelta(from params: Any) -> CodexAppServerAgentMessageDelta? {
+        guard let params = params as? [String: Any],
+              let threadID = params["threadId"] as? String,
+              let text = outputDeltaPreview(from: params) else {
+            return nil
+        }
+
+        return CodexAppServerAgentMessageDelta(
+            threadID: threadID,
+            turnID: params["turnId"] as? String,
+            itemID: params["itemId"] as? String,
+            text: text
+        )
+    }
+
+    private static func rawResponseItem(from params: Any) -> CodexAppServerRawResponseItem? {
+        guard let params = params as? [String: Any],
+              let threadID = params["threadId"] as? String,
+              let item = params["item"] as? [String: Any],
+              let type = item["type"] as? String else {
+            return nil
+        }
+
+        let turnID = params["turnId"] as? String
+        let itemID = item["id"] as? String ?? params["itemId"] as? String
+
+        if type == "message",
+           item["role"] as? String == "assistant",
+           let text = responseMessageText(from: item, textType: "output_text") {
+            return CodexAppServerRawResponseItem(
+                threadID: threadID,
+                turnID: turnID,
+                itemID: itemID,
+                assistantText: text
+            )
+        }
+
+        if (type == "function_call" || type == "custom_tool_call"),
+           let toolName = item["name"] as? String,
+           !toolName.isEmpty {
+            return CodexAppServerRawResponseItem(
+                threadID: threadID,
+                turnID: turnID,
+                itemID: itemID,
+                toolName: toolName,
+                preview: rawResponseFunctionCallPreview(toolName: toolName, item: item)
+            )
+        }
+
+        let activity = itemActivity(from: [
+            "threadId": threadID,
+            "turnId": turnID as Any,
+            "item": item,
+        ])
+        guard let activity else {
+            return CodexAppServerRawResponseItem(
+                threadID: threadID,
+                turnID: turnID,
+                itemID: itemID
+            )
+        }
+
+        return CodexAppServerRawResponseItem(
+            threadID: threadID,
+            turnID: activity.turnID,
+            itemID: activity.itemID,
+            toolName: activity.toolName,
+            preview: activity.preview
+        )
+    }
+
+    private static func commandParts(from value: Any?) -> [String] {
+        if let values = value as? [String] {
+            return values
+        }
+        if let value = value as? String {
+            return [value]
+        }
+        return []
+    }
+
+    private static func commandPreview(from value: Any?) -> String? {
+        let parts = commandParts(from: value)
+        guard !parts.isEmpty else { return nil }
+        if parts.count >= 3, parts[1] == "-lc" {
+            return parts[2]
+        }
+        return parts.joined(separator: " ")
+    }
+
+    private static func fileChangePreview(from item: [String: Any]) -> String? {
+        if let path = item["path"] as? String {
+            return URL(fileURLWithPath: path).lastPathComponent
+        }
+        if let paths = item["paths"] as? [String], let first = paths.first {
+            return URL(fileURLWithPath: first).lastPathComponent
+        }
+        if let files = item["files"] as? [String], let first = files.first {
+            return URL(fileURLWithPath: first).lastPathComponent
+        }
+        if let changes = item["changes"] as? [String: Any], let first = changes.keys.sorted().first {
+            return URL(fileURLWithPath: first).lastPathComponent
+        }
+        if let patch = item["patch"] as? String,
+           let filename = patchPreviewFilename(from: patch) {
+            return filename
+        }
+        return nil
+    }
+
+    private static func patchPreviewFilename(from patch: String) -> String? {
+        for line in patch.split(whereSeparator: \.isNewline) {
+            let text = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            for prefix in ["*** Update File: ", "*** Add File: ", "*** Delete File: ", "+++ b/"] {
+                guard text.hasPrefix(prefix) else { continue }
+                let path = String(text.dropFirst(prefix.count))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !path.isEmpty, path != "/dev/null" else { continue }
+                return URL(fileURLWithPath: path).lastPathComponent
+            }
+        }
+        return nil
+    }
+
+    private static func jsonPreview(from value: Any?) -> String? {
+        guard let value,
+              JSONSerialization.isValidJSONObject(value),
+              let data = try? JSONSerialization.data(withJSONObject: value),
+              let text = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return text.count > 160 ? String(text.prefix(157)) + "..." : text
+    }
+
+    private static func outputDeltaPreview(from params: [String: Any]) -> String? {
+        let raw = params["delta"] as? String
+            ?? params["output"] as? String
+            ?? params["text"] as? String
+            ?? params["chunk"] as? String
+        guard let raw else { return nil }
+
+        let compact = raw
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        guard !compact.isEmpty else { return nil }
+        return compact.count > 160 ? String(compact.prefix(157)) + "..." : compact
+    }
+
+    private static func responseMessageText(from item: [String: Any], textType: String) -> String? {
+        guard let content = item["content"] as? [[String: Any]] else {
+            return nil
+        }
+        let text = content.compactMap { part -> String? in
+            guard part["type"] as? String == textType,
+                  let text = part["text"] as? String else {
+                return nil
+            }
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }.joined(separator: " ")
+
+        guard !text.isEmpty else { return nil }
+        return text.count > 160 ? String(text.prefix(157)) + "..." : text
+    }
+
+    private static func rawResponseFunctionCallPreview(toolName: String, item: [String: Any]) -> String? {
+        guard let arguments = item["arguments"] else {
+            return nil
+        }
+        if let object = arguments as? [String: Any] {
+            switch toolName {
+            case "exec_command":
+                if let cmd = object["cmd"] as? String {
+                    return cmd
+                }
+            case "write_stdin":
+                if let chars = object["chars"] as? String {
+                    return chars
+                }
+            case "view_image":
+                if let path = object["path"] as? String {
+                    return path
+                }
+            default:
+                break
+            }
+        }
+        return jsonPreview(from: arguments)
     }
 }
 
@@ -411,6 +951,117 @@ private struct ThreadNameUpdatedParams: Codable {
 private struct TurnNotificationParams: Codable {
     let threadId: String
     let turn: CodexTurn
+}
+
+private struct ServerRequestResolvedParams: Codable {
+    let threadId: String
+    let requestId: Int?
+}
+
+private struct AccountRateLimitsReadResult: Decodable {
+    let rateLimits: CodexAppServerRateLimitSnapshot?
+}
+
+private struct AccountRateLimitsUpdatedParams: Decodable {
+    let rateLimits: CodexAppServerRateLimitSnapshot
+}
+
+private struct CodexAppServerRateLimitSnapshot: Decodable {
+    let limitId: String?
+    let limitName: String?
+    let primary: CodexAppServerRateLimitWindow?
+    let secondary: CodexAppServerRateLimitWindow?
+    let planType: String?
+
+    func usageSnapshot(source: String) -> CodexUsageSnapshot? {
+        let normalizedLimitID = limitId?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        guard normalizedLimitID == nil || normalizedLimitID == "codex" else {
+            return nil
+        }
+
+        let windows = [
+            primary?.usageWindow(key: "primary"),
+            secondary?.usageWindow(key: "secondary"),
+        ].compactMap { $0 }
+        guard !windows.isEmpty else {
+            return nil
+        }
+
+        let snapshot = CodexUsageSnapshot(
+            sourceFilePath: source,
+            capturedAt: .now,
+            planType: planType,
+            limitID: limitId,
+            windows: windows
+        )
+        return snapshot.isAllZeroPlaceholder ? nil : snapshot
+    }
+}
+
+private struct CodexAppServerRateLimitWindow: Decodable {
+    let usedPercent: Double
+    let windowDurationMins: Int
+    let resetsAt: Double?
+
+    func usageWindow(key: String) -> CodexUsageWindow {
+        CodexUsageWindow(
+            key: key,
+            label: CodexUsageLoader.windowLabel(forMinutes: windowDurationMins),
+            usedPercentage: usedPercent,
+            leftPercentage: max(0, 100 - usedPercent),
+            windowMinutes: windowDurationMins,
+            resetsAt: resetsAt.map(Date.init(timeIntervalSince1970:))
+        )
+    }
+}
+
+private extension CodexHookJSONValue {
+    init?(jsonObject: Any) {
+        switch jsonObject {
+        case let value as String:
+            self = .string(value)
+        case let value as Bool:
+            self = .boolean(value)
+        case let value as Int:
+            self = .number(Double(value))
+        case let value as Double:
+            self = .number(value)
+        case let value as [Any]:
+            self = .array(value.compactMap(CodexHookJSONValue.init(jsonObject:)))
+        case let value as [String: Any]:
+            var object: [String: CodexHookJSONValue] = [:]
+            for (key, child) in value {
+                guard let jsonValue = CodexHookJSONValue(jsonObject: child) else {
+                    return nil
+                }
+                object[key] = jsonValue
+            }
+            self = .object(object)
+        case _ as NSNull:
+            self = .null
+        default:
+            return nil
+        }
+    }
+
+    var jsonObject: Any {
+        switch self {
+        case let .string(value):
+            value
+        case let .number(value):
+            value
+        case let .boolean(value):
+            value
+        case let .object(value):
+            value.mapValues(\.jsonObject)
+        case let .array(value):
+            value.map(\.jsonObject)
+        case .null:
+            NSNull()
+        }
+    }
 }
 
 // MARK: - Errors

--- a/Sources/OpenIslandCore/CodexAppServer.swift
+++ b/Sources/OpenIslandCore/CodexAppServer.swift
@@ -50,7 +50,11 @@ public enum CodexThreadSource: String, Codable, Sendable {
     case unknown
 
     public init(from decoder: Decoder) throws {
-        let value = try decoder.singleValueContainer().decode(String.self)
+        let container = try decoder.singleValueContainer()
+        guard let value = try? container.decode(String.self) else {
+            self = .unknown
+            return
+        }
         self = CodexThreadSource(rawValue: value) ?? .unknown
     }
 }
@@ -182,19 +186,50 @@ public final class CodexAppServerClient: @unchecked Sendable {
     /// List currently loaded threads from the app-server.
     public func listLoadedThreads() async throws -> [CodexThread] {
         struct Params: Encodable {}
-        struct Result: Decodable { let threads: [CodexThread] }
+        struct Result: Decodable {
+            let threads: [CodexThread]?
+            let data: [String]?
+        }
         let data = try await sendRequest(method: "thread/loaded/list", params: Params())
         let result = try JSONDecoder().decode(Result.self, from: data)
-        return result.threads
+        if let threads = result.threads {
+            return threads
+        }
+
+        var threads: [CodexThread] = []
+        for threadID in result.data ?? [] {
+            if let thread = try? await readThread(threadID: threadID) {
+                threads.append(thread)
+            }
+        }
+        return threads
     }
 
     /// List all threads (including not-loaded) from the app-server.
     public func listThreads(limit: Int? = nil) async throws -> [CodexThread] {
         struct Params: Encodable { let limit: Int? }
-        struct Result: Decodable { let threads: [CodexThread] }
+        struct Result: Decodable {
+            let threads: [CodexThread]?
+            let data: [CodexThread]?
+        }
         let data = try await sendRequest(method: "thread/list", params: Params(limit: limit))
         let result = try JSONDecoder().decode(Result.self, from: data)
-        return result.threads
+        return result.threads ?? result.data ?? []
+    }
+
+    /// Read a single thread by id from the app-server.
+    public func readThread(threadID: String) async throws -> CodexThread {
+        struct Params: Encodable {
+            let threadId: String
+            let includeTurns: Bool
+        }
+        struct Result: Decodable { let thread: CodexThread }
+        let data = try await sendRequest(
+            method: "thread/read",
+            params: Params(threadId: threadID, includeTurns: false)
+        )
+        let result = try JSONDecoder().decode(Result.self, from: data)
+        return result.thread
     }
 
     // MARK: - JSON-RPC transport

--- a/Sources/OpenIslandCore/CodexHookInstaller.swift
+++ b/Sources/OpenIslandCore/CodexHookInstaller.swift
@@ -77,13 +77,14 @@ public enum CodexHookInstaller {
     private static let currentFeatureKey = CodexHooksFeatureFlagKey.current.rawValue
     private static let legacyFeatureKey = CodexHooksFeatureFlagKey.legacy.rawValue
 
-    // Keep the managed Codex install aligned with the original app's low-noise footprint.
-    // The bridge still understands richer hook events, but we do not install them by default
-    // because per-command Bash hooks produce a large amount of terminal log spam.
+    // Keep the managed Codex install aligned with Vibe Island's low-noise footprint:
+    // turn/session events plus PostToolUse for tool completion. PreToolUse stays out
+    // by default because per-command start hooks produce noisy terminal log spam.
     private static let eventSpecs: [(name: String, matcher: String?, timeout: Int)] = [
         ("SessionStart", "startup|resume", managedTimeout),
         ("UserPromptSubmit", nil, managedTimeout),
         ("PermissionRequest", nil, managedInteractiveTimeout),
+        ("PostToolUse", nil, managedTimeout),
         ("Stop", nil, managedTimeout),
     ]
 

--- a/Sources/OpenIslandCore/CodexHooks.swift
+++ b/Sources/OpenIslandCore/CodexHooks.swift
@@ -235,11 +235,12 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
 }
 
 public enum CodexPermissionRequestDecision: Equatable, Codable, Sendable {
-    case allow
+    case allow(updatedInput: CodexHookJSONValue? = nil)
     case deny(message: String? = nil)
 
     private enum CodingKeys: String, CodingKey {
         case behavior
+        case updatedInput
         case message
     }
 
@@ -254,7 +255,7 @@ public enum CodexPermissionRequestDecision: Equatable, Codable, Sendable {
 
         switch behavior {
         case .allow:
-            self = .allow
+            self = .allow(updatedInput: try container.decodeIfPresent(CodexHookJSONValue.self, forKey: .updatedInput))
         case .deny:
             self = .deny(message: try container.decodeIfPresent(String.self, forKey: .message))
         }
@@ -264,8 +265,9 @@ public enum CodexPermissionRequestDecision: Equatable, Codable, Sendable {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         switch self {
-        case .allow:
+        case let .allow(updatedInput):
             try container.encode(Behavior.allow, forKey: .behavior)
+            try container.encodeIfPresent(updatedInput, forKey: .updatedInput)
         case let .deny(message):
             try container.encode(Behavior.deny, forKey: .behavior)
             try container.encodeIfPresent(message, forKey: .message)
@@ -473,6 +475,25 @@ public extension CodexHookPayload {
         commandText ?? toolInput?.description ?? toolName ?? "Permission request"
     }
 
+    var toolActivitySummary: String {
+        if let toolName, !toolName.isEmpty {
+            let label = codexToolDisplayName(for: toolName)
+            if let commandPreview, !commandPreview.isEmpty {
+                return "\(label) \(commandPreview)"
+            }
+            if let description = clipped(toolInput?.description), !description.isEmpty {
+                return "\(label) \(description)"
+            }
+            return label
+        }
+
+        if let commandPreview, !commandPreview.isEmpty {
+            return "Bash \(commandPreview)"
+        }
+
+        return implicitStartSummary
+    }
+
     var promptPreview: String? {
         clipped(prompt)
     }
@@ -492,6 +513,27 @@ public extension CodexHookPayload {
     private func isBashToolName(_ toolName: String) -> Bool {
         let normalized = toolName.lowercased()
         return normalized == "bash" || normalized == "shell"
+    }
+
+    private func codexToolDisplayName(for toolName: String) -> String {
+        switch toolName {
+        case "exec_command", "Bash", "shell":
+            return "Bash"
+        case "apply_patch":
+            return "Patch"
+        case "write_stdin":
+            return "Input"
+        case "web_search", "tool_search":
+            return "Search"
+        case "image_generation", "view_image":
+            return "Image"
+        case "update_plan":
+            return "Plan"
+        case "request_user_input", "AskUserQuestion":
+            return "Question"
+        default:
+            return toolName
+        }
     }
 
     private func clipped(_ value: String?, limit: Int = 110) -> String? {

--- a/Sources/OpenIslandCore/CodexSessionTracking.swift
+++ b/Sources/OpenIslandCore/CodexSessionTracking.swift
@@ -229,6 +229,7 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
         var sessionID: String
         var cwd: String
         var timestamp: Date?
+        var isCodexDesktopApp: Bool
 
         var workspaceName: String {
             let workspace = URL(fileURLWithPath: cwd).lastPathComponent
@@ -389,6 +390,13 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             currentTool: snapshot.currentTool,
             currentCommandPreview: snapshot.currentCommandPreview
         )
+        let jumpTarget = sessionMeta.isCodexDesktopApp ? JumpTarget(
+            terminalApp: "Codex.app",
+            workspaceName: sessionMeta.workspaceName,
+            paneTitle: sessionMeta.sessionTitle,
+            workingDirectory: sessionMeta.cwd,
+            codexThreadID: sessionMeta.sessionID
+        ) : nil
 
         return CodexTrackedSessionRecord(
             sessionID: sessionMeta.sessionID,
@@ -398,6 +406,7 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             summary: summary,
             phase: snapshot.phase,
             updatedAt: updatedAt,
+            jumpTarget: jumpTarget,
             codexMetadata: metadata
         )
     }
@@ -423,7 +432,8 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             cwd: cwd,
             timestamp: codexRolloutParseTimestamp(
                 (payload["timestamp"] as? String) ?? (object["timestamp"] as? String)
-            )
+            ),
+            isCodexDesktopApp: (payload["originator"] as? String) == "Codex Desktop"
         )
     }
 

--- a/Sources/OpenIslandCore/CodexSessionTracking.swift
+++ b/Sources/OpenIslandCore/CodexSessionTracking.swift
@@ -8,6 +8,7 @@ public struct CodexSessionMetadata: Equatable, Codable, Sendable {
     public var lastAssistantMessage: String?
     public var currentTool: String?
     public var currentCommandPreview: String?
+    public var isSubagentSession: Bool
 
     public init(
         transcriptPath: String? = nil,
@@ -15,7 +16,8 @@ public struct CodexSessionMetadata: Equatable, Codable, Sendable {
         lastUserPrompt: String? = nil,
         lastAssistantMessage: String? = nil,
         currentTool: String? = nil,
-        currentCommandPreview: String? = nil
+        currentCommandPreview: String? = nil,
+        isSubagentSession: Bool = false
     ) {
         self.transcriptPath = transcriptPath
         self.initialUserPrompt = initialUserPrompt
@@ -23,6 +25,7 @@ public struct CodexSessionMetadata: Equatable, Codable, Sendable {
         self.lastAssistantMessage = lastAssistantMessage
         self.currentTool = currentTool
         self.currentCommandPreview = currentCommandPreview
+        self.isSubagentSession = isSubagentSession
     }
 
     public var isEmpty: Bool {
@@ -32,6 +35,41 @@ public struct CodexSessionMetadata: Equatable, Codable, Sendable {
             && lastAssistantMessage == nil
             && currentTool == nil
             && currentCommandPreview == nil
+            && !isSubagentSession
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case transcriptPath
+        case initialUserPrompt
+        case lastUserPrompt
+        case lastAssistantMessage
+        case currentTool
+        case currentCommandPreview
+        case isSubagentSession
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        transcriptPath = try container.decodeIfPresent(String.self, forKey: .transcriptPath)
+        initialUserPrompt = try container.decodeIfPresent(String.self, forKey: .initialUserPrompt)
+        lastUserPrompt = try container.decodeIfPresent(String.self, forKey: .lastUserPrompt)
+        lastAssistantMessage = try container.decodeIfPresent(String.self, forKey: .lastAssistantMessage)
+        currentTool = try container.decodeIfPresent(String.self, forKey: .currentTool)
+        currentCommandPreview = try container.decodeIfPresent(String.self, forKey: .currentCommandPreview)
+        isSubagentSession = try container.decodeIfPresent(Bool.self, forKey: .isSubagentSession) ?? false
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(transcriptPath, forKey: .transcriptPath)
+        try container.encodeIfPresent(initialUserPrompt, forKey: .initialUserPrompt)
+        try container.encodeIfPresent(lastUserPrompt, forKey: .lastUserPrompt)
+        try container.encodeIfPresent(lastAssistantMessage, forKey: .lastAssistantMessage)
+        try container.encodeIfPresent(currentTool, forKey: .currentTool)
+        try container.encodeIfPresent(currentCommandPreview, forKey: .currentCommandPreview)
+        if isSubagentSession {
+            try container.encode(isSubagentSession, forKey: .isSubagentSession)
+        }
     }
 }
 
@@ -230,6 +268,7 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
         var cwd: String
         var timestamp: Date?
         var isCodexDesktopApp: Bool
+        var isSubagentSession: Bool
 
         var workspaceName: String {
             let workspace = URL(fileURLWithPath: cwd).lastPathComponent
@@ -254,17 +293,26 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
     private let fileManager: FileManager
     private let maxAge: TimeInterval
     private let maxFiles: Int
+    private let maxFullScanBytes: UInt64
+    private let largeFileHeadBytes: UInt64
+    private let largeFileTailBytes: UInt64
 
     public init(
         rootURL: URL = CodexRolloutDiscovery.defaultRootURL,
         fileManager: FileManager = .default,
         maxAge: TimeInterval = 86_400,
-        maxFiles: Int = 40
+        maxFiles: Int = 20,
+        maxFullScanBytes: UInt64 = 1 * 1_024 * 1_024,
+        largeFileHeadBytes: UInt64 = 256 * 1_024,
+        largeFileTailBytes: UInt64 = 512 * 1_024
     ) {
         self.rootURL = rootURL
         self.fileManager = fileManager
         self.maxAge = maxAge
         self.maxFiles = maxFiles
+        self.maxFullScanBytes = maxFullScanBytes
+        self.largeFileHeadBytes = largeFileHeadBytes
+        self.largeFileTailBytes = largeFileTailBytes
     }
 
     public func discoverRecentSessions(now: Date = .now) -> [CodexTrackedSessionRecord] {
@@ -311,11 +359,15 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             }
             .prefix(maxFiles)
 
+        let threadNamesByID = Self.loadSessionIndexThreadNames(
+            indexURL: rootURL.deletingLastPathComponent().appendingPathComponent("session_index.jsonl")
+        )
         var recordsByID: [String: CodexTrackedSessionRecord] = [:]
         for candidate in recentCandidates {
             guard let record = discoverRecord(
                 fileURL: candidate.fileURL,
-                modifiedAt: candidate.modifiedAt
+                modifiedAt: candidate.modifiedAt,
+                threadNamesByID: threadNamesByID
             ) else {
                 continue
             }
@@ -338,8 +390,19 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
 
     private func discoverRecord(
         fileURL: URL,
-        modifiedAt: Date
+        modifiedAt: Date,
+        threadNamesByID: [String: String]
     ) -> CodexTrackedSessionRecord? {
+        let fileSize = (try? fileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize).map(UInt64.init) ?? 0
+        if fileSize > maxFullScanBytes {
+            return discoverLargeRecord(
+                fileURL: fileURL,
+                modifiedAt: modifiedAt,
+                fileSize: fileSize,
+                threadNamesByID: threadNamesByID
+            )
+        }
+
         // Stream the rollout line by line instead of slurping the whole
         // file. Long-lived Codex sessions accumulate JSONL files of tens
         // of MB; combined with the 10s rediscover throttle that meant a
@@ -359,7 +422,7 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
         while let chunk = try? fileHandle.read(upToCount: Self.streamingChunkSize),
               !chunk.isEmpty {
             buffer.append(chunk)
-            for line in extractCompleteLines(from: &buffer) {
+            Self.consumeCompleteLines(from: &buffer) { line in
                 CodexRolloutReducer.apply(line: line, to: &snapshot)
                 if sessionMeta == nil {
                     sessionMeta = parseSessionMeta(fromLine: line)
@@ -380,6 +443,7 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
 
         guard let sessionMeta else { return nil }
 
+        let title = threadNamesByID[sessionMeta.sessionID] ?? sessionMeta.sessionTitle
         let summary = snapshot.summary ?? sessionMeta.defaultSummary
         let updatedAt = snapshot.updatedAt ?? sessionMeta.timestamp ?? modifiedAt
         let metadata = CodexSessionMetadata(
@@ -388,19 +452,20 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             lastUserPrompt: snapshot.lastUserPrompt,
             lastAssistantMessage: snapshot.lastAssistantMessage,
             currentTool: snapshot.currentTool,
-            currentCommandPreview: snapshot.currentCommandPreview
+            currentCommandPreview: snapshot.currentCommandPreview,
+            isSubagentSession: sessionMeta.isSubagentSession
         )
         let jumpTarget = sessionMeta.isCodexDesktopApp ? JumpTarget(
             terminalApp: "Codex.app",
             workspaceName: sessionMeta.workspaceName,
-            paneTitle: sessionMeta.sessionTitle,
+            paneTitle: title,
             workingDirectory: sessionMeta.cwd,
             codexThreadID: sessionMeta.sessionID
         ) : nil
 
         return CodexTrackedSessionRecord(
             sessionID: sessionMeta.sessionID,
-            title: sessionMeta.sessionTitle,
+            title: title,
             origin: .live,
             attachmentState: .stale,
             summary: summary,
@@ -411,7 +476,155 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
         )
     }
 
+    private func discoverLargeRecord(
+        fileURL: URL,
+        modifiedAt: Date,
+        fileSize: UInt64,
+        threadNamesByID: [String: String]
+    ) -> CodexTrackedSessionRecord? {
+        guard let fileHandle = try? FileHandle(forReadingFrom: fileURL) else {
+            return nil
+        }
+        defer { try? fileHandle.close() }
+
+        let sessionMeta = parseSessionMetaFromHead(fileHandle: fileHandle)
+        let snapshot = parseSnapshotFromTail(
+            fileHandle: fileHandle,
+            fileSize: fileSize
+        )
+
+        guard let sessionMeta else { return nil }
+
+        let title = threadNamesByID[sessionMeta.sessionID] ?? sessionMeta.sessionTitle
+        let summary = snapshot.summary ?? sessionMeta.defaultSummary
+        let updatedAt = snapshot.updatedAt ?? sessionMeta.timestamp ?? modifiedAt
+        let metadata = CodexSessionMetadata(
+            transcriptPath: fileURL.path,
+            initialUserPrompt: snapshot.initialUserPrompt,
+            lastUserPrompt: snapshot.lastUserPrompt,
+            lastAssistantMessage: snapshot.lastAssistantMessage,
+            currentTool: snapshot.currentTool,
+            currentCommandPreview: snapshot.currentCommandPreview,
+            isSubagentSession: sessionMeta.isSubagentSession
+        )
+        let jumpTarget = sessionMeta.isCodexDesktopApp ? JumpTarget(
+            terminalApp: "Codex.app",
+            workspaceName: sessionMeta.workspaceName,
+            paneTitle: title,
+            workingDirectory: sessionMeta.cwd,
+            codexThreadID: sessionMeta.sessionID
+        ) : nil
+
+        return CodexTrackedSessionRecord(
+            sessionID: sessionMeta.sessionID,
+            title: title,
+            origin: .live,
+            attachmentState: .stale,
+            summary: summary,
+            phase: snapshot.phase,
+            updatedAt: updatedAt,
+            jumpTarget: jumpTarget,
+            codexMetadata: metadata
+        )
+    }
+
+    private func parseSessionMetaFromHead(fileHandle: FileHandle) -> SessionMeta? {
+        try? fileHandle.seek(toOffset: 0)
+
+        var remaining = largeFileHeadBytes
+        var buffer = Data()
+        while remaining > 0 {
+            let count = Int(min(UInt64(Self.streamingChunkSize), remaining))
+            guard let chunk = try? fileHandle.read(upToCount: count),
+                  !chunk.isEmpty else {
+                break
+            }
+            remaining -= UInt64(chunk.count)
+            buffer.append(chunk)
+            var found: SessionMeta?
+            Self.consumeCompleteLines(from: &buffer) { line in
+                if found == nil {
+                    found = parseSessionMeta(fromLine: line)
+                }
+            }
+            if let found {
+                return found
+            }
+        }
+
+        if !buffer.isEmpty {
+            return parseSessionMeta(fromLine: String(decoding: buffer, as: UTF8.self))
+        }
+        return nil
+    }
+
+    private func parseSnapshotFromTail(
+        fileHandle: FileHandle,
+        fileSize: UInt64
+    ) -> CodexRolloutSnapshot {
+        let tailBytes = min(largeFileTailBytes, fileSize)
+        let startOffset = fileSize - tailBytes
+        try? fileHandle.seek(toOffset: startOffset)
+
+        var snapshot = CodexRolloutSnapshot()
+        var buffer = (try? fileHandle.readToEnd()) ?? Data()
+        if startOffset > 0 {
+            trimLeadingPartialLine(from: &buffer)
+        }
+
+        Self.consumeCompleteLines(from: &buffer) { line in
+            CodexRolloutReducer.apply(line: line, to: &snapshot)
+        }
+        if !buffer.isEmpty {
+            let trailing = String(decoding: buffer, as: UTF8.self)
+            if !trailing.isEmpty {
+                CodexRolloutReducer.apply(line: trailing, to: &snapshot)
+            }
+        }
+
+        return snapshot
+    }
+
     private static let streamingChunkSize = 64 * 1_024
+
+    static func loadSessionIndexThreadNames(indexURL: URL) -> [String: String] {
+        guard let fileHandle = try? FileHandle(forReadingFrom: indexURL) else {
+            return [:]
+        }
+        defer { try? fileHandle.close() }
+
+        var namesByID: [String: String] = [:]
+        var buffer = Data()
+        while let chunk = try? fileHandle.read(upToCount: streamingChunkSize),
+              !chunk.isEmpty {
+            buffer.append(chunk)
+            for line in Self.extractCompleteLines(from: &buffer) {
+                parseSessionIndexLine(line).map { namesByID[$0.id] = $0.threadName }
+            }
+        }
+
+        if !buffer.isEmpty {
+            let trailing = String(decoding: buffer, as: UTF8.self)
+            parseSessionIndexLine(trailing).map { namesByID[$0.id] = $0.threadName }
+        }
+
+        return namesByID
+    }
+
+    private static func parseSessionIndexLine(_ line: String) -> (id: String, threadName: String)? {
+        guard let object = codexRolloutJSONObject(for: line),
+              let id = object["id"] as? String,
+              let threadName = object["thread_name"] as? String else {
+            return nil
+        }
+
+        let trimmed = threadName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !id.isEmpty, !trimmed.isEmpty else {
+            return nil
+        }
+
+        return (id, trimmed)
+    }
 
     private func parseSessionMeta(fromLine line: String) -> SessionMeta? {
         guard let object = codexRolloutJSONObject(for: line),
@@ -433,20 +646,60 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             timestamp: codexRolloutParseTimestamp(
                 (payload["timestamp"] as? String) ?? (object["timestamp"] as? String)
             ),
-            isCodexDesktopApp: (payload["originator"] as? String) == "Codex Desktop"
+            isCodexDesktopApp: (payload["originator"] as? String) == "Codex Desktop",
+            isSubagentSession: (payload["thread_source"] as? String) == "subagent"
         )
     }
 
-    private func extractCompleteLines(from buffer: inout Data) -> [String] {
+    private static func extractCompleteLines(from buffer: inout Data) -> [String] {
         let newline = UInt8(ascii: "\n")
         var lines: [String] = []
-        while let newlineIndex = buffer.firstIndex(of: newline) {
-            let lineData = buffer.prefix(upTo: newlineIndex)
-            buffer.removeSubrange(...newlineIndex)
-            guard !lineData.isEmpty else { continue }
-            lines.append(String(decoding: lineData, as: UTF8.self))
+        var lineStart = buffer.startIndex
+        var consumedEnd: Data.Index?
+
+        while let newlineIndex = buffer[lineStart...].firstIndex(of: newline) {
+            if newlineIndex > lineStart {
+                let lineData = buffer[lineStart..<newlineIndex]
+                lines.append(String(decoding: lineData, as: UTF8.self))
+            }
+            lineStart = buffer.index(after: newlineIndex)
+            consumedEnd = lineStart
         }
+
+        if let consumedEnd {
+            buffer.removeSubrange(buffer.startIndex..<consumedEnd)
+        }
+
         return lines
+    }
+
+    private static func consumeCompleteLines(from buffer: inout Data, _ consume: (String) -> Void) {
+        let newline = UInt8(ascii: "\n")
+        var lineStart = buffer.startIndex
+        var consumedEnd: Data.Index?
+
+        while let newlineIndex = buffer[lineStart...].firstIndex(of: newline) {
+            if newlineIndex > lineStart {
+                let lineData = buffer[lineStart..<newlineIndex]
+                consume(String(decoding: lineData, as: UTF8.self))
+            }
+            lineStart = buffer.index(after: newlineIndex)
+            consumedEnd = lineStart
+        }
+
+        if let consumedEnd {
+            buffer.removeSubrange(buffer.startIndex..<consumedEnd)
+        }
+    }
+
+    private func trimLeadingPartialLine(from buffer: inout Data) {
+        let newline = UInt8(ascii: "\n")
+        guard let newlineIndex = buffer.firstIndex(of: newline) else {
+            buffer.removeAll(keepingCapacity: false)
+            return
+        }
+
+        buffer.removeSubrange(...newlineIndex)
     }
 }
 
@@ -469,6 +722,7 @@ public struct CodexRolloutSnapshot: Equatable, Sendable {
     public var lastAssistantMessage: String?
     public var currentTool: String?
     public var currentCommandPreview: String?
+    public var hasActiveTool: Bool
     public var isCompleted: Bool
     public var isInterrupted: Bool
 
@@ -481,6 +735,7 @@ public struct CodexRolloutSnapshot: Equatable, Sendable {
         lastAssistantMessage: String? = nil,
         currentTool: String? = nil,
         currentCommandPreview: String? = nil,
+        hasActiveTool: Bool = false,
         isCompleted: Bool = false,
         isInterrupted: Bool = false
     ) {
@@ -492,6 +747,7 @@ public struct CodexRolloutSnapshot: Equatable, Sendable {
         self.lastAssistantMessage = lastAssistantMessage
         self.currentTool = currentTool
         self.currentCommandPreview = currentCommandPreview
+        self.hasActiveTool = hasActiveTool
         self.isCompleted = isCompleted
         self.isInterrupted = isInterrupted
     }
@@ -634,6 +890,7 @@ public enum CodexRolloutReducer {
         case "task_complete", "turn_complete":
             snapshot.currentTool = nil
             snapshot.currentCommandPreview = nil
+            snapshot.hasActiveTool = false
             snapshot.phase = .completed
             snapshot.isCompleted = true
             snapshot.isInterrupted = false
@@ -647,90 +904,110 @@ public enum CodexRolloutReducer {
         case "turn_aborted":
             snapshot.currentTool = nil
             snapshot.currentCommandPreview = nil
+            snapshot.hasActiveTool = false
             snapshot.phase = .completed
             snapshot.isCompleted = true
             snapshot.isInterrupted = true
             snapshot.summary = "Codex turn was interrupted."
         case "agent_reasoning", "agent_reasoning_raw_content", "agent_reasoning_section_break":
-            applyThinking(to: &snapshot)
+            applyThinking(timestamp: timestamp, to: &snapshot)
         case "exec_command_begin":
             applyToolActivity(
                 "exec_command",
                 preview: commandPreview(fromCommandValue: payload["command"]),
+                timestamp: timestamp,
                 to: &snapshot
             )
         case "terminal_interaction":
             applyToolActivity(
                 "write_stdin",
                 preview: clipped(payload["stdin"] as? String),
+                timestamp: timestamp,
                 to: &snapshot
             )
         case "exec_command_end":
-            applyThinking(to: &snapshot)
+            settleToolActivity(timestamp: timestamp, to: &snapshot)
         case "patch_apply_begin", "patch_apply_updated":
             applyToolActivity(
                 "apply_patch",
                 preview: changesPreview(from: payload),
+                timestamp: timestamp,
                 to: &snapshot
             )
         case "patch_apply_end":
-            applyThinking(to: &snapshot)
+            if payload["success"] as? Bool == true {
+                settleToolActivity(
+                    "apply_patch",
+                    preview: changesPreview(from: payload) ?? snapshot.currentCommandPreview,
+                    timestamp: timestamp,
+                    to: &snapshot
+                )
+            } else {
+                applyThinking(timestamp: timestamp, to: &snapshot)
+            }
         case "mcp_tool_call_begin":
             if let toolName = mcpToolName(from: payload) {
                 applyToolActivity(
                     toolName,
                     preview: mcpToolPreview(from: payload),
+                    timestamp: timestamp,
                     to: &snapshot
                 )
             }
         case "mcp_tool_call_end", "dynamic_tool_call_response":
-            applyThinking(to: &snapshot)
+            settleToolActivity(timestamp: timestamp, to: &snapshot)
         case "dynamic_tool_call_request":
             if let toolName = clipped(payload["tool"] as? String) {
                 applyToolActivity(
                     toolName,
                     preview: jsonPreview(from: payload["arguments"]),
+                    timestamp: timestamp,
                     to: &snapshot
                 )
             }
         case "web_search_begin":
-            applyToolActivity("web_search", preview: nil, to: &snapshot)
+            applyToolActivity("web_search", preview: nil, timestamp: timestamp, to: &snapshot)
         case "web_search_end":
             applyToolActivity(
                 "web_search",
                 preview: webSearchPreview(from: payload),
+                timestamp: timestamp,
                 to: &snapshot
             )
         case "image_generation_begin":
-            applyToolActivity("image_generation", preview: nil, to: &snapshot)
+            applyToolActivity("image_generation", preview: nil, timestamp: timestamp, to: &snapshot)
         case "image_generation_end":
             applyToolActivity(
                 "image_generation",
                 preview: clipped(payload["revised_prompt"] as? String),
+                timestamp: timestamp,
                 to: &snapshot
             )
         case "view_image_tool_call":
             applyToolActivity(
                 "view_image",
                 preview: clipped(payload["path"] as? String),
+                timestamp: timestamp,
                 to: &snapshot
             )
         case "plan_update":
-            applyToolActivity("update_plan", preview: nil, to: &snapshot)
+            applyToolActivity("update_plan", preview: nil, timestamp: timestamp, to: &snapshot)
         case "request_user_input", "elicitation_request":
             applyQuestionRequest(
                 summary: clipped(payload["prompt"] as? String)
                     ?? clipped(payload["message"] as? String),
+                timestamp: timestamp,
                 to: &snapshot
             )
         case "exec_approval_request", "apply_patch_approval_request", "request_permissions":
             applyApprovalRequest(
                 summary: clipped(payload["reason"] as? String)
                     ?? clipped(payload["message"] as? String),
+                timestamp: timestamp,
                 to: &snapshot
             )
         case "context_compacted":
-            applyThinking(to: &snapshot)
+            applyThinking(timestamp: timestamp, to: &snapshot)
         default:
             break
         }
@@ -770,7 +1047,7 @@ public enum CodexRolloutReducer {
 
             return
         case "reasoning":
-            applyThinking(to: &snapshot)
+            applyThinking(timestamp: timestamp, to: &snapshot)
         case "function_call", "custom_tool_call":
             guard let toolName = payload["name"] as? String, !toolName.isEmpty else {
                 return
@@ -779,36 +1056,41 @@ public enum CodexRolloutReducer {
             applyToolActivity(
                 toolName,
                 preview: commandPreview(for: toolName, payload: payload),
+                timestamp: timestamp,
                 to: &snapshot
             )
         case "local_shell_call":
             applyToolActivity(
                 "exec_command",
                 preview: localShellCommandPreview(from: payload),
+                timestamp: timestamp,
                 to: &snapshot
             )
         case "tool_search_call":
             applyToolActivity(
                 "tool_search",
                 preview: toolSearchPreview(from: payload),
+                timestamp: timestamp,
                 to: &snapshot
             )
         case "web_search_call":
             applyToolActivity(
                 "web_search",
                 preview: webSearchPreview(from: payload),
+                timestamp: timestamp,
                 to: &snapshot
             )
         case "image_generation_call":
             applyToolActivity(
                 "image_generation",
                 preview: clipped(payload["revised_prompt"] as? String),
+                timestamp: timestamp,
                 to: &snapshot
             )
         case "compaction", "compaction_summary", "context_compaction":
-            applyToolActivity("context_compaction", preview: nil, to: &snapshot)
+            applyToolActivity("context_compaction", preview: nil, timestamp: timestamp, to: &snapshot)
         case "function_call_output", "custom_tool_call_output", "tool_search_output":
-            applyThinking(to: &snapshot)
+            settleToolActivity(timestamp: timestamp, to: &snapshot)
         default:
             return
         }
@@ -821,60 +1103,125 @@ public enum CodexRolloutReducer {
     private static func applyToolActivity(
         _ toolName: String,
         preview: String?,
+        timestamp: Date?,
         to snapshot: inout CodexRolloutSnapshot
     ) {
         // After task_complete, trailing tool lifecycle records can still be
         // flushed into the JSONL. They may refresh updatedAt, but must not
         // reopen the completed turn or replace the final assistant summary.
-        guard !snapshot.isCompleted else {
+        guard !snapshot.isCompleted || shouldReopenCompletedSnapshot(snapshot, timestamp: timestamp) else {
             return
         }
 
         snapshot.currentTool = toolName
         snapshot.currentCommandPreview = preview
+        snapshot.hasActiveTool = true
         snapshot.phase = .running
         snapshot.isCompleted = false
         snapshot.isInterrupted = false
         snapshot.summary = "Running \(displayName(for: toolName))."
     }
 
-    private static func applyThinking(to snapshot: inout CodexRolloutSnapshot) {
-        guard !snapshot.isCompleted else {
+    private static func settleToolActivity(
+        _ toolName: String? = nil,
+        preview: String? = nil,
+        timestamp: Date?,
+        to snapshot: inout CodexRolloutSnapshot
+    ) {
+        guard !snapshot.isCompleted || shouldReopenCompletedSnapshot(snapshot, timestamp: timestamp) else {
+            return
+        }
+
+        if let toolName {
+            snapshot.currentTool = toolName
+        }
+        if let preview {
+            snapshot.currentCommandPreview = preview
+        }
+        snapshot.hasActiveTool = false
+        snapshot.phase = .running
+        snapshot.isCompleted = false
+        snapshot.isInterrupted = false
+        if let currentTool = snapshot.currentTool {
+            snapshot.summary = "Running \(displayName(for: currentTool))."
+        } else {
+            snapshot.summary = snapshot.summary ?? "Codex is processing."
+        }
+
+        if let timestamp {
+            snapshot.updatedAt = timestamp
+        }
+    }
+
+    private static func applyThinking(timestamp: Date?, to snapshot: inout CodexRolloutSnapshot) {
+        guard !snapshot.isCompleted || shouldReopenCompletedSnapshot(snapshot, timestamp: timestamp) else {
+            return
+        }
+        guard !snapshot.hasActiveTool else {
+            if let timestamp {
+                snapshot.updatedAt = timestamp
+            }
+            return
+        }
+        guard snapshot.currentTool == nil, snapshot.currentCommandPreview == nil else {
+            if let timestamp {
+                snapshot.updatedAt = timestamp
+            }
             return
         }
 
         snapshot.currentTool = nil
         snapshot.currentCommandPreview = nil
+        snapshot.hasActiveTool = false
         snapshot.phase = .running
         snapshot.isCompleted = false
         snapshot.isInterrupted = false
         snapshot.summary = "Thinking."
     }
 
-    private static func applyApprovalRequest(summary: String?, to snapshot: inout CodexRolloutSnapshot) {
-        guard !snapshot.isCompleted else {
+    private static func applyApprovalRequest(summary: String?, timestamp: Date?, to snapshot: inout CodexRolloutSnapshot) {
+        guard !snapshot.isCompleted || shouldReopenCompletedSnapshot(snapshot, timestamp: timestamp) else {
             return
         }
 
         snapshot.currentTool = nil
         snapshot.currentCommandPreview = nil
+        snapshot.hasActiveTool = false
         snapshot.phase = .waitingForApproval
         snapshot.isCompleted = false
         snapshot.isInterrupted = false
         snapshot.summary = summary ?? "Approval needed."
     }
 
-    private static func applyQuestionRequest(summary: String?, to snapshot: inout CodexRolloutSnapshot) {
-        guard !snapshot.isCompleted else {
+    private static func applyQuestionRequest(summary: String?, timestamp: Date?, to snapshot: inout CodexRolloutSnapshot) {
+        guard !snapshot.isCompleted || shouldReopenCompletedSnapshot(snapshot, timestamp: timestamp) else {
             return
         }
 
         snapshot.currentTool = nil
         snapshot.currentCommandPreview = nil
+        snapshot.hasActiveTool = false
         snapshot.phase = .waitingForAnswer
         snapshot.isCompleted = false
         snapshot.isInterrupted = false
         snapshot.summary = summary ?? "Answer needed."
+    }
+
+    private static func shouldReopenCompletedSnapshot(
+        _ snapshot: CodexRolloutSnapshot,
+        timestamp: Date?
+    ) -> Bool {
+        guard snapshot.isCompleted,
+              let timestamp,
+              let completedAt = snapshot.updatedAt else {
+            return false
+        }
+
+        // Codex.app can append a new turn to the same rollout without a clean
+        // `user_message` event visible to the reducer. Reopen only when the
+        // activity is clearly later than the completion event; near-tail
+        // records remain treated as completion flush noise.
+        return timestamp.timeIntervalSince(completedAt) > 10
     }
 
     private static func applyUserMessage(
@@ -886,6 +1233,7 @@ public enum CodexRolloutReducer {
         snapshot.lastUserPrompt = message
         snapshot.currentTool = nil
         snapshot.currentCommandPreview = nil
+        snapshot.hasActiveTool = false
         snapshot.phase = .running
         snapshot.isCompleted = false
         snapshot.isInterrupted = false
@@ -911,6 +1259,7 @@ public enum CodexRolloutReducer {
         if !snapshot.isCompleted {
             snapshot.currentTool = nil
             snapshot.currentCommandPreview = nil
+            snapshot.hasActiveTool = false
             snapshot.phase = .running
             snapshot.isInterrupted = false
         }
@@ -1485,13 +1834,15 @@ public final class CodexRolloutWatcher: @unchecked Sendable {
 }
 
 private func codexRolloutJSONObject(for line: String) -> [String: Any]? {
-    guard let data = line.data(using: .utf8),
-          let object = try? JSONSerialization.jsonObject(with: data),
-          let dictionary = object as? [String: Any] else {
-        return nil
-    }
+    autoreleasepool {
+        guard let data = line.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              let dictionary = object as? [String: Any] else {
+            return nil
+        }
 
-    return dictionary
+        return dictionary
+    }
 }
 
 private func codexRolloutParseTimestamp(_ string: String?) -> Date? {

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -112,6 +112,28 @@ public struct SessionState: Equatable, Sendable {
             session.updatedAt = payload.timestamp
             upsert(session)
 
+        case let .sessionRefreshed(payload):
+            guard var session = sessionsByID[payload.sessionID] else {
+                return
+            }
+
+            session.title = payload.title
+            session.jumpTarget = payload.jumpTarget ?? session.jumpTarget
+            session.codexMetadata = payload.codexMetadata?.isEmpty == true ? nil : payload.codexMetadata
+            session.updatedAt = payload.timestamp
+            session.isSessionEnded = false
+            session.isProcessAlive = true
+            session.processNotSeenCount = 0
+            Self.refreshCodexAppClassification(for: &session)
+
+            let preservesActionableState = session.phase == .waitingForApproval || session.phase == .waitingForAnswer
+            if !preservesActionableState {
+                session.phase = payload.phase
+                session.summary = payload.summary
+            }
+
+            upsert(session)
+
         case let .permissionRequested(payload):
             guard var session = sessionsByID[payload.sessionID] else {
                 return

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -4,7 +4,11 @@ public struct SessionState: Equatable, Sendable {
     public private(set) var sessionsByID: [String: AgentSession]
 
     public init(sessions: [AgentSession] = []) {
-        self.sessionsByID = Dictionary(uniqueKeysWithValues: sessions.map { ($0.id, $0) })
+        self.sessionsByID = Dictionary(uniqueKeysWithValues: sessions.map { session in
+            var normalized = session
+            Self.refreshCodexAppClassification(for: &normalized)
+            return (normalized.id, normalized)
+        })
     }
 
     public var sessions: [AgentSession] {
@@ -120,11 +124,17 @@ public struct SessionState: Equatable, Sendable {
             session.title = payload.title
             session.jumpTarget = payload.jumpTarget ?? session.jumpTarget
             session.codexMetadata = payload.codexMetadata?.isEmpty == true ? nil : payload.codexMetadata
-            session.updatedAt = payload.timestamp
+            Self.refreshCodexAppClassification(for: &session)
+            if !Self.shouldPreserveCodexAppActivityTimestamp(
+                current: session,
+                incomingPhase: payload.phase,
+                incomingTimestamp: payload.timestamp
+            ) {
+                session.updatedAt = payload.timestamp
+            }
             session.isSessionEnded = false
             session.isProcessAlive = true
             session.processNotSeenCount = 0
-            Self.refreshCodexAppClassification(for: &session)
 
             let preservesActionableState = session.phase == .waitingForApproval || session.phase == .waitingForAnswer
             if !preservesActionableState {
@@ -351,6 +361,25 @@ public struct SessionState: Equatable, Sendable {
         }
     }
 
+    static func shouldPreserveCodexAppActivityTimestamp(
+        current session: AgentSession,
+        incomingPhase: SessionPhase,
+        incomingTimestamp: Date
+    ) -> Bool {
+        guard session.isCodexAppSession,
+              incomingPhase == .completed,
+              session.phase == .completed,
+              incomingTimestamp > session.updatedAt else {
+            return false
+        }
+
+        // Codex.app startup refresh can enumerate historical idle threads
+        // and report them through the app-server as freshly observed. Keep
+        // the last real rollout activity timestamp so the island age badge
+        // does not show every historical thread as "<1m".
+        return true
+    }
+
     /// Mark a single session as alive (e.g. when a hook event is received).
     /// Does not affect other sessions' processNotSeenCount.
     public mutating func markSingleSessionAlive(sessionID: String) {
@@ -382,7 +411,7 @@ public struct SessionState: Equatable, Sendable {
             // the rollout watcher / app-server notifications.
             if session.isCodexAppSession {
                 let wasAlive = session.isProcessAlive
-                session.isProcessAlive = aliveSessionIDs.contains(id)
+                session.isProcessAlive = isCodexAppRunning
                 if session.isProcessAlive != wasAlive {
                     changed.insert(id)
                 }

--- a/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
+++ b/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
@@ -333,4 +333,33 @@ struct AgentSessionPresentationTests {
         #expect(session.spotlightSecondaryText == "Running Search")
         #expect(session.displayCurrentToolName == "Search")
     }
+
+    @Test
+    func codexDesktopSessionUsesThreadTitleForHeadlineAndHidesTerminalBadge() {
+        let session = AgentSession(
+            id: "codex-app-session",
+            title: "Open Island issue check",
+            tool: .codex,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Thinking.",
+            updatedAt: Date(timeIntervalSince1970: 10_000),
+            jumpTarget: JumpTarget(
+                terminalApp: "Codex.app",
+                workspaceName: "lijie10",
+                paneTitle: "Open Island issue check",
+                workingDirectory: "/Users/lijie10",
+                codexThreadID: "codex-app-session"
+            ),
+            codexMetadata: CodexSessionMetadata(
+                initialUserPrompt: "https://vibeisland.app/zh/ 看看这个 app",
+                lastUserPrompt: "看看有没有现成 issue"
+            )
+        )
+
+        #expect(session.spotlightHeadlineText == "lijie10 · Open Island issue check")
+        #expect(session.spotlightPromptLineText == "You: 看看有没有现成 issue")
+        #expect(session.spotlightTerminalBadge == nil)
+    }
 }

--- a/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
+++ b/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
@@ -358,8 +358,57 @@ struct AgentSessionPresentationTests {
             )
         )
 
-        #expect(session.spotlightHeadlineText == "lijie10 · Open Island issue check")
+        #expect(session.spotlightHeadlineText == "lijie10：Open Island issue check")
         #expect(session.spotlightPromptLineText == "You: 看看有没有现成 issue")
         #expect(session.spotlightTerminalBadge == nil)
+    }
+
+    @Test
+    func codexDesktopHeadlineStripsCodexPrefixFromThreadTitle() {
+        let session = AgentSession(
+            id: "codex-app-session",
+            title: "Codex · hera",
+            tool: .codex,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Thinking.",
+            updatedAt: Date(timeIntervalSince1970: 10_000),
+            jumpTarget: JumpTarget(
+                terminalApp: "Codex.app",
+                workspaceName: "hera",
+                paneTitle: "Codex · hera",
+                workingDirectory: "/Users/lijie10/Desktop/code/hera",
+                codexThreadID: "codex-app-session"
+            )
+        )
+
+        #expect(session.spotlightHeadlineText == "hera")
+    }
+
+    @Test
+    func codexDesktopHeadlineUsesPromptWhenThreadTitleIsWorkspaceFallback() {
+        let session = AgentSession(
+            id: "codex-app-session",
+            title: "Codex · hera",
+            tool: .codex,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Thinking.",
+            updatedAt: Date(timeIntervalSince1970: 10_000),
+            jumpTarget: JumpTarget(
+                terminalApp: "Codex.app",
+                workspaceName: "hera",
+                paneTitle: "Codex · hera",
+                workingDirectory: "/Users/lijie10/Desktop/code/hera",
+                codexThreadID: "codex-app-session"
+            ),
+            codexMetadata: CodexSessionMetadata(
+                initialUserPrompt: "web 模拟器画面现在还是截图预览"
+            )
+        )
+
+        #expect(session.spotlightHeadlineText == "hera：web 模拟器画面现在还是截图预览")
     }
 }

--- a/Tests/OpenIslandAppTests/CodexAppServerCoordinatorTests.swift
+++ b/Tests/OpenIslandAppTests/CodexAppServerCoordinatorTests.swift
@@ -1,0 +1,494 @@
+import Foundation
+import Testing
+@testable import OpenIslandApp
+@testable import OpenIslandCore
+
+@MainActor
+struct CodexAppServerCoordinatorTests {
+    @Test
+    func syncListMergesLoadedAndRecentThreadsWithLoadedFirst() {
+        let loaded = [
+            makeThread(id: "live-1", updatedAt: 1_780_000_000_000),
+            makeThread(id: "live-2", updatedAt: 1_780_000_001_000),
+        ]
+        let recent = [
+            makeThread(id: "live-2", updatedAt: 1_780_000_001_000),
+            makeThread(id: "recent-1", updatedAt: 1_779_999_000_000),
+            makeThread(id: "recent-2", updatedAt: 1_779_998_000_000),
+        ]
+
+        let merged = CodexAppServerCoordinator.mergedThreadSyncList(
+            loadedThreads: loaded,
+            recentThreads: recent
+        )
+
+        #expect(merged.map(\.id) == ["live-1", "live-2", "recent-1", "recent-2"])
+    }
+
+    @Test
+    func threadUpdatedAtDateDecodesMillisecondsWithoutUsingNow() throws {
+        let date = try #require(CodexAppServerCoordinator.threadUpdatedAtDate(from: 1_780_000_000_000))
+
+        #expect(date == Date(timeIntervalSince1970: 1_780_000_000))
+    }
+
+    @Test
+    func threadUpdatedAtDateDecodesSeconds() throws {
+        let date = try #require(CodexAppServerCoordinator.threadUpdatedAtDate(from: 1_780_000_000))
+
+        #expect(date == Date(timeIntervalSince1970: 1_780_000_000))
+    }
+
+    @Test
+    func itemActivityMetadataPreservesExistingThreadContext() {
+        let existing = CodexSessionMetadata(
+            transcriptPath: "/tmp/rollout.jsonl",
+            initialUserPrompt: "检查状态展示",
+            lastUserPrompt: "继续",
+            lastAssistantMessage: "正在处理",
+            currentTool: nil,
+            currentCommandPreview: nil,
+            isSubagentSession: false
+        )
+        let activity = CodexAppServerItemActivity(
+            threadID: "thread-1",
+            toolName: "exec_command",
+            preview: "swift test --filter CodexAppServerCoordinatorTests"
+        )
+
+        let metadata = CodexAppServerCoordinator.codexMetadata(existing: existing, activity: activity)
+
+        #expect(metadata.transcriptPath == "/tmp/rollout.jsonl")
+        #expect(metadata.initialUserPrompt == "检查状态展示")
+        #expect(metadata.lastUserPrompt == "继续")
+        #expect(metadata.lastAssistantMessage == "正在处理")
+        #expect(metadata.currentTool == "exec_command")
+        #expect(metadata.currentCommandPreview == "swift test --filter CodexAppServerCoordinatorTests")
+    }
+
+    @Test
+    func clearingItemActivityMetadataPreservesExistingThreadContext() {
+        let existing = CodexSessionMetadata(
+            transcriptPath: "/tmp/rollout.jsonl",
+            initialUserPrompt: "检查状态展示",
+            lastUserPrompt: "继续",
+            lastAssistantMessage: "完成",
+            currentTool: "exec_command",
+            currentCommandPreview: "swift test",
+            isSubagentSession: true
+        )
+
+        let metadata = CodexAppServerCoordinator.codexMetadataClearingTool(existing: existing)
+
+        #expect(metadata.transcriptPath == "/tmp/rollout.jsonl")
+        #expect(metadata.initialUserPrompt == "检查状态展示")
+        #expect(metadata.lastUserPrompt == "继续")
+        #expect(metadata.lastAssistantMessage == "完成")
+        #expect(metadata.currentTool == nil)
+        #expect(metadata.currentCommandPreview == nil)
+        #expect(metadata.isSubagentSession)
+    }
+
+    @Test
+    func outputDeltaMetadataKeepsExistingCommandPreview() {
+        let existing = CodexSessionMetadata(
+            transcriptPath: "/tmp/rollout.jsonl",
+            initialUserPrompt: "运行测试",
+            lastUserPrompt: "继续",
+            lastAssistantMessage: "正在处理",
+            currentTool: "exec_command",
+            currentCommandPreview: "swift test --filter AppModelSessionListTests"
+        )
+        let activity = CodexAppServerItemActivity(
+            threadID: "thread-1",
+            toolName: "exec_command",
+            preview: "Building for debugging..."
+        )
+
+        let metadata = CodexAppServerCoordinator.codexMetadataForOutputDelta(
+            existing: existing,
+            activity: activity
+        )
+
+        #expect(metadata.transcriptPath == "/tmp/rollout.jsonl")
+        #expect(metadata.initialUserPrompt == "运行测试")
+        #expect(metadata.currentTool == "exec_command")
+        #expect(metadata.currentCommandPreview == "swift test --filter AppModelSessionListTests")
+    }
+
+    @Test
+    func outputDeltaMetadataUsesOutputAsPreviewWhenCommandIsMissing() {
+        let existing = CodexSessionMetadata(
+            transcriptPath: "/tmp/rollout.jsonl",
+            initialUserPrompt: "运行测试"
+        )
+        let activity = CodexAppServerItemActivity(
+            threadID: "thread-1",
+            toolName: "exec_command",
+            preview: "Building for debugging..."
+        )
+
+        let metadata = CodexAppServerCoordinator.codexMetadataForOutputDelta(
+            existing: existing,
+            activity: activity
+        )
+
+        #expect(metadata.transcriptPath == "/tmp/rollout.jsonl")
+        #expect(metadata.currentTool == "exec_command")
+        #expect(metadata.currentCommandPreview == "Building for debugging...")
+    }
+
+    @Test
+    func patchUpdatedMetadataDisplaysEditingTarget() {
+        let existing = CodexSessionMetadata(
+            transcriptPath: "/tmp/rollout.jsonl",
+            initialUserPrompt: "优化动画",
+            lastUserPrompt: "继续",
+            lastAssistantMessage: "正在处理"
+        )
+        let activity = CodexAppServerItemActivity(
+            threadID: "thread-1",
+            toolName: "apply_patch",
+            preview: "IslandPanelView.swift"
+        )
+
+        let metadata = CodexAppServerCoordinator.codexMetadata(
+            existing: existing,
+            activity: activity
+        )
+
+        #expect(metadata.transcriptPath == "/tmp/rollout.jsonl")
+        #expect(metadata.initialUserPrompt == "优化动画")
+        #expect(metadata.lastUserPrompt == "继续")
+        #expect(metadata.currentTool == "apply_patch")
+        #expect(metadata.currentCommandPreview == "IslandPanelView.swift")
+    }
+
+    @Test
+    func assistantDeltaMetadataPreservesRunningToolContext() {
+        let existing = CodexSessionMetadata(
+            transcriptPath: "/tmp/rollout.jsonl",
+            initialUserPrompt: "对齐 Vibe Island",
+            lastUserPrompt: "继续",
+            lastAssistantMessage: "我先检查",
+            currentTool: "exec_command",
+            currentCommandPreview: "swift test --filter CodexSessionTrackingTests"
+        )
+        let delta = CodexAppServerAgentMessageDelta(
+            threadID: "thread-1",
+            turnID: "turn-1",
+            itemID: "item-3",
+            text: "我先检查 reducer。"
+        )
+
+        let metadata = CodexAppServerCoordinator.codexMetadataForAgentMessageDelta(
+            existing: existing,
+            delta: delta
+        )
+
+        #expect(metadata.transcriptPath == "/tmp/rollout.jsonl")
+        #expect(metadata.initialUserPrompt == "对齐 Vibe Island")
+        #expect(metadata.lastUserPrompt == "继续")
+        #expect(metadata.lastAssistantMessage == "我先检查 reducer。")
+        #expect(metadata.currentTool == "exec_command")
+        #expect(metadata.currentCommandPreview == "swift test --filter CodexSessionTrackingTests")
+    }
+
+    @Test
+    func rawResponseItemFunctionCallMetadataDisplaysToolTarget() {
+        let existing = CodexSessionMetadata(
+            transcriptPath: "/tmp/rollout.jsonl",
+            initialUserPrompt: "继续对齐事件"
+        )
+        let item = CodexAppServerRawResponseItem(
+            threadID: "thread-1",
+            turnID: "turn-1",
+            itemID: "call-1",
+            toolName: "exec_command",
+            preview: "swift test --filter CodexAppServerDecodingTests"
+        )
+
+        let metadata = CodexAppServerCoordinator.codexMetadataForRawResponseItem(
+            existing: existing,
+            item: item
+        )
+
+        #expect(metadata.transcriptPath == "/tmp/rollout.jsonl")
+        #expect(metadata.initialUserPrompt == "继续对齐事件")
+        #expect(metadata.currentTool == "exec_command")
+        #expect(metadata.currentCommandPreview == "swift test --filter CodexAppServerDecodingTests")
+    }
+
+    @Test
+    func rawResponseItemAssistantMessageUpdatesAssistantTextWithoutClearingContext() {
+        let existing = CodexSessionMetadata(
+            transcriptPath: "/tmp/rollout.jsonl",
+            initialUserPrompt: "继续对齐事件",
+            lastUserPrompt: "继续",
+            currentTool: "exec_command",
+            currentCommandPreview: "swift test"
+        )
+        let item = CodexAppServerRawResponseItem(
+            threadID: "thread-1",
+            turnID: "turn-1",
+            itemID: "msg-1",
+            assistantText: "已经完成事件对齐。"
+        )
+
+        let metadata = CodexAppServerCoordinator.codexMetadataForRawResponseItem(
+            existing: existing,
+            item: item
+        )
+
+        #expect(metadata.transcriptPath == "/tmp/rollout.jsonl")
+        #expect(metadata.lastUserPrompt == "继续")
+        #expect(metadata.lastAssistantMessage == "已经完成事件对齐。")
+        #expect(metadata.currentTool == "exec_command")
+        #expect(metadata.currentCommandPreview == "swift test")
+    }
+
+    @Test
+    func rolloutActivityDateUsesLatestJSONLTimestamp() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-codex-app-server-\(UUID().uuidString)", isDirectory: true)
+        let rolloutURL = rootURL.appendingPathComponent("rollout.jsonl")
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        try """
+        {"timestamp":"2026-06-04T06:00:00.000Z","type":"session_meta","payload":{"id":"thread-1"}}
+        {"timestamp":"2026-06-04T06:42:30Z","type":"event_msg","payload":{"type":"agent_message","message":"Done."}}
+
+        """.write(to: rolloutURL, atomically: true, encoding: .utf8)
+
+        let date = try #require(CodexAppServerCoordinator.rolloutActivityDate(atPath: rolloutURL.path))
+
+        #expect(date == ISO8601DateFormatter().date(from: "2026-06-04T06:42:30Z"))
+    }
+
+    @Test
+    func rolloutSnapshotUsesPromptForWorkspaceFallbackTitle() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-codex-app-server-\(UUID().uuidString)", isDirectory: true)
+        let rolloutURL = rootURL.appendingPathComponent("rollout.jsonl")
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        try """
+        {"timestamp":"2026-06-04T06:00:00.000Z","type":"session_meta","payload":{"id":"thread-1"}}
+        {"timestamp":"2026-06-04T06:00:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"web 模拟器画面现在还是截图预览"}]}}
+        {"timestamp":"2026-06-04T06:00:02.000Z","type":"response_item","payload":{"type":"reasoning"}}
+
+        """.write(to: rolloutURL, atomically: true, encoding: .utf8)
+
+        let payload = CodexAppServerCoordinator.threadPayload(
+            from: makeThread(
+                id: "thread-1",
+                cwd: "/Users/lijie10/Desktop/code/hera",
+                name: "Codex · hera",
+                path: rolloutURL.path,
+                status: CodexThreadStatus(type: .idle, activeFlags: nil)
+            )
+        )
+
+        #expect(payload.title == "web 模拟器画面现在还是截图预览")
+        #expect(payload.jumpTarget.workspaceName == "hera")
+        #expect(payload.jumpTarget.paneTitle == "web 模拟器画面现在还是截图预览")
+        #expect(payload.codexMetadata.initialUserPrompt == "web 模拟器画面现在还是截图预览")
+    }
+
+    @Test
+    func threadPayloadMarksSubagentSessionFromRolloutSessionMeta() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-codex-app-server-subagent-\(UUID().uuidString)", isDirectory: true)
+        let rolloutURL = rootURL.appendingPathComponent("rollout-subagent.jsonl")
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        try """
+        {"timestamp":"2026-06-04T08:39:14.100Z","type":"session_meta","payload":{"id":"019e91c9-5f68-7310-ad42-4c460c4516cd","cwd":"/Users/lijie10/Desktop/code/hera","originator":"Codex Desktop","source":"vscode","thread_source":"subagent"}}
+        {"timestamp":"2026-06-04T08:39:20.875Z","type":"event_msg","payload":{"type":"user_message","message":"排查 PreviewRuntime 权限门"}}
+
+        """.write(to: rolloutURL, atomically: true, encoding: .utf8)
+
+        let payload = CodexAppServerCoordinator.threadPayload(
+            from: makeThread(
+                id: "019e91c9-5f68-7310-ad42-4c460c4516cd",
+                cwd: "/Users/lijie10/Desktop/code/hera",
+                name: "排查 PreviewRuntime 权限门",
+                path: rolloutURL.path,
+                status: CodexThreadStatus(type: .active, activeFlags: nil)
+            )
+        )
+
+        #expect(payload.codexMetadata.isSubagentSession)
+    }
+
+    @Test
+    func recentRunningRolloutOverridesIdleAppServerStatus() throws {
+        let now = Date(timeIntervalSince1970: 1_780_000_000)
+        let snapshot = CodexRolloutSnapshot(
+            summary: "Thinking.",
+            phase: .running,
+            updatedAt: now.addingTimeInterval(-30),
+            initialUserPrompt: "修复 bundle id 冲突",
+            isCompleted: false
+        )
+
+        let phase = CodexAppServerCoordinator.threadPhase(
+            from: CodexThreadStatus(type: .idle, activeFlags: nil),
+            rolloutSnapshot: snapshot,
+            now: now
+        )
+
+        #expect(phase == .running)
+    }
+
+    @Test
+    func recentRunningRolloutOverridesNotLoadedAppServerStatus() throws {
+        let now = Date(timeIntervalSince1970: 1_780_000_000)
+        let snapshot = CodexRolloutSnapshot(
+            summary: "Thinking.",
+            phase: .running,
+            updatedAt: now.addingTimeInterval(-30),
+            initialUserPrompt: "web 模拟器画面",
+            isCompleted: false
+        )
+
+        let phase = CodexAppServerCoordinator.threadPhase(
+            from: CodexThreadStatus(type: .notLoaded, activeFlags: nil),
+            rolloutSnapshot: snapshot,
+            now: now
+        )
+
+        #expect(phase == .running)
+    }
+
+    @Test
+    func recentThreadUpdateKeepsNotLoadedDesktopThreadRunning() throws {
+        let now = Date(timeIntervalSince1970: 1_780_000_000)
+        let staleSnapshot = CodexRolloutSnapshot(
+            summary: "Ready.",
+            phase: .completed,
+            updatedAt: now.addingTimeInterval(-24 * 60 * 60),
+            initialUserPrompt: "web 模拟器画面",
+            isCompleted: false
+        )
+
+        let phase = CodexAppServerCoordinator.threadPhase(
+            from: CodexThreadStatus(type: .notLoaded, activeFlags: nil),
+            rolloutSnapshot: staleSnapshot,
+            threadUpdatedAt: now.addingTimeInterval(-20),
+            now: now
+        )
+
+        #expect(phase == .running)
+    }
+
+    @Test
+    func threadPayloadPrefersFreshThreadUpdateOverStaleRolloutTimestamp() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-thread-updated-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        let rolloutURL = rootURL.appendingPathComponent("rollout.jsonl")
+        try """
+        {"timestamp":"2026-06-04T00:00:00Z","type":"event_msg","payload":{"type":"agent_message","message":"Ready."}}
+
+        """.write(to: rolloutURL, atomically: true, encoding: .utf8)
+
+        let threadUpdatedAt = 1_780_629_108
+        let payload = CodexAppServerCoordinator.threadPayload(
+            from: makeThread(
+                id: "thread-1",
+                name: "web 模拟器画面",
+                updatedAt: threadUpdatedAt,
+                path: rolloutURL.path,
+                status: CodexThreadStatus(type: .notLoaded, activeFlags: nil)
+            ),
+            now: Date(timeIntervalSince1970: Double(threadUpdatedAt) + 20)
+        )
+
+        #expect(payload.phase == .running)
+        #expect(payload.timestamp == Date(timeIntervalSince1970: Double(threadUpdatedAt)))
+    }
+
+    @Test
+    func oldRunningRolloutDoesNotOverrideIdleAppServerStatus() {
+        let now = Date(timeIntervalSince1970: 1_780_000_000)
+        let snapshot = CodexRolloutSnapshot(
+            summary: "Thinking.",
+            phase: .running,
+            updatedAt: now.addingTimeInterval(-3_600),
+            initialUserPrompt: "old prompt",
+            isCompleted: false
+        )
+
+        let phase = CodexAppServerCoordinator.threadPhase(
+            from: CodexThreadStatus(type: .idle, activeFlags: nil),
+            rolloutSnapshot: snapshot,
+            now: now
+        )
+
+        #expect(phase == .completed)
+    }
+
+    @Test
+    func commandApprovalRequestUsesCommandAsPermissionSummary() {
+        let request = CodexAppServerApprovalRequest(
+            requestID: 51,
+            kind: .commandExecution,
+            threadID: "thread-1",
+            reason: "Needs shell",
+            command: ["git", "status"],
+            cwd: "/tmp/project"
+        )
+
+        let permission = CodexAppServerCoordinator.permissionRequest(from: request)
+
+        #expect(permission.title == "Command approval")
+        #expect(permission.summary == "git status")
+        #expect(permission.affectedPath == "/tmp/project")
+        #expect(permission.toolName == "command")
+    }
+
+    @Test
+    func waitingOnApprovalStatusDoesNotCreateFakePermissionCard() {
+        let event = CodexAppServerCoordinator.eventForThreadStatusChanged(
+            threadId: "thread-1",
+            status: CodexThreadStatus(type: .active, activeFlags: ["waitingOnApproval"]),
+            timestamp: Date(timeIntervalSince1970: 1_780_000_000)
+        )
+
+        guard case let .activityUpdated(update)? = event else {
+            Issue.record("Expected a non-actionable activity update for waitingOnApproval status hints.")
+            return
+        }
+        #expect(update.sessionID == "thread-1")
+        #expect(update.phase == .running)
+        #expect(update.summary == "Codex is waiting for approval.")
+    }
+
+    private func makeThread(
+        id: String,
+        cwd: String? = nil,
+        name: String? = nil,
+        updatedAt: Int = 1_780_000_000_000,
+        path: String? = nil,
+        status: CodexThreadStatus? = nil
+    ) -> CodexThread {
+        CodexThread(
+            id: id,
+            cwd: cwd ?? "/tmp/\(id)",
+            name: name ?? id,
+            preview: "preview \(id)",
+            modelProvider: "openai",
+            createdAt: updatedAt,
+            updatedAt: updatedAt,
+            ephemeral: false,
+            path: path ?? "/tmp/\(id).jsonl",
+            status: status ?? CodexThreadStatus(type: .idle, activeFlags: nil),
+            source: .vscode,
+            turns: nil
+        )
+    }
+}

--- a/Tests/OpenIslandAppTests/SessionDiscoveryColdStartTests.swift
+++ b/Tests/OpenIslandAppTests/SessionDiscoveryColdStartTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import OpenIslandApp
+import OpenIslandCore
+
+@MainActor
+struct SessionDiscoveryColdStartTests {
+    @Test
+    func restoresPersistedCodexSnapshotSynchronouslyBeforeAsyncDiscovery() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-cold-start-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let codexStore = CodexSessionStore(
+            fileURL: rootURL.appendingPathComponent("session-terminals.json")
+        )
+        try codexStore.save([
+            CodexTrackedSessionRecord(
+                sessionID: "codex-thread",
+                title: "查找开源实现",
+                origin: .live,
+                attachmentState: .stale,
+                summary: "Thinking.",
+                phase: .running,
+                updatedAt: Date(),
+                jumpTarget: JumpTarget(
+                    terminalApp: "Codex.app",
+                    workspaceName: "lijie10",
+                    paneTitle: "查找开源实现",
+                    workingDirectory: "/Users/lijie10",
+                    codexThreadID: "codex-thread"
+                ),
+                codexMetadata: CodexSessionMetadata(
+                    transcriptPath: "/tmp/rollout.jsonl",
+                    lastUserPrompt: "冷启动 app"
+                )
+            ),
+        ])
+
+        var state = SessionState()
+        let discovery = SessionDiscoveryCoordinator(
+            codexSessionStore: codexStore,
+            claudeSessionRegistry: ClaudeSessionRegistry(fileURL: rootURL.appendingPathComponent("claude.json")),
+            openCodeSessionRegistry: OpenCodeSessionRegistry(fileURL: rootURL.appendingPathComponent("opencode.json")),
+            cursorSessionRegistry: CursorSessionRegistry(fileURL: rootURL.appendingPathComponent("cursor.json"))
+        )
+        discovery.stateAccessor = { state }
+        discovery.stateUpdater = { state = $0 }
+
+        let restoredCount = discovery.restorePersistedSessionsImmediately()
+
+        #expect(restoredCount == 1)
+        let session = try #require(state.session(id: "codex-thread"))
+        #expect(session.title == "查找开源实现")
+        #expect(session.isCodexAppSession)
+        #expect(session.isProcessAlive)
+        #expect(session.codexMetadata?.lastUserPrompt == "冷启动 app")
+    }
+}

--- a/Tests/OpenIslandCoreTests/CodexAppServerDecodingTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexAppServerDecodingTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+struct CodexAppServerDecodingTests {
+    @Test
+    func codexThreadDecodesObjectSourceAsUnknown() throws {
+        let json = Data(
+            """
+            {
+              "id": "019e6cb5-46dc-7e11-ad95-e1df0de7cdb7",
+              "cwd": "/Users/pojue/Documents/Codex",
+              "name": "Investigate Open Island",
+              "preview": "Looking at Codex app-server output.",
+              "modelProvider": "openai",
+              "createdAt": 1779940000000,
+              "updatedAt": 1779940300000,
+              "ephemeral": false,
+              "path": "/Users/pojue/.codex/sessions/2026/05/28/rollout.jsonl",
+              "status": {
+                "type": "notLoaded"
+              },
+              "source": {
+                "kind": "subagent",
+                "parentThreadId": "019e6cb5-46dc-7e11-ad95-e1df0de7cdb7"
+              },
+              "turns": []
+            }
+            """.utf8
+        )
+
+        let thread = try JSONDecoder().decode(CodexThread.self, from: json)
+
+        #expect(thread.source == .unknown)
+    }
+}

--- a/Tests/OpenIslandCoreTests/CodexAppServerDecodingTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexAppServerDecodingTests.swift
@@ -33,4 +33,320 @@ struct CodexAppServerDecodingTests {
 
         #expect(thread.source == .unknown)
     }
+
+    @Test
+    func serverInitiatedCommandApprovalRequestEmitsNotificationInsteadOfBeingTreatedAsResponse() throws {
+        let client = CodexAppServerClient()
+        let received = LockedCodexAppServerNotifications()
+        client.onNotification = { received.append($0) }
+
+        client.handleIncomingData(Data(
+            """
+            {"jsonrpc":"2.0","id":41,"method":"item/commandExecution/requestApproval","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"item-1","reason":"needs shell","command":["git","status"],"cwd":"/tmp/project"}}
+
+            """.utf8
+        ))
+
+        let notification = try #require(received.snapshot().first)
+        guard case let .approvalRequested(request) = notification else {
+            Issue.record("Expected approvalRequested notification, got \(notification)")
+            return
+        }
+
+        #expect(request.requestID == 41)
+        #expect(request.kind == .commandExecution)
+        #expect(request.threadID == "thread-1")
+        #expect(request.command == ["git", "status"])
+        #expect(request.cwd == "/tmp/project")
+    }
+
+    @Test
+    func resolvesCommandApprovalByWritingJsonRpcDecisionResponse() throws {
+        let client = CodexAppServerClient()
+        let pipe = Pipe()
+        client.stdin = pipe.fileHandleForWriting
+
+        let request = CodexAppServerApprovalRequest(
+            requestID: 42,
+            kind: .commandExecution,
+            threadID: "thread-1"
+        )
+
+        try client.resolveApprovalRequest(request, resolution: .allowOnce())
+        pipe.fileHandleForWriting.closeFile()
+
+        let line = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+        let json = try #require(line?.data(using: .utf8))
+        let object = try #require(JSONSerialization.jsonObject(with: json) as? [String: Any])
+        let result = try #require(object["result"] as? [String: Any])
+
+        #expect(object["id"] as? Int == 42)
+        #expect(result["decision"] as? String == "accept")
+    }
+
+    @Test
+    func resolvesPermissionApprovalWithRequestedPermissionsSubset() throws {
+        let client = CodexAppServerClient()
+        let pipe = Pipe()
+        client.stdin = pipe.fileHandleForWriting
+
+        client.handleIncomingData(Data(
+            """
+            {"jsonrpc":"2.0","id":43,"method":"item/permissions/requestApproval","params":{"threadId":"thread-1","itemId":"item-1","cwd":"/tmp/project","reason":"needs workspace","permissions":{"fileSystem":{"write":["/tmp/project"]},"network":{"enabled":true}}}}
+
+            """.utf8
+        ))
+
+        let request = CodexAppServerApprovalRequest(
+            requestID: 43,
+            kind: .permissions,
+            threadID: "thread-1",
+            permissions: .object([
+                "fileSystem": .object(["write": .array([.string("/tmp/project")])]),
+                "network": .object(["enabled": .boolean(true)]),
+            ])
+        )
+
+        try client.resolveApprovalRequest(request, resolution: .allowOnce())
+        pipe.fileHandleForWriting.closeFile()
+
+        let line = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+        let json = try #require(line?.data(using: .utf8))
+        let object = try #require(JSONSerialization.jsonObject(with: json) as? [String: Any])
+        let result = try #require(object["result"] as? [String: Any])
+        let permissions = try #require(result["permissions"] as? [String: Any])
+
+        #expect(object["id"] as? Int == 43)
+        #expect(permissions["fileSystem"] != nil)
+        #expect(permissions["network"] != nil)
+    }
+
+    @Test
+    func readsAccountRateLimitsFromAppServerMainSnapshot() async throws {
+        let client = CodexAppServerClient()
+        client.requestTimeoutSeconds = 1
+        let pipe = Pipe()
+        client.stdin = pipe.fileHandleForWriting
+
+        let task = Task {
+            try await client.readAccountRateLimits()
+        }
+
+        let requestLine = pipe.fileHandleForReading.availableData
+        let requestObject = try #require(JSONSerialization.jsonObject(with: requestLine) as? [String: Any])
+        let requestID = try #require(requestObject["id"] as? Int)
+        #expect(requestObject["method"] as? String == "account/rateLimits/read")
+
+        client.handleIncomingData(Data(
+            """
+            {"jsonrpc":"2.0","id":\(requestID),"result":{"rateLimits":{"limitId":"codex","limitName":null,"primary":{"usedPercent":53,"windowDurationMins":300,"resetsAt":1780571047},"secondary":{"usedPercent":10,"windowDurationMins":10080,"resetsAt":1781139840},"credits":{"hasCredits":false,"unlimited":false,"balance":"0"},"planType":"pro","rateLimitReachedType":null},"rateLimitsByLimitId":{"codex_bengalfox":{"limitId":"codex_bengalfox","limitName":"GPT-5.3-Codex-Spark","primary":{"usedPercent":0,"windowDurationMins":300,"resetsAt":1780588623},"secondary":{"usedPercent":0,"windowDurationMins":10080,"resetsAt":1781175423},"credits":null,"planType":"pro","rateLimitReachedType":null}}}}
+
+            """.utf8
+        ))
+
+        let snapshot = try #require(await task.value)
+
+        #expect(snapshot.sourceFilePath == "codex-app-server")
+        #expect(snapshot.limitID == "codex")
+        #expect(snapshot.planType == "pro")
+        #expect(snapshot.windows.map(\.label) == ["5h", "7d"])
+        #expect(snapshot.windows.map(\.roundedUsedPercentage) == [53, 10])
+    }
+
+    @Test
+    func accountRateLimitsUpdatedNotificationEmitsUsageSnapshot() throws {
+        let client = CodexAppServerClient()
+        let received = LockedCodexAppServerNotifications()
+        client.onNotification = { received.append($0) }
+
+        client.handleIncomingData(Data(
+            """
+            {"jsonrpc":"2.0","method":"account/rateLimits/updated","params":{"rateLimits":{"limitId":"codex","primary":{"usedPercent":52,"windowDurationMins":300,"resetsAt":1780571047},"secondary":{"usedPercent":10,"windowDurationMins":10080,"resetsAt":1781139840},"planType":"pro"}}}
+
+            """.utf8
+        ))
+
+        let notification = try #require(received.snapshot().first)
+        guard case let .accountRateLimitsUpdated(snapshot) = notification else {
+            Issue.record("Expected accountRateLimitsUpdated notification, got \(notification)")
+            return
+        }
+
+        #expect(snapshot.sourceFilePath == "codex-app-server-notification")
+        #expect(snapshot.limitID == "codex")
+        #expect(snapshot.windows.map(\.roundedUsedPercentage) == [52, 10])
+    }
+
+    @Test
+    func itemStartedCommandExecutionNotificationEmitsToolActivity() throws {
+        let client = CodexAppServerClient()
+        let received = LockedCodexAppServerNotifications()
+        client.onNotification = { received.append($0) }
+
+        client.handleIncomingData(Data(
+            """
+            {"jsonrpc":"2.0","method":"item/started","params":{"threadId":"thread-1","turnId":"turn-1","item":{"id":"item-1","type":"commandExecution","command":["zsh","-lc","swift test --filter CodexSessionTrackingTests"],"cwd":"/tmp/project","status":"inProgress"}}}
+
+            """.utf8
+        ))
+
+        let notification = try #require(received.snapshot().first)
+        guard case let .itemStarted(activity) = notification else {
+            Issue.record("Expected itemStarted notification, got \(notification)")
+            return
+        }
+
+        #expect(activity.threadID == "thread-1")
+        #expect(activity.toolName == "exec_command")
+        #expect(activity.preview == "swift test --filter CodexSessionTrackingTests")
+    }
+
+    @Test
+    func commandExecutionOutputDeltaEmitsToolActivityHeartbeat() throws {
+        let client = CodexAppServerClient()
+        let received = LockedCodexAppServerNotifications()
+        client.onNotification = { received.append($0) }
+
+        client.handleIncomingData(Data(
+            """
+            {"jsonrpc":"2.0","method":"item/commandExecution/outputDelta","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"item-1","delta":"Building for debugging...\\n[1/3] Compiling"}}
+
+            """.utf8
+        ))
+
+        let notification = try #require(received.snapshot().first)
+        guard case let .itemOutputDelta(activity) = notification else {
+            Issue.record("Expected itemOutputDelta notification, got \(notification)")
+            return
+        }
+
+        #expect(activity.threadID == "thread-1")
+        #expect(activity.turnID == "turn-1")
+        #expect(activity.itemID == "item-1")
+        #expect(activity.toolName == "exec_command")
+        #expect(activity.preview == "Building for debugging... [1/3] Compiling")
+    }
+
+    @Test
+    func fileChangePatchUpdatedEmitsEditingActivity() throws {
+        let client = CodexAppServerClient()
+        let received = LockedCodexAppServerNotifications()
+        client.onNotification = { received.append($0) }
+
+        client.handleIncomingData(Data(
+            """
+            {"jsonrpc":"2.0","method":"item/fileChange/patchUpdated","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"item-2","patch":"*** Begin Patch\\n*** Update File: Sources/OpenIslandApp/Views/IslandPanelView.swift\\n@@\\n-old\\n+new\\n*** End Patch"}}
+
+            """.utf8
+        ))
+
+        let notification = try #require(received.snapshot().first)
+        guard case let .itemPatchUpdated(activity) = notification else {
+            Issue.record("Expected itemPatchUpdated notification, got \(notification)")
+            return
+        }
+
+        #expect(activity.threadID == "thread-1")
+        #expect(activity.turnID == "turn-1")
+        #expect(activity.itemID == "item-2")
+        #expect(activity.toolName == "apply_patch")
+        #expect(activity.preview == "IslandPanelView.swift")
+    }
+
+    @Test
+    func agentMessageDeltaEmitsAssistantDelta() throws {
+        let client = CodexAppServerClient()
+        let received = LockedCodexAppServerNotifications()
+        client.onNotification = { received.append($0) }
+
+        client.handleIncomingData(Data(
+            """
+            {"jsonrpc":"2.0","method":"item/agentMessage/delta","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"item-3","delta":"正在整理 reducer 规则"}}
+
+            """.utf8
+        ))
+
+        let notification = try #require(received.snapshot().first)
+        guard case let .agentMessageDelta(delta) = notification else {
+            Issue.record("Expected agentMessageDelta notification, got \(notification)")
+            return
+        }
+
+        #expect(delta.threadID == "thread-1")
+        #expect(delta.turnID == "turn-1")
+        #expect(delta.itemID == "item-3")
+        #expect(delta.text == "正在整理 reducer 规则")
+    }
+
+    @Test
+    func rawResponseItemCompletedFunctionCallEmitsToolActivity() throws {
+        let client = CodexAppServerClient()
+        let received = LockedCodexAppServerNotifications()
+        client.onNotification = { received.append($0) }
+
+        client.handleIncomingData(Data(
+            """
+            {"jsonrpc":"2.0","method":"rawResponseItem/completed","params":{"threadId":"thread-1","turnId":"turn-1","item":{"id":"call-1","type":"function_call","name":"exec_command","arguments":{"cmd":"swift test --filter CodexSessionTrackingTests"}}}}
+
+            """.utf8
+        ))
+
+        let notification = try #require(received.snapshot().first)
+        guard case let .rawResponseItemCompleted(item) = notification else {
+            Issue.record("Expected rawResponseItemCompleted notification, got \(notification)")
+            return
+        }
+
+        #expect(item.threadID == "thread-1")
+        #expect(item.turnID == "turn-1")
+        #expect(item.itemID == "call-1")
+        #expect(item.toolName == "exec_command")
+        #expect(item.preview == "swift test --filter CodexSessionTrackingTests")
+        #expect(item.assistantText == nil)
+    }
+
+    @Test
+    func rawResponseItemCompletedAssistantMessageEmitsAssistantText() throws {
+        let client = CodexAppServerClient()
+        let received = LockedCodexAppServerNotifications()
+        client.onNotification = { received.append($0) }
+
+        client.handleIncomingData(Data(
+            """
+            {"jsonrpc":"2.0","method":"rawResponseItem/completed","params":{"threadId":"thread-1","turnId":"turn-1","item":{"id":"msg-1","type":"message","role":"assistant","content":[{"type":"output_text","text":"已经完成 reducer 对齐。"}]}}}
+
+            """.utf8
+        ))
+
+        let notification = try #require(received.snapshot().first)
+        guard case let .rawResponseItemCompleted(item) = notification else {
+            Issue.record("Expected rawResponseItemCompleted notification, got \(notification)")
+            return
+        }
+
+        #expect(item.threadID == "thread-1")
+        #expect(item.turnID == "turn-1")
+        #expect(item.itemID == "msg-1")
+        #expect(item.toolName == nil)
+        #expect(item.preview == nil)
+        #expect(item.assistantText == "已经完成 reducer 对齐。")
+    }
+}
+
+private final class LockedCodexAppServerNotifications: @unchecked Sendable {
+    private let lock = NSLock()
+    private var notifications: [CodexAppServerNotification] = []
+
+    func append(_ notification: CodexAppServerNotification) {
+        lock.lock()
+        notifications.append(notification)
+        lock.unlock()
+    }
+
+    func snapshot() -> [CodexAppServerNotification] {
+        lock.lock()
+        let copy = notifications
+        lock.unlock()
+        return copy
+    }
 }

--- a/Tests/OpenIslandCoreTests/CodexHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexHooksTests.swift
@@ -117,7 +117,7 @@ struct CodexHooksTests {
     @Test
     func codexHookOutputEncoderEncodesPermissionRequestAllowDecision() throws {
         let output = try CodexHookOutputEncoder.standardOutput(
-            for: .codexHookDirective(.permissionRequest(.allow))
+            for: .codexHookDirective(.permissionRequest(.allow()))
         )
 
         let payload = try #require(output)

--- a/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
@@ -285,9 +285,9 @@ struct CodexSessionTrackingTests {
             to: &snapshot
         )
 
-        #expect(snapshot.currentTool == nil)
-        #expect(snapshot.currentCommandPreview == nil)
-        #expect(snapshot.summary == "Thinking.")
+        #expect(snapshot.currentTool == "web_search")
+        #expect(snapshot.currentCommandPreview == "Codex rollout ResponseItem")
+        #expect(snapshot.summary == "Running web search.")
 
         CodexRolloutReducer.apply(
             line: rolloutLine(
@@ -384,9 +384,9 @@ struct CodexSessionTrackingTests {
             to: &snapshot
         )
 
-        #expect(snapshot.currentTool == nil)
-        #expect(snapshot.currentCommandPreview == nil)
-        #expect(snapshot.summary == "Thinking.")
+        #expect(snapshot.currentTool == "exec_command")
+        #expect(snapshot.currentCommandPreview == "git status -sb")
+        #expect(snapshot.summary == "Running command.")
 
         CodexRolloutReducer.apply(
             line: rolloutLine(
@@ -438,8 +438,9 @@ struct CodexSessionTrackingTests {
             to: &snapshot
         )
 
-        #expect(snapshot.currentTool == nil)
-        #expect(snapshot.summary == "Thinking.")
+        #expect(snapshot.currentTool == "apply_patch")
+        #expect(snapshot.currentCommandPreview == "CodexSessionTracking.swift")
+        #expect(snapshot.summary == "Running patch.")
 
         CodexRolloutReducer.apply(
             line: rolloutLine(
@@ -461,6 +462,95 @@ struct CodexSessionTrackingTests {
         #expect(snapshot.currentTool == "web_search")
         #expect(snapshot.currentCommandPreview == "'ResponseItem' in https://github.com/openai/codex")
         #expect(snapshot.summary == "Running web search.")
+    }
+
+    @Test
+    func codexRolloutReducerKeepsPatchActivityVisibleAfterPatchApplyEnd() {
+        var snapshot = CodexRolloutSnapshot()
+
+        CodexRolloutReducer.apply(
+            line: rolloutLine(
+                timestamp: "2026-04-02T04:03:47.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "patch_apply_begin",
+                    "changes": [
+                        "hera-web/src/components/vibe/VibeNativePreview.tsx": [:],
+                    ],
+                ]
+            ),
+            to: &snapshot
+        )
+        CodexRolloutReducer.apply(
+            line: rolloutLine(
+                timestamp: "2026-04-02T04:03:48.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "patch_apply_end",
+                    "success": true,
+                    "changes": [
+                        "hera-web/src/components/vibe/VibeNativePreview.tsx": [
+                            "type": "update",
+                        ],
+                    ],
+                    "status": "completed",
+                ]
+            ),
+            to: &snapshot
+        )
+
+        #expect(snapshot.currentTool == "apply_patch")
+        #expect(snapshot.currentCommandPreview == "VibeNativePreview.tsx")
+        #expect(snapshot.summary == "Running patch.")
+    }
+
+    @Test
+    func codexRolloutReducerDoesNotReplaceSettledToolWithTrailingThinking() {
+        var snapshot = CodexRolloutSnapshot()
+
+        CodexRolloutReducer.apply(
+            line: rolloutLine(
+                timestamp: "2026-04-02T04:03:49.000Z",
+                type: "response_item",
+                payload: [
+                    "type": "local_shell_call",
+                    "status": "in_progress",
+                    "action": [
+                        "type": "exec",
+                        "command": ["zsh", "-lc", "swift test --filter CodexSessionTrackingTests"],
+                    ],
+                ]
+            ),
+            to: &snapshot
+        )
+        CodexRolloutReducer.apply(
+            line: rolloutLine(
+                timestamp: "2026-04-02T04:03:50.000Z",
+                type: "response_item",
+                payload: [
+                    "type": "function_call_output",
+                    "call_id": "call-1",
+                    "output": "done",
+                ]
+            ),
+            to: &snapshot
+        )
+        CodexRolloutReducer.apply(
+            line: rolloutLine(
+                timestamp: "2026-04-02T04:03:51.000Z",
+                type: "response_item",
+                payload: [
+                    "type": "reasoning",
+                    "summary": [],
+                ]
+            ),
+            to: &snapshot
+        )
+
+        #expect(snapshot.currentTool == "exec_command")
+        #expect(snapshot.currentCommandPreview == "swift test --filter CodexSessionTrackingTests")
+        #expect(snapshot.summary == "Running command.")
+        #expect(snapshot.updatedAt == Date(timeIntervalSince1970: 1_775_102_631))
     }
 
     @Test
@@ -522,6 +612,36 @@ struct CodexSessionTrackingTests {
         #expect(snapshot.currentCommandPreview == nil)
         #expect(snapshot.summary == "Final answer stays visible.")
         #expect(snapshot.updatedAt == Date(timeIntervalSince1970: 1_775_102_628))
+    }
+
+    @Test
+    func codexRolloutReducerReopensCompletionForLaterSameRolloutActivity() {
+        let snapshot = CodexRolloutReducer.snapshot(for: [
+            rolloutLine(
+                timestamp: "2026-04-02T04:03:45.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "task_complete",
+                    "last_agent_message": "Previous turn completed.",
+                ]
+            ),
+            rolloutLine(
+                timestamp: "2026-04-02T04:04:00.000Z",
+                type: "response_item",
+                payload: [
+                    "type": "function_call",
+                    "name": "exec_command",
+                    "arguments": [
+                        "cmd": "git status",
+                    ],
+                ]
+            ),
+        ])
+
+        #expect(snapshot.phase == .running)
+        #expect(!snapshot.isCompleted)
+        #expect(snapshot.currentTool == "exec_command")
+        #expect(snapshot.summary == "Running command.")
     }
 
     @Test
@@ -1093,12 +1213,91 @@ struct CodexSessionTrackingTests {
     }
 
     @Test
+    func codexRolloutDiscoveryBoundsLargeRolloutParsingToHeadAndTail() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-discovery-bounded-\(UUID().uuidString)", isDirectory: true)
+        let rolloutDirectoryURL = rootURL.appendingPathComponent("2026/06/04", isDirectory: true)
+        let rolloutURL = rolloutDirectoryURL.appendingPathComponent("rollout-huge.jsonl")
+        let now = Date(timeIntervalSince1970: 1_780_000_000)
+
+        try FileManager.default.createDirectory(at: rolloutDirectoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        FileManager.default.createFile(atPath: rolloutURL.path, contents: nil)
+        let handle = try FileHandle(forWritingTo: rolloutURL)
+
+        try writeLine(sessionMetaLine(
+            sessionID: "codex-session-huge",
+            timestamp: "2026-06-04T12:00:00.000Z",
+            cwd: "/Users/lijie10/Desktop/code/hera",
+            originator: "Codex Desktop"
+        ), to: handle)
+
+        // Middle content is deliberately larger than maxFullScanBytes and
+        // contains misleading old activity. The bounded path must not need
+        // to parse it to recover the current UI snapshot.
+        let middleLine = rolloutLine(
+            timestamp: "2026-06-04T12:01:00.000Z",
+            type: "event_msg",
+            payload: [
+                "type": "agent_message",
+                "message": String(repeating: "old middle payload ", count: 16),
+            ]
+        ).appending("\n")
+        for _ in 0..<220 {
+            try handle.write(contentsOf: Data(middleLine.utf8))
+        }
+
+        try writeLine(rolloutLine(
+            timestamp: "2026-06-04T12:10:00.000Z",
+            type: "event_msg",
+            payload: [
+                "type": "user_message",
+                "message": "Inspect the bounded rollout.",
+            ]
+        ), to: handle)
+        try writeLine(rolloutLine(
+            timestamp: "2026-06-04T12:10:03.000Z",
+            type: "event_msg",
+            payload: [
+                "type": "agent_message",
+                "message": "Recovered from the bounded rollout tail.",
+            ]
+        ), to: handle)
+        try handle.close()
+
+        try FileManager.default.setAttributes([.modificationDate: now], ofItemAtPath: rolloutURL.path)
+        let fileSize = (try FileManager.default.attributesOfItem(atPath: rolloutURL.path)[.size] as? NSNumber)?.uint64Value ?? 0
+        #expect(fileSize > 12 * 1_024)
+
+        let discovery = CodexRolloutDiscovery(
+            rootURL: rootURL,
+            fileManager: .default,
+            maxAge: 86_400,
+            maxFiles: 10,
+            maxFullScanBytes: 12 * 1_024,
+            largeFileHeadBytes: 2 * 1_024,
+            largeFileTailBytes: 4 * 1_024
+        )
+
+        let records = discovery.discoverRecentSessions(now: now)
+
+        #expect(records.count == 1)
+        #expect(records.first?.sessionID == "codex-session-huge")
+        #expect(records.first?.title == "Codex · hera")
+        #expect(records.first?.summary == "Recovered from the bounded rollout tail.")
+        #expect(records.first?.codexMetadata?.lastUserPrompt == "Inspect the bounded rollout.")
+        #expect(records.first?.codexMetadata?.lastAssistantMessage == "Recovered from the bounded rollout tail.")
+        #expect(records.first?.jumpTarget?.terminalApp == "Codex.app")
+    }
+
+    @Test
     func codexRolloutDiscoveryMarksCodexDesktopSessionsWithAppJumpTarget() throws {
         let rootURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("open-island-discovery-codex-app-\(UUID().uuidString)", isDirectory: true)
         let rolloutDirectoryURL = rootURL.appendingPathComponent("2026/05/28", isDirectory: true)
         let rolloutURL = rolloutDirectoryURL.appendingPathComponent("rollout-codex-app.jsonl")
-        let now = Date(timeIntervalSince1970: 1_779_940_000)
+        let now = Date(timeIntervalSince1970: 1_779_941_000)
 
         try FileManager.default.createDirectory(at: rolloutDirectoryURL, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: rootURL) }
@@ -1139,7 +1338,109 @@ struct CodexSessionTrackingTests {
         #expect(record?.jumpTarget?.terminalApp == "Codex.app")
         #expect(record?.jumpTarget?.workingDirectory == cwd)
         #expect(record?.jumpTarget?.codexThreadID == "019e6cb5-46dc-7e11-ad95-e1df0de7cdb7")
+        #expect(record?.updatedAt == ISO8601DateFormatter().date(from: "2026-05-28T03:51:22Z"))
         #expect(session?.isCodexAppSession == true)
+    }
+
+    @Test
+    func codexRolloutDiscoveryMarksSubagentSessionsFromThreadSource() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-discovery-codex-subagent-\(UUID().uuidString)", isDirectory: true)
+        let rolloutDirectoryURL = rootURL.appendingPathComponent("2026/06/04", isDirectory: true)
+        let rolloutURL = rolloutDirectoryURL.appendingPathComponent("rollout-codex-subagent.jsonl")
+        let now = Date(timeIntervalSince1970: 1_780_562_400)
+
+        try FileManager.default.createDirectory(at: rolloutDirectoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let lines = [
+            sessionMetaLine(
+                sessionID: "019e91c9-5f68-7310-ad42-4c460c4516cd",
+                timestamp: "2026-06-04T08:39:14.100Z",
+                cwd: "/Users/lijie10/Desktop/code/hera",
+                originator: "Codex Desktop",
+                source: "vscode",
+                threadSource: "subagent"
+            ),
+            rolloutLine(
+                timestamp: "2026-06-04T08:39:20.875Z",
+                type: "event_msg",
+                payload: [
+                    "type": "user_message",
+                    "message": "排查 PreviewRuntime 权限门",
+                ]
+            ),
+        ]
+        try lines.joined(separator: "\n").appending("\n").write(to: rolloutURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.modificationDate: now], ofItemAtPath: rolloutURL.path)
+
+        let discovery = CodexRolloutDiscovery(
+            rootURL: rootURL,
+            fileManager: .default,
+            maxAge: 86_400,
+            maxFiles: 10
+        )
+
+        let record = try #require(discovery.discoverRecentSessions(now: now).first)
+
+        #expect(record.codexMetadata?.isSubagentSession == true)
+    }
+
+    @Test
+    func codexRolloutDiscoveryUsesSessionIndexThreadNameForCodexDesktopTitle() throws {
+        let baseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-discovery-codex-index-\(UUID().uuidString)", isDirectory: true)
+        let rootURL = baseURL.appendingPathComponent("sessions", isDirectory: true)
+        let rolloutDirectoryURL = rootURL.appendingPathComponent("2026/06/04", isDirectory: true)
+        let rolloutURL = rolloutDirectoryURL.appendingPathComponent("rollout-codex-app.jsonl")
+        let indexURL = baseURL.appendingPathComponent("session_index.jsonl")
+        let now = Date(timeIntervalSince1970: 1_779_941_000)
+
+        try FileManager.default.createDirectory(at: rolloutDirectoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: baseURL) }
+
+        let lines = [
+            sessionMetaLine(
+                sessionID: "019e91b6-4eb3-7531-8fbc-318e21ffc8a2",
+                timestamp: "2026-06-04T08:18:24.000Z",
+                cwd: "/Users/lijie10/Desktop/code/hera",
+                originator: "Codex Desktop",
+                source: "vscode"
+            ),
+            rolloutLine(
+                timestamp: "2026-06-04T08:18:25.000Z",
+                type: "response_item",
+                payload: [
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        [
+                            "type": "input_text",
+                            "text": "heraweb现在也需要merge到release分支",
+                        ],
+                    ],
+                ]
+            ),
+        ]
+        try lines.joined(separator: "\n").appending("\n").write(to: rolloutURL, atomically: true, encoding: .utf8)
+        try """
+        {"id":"019e91b6-4eb3-7531-8fbc-318e21ffc8a2","thread_name":"合并 hera-web 到 release","updated_at":"2026-06-04T08:20:03.376839Z"}
+
+        """.write(to: indexURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.modificationDate: now], ofItemAtPath: rolloutURL.path)
+
+        let discovery = CodexRolloutDiscovery(
+            rootURL: rootURL,
+            fileManager: .default,
+            maxAge: 86_400,
+            maxFiles: 10
+        )
+
+        let record = try #require(discovery.discoverRecentSessions(now: now).first)
+
+        #expect(record.title == "合并 hera-web 到 release")
+        #expect(record.jumpTarget?.paneTitle == "合并 hera-web 到 release")
+        #expect(record.codexMetadata?.initialUserPrompt == "heraweb现在也需要merge到release分支")
     }
 
     @Test
@@ -1218,6 +1519,10 @@ private func appendRolloutLine(_ line: String, to fileURL: URL) throws {
     try handle.write(contentsOf: data)
 }
 
+private func writeLine(_ line: String, to handle: FileHandle) throws {
+    try handle.write(contentsOf: Data("\(line)\n".utf8))
+}
+
 private func rolloutLine(
     timestamp: String,
     type: String,
@@ -1237,18 +1542,24 @@ private func sessionMetaLine(
     timestamp: String,
     cwd: String,
     originator: String = "codex-tui",
-    source: String = "cli"
+    source: String = "cli",
+    threadSource: String? = nil
 ) -> String {
-    rolloutLine(
+    var payload: [String: Any] = [
+        "id": sessionID,
+        "timestamp": timestamp,
+        "cwd": cwd,
+        "originator": originator,
+        "source": source,
+    ]
+    if let threadSource {
+        payload["thread_source"] = threadSource
+    }
+
+    return rolloutLine(
         timestamp: timestamp,
         type: "session_meta",
-        payload: [
-            "id": sessionID,
-            "timestamp": timestamp,
-            "cwd": cwd,
-            "originator": originator,
-            "source": source,
-        ]
+        payload: payload
     )
 }
 

--- a/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
@@ -1093,6 +1093,56 @@ struct CodexSessionTrackingTests {
     }
 
     @Test
+    func codexRolloutDiscoveryMarksCodexDesktopSessionsWithAppJumpTarget() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-discovery-codex-app-\(UUID().uuidString)", isDirectory: true)
+        let rolloutDirectoryURL = rootURL.appendingPathComponent("2026/05/28", isDirectory: true)
+        let rolloutURL = rolloutDirectoryURL.appendingPathComponent("rollout-codex-app.jsonl")
+        let now = Date(timeIntervalSince1970: 1_779_940_000)
+
+        try FileManager.default.createDirectory(at: rolloutDirectoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let cwd = "/Users/pojue/Documents/Codex/2026-05-28/hatch-pet-users-pojue-codex-skills"
+        let lines = [
+            sessionMetaLine(
+                sessionID: "019e6cb5-46dc-7e11-ad95-e1df0de7cdb7",
+                timestamp: "2026-05-28T03:51:20.275Z",
+                cwd: cwd,
+                originator: "Codex Desktop",
+                source: "vscode"
+            ),
+            rolloutLine(
+                timestamp: "2026-05-28T03:51:22.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "turn_complete",
+                    "last_agent_message": "Turn completed.",
+                ]
+            ),
+        ]
+        try lines.joined(separator: "\n").appending("\n").write(to: rolloutURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.modificationDate: now], ofItemAtPath: rolloutURL.path)
+
+        let discovery = CodexRolloutDiscovery(
+            rootURL: rootURL,
+            fileManager: .default,
+            maxAge: 86_400,
+            maxFiles: 10
+        )
+
+        let records = discovery.discoverRecentSessions(now: now)
+        let record = records.first
+        let session = record?.session
+
+        #expect(records.count == 1)
+        #expect(record?.jumpTarget?.terminalApp == "Codex.app")
+        #expect(record?.jumpTarget?.workingDirectory == cwd)
+        #expect(record?.jumpTarget?.codexThreadID == "019e6cb5-46dc-7e11-ad95-e1df0de7cdb7")
+        #expect(session?.isCodexAppSession == true)
+    }
+
+    @Test
     func codexRolloutDiscoveryHandlesTrailingLineWithoutNewline() throws {
         // A rollout written by Codex while the process is mid-flush
         // can land on disk without a trailing newline. The streamed
@@ -1185,7 +1235,9 @@ private func rolloutLine(
 private func sessionMetaLine(
     sessionID: String,
     timestamp: String,
-    cwd: String
+    cwd: String,
+    originator: String = "codex-tui",
+    source: String = "cli"
 ) -> String {
     rolloutLine(
         timestamp: timestamp,
@@ -1194,8 +1246,8 @@ private func sessionMetaLine(
             "id": sessionID,
             "timestamp": timestamp,
             "cwd": cwd,
-            "originator": "codex-tui",
-            "source": "cli",
+            "originator": originator,
+            "source": source,
         ]
     )
 }

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -483,7 +483,7 @@ struct SessionStateTests {
     }
 
     @Test
-    func codexPreToolUseWaitsForApprovalAndReturnsDenyDirective() async throws {
+    func codexPreToolUseMarksToolRunningWithoutRequestingApproval() async throws {
         let socketURL = BridgeSocketLocation.uniqueTestURL()
         let server = BridgeServer(socketURL: socketURL)
         try server.start()
@@ -504,27 +504,25 @@ struct SessionStateTests {
             turnID: "turn-1",
             toolName: "Bash",
             toolUseID: "tool-use-1",
-            toolInput: CodexHookToolInput(command: "rm -rf build")
+            toolInput: CodexHookToolInput(command: "swift test --filter AppModelSessionListTests")
         )
 
-        async let responseTask = sendOnGCDThread(.processCodexHook(payload), socketURL: socketURL)
+        let responseTask = Task {
+            try BridgeCommandClient(socketURL: socketURL).send(.processCodexHook(payload))
+        }
 
         var iterator = stream.makeAsyncIterator()
         let startedEvent = try await nextEvent(from: &iterator)
-        let permissionEvent = try await nextEvent(from: &iterator)
+        let activityEvent = try await nextEvent(from: &iterator)
 
         #expect(startedEvent.isSessionStarted)
-        #expect(permissionEvent.isPermissionRequested)
+        #expect(startedEvent.sessionStarted?.codexMetadata?.currentTool == "Bash")
+        #expect(startedEvent.sessionStarted?.codexMetadata?.currentCommandPreview == "swift test --filter AppModelSessionListTests")
+        #expect(activityEvent.activityUpdate?.phase == .running)
+        #expect(activityEvent.activityUpdate?.summary == "Bash swift test --filter AppModelSessionListTests")
 
-        try await observer.send(
-            .resolvePermission(
-                sessionID: "codex-session-1",
-                resolution: .deny(message: "Use the project cleanup script instead.")
-            )
-        )
-
-        let response = try await responseTask
-        #expect(response == .codexHookDirective(.deny(reason: "Use the project cleanup script instead.")))
+        let response = try await responseTask.value
+        #expect(response == .acknowledged)
     }
 
     @Test
@@ -574,7 +572,75 @@ struct SessionStateTests {
         let response = try await responseTask
 
         #expect(activityEvent.activityUpdate?.summary == "Permission approved. Codex continued the tool.")
-        #expect(response == .codexHookDirective(.permissionRequest(.allow)))
+        #expect(response == .codexHookDirective(.permissionRequest(.allow())))
+    }
+
+    @Test
+    func codexAskUserQuestionReturnsUpdatedAnswers() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let data = """
+        {
+          "cwd": "/tmp/worktree",
+          "hook_event_name": "PermissionRequest",
+          "model": "gpt-5-codex",
+          "permission_mode": "default",
+          "session_id": "codex-question",
+          "tool_name": "AskUserQuestion",
+          "tool_input": {
+            "questions": [
+              {
+                "id": "q1",
+                "question": "Proceed?"
+              }
+            ]
+          },
+          "turn_id": "turn-1"
+        }
+        """.data(using: .utf8)!
+        let payload = try JSONDecoder().decode(CodexHookPayload.self, from: data)
+
+        async let responseTask = sendOnGCDThread(.processCodexHook(payload), socketURL: socketURL)
+
+        var iterator = stream.makeAsyncIterator()
+        let startedEvent = try await nextEvent(from: &iterator)
+        let questionEvent = try await nextEvent(from: &iterator)
+
+        #expect(startedEvent.isSessionStarted)
+        guard case let .questionAsked(question) = questionEvent else {
+            Issue.record("Expected Codex AskUserQuestion event")
+            return
+        }
+        #expect(question.prompt.questions.first?.header == "q1")
+        #expect(question.prompt.questions.first?.question == "Proceed?")
+
+        try await observer.send(
+            .answerQuestion(
+                sessionID: "codex-question",
+                response: QuestionPromptResponse(answers: ["q1": "yes"])
+            )
+        )
+
+        let activityEvent = try await nextEvent(from: &iterator)
+        let response = try await responseTask
+
+        #expect(activityEvent.activityUpdate?.summary == "Answered: q1: yes")
+        guard case let .some(.codexHookDirective(.permissionRequest(.allow(updatedInput)))) = response,
+              case let .object(root)? = updatedInput,
+              case let .object(answers)? = root["answers"],
+              case let .string(answer)? = answers["q1"] else {
+            Issue.record("Expected Codex AskUserQuestion answers to round-trip through updatedInput")
+            return
+        }
+        #expect(answer == "yes")
     }
 
     @Test
@@ -642,7 +708,7 @@ struct SessionStateTests {
     }
 
     @Test
-    func codexPreToolUseStillRequiresResolutionWhenHookArrivesInDontAskMode() async throws {
+    func codexPreToolUseInDontAskModeStillOnlyMarksToolRunning() async throws {
         let socketURL = BridgeSocketLocation.uniqueTestURL()
         let server = BridgeServer(socketURL: socketURL)
         try server.start()
@@ -668,22 +734,73 @@ struct SessionStateTests {
             toolInput: CodexHookToolInput(command: "ls")
         )
 
-        async let responseTask = sendOnGCDThread(.processCodexHook(payload), socketURL: socketURL)
+        let responseTask = Task {
+            try BridgeCommandClient(socketURL: socketURL).send(.processCodexHook(payload))
+        }
 
         var iterator = stream.makeAsyncIterator()
         let startedEvent = try await nextEvent(from: &iterator)
-        let permissionEvent = try await nextEvent(from: &iterator)
+        let activityEvent = try await nextEvent(from: &iterator)
 
         #expect(startedEvent.isSessionStarted)
-        #expect(permissionEvent.isPermissionRequested)
-
-        try await observer.send(.resolvePermission(sessionID: "codex-session-no-ask", resolution: .allowOnce()))
-
-        let activityEvent = try await nextEvent(from: &iterator)
-        let response = try await responseTask
-
-        #expect(activityEvent.activityUpdate?.summary == "Permission approved. Codex continued the command.")
+        #expect(activityEvent.activityUpdate?.summary == "Bash ls")
+        #expect(activityEvent.activityUpdate?.phase == .running)
+        let response = try await responseTask.value
         #expect(response == .acknowledged)
+    }
+
+    @Test
+    func codexPostToolUseClearsCurrentToolMetadata() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let preToolPayload = CodexHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .preToolUse,
+            model: "gpt-5-codex",
+            permissionMode: .default,
+            sessionID: "codex-post-clear",
+            transcriptPath: nil,
+            turnID: "turn-1",
+            toolName: "Bash",
+            toolUseID: "tool-use-1",
+            toolInput: CodexHookToolInput(command: "git status -sb")
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(.processCodexHook(preToolPayload))
+
+        var iterator = stream.makeAsyncIterator()
+        let startedEvent = try await nextEvent(from: &iterator)
+        _ = try await nextEvent(from: &iterator)
+        #expect(startedEvent.sessionStarted?.codexMetadata?.currentTool == "Bash")
+        #expect(startedEvent.sessionStarted?.codexMetadata?.currentCommandPreview == "git status -sb")
+
+        let postToolPayload = CodexHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .postToolUse,
+            model: "gpt-5-codex",
+            permissionMode: .default,
+            sessionID: "codex-post-clear",
+            transcriptPath: nil,
+            turnID: "turn-1",
+            toolName: "Bash",
+            toolUseID: "tool-use-1",
+            toolInput: CodexHookToolInput(command: "git status -sb")
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(.processCodexHook(postToolPayload))
+
+        let metadataEvent = try await nextEvent(from: &iterator)
+        let activityEvent = try await nextEvent(from: &iterator)
+
+        #expect(metadataEvent.trackedMetadataUpdate?.codexMetadata.currentTool == nil)
+        #expect(metadataEvent.trackedMetadataUpdate?.codexMetadata.currentCommandPreview == nil)
+        #expect(activityEvent.activityUpdate?.summary == "Bash finished: git status -sb")
     }
 
     @Test
@@ -879,14 +996,19 @@ struct SessionStateTests {
 
         let sessionStartGroups = hooks?["SessionStart"] as? [[String: Any]]
         let permissionGroups = hooks?["PermissionRequest"] as? [[String: Any]]
+        let postToolGroups = hooks?["PostToolUse"] as? [[String: Any]]
         let managedPermissionHook = permissionGroups?
+            .compactMap { $0["hooks"] as? [[String: Any]] }
+            .flatMap { $0 }
+            .first(where: { $0["command"] as? String == "'/tmp/OpenIslandHooks'" })
+        let managedPostToolHook = postToolGroups?
             .compactMap { $0["hooks"] as? [[String: Any]] }
             .flatMap { $0 }
             .first(where: { $0["command"] as? String == "'/tmp/OpenIslandHooks'" })
         #expect(sessionStartGroups?.contains(where: { $0["matcher"] as? String == "startup|resume" }) == true)
         #expect(managedPermissionHook?["timeout"] as? Int == CodexHookInstaller.managedInteractiveTimeout)
+        #expect(managedPostToolHook?["timeout"] as? Int == CodexHookInstaller.managedTimeout)
         #expect(hooks?["PreToolUse"] == nil)
-        #expect(hooks?["PostToolUse"] == nil)
     }
 
     @Test
@@ -955,10 +1077,15 @@ struct SessionStateTests {
             .compactMap { $0["hooks"] as? [[String: Any]] }
             .flatMap { $0 }
             .compactMap { $0["command"] as? String } ?? []
+        let postToolGroups = hooks?["PostToolUse"] as? [[String: Any]]
+        let postToolCommands = postToolGroups?
+            .compactMap { $0["hooks"] as? [[String: Any]] }
+            .flatMap { $0 }
+            .compactMap { $0["command"] as? String } ?? []
 
         #expect(preToolCommands == ["/usr/bin/printf"])
         #expect(permissionCommands == ["'/tmp/new-release/OpenIslandHooks'"])
-        #expect(hooks?["PostToolUse"] == nil)
+        #expect(postToolCommands == ["'/tmp/new-release/OpenIslandHooks'"])
         #expect(stopCommands.contains("/usr/bin/true"))
         #expect(stopCommands.contains("'/tmp/new-release/OpenIslandHooks'"))
         #expect(!stopCommands.contains("'/Users/test/.open-island/bin/open-island-bridge' --source codex"))
@@ -1420,6 +1547,81 @@ struct SessionStateTests {
         #expect(session?.isCodexAppSession == true)
         #expect(session?.codexMetadata?.transcriptPath == "/tmp/rollout.jsonl")
     }
+
+    @Test
+    func completedCodexDesktopRefreshDoesNotMakeHistoricalThreadLookNew() {
+        let historicalActivity = Date(timeIntervalSince1970: 10_000)
+        let appServerRefresh = historicalActivity.addingTimeInterval(1_800)
+        var state = SessionState(sessions: [
+            AgentSession(
+                id: "codex-app-history",
+                title: "Old title",
+                tool: .codex,
+                origin: .live,
+                attachmentState: .stale,
+                phase: .completed,
+                summary: "Done",
+                updatedAt: historicalActivity,
+                jumpTarget: JumpTarget(
+                    terminalApp: "Codex.app",
+                    workspaceName: "hera",
+                    paneTitle: "Old title",
+                    workingDirectory: "/Users/lijie10/Desktop/code/hera",
+                    codexThreadID: "codex-app-history"
+                )
+            ),
+        ])
+
+        state.apply(.sessionRefreshed(SessionRefreshed(
+            sessionID: "codex-app-history",
+            title: "Summarized title",
+            summary: "Idle.",
+            phase: .completed,
+            timestamp: appServerRefresh,
+            jumpTarget: JumpTarget(
+                terminalApp: "Codex.app",
+                workspaceName: "hera",
+                paneTitle: "Summarized title",
+                workingDirectory: "/Users/lijie10/Desktop/code/hera",
+                codexThreadID: "codex-app-history"
+            )
+        )))
+
+        let session = state.session(id: "codex-app-history")
+        #expect(session?.title == "Summarized title")
+        #expect(session?.updatedAt == historicalActivity)
+        #expect(session?.phase == .completed)
+        #expect(session?.isProcessAlive == true)
+    }
+
+    @Test
+    func codexDesktopLivenessUsesAppRunningStateInsteadOfCliProcessID() {
+        var state = SessionState(sessions: [
+            AgentSession(
+                id: "codex-app-1",
+                title: "Open Island issue check",
+                tool: .codex,
+                origin: .live,
+                attachmentState: .stale,
+                phase: .running,
+                summary: "Thinking",
+                updatedAt: Date(timeIntervalSince1970: 1_000),
+                jumpTarget: JumpTarget(
+                    terminalApp: "Codex.app",
+                    workspaceName: "lijie10",
+                    paneTitle: "Open Island issue check",
+                    workingDirectory: "/Users/lijie10",
+                    codexThreadID: "codex-app-1"
+                )
+            ),
+        ])
+
+        #expect(state.session(id: "codex-app-1")?.isCodexAppSession == true)
+
+        state.markProcessLiveness(aliveSessionIDs: [], isCodexAppRunning: true)
+
+        #expect(state.session(id: "codex-app-1")?.isProcessAlive == true)
+    }
 }
 
 private enum SessionStateTestError: Error {
@@ -1437,6 +1639,14 @@ private func nextEvent(
 }
 
 private extension AgentEvent {
+    var sessionStarted: SessionStarted? {
+        if case let .sessionStarted(payload) = self {
+            payload
+        } else {
+            nil
+        }
+    }
+
     var isSessionStarted: Bool {
         if case .sessionStarted = self {
             true

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -1357,6 +1357,69 @@ struct SessionStateTests {
         let legacyUpdated = ISO8601DateFormatter().date(from: "2026-01-01T00:00:00Z")
         #expect(legacy.session.firstSeenAt == legacyUpdated)
     }
+
+    @Test
+    func sessionRefreshedUpdatesCodexDesktopTitleAndPreservesApprovalState() {
+        let t0 = Date(timeIntervalSince1970: 10_000)
+        var state = SessionState()
+        state.apply(.sessionStarted(SessionStarted(
+            sessionID: "codex-app-1",
+            title: "Initial",
+            tool: .codex,
+            origin: .live,
+            initialPhase: .running,
+            summary: "Working",
+            timestamp: t0,
+            jumpTarget: JumpTarget(
+                terminalApp: "Codex.app",
+                workspaceName: "lijie10",
+                paneTitle: "Initial",
+                workingDirectory: "/Users/lijie10",
+                codexThreadID: "codex-app-1"
+            ),
+            codexMetadata: CodexSessionMetadata(
+                initialUserPrompt: "first prompt"
+            )
+        )))
+
+        state.apply(.permissionRequested(PermissionRequested(
+            sessionID: "codex-app-1",
+            request: PermissionRequest(
+                title: "Approval Required",
+                summary: "Codex is waiting for approval.",
+                affectedPath: ""
+            ),
+            timestamp: t0.addingTimeInterval(10)
+        )))
+
+        state.apply(.sessionRefreshed(SessionRefreshed(
+            sessionID: "codex-app-1",
+            title: "Open Island issue check",
+            summary: "Updated preview",
+            phase: .running,
+            timestamp: t0.addingTimeInterval(20),
+            jumpTarget: JumpTarget(
+                terminalApp: "Codex.app",
+                workspaceName: "lijie10",
+                paneTitle: "Open Island issue check",
+                workingDirectory: "/Users/lijie10",
+                codexThreadID: "codex-app-1"
+            ),
+            codexMetadata: CodexSessionMetadata(
+                transcriptPath: "/tmp/rollout.jsonl",
+                initialUserPrompt: "first prompt"
+            )
+        )))
+
+        let session = state.session(id: "codex-app-1")
+        #expect(session?.title == "Open Island issue check")
+        #expect(session?.jumpTarget?.paneTitle == "Open Island issue check")
+        #expect(session?.phase == .waitingForApproval)
+        #expect(session?.permissionRequest?.summary == "Codex is waiting for approval.")
+        #expect(session?.isProcessAlive == true)
+        #expect(session?.isCodexAppSession == true)
+        #expect(session?.codexMetadata?.transcriptPath == "/tmp/rollout.jsonl")
+    }
 }
 
 private enum SessionStateTestError: Error {


### PR DESCRIPTION
Closes #530

## Stack note
This is part of a fork-based stack because I cannot push feature branches to the upstream repository. Later PRs are opened against \, so their GitHub diff is cumulative; review focus for this PR is the commit listed below.

1. #534 Codex.app startup live restore.\n2. #535 Codex hook/app-server event normalization.\n3. This PR: Codex session index and rollout recovery.

Depends on #535.

## Review focus
Bootstrap from Codex session_index and rollout JSONL snapshots, recover title/activity/tool/subagent/completion metadata, and keep cold-start recovery bounded.

## Main commit
- \

## Verification
swift test --filter CodexAppServerDecodingTests --filter CodexAppServerCoordinatorTests --filter CodexSessionTrackingTests --filter CodexUsageTests --filter AppModelSessionListTests --filter OverlayPanelControllerTests --filter IslandAnimationPolicyTests --filter IslandSessionRowInteractionTests --filter SessionStateTests\n\nResult from local verification: 175 tests passed in 9 suites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Session refresh events now track title and metadata updates
- User question-answer integration for interactive workflows

**Improvements**
- Enhanced Codex Desktop session display and headline formatting
- Tool labels updated for clarity ("apply_patch" now displays as "Editing")
- Improved permission request and approval workflows
- Better session metadata tracking and activity updates
- Memory optimization during app monitoring

<!-- end of auto-generated comment: release notes by coderabbit.ai -->