### PR TITLE
feat: add Pi extension support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Think of it as an open-source [Vibe Island](https://vibeisland.app/) — **free,
 
 ## Supported Agents & Terminals
 
-**10 agents**: Claude Code, Codex, Cursor, Gemini CLI, Kimi CLI, OpenCode, Qoder, Qwen Code, Factory, CodeBuddy
+**11 agents**: Claude Code, Codex, Cursor, Gemini CLI, Kimi CLI, OpenCode, Pi, Qoder, Qwen Code, Factory, CodeBuddy
 
 **15+ terminals & IDEs**: Terminal.app, Ghostty, iTerm2, WezTerm, Zellij, tmux, cmux, Kaku, VS Code, Cursor, Windsurf, Trae, JetBrains IDEs (IDEA, WebStorm, PyCharm, GoLand, CLion, RubyMine, PhpStorm, Rider, RustRover)
 
@@ -72,6 +72,7 @@ Think of it as an open-source [Vibe Island](https://vibeisland.app/) — **free,
 | **Cursor** | Supported | Hook integration via `~/.cursor/hooks.json`, session tracking, workspace jump-back |
 | **Gemini CLI** | Supported | Hook integration via `~/.gemini/settings.json`, session tracking, fire-and-forget events |
 | **Kimi CLI** | Supported | Hook integration via `~/.kimi/config.toml` `[[hooks]]`, session tracking, permission flow (reuses Claude payload) |
+| **Pi** | Supported | Pi Extension API bridge, session tracking, tool approval for mutating built-in tools |
 
 ### Terminals & IDEs
 
@@ -276,6 +277,7 @@ Developers who already live in the terminal and want a better way to work with c
   swift run OpenIslandSetup statusKimi     # report whether managed hooks are present
   swift run OpenIslandSetup uninstallKimi  # remove managed entries, preserve user-authored [[hooks]]
   ```
+- **Pi** — Extension-based integration via Pi's official TypeScript Extension API. Open Island ships `open-island-pi.ts`; install it as `~/.pi/agent/extensions/open-island.ts` and run `/reload` in Pi. The extension sends session lifecycle events directly to the Open Island socket and turns mutating built-in tools (`bash`, `edit`, `write`) into Open Island approval cards. Open Island does not patch Pi internals.
 
 ### Terminal Support
 

--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -222,6 +222,8 @@ extension AgentSession {
             return "Cursor"
         case .kimiCLI:
             return "Kimi"
+        case .pi:
+            return "Pi"
         }
     }
 

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1615,24 +1615,25 @@ final class AppModel {
         hooks.updateHooksBinaryIfNeeded()
 
         // Auto-install missing hooks and usage bridge, then run health checks.
-        if payload.hooksBinaryURL != nil {
-            Task { @MainActor [weak self] in
-                guard let self else { return }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
 
-                // Wait for all status reads to complete before checking install state.
-                await self.hooks.refreshAllHookStatusAndWait()
+            // Wait for all status reads to complete before checking install state.
+            await self.hooks.refreshAllHookStatusAndWait()
 
-                // Reconcile persisted intent with what is actually on disk. For
-                // legacy users this records existing hooks as `.installed` and
-                // marks first-launch as complete so onboarding does not appear
-                // on upgrade. Must run after status reads and before any
-                // install decision.
-                self.hooks.migrateIntentStoreIfNeeded()
+            // Reconcile persisted intent with what is actually on disk. For
+            // legacy users this records existing hooks as `.installed` and
+            // marks first-launch as complete so onboarding does not appear
+            // on upgrade. Must run after status reads and before any
+            // install decision.
+            self.hooks.migrateIntentStoreIfNeeded()
 
-                // Install only hooks the user has not explicitly opted out of.
-                // `shouldAutoInstall` skips `.uninstalled` agents and agents
-                // whose hooks are already present — it is the single checkpoint
-                // that fixes #324.
+            // Install only hooks the user has not explicitly opted out of.
+            // `shouldAutoInstall` skips `.uninstalled` agents and agents
+            // whose hooks are already present — it is the single checkpoint
+            // that fixes #324. Pi is extension-based and does not depend on the
+            // OpenIslandHooks binary, so check it outside the binary-gated block.
+            if payload.hooksBinaryURL != nil {
                 if self.hooks.shouldAutoInstall(.claudeCode) { self.installClaudeHooks() }
                 if self.hooks.shouldAutoInstall(.codex) { self.installCodexHooks() }
                 if self.hooks.shouldAutoInstall(.qoder) { self.installQoderHooks() }
@@ -1643,10 +1644,13 @@ final class AppModel {
                 if self.hooks.shouldAutoInstall(.cursor) { self.installCursorHooks() }
                 if self.hooks.shouldAutoInstall(.gemini) { self.installGeminiHooks() }
                 if self.hooks.shouldAutoInstall(.kimi) { self.installKimiHooks() }
-                if self.hooks.shouldAutoInstall(.pi) { self.installPiExtension() }
                 if self.hooks.shouldAutoInstall(.claudeUsageBridge) { self.installClaudeUsageBridge() }
+            }
+            if self.hooks.shouldAutoInstall(.pi) { self.installPiExtension() }
 
-                // Run health checks after install to detect stale paths, conflicts, etc.
+            // Run health checks after hook-binary installs to detect stale
+            // paths, conflicts, etc. Pi extension status is handled separately.
+            if payload.hooksBinaryURL != nil {
                 try? await Task.sleep(for: .milliseconds(500))
                 await self.hooks.repairHooksIfNeeded()
             }

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -137,6 +137,11 @@ final class AppModel {
     var kimiHookStatus: KimiHookInstallationStatus? { hooks.kimiHookStatus }
     var kimiHookStatusTitle: String { hooks.kimiHookStatusTitle }
     var kimiHookStatusSummary: String { hooks.kimiHookStatusSummary }
+    var piExtensionInstalled: Bool { hooks.piExtensionInstalled }
+    var isPiExtensionSetupBusy: Bool { hooks.isPiExtensionSetupBusy }
+    var piExtensionStatus: PiExtensionInstallationStatus? { hooks.piExtensionStatus }
+    var piExtensionStatusTitle: String { hooks.piExtensionStatusTitle }
+    var piExtensionStatusSummary: String { hooks.piExtensionStatusSummary }
     var codexHookStatusTitle: String { hooks.codexHookStatusTitle }
     var codexHookStatusSummary: String { hooks.codexHookStatusSummary }
 
@@ -163,6 +168,7 @@ final class AppModel {
             || hooks.openCodePluginInstalled
             || hooks.geminiHooksInstalled
             || hooks.kimiHooksInstalled
+            || hooks.piExtensionInstalled
     }
     func refreshCodexHookStatus() { hooks.refreshCodexHookStatus() }
     func refreshClaudeHookStatus() { hooks.refreshClaudeHookStatus() }
@@ -193,6 +199,9 @@ final class AppModel {
     func refreshKimiHookStatus() { hooks.refreshKimiHookStatus() }
     func installKimiHooks() { hooks.installKimiHooks() }
     func uninstallKimiHooks() { hooks.uninstallKimiHooks() }
+    func refreshPiExtensionStatus() { hooks.refreshPiExtensionStatus() }
+    func installPiExtension() { hooks.installPiExtension() }
+    func uninstallPiExtension() { hooks.uninstallPiExtension() }
     func installClaudeUsageBridge() { hooks.installClaudeUsageBridge() }
     func uninstallClaudeUsageBridge() { hooks.uninstallClaudeUsageBridge() }
     func updateClaudeConfigDirectory(to newDirectory: URL?) { hooks.updateClaudeConfigDirectory(to: newDirectory) }
@@ -1634,6 +1643,7 @@ final class AppModel {
                 if self.hooks.shouldAutoInstall(.cursor) { self.installCursorHooks() }
                 if self.hooks.shouldAutoInstall(.gemini) { self.installGeminiHooks() }
                 if self.hooks.shouldAutoInstall(.kimi) { self.installKimiHooks() }
+                if self.hooks.shouldAutoInstall(.pi) { self.installPiExtension() }
                 if self.hooks.shouldAutoInstall(.claudeUsageBridge) { self.installClaudeUsageBridge() }
 
                 // Run health checks after install to detect stale paths, conflicts, etc.

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -22,6 +22,7 @@ final class HookInstallationCoordinator {
     var cursorHookStatus: CursorHookInstallationStatus?
     var geminiHookStatus: GeminiHookInstallationStatus?
     var kimiHookStatus: KimiHookInstallationStatus?
+    var piExtensionStatus: PiExtensionInstallationStatus?
     var claudeStatusLineStatus: ClaudeStatusLineInstallationStatus?
     var claudeUsageSnapshot: ClaudeUsageSnapshot?
     var codexUsageSnapshot: CodexUsageSnapshot?
@@ -36,6 +37,7 @@ final class HookInstallationCoordinator {
     var isCursorHookSetupBusy = false
     var isGeminiHookSetupBusy = false
     var isKimiHookSetupBusy = false
+    var isPiExtensionSetupBusy = false
     var isClaudeUsageSetupBusy = false
 
     @ObservationIgnored
@@ -84,6 +86,9 @@ final class HookInstallationCoordinator {
 
     @ObservationIgnored
     private let kimiHookInstallationManager = KimiHookInstallationManager()
+
+    @ObservationIgnored
+    private let piExtensionInstallationManager = PiExtensionInstallationManager()
 
     /// Computed so it always reflects the latest `ClaudeConfigDirectory` setting.
     private var claudeStatusLineInstallationManager: ClaudeStatusLineInstallationManager {
@@ -143,6 +148,10 @@ final class HookInstallationCoordinator {
 
     var kimiHooksInstalled: Bool {
         kimiHookStatus?.managedHooksPresent == true
+    }
+
+    var piExtensionInstalled: Bool {
+        piExtensionStatus?.isInstalled == true
     }
 
     var claudeUsageInstalled: Bool {
@@ -376,6 +385,26 @@ final class HookInstallationCoordinator {
         }
 
         return "no managed Kimi hooks"
+    }
+
+    var piExtensionStatusTitle: String {
+        if piExtensionInstalled {
+            return "Pi extension installed"
+        }
+
+        return "Pi extension not installed"
+    }
+
+    var piExtensionStatusSummary: String {
+        guard piExtensionStatus != nil else {
+            return "Reading ~/.pi/agent/extensions/open-island.ts."
+        }
+
+        if piExtensionInstalled {
+            return "extension present · run /reload in Pi after changes"
+        }
+
+        return "no managed Pi extension"
     }
 
     var codexHookStatusTitle: String {
@@ -689,6 +718,16 @@ final class HookInstallationCoordinator {
                     self.onStatusMessage?("Failed to read Kimi hook status: \(error.localizedDescription)")
                 }
             }
+
+            group.addTask { @MainActor [weak self] in
+                guard let self else { return }
+                do {
+                    let status = try self.piExtensionInstallationManager.status()
+                    self.piExtensionStatus = status
+                } catch {
+                    self.onStatusMessage?("Failed to read Pi extension status: \(error.localizedDescription)")
+                }
+            }
         }
     }
 
@@ -740,6 +779,19 @@ final class HookInstallationCoordinator {
                 self.kimiHookStatus = status
             } catch {
                 self.onStatusMessage?("Failed to read Kimi hook status: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    func refreshPiExtensionStatus() {
+        Task { [weak self] in
+            guard let self else { return }
+
+            do {
+                let status = try self.piExtensionInstallationManager.status()
+                self.piExtensionStatus = status
+            } catch {
+                self.onStatusMessage?("Failed to read Pi extension status: \(error.localizedDescription)")
             }
         }
     }
@@ -814,6 +866,7 @@ final class HookInstallationCoordinator {
         case .openCode: return !openCodePluginInstalled
         case .gemini: return !geminiHooksInstalled
         case .kimi: return !kimiHooksInstalled
+        case .pi: return !piExtensionInstalled
         case .claudeUsageBridge: return !claudeUsageInstalled
         }
     }
@@ -838,6 +891,7 @@ final class HookInstallationCoordinator {
             case .openCode: return openCodePluginInstalled
             case .gemini: return geminiHooksInstalled
             case .kimi: return kimiHooksInstalled
+            case .pi: return piExtensionInstalled
             case .claudeUsageBridge: return claudeUsageInstalled
             }
         }
@@ -1046,6 +1100,55 @@ final class HookInstallationCoordinator {
     func uninstallKimiHooks() {
         updateKimiHooks(userMessage: "Removing Kimi hooks.", intent: .uninstalled) { manager in
             try manager.uninstall()
+        }
+    }
+
+    func installPiExtension() {
+        guard let extensionData = loadBundledPiExtension() else {
+            onStatusMessage?("Could not find the bundled Pi extension resource.")
+            return
+        }
+
+        isPiExtensionSetupBusy = true
+        onStatusMessage?("Installing Pi extension.")
+
+        Task { [weak self] in
+            guard let self else { return }
+
+            defer { self.isPiExtensionSetupBusy = false }
+
+            do {
+                let status = try self.piExtensionInstallationManager.install(extensionSourceData: extensionData)
+                self.piExtensionStatus = status
+                self.intentStore.setIntent(.installed, for: .pi)
+                if status.isInstalled {
+                    self.onStatusMessage?("Pi extension is installed. Run /reload in Pi to activate.")
+                } else {
+                    self.onStatusMessage?("Pi extension installation incomplete.")
+                }
+            } catch {
+                self.onStatusMessage?("Pi extension install failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    func uninstallPiExtension() {
+        isPiExtensionSetupBusy = true
+        onStatusMessage?("Removing Pi extension.")
+
+        Task { [weak self] in
+            guard let self else { return }
+
+            defer { self.isPiExtensionSetupBusy = false }
+
+            do {
+                let status = try self.piExtensionInstallationManager.uninstall()
+                self.piExtensionStatus = status
+                self.intentStore.setIntent(.uninstalled, for: .pi)
+                self.onStatusMessage?("Pi extension removed. Run /reload in Pi to deactivate.")
+            } catch {
+                self.onStatusMessage?("Pi extension removal failed: \(error.localizedDescription)")
+            }
         }
     }
 
@@ -1302,6 +1405,18 @@ final class HookInstallationCoordinator {
 
         // Fallback: Bundle.main for Xcode builds
         if let url = Bundle.main.url(forResource: "open-island-opencode", withExtension: "js") {
+            return try? Data(contentsOf: url)
+        }
+
+        return nil
+    }
+
+    private func loadBundledPiExtension() -> Data? {
+        if let url = Bundle.appResources.url(forResource: "open-island-pi", withExtension: "ts") {
+            return try? Data(contentsOf: url)
+        }
+
+        if let url = Bundle.main.url(forResource: "open-island-pi", withExtension: "ts") {
             return try? Data(contentsOf: url)
         }
 

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -990,6 +990,10 @@ final class ProcessMonitoringCoordinator {
             return .claudeCode
         }
 
+        if normalized.hasPrefix("pi ") {
+            return .pi
+        }
+
         return nil
     }
 

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -1015,6 +1015,8 @@ final class ProcessMonitoringCoordinator {
             return "Cursor \(session.id.prefix(8))"
         case .kimiCLI:
             return "Kimi \(session.id.prefix(8))"
+        case .pi:
+            return "Pi \(session.id.prefix(8))"
         }
     }
 }

--- a/Sources/OpenIslandApp/Resources/open-island-pi.ts
+++ b/Sources/OpenIslandApp/Resources/open-island-pi.ts
@@ -1,0 +1,184 @@
+// Open Island extension for Pi
+// Bridges Pi runtime events to the Open Island desktop app via Unix socket.
+// Install: copy to ~/.pi/agent/extensions/open-island.ts, then run /reload in Pi.
+import { connect } from "node:net";
+import { appendFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { execFileSync } from "node:child_process";
+
+const DEBUG_LOG = "/tmp/open-island-pi-debug.log";
+const APPROVAL_TOOL_NAMES = new Set(["bash", "edit", "write"]);
+
+function debugLog(message: string) {
+  if (process.env.OPEN_ISLAND_PI_DEBUG !== "1") return;
+  try { appendFileSync(DEBUG_LOG, `[${new Date().toISOString()}] ${message}\n`); } catch {}
+}
+
+const SOCKET_PATH =
+  process.env.OPEN_ISLAND_SOCKET_PATH ||
+  `${process.env.HOME || homedir()}/Library/Application Support/OpenIsland/bridge.sock`;
+
+function encodeEnvelope(command: unknown) {
+  return JSON.stringify({ type: "command", command }) + "\n";
+}
+
+function sendToSocket(command: unknown, timeoutMs = 3000): Promise<unknown | null> {
+  return new Promise((resolve) => {
+    try {
+      const sock = connect({ path: SOCKET_PATH }, () => {
+        sock.write(encodeEnvelope(command));
+      });
+      let buffer = "";
+      let resolved = false;
+      const finish = (value: unknown | null) => {
+        if (resolved) return;
+        resolved = true;
+        try { sock.destroy(); } catch {}
+        resolve(value);
+      };
+      sock.on("data", (chunk) => {
+        buffer += chunk.toString();
+        const lines = buffer.split("\n").filter(Boolean);
+        // BridgeServer sends hello first, then the command response.
+        if (lines.length < 2) return;
+        try { finish(JSON.parse(lines[1])); } catch { finish(null); }
+      });
+      sock.on("end", () => finish(null));
+      sock.on("error", () => finish(null));
+      sock.setTimeout(timeoutMs, () => finish(null));
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+function fireAndForget(command: unknown) {
+  void sendToSocket(command).catch((error) => debugLog(`send failed: ${String(error)}`));
+}
+
+let detectedTty: string | undefined;
+try {
+  const tty = execFileSync("/usr/bin/tty", { timeout: 1000 }).toString().trim();
+  if (tty && tty !== "not a tty") detectedTty = tty;
+} catch {}
+
+function terminalFields() {
+  const env = process.env;
+  const result: Record<string, string> = {};
+  if (env.ITERM_SESSION_ID) {
+    result.terminal_app = "iTerm";
+    result.terminal_session_id = env.ITERM_SESSION_ID;
+  } else if (env.CMUX_WORKSPACE_ID || env.CMUX_SOCKET_PATH) {
+    result.terminal_app = "cmux";
+    if (env.CMUX_SURFACE_ID) result.terminal_session_id = env.CMUX_SURFACE_ID;
+  } else if (env.GHOSTTY_RESOURCES_DIR || (env.TERM_PROGRAM || "").toLowerCase().includes("ghostty")) {
+    result.terminal_app = "Ghostty";
+  } else if (env.TERM_PROGRAM === "Apple_Terminal") {
+    result.terminal_app = "Terminal";
+  } else if (env.TERM_PROGRAM) {
+    result.terminal_app = env.TERM_PROGRAM;
+  }
+  if (detectedTty) result.terminal_tty = detectedTty;
+  return result;
+}
+
+function textFromContent(content: unknown): string | undefined {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return undefined;
+  const text = content
+    .map((block: any) => block?.type === "text" ? block.text : undefined)
+    .filter(Boolean)
+    .join("\n");
+  return text || undefined;
+}
+
+function compact(value: unknown, limit = 4000): string | undefined {
+  if (value == null) return undefined;
+  let text: string;
+  if (typeof value === "string") text = value;
+  else {
+    try { text = JSON.stringify(value); } catch { text = String(value); }
+  }
+  if (text.length <= limit) return text;
+  return `${text.slice(0, limit)}…`;
+}
+
+export default function (pi: any) {
+  function sessionID(ctx: any): string {
+    return `pi-${ctx.sessionManager?.getSessionId?.() || ctx.sessionManager?.getSessionFile?.() || "ephemeral"}`;
+  }
+
+  function basePayload(ctx: any) {
+    const model = ctx.model ? `${ctx.model.provider || ""}/${ctx.model.id || ctx.model.name || ""}`.replace(/^\//, "") : undefined;
+    return {
+      session_id: sessionID(ctx),
+      cwd: ctx.cwd || process.cwd(),
+      transcript_path: ctx.sessionManager?.getSessionFile?.(),
+      model,
+      ...terminalFields(),
+    };
+  }
+
+  function command(ctx: any, hook_event_name: string, extra: Record<string, unknown> = {}) {
+    return {
+      type: "processPiHook",
+      piHook: {
+        hook_event_name,
+        ...basePayload(ctx),
+        ...extra,
+      },
+    };
+  }
+
+  pi.on("session_start", async (_event: any, ctx: any) => {
+    fireAndForget(command(ctx, "SessionStart"));
+  });
+
+  pi.on("input", async (event: any, ctx: any) => {
+    if (event.source === "extension") return { action: "continue" };
+    fireAndForget(command(ctx, "UserPromptSubmit", { prompt: event.text }));
+    return { action: "continue" };
+  });
+
+  pi.on("agent_start", async (_event: any, ctx: any) => {
+    fireAndForget(command(ctx, "AgentStart"));
+  });
+
+  pi.on("tool_call", async (event: any, ctx: any) => {
+    const payload = {
+      tool_name: event.toolName,
+      tool_use_id: event.toolCallId,
+      tool_input: compact(event.input),
+    };
+
+    if (!APPROVAL_TOOL_NAMES.has(event.toolName)) {
+      fireAndForget(command(ctx, "PostToolUse", payload));
+      return;
+    }
+
+    const response: any = await sendToSocket(command(ctx, "PreToolUse", payload), 24 * 60 * 60 * 1000);
+    const directive = response?.response?.directive;
+    if (response?.response?.type === "piHookDirective" && directive?.type === "deny") {
+      return { block: true, reason: directive.reason || "Denied by Open Island" };
+    }
+  });
+
+  pi.on("tool_result", async (event: any, ctx: any) => {
+    fireAndForget(command(ctx, "PostToolUse", {
+      tool_name: event.toolName,
+      tool_use_id: event.toolCallId,
+      tool_input: compact(event.input),
+    }));
+  });
+
+  pi.on("agent_end", async (event: any, ctx: any) => {
+    const lastAssistant = [...(event.messages || [])].reverse().find((m: any) => m?.role === "assistant");
+    fireAndForget(command(ctx, "Stop", {
+      last_assistant_message: textFromContent(lastAssistant?.content),
+    }));
+  });
+
+  pi.on("session_shutdown", async (_event: any, ctx: any) => {
+    fireAndForget(command(ctx, "SessionEnd"));
+  });
+}

--- a/Sources/OpenIslandApp/Resources/open-island-pi.ts
+++ b/Sources/OpenIslandApp/Resources/open-island-pi.ts
@@ -104,6 +104,9 @@ function compact(value: unknown, limit = 4000): string | undefined {
 }
 
 export default function (pi: any) {
+  let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+  let heartbeatContext: any | undefined;
+
   function sessionID(ctx: any): string {
     return `pi-${ctx.sessionManager?.getSessionId?.() || ctx.sessionManager?.getSessionFile?.() || "ephemeral"}`;
   }
@@ -130,8 +133,17 @@ export default function (pi: any) {
     };
   }
 
+  function sendHeartbeat() {
+    if (!heartbeatContext) return;
+    fireAndForget(command(heartbeatContext, "Heartbeat"));
+  }
+
   pi.on("session_start", async (_event: any, ctx: any) => {
+    heartbeatContext = ctx;
     fireAndForget(command(ctx, "SessionStart"));
+    if (!heartbeatTimer) {
+      heartbeatTimer = setInterval(sendHeartbeat, 10_000);
+    }
   });
 
   pi.on("input", async (event: any, ctx: any) => {
@@ -179,6 +191,11 @@ export default function (pi: any) {
   });
 
   pi.on("session_shutdown", async (_event: any, ctx: any) => {
+    if (heartbeatTimer) {
+      clearInterval(heartbeatTimer);
+      heartbeatTimer = undefined;
+    }
+    heartbeatContext = undefined;
     fireAndForget(command(ctx, "SessionEnd"));
   });
 }

--- a/Sources/OpenIslandApp/Resources/open-island-pi.ts
+++ b/Sources/OpenIslandApp/Resources/open-island-pi.ts
@@ -38,10 +38,24 @@ function sendToSocket(command: unknown, timeoutMs = 3000): Promise<unknown | nul
       };
       sock.on("data", (chunk) => {
         buffer += chunk.toString();
-        const lines = buffer.split("\n").filter(Boolean);
-        // BridgeServer sends hello first, then the command response.
-        if (lines.length < 2) return;
-        try { finish(JSON.parse(lines[1])); } catch { finish(null); }
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            const message = JSON.parse(line);
+            // BridgeServer may send hello and live events before the command response.
+            // Approval requests intentionally emit permissionRequested and only return
+            // a response after the user chooses Allow/Deny, so ignore non-responses.
+            if (message?.type === "response") {
+              finish(message);
+              return;
+            }
+          } catch {
+            finish(null);
+            return;
+          }
+        }
       });
       sock.on("end", () => finish(null));
       sock.on("error", () => finish(null));

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -418,6 +418,7 @@ struct SetupSettingsPane: View {
     @State private var confirmingUninstallCursor = false
     @State private var confirmingUninstallGemini = false
     @State private var confirmingUninstallKimi = false
+    @State private var confirmingUninstallPi = false
     @State private var confirmingUninstallClaudeUsage = false
 
     private var lang: LanguageManager { model.lang }
@@ -602,6 +603,24 @@ struct SetupSettingsPane: View {
                 } message: {
                     Text("This will remove Open Island hooks from ~/.kimi/config.toml.")
                 }
+
+                hookRow(
+                    name: "Pi",
+                    installed: model.piExtensionInstalled,
+                    busy: model.isPiExtensionSetupBusy,
+                    requiresBinary: false,
+                    configLocationURL: model.piExtensionStatus?.extensionFileURL,
+                    installAction: { model.installPiExtension() },
+                    uninstallAction: { confirmingUninstallPi = true }
+                )
+                .alert(lang.t("settings.general.uninstallConfirmTitle"), isPresented: $confirmingUninstallPi) {
+                    Button(lang.t("settings.general.uninstallConfirmAction"), role: .destructive) {
+                        model.uninstallPiExtension()
+                    }
+                    Button(lang.t("settings.general.cancel"), role: .cancel) {}
+                } message: {
+                    Text("This will remove the Open Island Pi extension from ~/.pi/agent/extensions/open-island.ts. Run /reload in Pi after changing it.")
+                }
             }
 
             Section {
@@ -679,6 +698,7 @@ struct SetupSettingsPane: View {
                     if !model.cursorHooksInstalled { model.installCursorHooks() }
                     if !model.geminiHooksInstalled { model.installGeminiHooks() }
                     if !model.kimiHooksInstalled { model.installKimiHooks() }
+                    if !model.piExtensionInstalled { model.installPiExtension() }
                     if !model.claudeUsageInstalled { model.installClaudeUsageBridge() }
                 }
                 .disabled(model.hooksBinaryURL == nil || allReady)
@@ -740,7 +760,7 @@ struct SetupSettingsPane: View {
     private var allReady: Bool {
         model.claudeHooksInstalled && model.codexHooksInstalled && model.openCodePluginInstalled
             && model.qoderHooksInstalled && model.qwenCodeHooksInstalled && model.factoryHooksInstalled && model.codebuddyHooksInstalled
-            && model.cursorHooksInstalled && model.geminiHooksInstalled && model.kimiHooksInstalled && model.claudeUsageInstalled
+            && model.cursorHooksInstalled && model.geminiHooksInstalled && model.kimiHooksInstalled && model.piExtensionInstalled && model.claudeUsageInstalled
     }
 
     @ViewBuilder

--- a/Sources/OpenIslandCore/AgentHookIntent.swift
+++ b/Sources/OpenIslandCore/AgentHookIntent.swift
@@ -27,5 +27,6 @@ public enum AgentIdentifier: String, Codable, Sendable, CaseIterable {
     case openCode
     case gemini
     case kimi
+    case pi
     case claudeUsageBridge
 }

--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -11,6 +11,7 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
     case codebuddy
     case cursor
     case kimiCLI
+    case pi
 
     public var displayName: String {
         switch self {
@@ -34,6 +35,8 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
             "Cursor"
         case .kimiCLI:
             "Kimi CLI"
+        case .pi:
+            "Pi"
         }
     }
 
@@ -59,6 +62,8 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
             "CURSOR"
         case .kimiCLI:
             "KIMI"
+        case .pi:
+            "PI"
         }
     }
 
@@ -87,6 +92,7 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
         case .factory:    "#6e9fff"
         case .codebuddy:  "#fca5a5"
         case .kimiCLI:    "#fde047"
+        case .pi:         "#8bd5ff"
         }
     }
 }
@@ -508,7 +514,7 @@ public extension AgentSession {
     }
 
     var isTrackedLiveSession: Bool {
-        !isDemoSession && (tool == .codex || tool == .claudeCode || tool == .geminiCLI || tool == .openCode || tool == .qoder || tool == .qwenCode || tool == .factory || tool == .codebuddy || tool == .cursor || tool == .kimiCLI)
+        !isDemoSession && (tool == .codex || tool == .claudeCode || tool == .geminiCLI || tool == .openCode || tool == .qoder || tool == .qwenCode || tool == .factory || tool == .codebuddy || tool == .cursor || tool == .kimiCLI || tool == .pi)
     }
 
     var isTrackedLiveCodexSession: Bool {

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -1367,6 +1367,11 @@ public final class BridgeServer: @unchecked Sendable {
             )
             send(.response(.acknowledged), to: clientID)
 
+        case .heartbeat:
+            ensurePiSessionExists(for: payload)
+            synchronizePiJumpTarget(for: payload)
+            send(.response(.acknowledged), to: clientID)
+
         case .userPromptSubmit:
             clearStalePiInteractionIfNeeded(for: payload.sessionID)
             ensurePiSessionExists(for: payload)
@@ -1474,7 +1479,7 @@ public final class BridgeServer: @unchecked Sendable {
     }
 
     private func ensurePiSessionExists(for payload: PiHookPayload) {
-        guard !hasSession(id: payload.sessionID) else {
+        if let existing = localState.session(id: payload.sessionID), !existing.isSessionEnded {
             return
         }
 

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -2894,6 +2894,24 @@ public final class BridgeServer: @unchecked Sendable {
             )
         }
 
+        let pendingPiSessionIDs = pendingPiInteractions.compactMap { entry -> String? in
+            let (sessionID, pendingInteraction) = entry
+            return pendingInteraction.clientID == clientID ? sessionID : nil
+        }
+
+        for sessionID in pendingPiSessionIDs {
+            pendingPiInteractions.removeValue(forKey: sessionID)
+            emit(
+                .actionableStateResolved(
+                    ActionableStateResolved(
+                        sessionID: sessionID,
+                        summary: "Pi extension disconnected.",
+                        timestamp: .now
+                    )
+                )
+            )
+        }
+
         let pendingCursorSessionIDs = pendingCursorInteractions.compactMap { entry -> String? in
             let (sessionID, pendingInteraction) = entry
             return pendingInteraction.clientID == clientID ? sessionID : nil

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -48,6 +48,11 @@ public final class BridgeServer: @unchecked Sendable {
         let kind: Kind
     }
 
+    private struct PendingPiInteraction {
+        let clientID: UUID
+        let payload: PiHookPayload
+    }
+
     private struct Listener {
         let fileDescriptor: Int32
         let acceptSource: DispatchSourceRead
@@ -70,6 +75,7 @@ public final class BridgeServer: @unchecked Sendable {
     private var pendingClaudeInteractions: [String: PendingClaudeInteraction] = [:]
     private var pendingOpenCodeInteractions: [String: PendingOpenCodeInteraction] = [:]
     private var pendingCursorInteractions: [String: PendingCursorInteraction] = [:]
+    private var pendingPiInteractions: [String: PendingPiInteraction] = [:]
     /// Caches Agent tool description from preToolUse for use by the next subagentStart.
     private var pendingAgentDescriptions: [String: String] = [:]
     /// Maps toolUseID → temporary task ID for TaskCreate, so postToolUse can update with real ID.
@@ -186,6 +192,7 @@ public final class BridgeServer: @unchecked Sendable {
         pendingTaskCreations.removeAll()
         pendingOpenCodeInteractions.removeAll()
         pendingCursorInteractions.removeAll()
+        pendingPiInteractions.removeAll()
 
         let activeConnections = Array(clients.values)
         activeConnections.forEach { $0.readSource.cancel() }
@@ -340,6 +347,45 @@ public final class BridgeServer: @unchecked Sendable {
                 return
             }
 
+            if let interaction = pendingPiInteractions.removeValue(forKey: sessionID) {
+                let directive: PiHookDirective
+                let summary: String
+                let phase: SessionPhase
+                switch resolution {
+                case .allowOnce:
+                    directive = .allow
+                    summary = "Permission approved. Pi continued the tool."
+                    phase = .running
+                case let .deny(message, _):
+                    directive = .deny(reason: message)
+                    summary = message ?? "Permission denied in Open Island."
+                    phase = .completed
+                }
+
+                emit(
+                    phase == .completed
+                        ? .sessionCompleted(
+                            SessionCompleted(
+                                sessionID: sessionID,
+                                summary: summary,
+                                timestamp: .now
+                            )
+                        )
+                        : .activityUpdated(
+                            SessionActivityUpdated(
+                                sessionID: sessionID,
+                                summary: summary,
+                                phase: phase,
+                                timestamp: .now
+                            )
+                        )
+                )
+
+                send(.response(.piHookDirective(directive)), to: interaction.clientID)
+                send(.response(.acknowledged), to: clientID)
+                return
+            }
+
             if let interaction = pendingCursorInteractions.removeValue(forKey: sessionID) {
                 let directive: CursorHookDirective
                 let summary: String
@@ -468,6 +514,9 @@ public final class BridgeServer: @unchecked Sendable {
 
         case let .processGeminiHook(payload):
             handleGeminiHook(payload, from: clientID)
+
+        case let .processPiHook(payload):
+            handlePiHook(payload, from: clientID)
         }
     }
 
@@ -1296,6 +1345,194 @@ public final class BridgeServer: @unchecked Sendable {
             )
             send(.response(.acknowledged), to: clientID)
         }
+    }
+
+    private func handlePiHook(_ payload: PiHookPayload, from clientID: UUID) {
+        switch payload.hookEventName {
+        case .sessionStart:
+            clearStalePiInteractionIfNeeded(for: payload.sessionID)
+            emit(
+                .sessionStarted(
+                    SessionStarted(
+                        sessionID: payload.sessionID,
+                        title: payload.sessionTitle,
+                        tool: .pi,
+                        origin: .live,
+                        initialPhase: .completed,
+                        summary: payload.implicitStartSummary,
+                        timestamp: .now,
+                        jumpTarget: payload.defaultJumpTarget
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .userPromptSubmit:
+            clearStalePiInteractionIfNeeded(for: payload.sessionID)
+            ensurePiSessionExists(for: payload)
+            synchronizePiJumpTarget(for: payload)
+            emit(
+                .activityUpdated(
+                    SessionActivityUpdated(
+                        sessionID: payload.sessionID,
+                        summary: payload.promptPreview.map { "Prompt: \($0)" } ?? payload.implicitStartSummary,
+                        phase: .running,
+                        timestamp: .now
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .agentStart:
+            clearStalePiInteractionIfNeeded(for: payload.sessionID)
+            ensurePiSessionExists(for: payload)
+            synchronizePiJumpTarget(for: payload)
+            emit(
+                .activityUpdated(
+                    SessionActivityUpdated(
+                        sessionID: payload.sessionID,
+                        summary: "Pi is working…",
+                        phase: .running,
+                        timestamp: .now
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .preToolUse:
+            clearStalePiInteractionIfNeeded(for: payload.sessionID)
+            ensurePiSessionExists(for: payload)
+            synchronizePiJumpTarget(for: payload)
+            emit(
+                .permissionRequested(
+                    PermissionRequested(
+                        sessionID: payload.sessionID,
+                        request: PermissionRequest(
+                            title: payload.toolName.map { "Allow Pi \($0)" } ?? "Allow Pi tool",
+                            summary: payload.toolActivitySummary,
+                            affectedPath: payload.toolInputPreview ?? payload.cwd,
+                            primaryActionTitle: "Allow",
+                            secondaryActionTitle: "Deny",
+                            toolName: payload.toolName,
+                            toolUseID: payload.toolUseID
+                        ),
+                        timestamp: .now
+                    )
+                )
+            )
+            pendingPiInteractions[payload.sessionID] = PendingPiInteraction(clientID: clientID, payload: payload)
+
+        case .postToolUse:
+            clearStalePiInteractionIfNeeded(for: payload.sessionID)
+            ensurePiSessionExists(for: payload)
+            synchronizePiJumpTarget(for: payload)
+            let summary = payload.toolName.map { "\($0) finished." } ?? "Pi tool finished."
+            emit(
+                .activityUpdated(
+                    SessionActivityUpdated(
+                        sessionID: payload.sessionID,
+                        summary: summary,
+                        phase: .running,
+                        timestamp: .now
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .stop:
+            clearStalePiInteractionIfNeeded(for: payload.sessionID)
+            ensurePiSessionExists(for: payload)
+            synchronizePiJumpTarget(for: payload)
+            emit(
+                .sessionCompleted(
+                    SessionCompleted(
+                        sessionID: payload.sessionID,
+                        summary: payload.assistantMessagePreview ?? "Pi completed the turn.",
+                        timestamp: .now
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .sessionEnd:
+            clearStalePiInteractionIfNeeded(for: payload.sessionID)
+            ensurePiSessionExists(for: payload)
+            synchronizePiJumpTarget(for: payload)
+            emit(
+                .sessionCompleted(
+                    SessionCompleted(
+                        sessionID: payload.sessionID,
+                        summary: "Pi session ended.",
+                        timestamp: .now,
+                        isInterrupt: true,
+                        isSessionEnd: true
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+        }
+    }
+
+    private func ensurePiSessionExists(for payload: PiHookPayload) {
+        guard !hasSession(id: payload.sessionID) else {
+            return
+        }
+
+        emit(
+            .sessionStarted(
+                SessionStarted(
+                    sessionID: payload.sessionID,
+                    title: payload.sessionTitle,
+                    tool: .pi,
+                    origin: .live,
+                    initialPhase: .completed,
+                    summary: payload.implicitStartSummary,
+                    timestamp: .now,
+                    jumpTarget: payload.defaultJumpTarget
+                )
+            )
+        )
+    }
+
+    private func synchronizePiJumpTarget(for payload: PiHookPayload) {
+        guard let existingSession = localState.session(id: payload.sessionID) else {
+            return
+        }
+
+        let jumpTarget = Self.mergeJumpTargetPreservingExistingResolvedFields(
+            incoming: payload.defaultJumpTarget,
+            existing: existingSession.jumpTarget
+        )
+
+        guard existingSession.jumpTarget != jumpTarget else {
+            return
+        }
+
+        emit(
+            .jumpTargetUpdated(
+                JumpTargetUpdated(
+                    sessionID: payload.sessionID,
+                    jumpTarget: jumpTarget,
+                    timestamp: .now
+                )
+            )
+        )
+    }
+
+    private func clearStalePiInteractionIfNeeded(for sessionID: String) {
+        guard pendingPiInteractions.removeValue(forKey: sessionID) != nil else {
+            return
+        }
+
+        emit(
+            .actionableStateResolved(
+                ActionableStateResolved(
+                    sessionID: sessionID,
+                    summary: "Approval was handled outside Open Island.",
+                    timestamp: .now
+                )
+            )
+        )
     }
 
     private func handleGeminiHook(_ payload: GeminiHookPayload, from clientID: UUID) {

--- a/Sources/OpenIslandCore/BridgeTransport.swift
+++ b/Sources/OpenIslandCore/BridgeTransport.swift
@@ -89,6 +89,7 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
     case processOpenCodeHook(OpenCodeHookPayload)
     case processCursorHook(CursorHookPayload)
     case processGeminiHook(GeminiHookPayload)
+    case processPiHook(PiHookPayload)
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -102,6 +103,7 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
         case openCodeHook
         case cursorHook
         case geminiHook
+        case piHook
     }
 
     private enum CommandType: String, Codable {
@@ -114,6 +116,7 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
         case processOpenCodeHook
         case processCursorHook
         case processGeminiHook
+        case processPiHook
     }
 
     public init(from decoder: any Decoder) throws {
@@ -148,6 +151,8 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
             self = .processCursorHook(try container.decode(CursorHookPayload.self, forKey: .cursorHook))
         case .processGeminiHook:
             self = .processGeminiHook(try container.decode(GeminiHookPayload.self, forKey: .geminiHook))
+        case .processPiHook:
+            self = .processPiHook(try container.decode(PiHookPayload.self, forKey: .piHook))
         }
     }
 
@@ -185,6 +190,9 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
         case let .processGeminiHook(payload):
             try container.encode(CommandType.processGeminiHook, forKey: .type)
             try container.encode(payload, forKey: .geminiHook)
+        case let .processPiHook(payload):
+            try container.encode(CommandType.processPiHook, forKey: .type)
+            try container.encode(payload, forKey: .piHook)
         }
     }
 }
@@ -195,6 +203,7 @@ public enum BridgeResponse: Equatable, Codable, Sendable {
     case claudeHookDirective(ClaudeHookDirective)
     case openCodeHookDirective(OpenCodeHookDirective)
     case cursorHookDirective(CursorHookDirective)
+    case piHookDirective(PiHookDirective)
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -207,6 +216,7 @@ public enum BridgeResponse: Equatable, Codable, Sendable {
         case claudeHookDirective
         case openCodeHookDirective
         case cursorHookDirective
+        case piHookDirective
     }
 
     public init(from decoder: any Decoder) throws {
@@ -224,6 +234,8 @@ public enum BridgeResponse: Equatable, Codable, Sendable {
             self = .openCodeHookDirective(try container.decode(OpenCodeHookDirective.self, forKey: .directive))
         case .cursorHookDirective:
             self = .cursorHookDirective(try container.decode(CursorHookDirective.self, forKey: .directive))
+        case .piHookDirective:
+            self = .piHookDirective(try container.decode(PiHookDirective.self, forKey: .directive))
         }
     }
 
@@ -244,6 +256,9 @@ public enum BridgeResponse: Equatable, Codable, Sendable {
             try container.encode(directive, forKey: .directive)
         case let .cursorHookDirective(directive):
             try container.encode(ResponseType.cursorHookDirective, forKey: .type)
+            try container.encode(directive, forKey: .directive)
+        case let .piHookDirective(directive):
+            try container.encode(ResponseType.piHookDirective, forKey: .type)
             try container.encode(directive, forKey: .directive)
         }
     }

--- a/Sources/OpenIslandCore/ClaudeHooks.swift
+++ b/Sources/OpenIslandCore/ClaudeHooks.swift
@@ -647,6 +647,8 @@ public enum ClaudeHookOutputEncoder {
             data = nil
         case .cursorHookDirective:
             data = nil
+        case .piHookDirective:
+            data = nil
         case let .claudeHookDirective(directive):
             switch directive {
             case let .preToolUse(payload):

--- a/Sources/OpenIslandCore/CodexHooks.swift
+++ b/Sources/OpenIslandCore/CodexHooks.swift
@@ -365,6 +365,8 @@ public enum CodexHookOutputEncoder {
             return nil
         case .cursorHookDirective:
             return nil
+        case .piHookDirective:
+            return nil
         }
     }
 }

--- a/Sources/OpenIslandCore/PiExtensionInstallationManager.swift
+++ b/Sources/OpenIslandCore/PiExtensionInstallationManager.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+public struct PiExtensionInstallationStatus: Equatable, Sendable {
+    public var piConfigDirectory: URL
+    public var extensionsDirectory: URL
+    public var extensionFileURL: URL
+    public var manifestURL: URL
+    public var extensionFilePresent: Bool
+    public var manifest: PiExtensionInstallerManifest?
+
+    public var isInstalled: Bool {
+        extensionFilePresent
+    }
+
+    public init(
+        piConfigDirectory: URL,
+        extensionsDirectory: URL,
+        extensionFileURL: URL,
+        manifestURL: URL,
+        extensionFilePresent: Bool,
+        manifest: PiExtensionInstallerManifest?
+    ) {
+        self.piConfigDirectory = piConfigDirectory
+        self.extensionsDirectory = extensionsDirectory
+        self.extensionFileURL = extensionFileURL
+        self.manifestURL = manifestURL
+        self.extensionFilePresent = extensionFilePresent
+        self.manifest = manifest
+    }
+}
+
+public struct PiExtensionInstallerManifest: Equatable, Codable, Sendable {
+    public static let fileName = "open-island-pi-extension-install.json"
+
+    public var extensionPath: String
+    public var installedAt: Date
+
+    public init(extensionPath: String, installedAt: Date = .now) {
+        self.extensionPath = extensionPath
+        self.installedAt = installedAt
+    }
+}
+
+public final class PiExtensionInstallationManager: @unchecked Sendable {
+    public static let extensionFileName = "open-island.ts"
+
+    public let piConfigDirectory: URL
+    private let fileManager: FileManager
+
+    public init(
+        piConfigDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".pi/agent", isDirectory: true),
+        fileManager: FileManager = .default
+    ) {
+        self.piConfigDirectory = piConfigDirectory
+        self.fileManager = fileManager
+    }
+
+    private var extensionsDirectory: URL {
+        piConfigDirectory.appendingPathComponent("extensions", isDirectory: true)
+    }
+
+    private var extensionFileURL: URL {
+        extensionsDirectory.appendingPathComponent(Self.extensionFileName)
+    }
+
+    private var manifestURL: URL {
+        piConfigDirectory.appendingPathComponent(PiExtensionInstallerManifest.fileName)
+    }
+
+    public func status() throws -> PiExtensionInstallationStatus {
+        PiExtensionInstallationStatus(
+            piConfigDirectory: piConfigDirectory,
+            extensionsDirectory: extensionsDirectory,
+            extensionFileURL: extensionFileURL,
+            manifestURL: manifestURL,
+            extensionFilePresent: fileManager.fileExists(atPath: extensionFileURL.path),
+            manifest: try loadManifest()
+        )
+    }
+
+    @discardableResult
+    public func install(extensionSourceData: Data) throws -> PiExtensionInstallationStatus {
+        try fileManager.createDirectory(at: extensionsDirectory, withIntermediateDirectories: true)
+
+        if fileManager.fileExists(atPath: extensionFileURL.path) {
+            try backupFile(at: extensionFileURL)
+        }
+
+        try extensionSourceData.write(to: extensionFileURL, options: .atomic)
+
+        let manifest = PiExtensionInstallerManifest(extensionPath: extensionFileURL.path)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(manifest).write(to: manifestURL, options: .atomic)
+
+        return try status()
+    }
+
+    @discardableResult
+    public func uninstall() throws -> PiExtensionInstallationStatus {
+        if fileManager.fileExists(atPath: extensionFileURL.path) {
+            try fileManager.removeItem(at: extensionFileURL)
+        }
+
+        if fileManager.fileExists(atPath: manifestURL.path) {
+            try fileManager.removeItem(at: manifestURL)
+        }
+
+        return try status()
+    }
+
+    private func loadManifest() throws -> PiExtensionInstallerManifest? {
+        guard fileManager.fileExists(atPath: manifestURL.path) else {
+            return nil
+        }
+
+        let data = try Data(contentsOf: manifestURL)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(PiExtensionInstallerManifest.self, from: data)
+    }
+
+    private func backupFile(at url: URL) throws {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let stamp = formatter.string(from: Date()).replacingOccurrences(of: ":", with: "-")
+        let backupURL = url.deletingLastPathComponent()
+            .appendingPathComponent("\(url.lastPathComponent).backup.\(stamp)")
+        try fileManager.copyItem(at: url, to: backupURL)
+    }
+}

--- a/Sources/OpenIslandCore/PiExtensionInstallationManager.swift
+++ b/Sources/OpenIslandCore/PiExtensionInstallationManager.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct PiExtensionInstallationStatus: Equatable, Sendable {
+public struct PiExtensionInstallationStatus: Equatable, Codable, Sendable {
     public var piConfigDirectory: URL
     public var extensionsDirectory: URL
     public var extensionFileURL: URL

--- a/Sources/OpenIslandCore/PiHooks.swift
+++ b/Sources/OpenIslandCore/PiHooks.swift
@@ -3,6 +3,7 @@ import Foundation
 public enum PiHookEventName: String, Codable, Sendable {
     case sessionStart = "SessionStart"
     case sessionEnd = "SessionEnd"
+    case heartbeat = "Heartbeat"
     case userPromptSubmit = "UserPromptSubmit"
     case agentStart = "AgentStart"
     case preToolUse = "PreToolUse"

--- a/Sources/OpenIslandCore/PiHooks.swift
+++ b/Sources/OpenIslandCore/PiHooks.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+public enum PiHookEventName: String, Codable, Sendable {
+    case sessionStart = "SessionStart"
+    case sessionEnd = "SessionEnd"
+    case userPromptSubmit = "UserPromptSubmit"
+    case agentStart = "AgentStart"
+    case preToolUse = "PreToolUse"
+    case postToolUse = "PostToolUse"
+    case stop = "Stop"
+}
+
+public struct PiHookPayload: Equatable, Codable, Sendable {
+    public var hookEventName: PiHookEventName
+    public var sessionID: String
+    public var cwd: String
+    public var transcriptPath: String?
+    public var model: String?
+    public var prompt: String?
+    public var lastAssistantMessage: String?
+    public var toolName: String?
+    public var toolInput: String?
+    public var toolUseID: String?
+    public var terminalApp: String?
+    public var terminalSessionID: String?
+    public var terminalTTY: String?
+    public var terminalTitle: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case hookEventName = "hook_event_name"
+        case sessionID = "session_id"
+        case cwd
+        case transcriptPath = "transcript_path"
+        case model
+        case prompt
+        case lastAssistantMessage = "last_assistant_message"
+        case toolName = "tool_name"
+        case toolInput = "tool_input"
+        case toolUseID = "tool_use_id"
+        case terminalApp = "terminal_app"
+        case terminalSessionID = "terminal_session_id"
+        case terminalTTY = "terminal_tty"
+        case terminalTitle = "terminal_title"
+    }
+
+    public init(
+        hookEventName: PiHookEventName,
+        sessionID: String,
+        cwd: String,
+        transcriptPath: String? = nil,
+        model: String? = nil,
+        prompt: String? = nil,
+        lastAssistantMessage: String? = nil,
+        toolName: String? = nil,
+        toolInput: String? = nil,
+        toolUseID: String? = nil,
+        terminalApp: String? = nil,
+        terminalSessionID: String? = nil,
+        terminalTTY: String? = nil,
+        terminalTitle: String? = nil
+    ) {
+        self.hookEventName = hookEventName
+        self.sessionID = sessionID
+        self.cwd = cwd
+        self.transcriptPath = transcriptPath
+        self.model = model
+        self.prompt = prompt
+        self.lastAssistantMessage = lastAssistantMessage
+        self.toolName = toolName
+        self.toolInput = toolInput
+        self.toolUseID = toolUseID
+        self.terminalApp = terminalApp
+        self.terminalSessionID = terminalSessionID
+        self.terminalTTY = terminalTTY
+        self.terminalTitle = terminalTitle
+    }
+}
+
+public enum PiHookDirective: Equatable, Codable, Sendable {
+    case allow
+    case deny(reason: String?)
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case reason
+    }
+
+    private enum DirectiveType: String, Codable {
+        case allow
+        case deny
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(DirectiveType.self, forKey: .type)
+
+        switch type {
+        case .allow:
+            self = .allow
+        case .deny:
+            self = .deny(reason: try container.decodeIfPresent(String.self, forKey: .reason))
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        switch self {
+        case .allow:
+            try container.encode(DirectiveType.allow, forKey: .type)
+        case let .deny(reason):
+            try container.encode(DirectiveType.deny, forKey: .type)
+            try container.encodeIfPresent(reason, forKey: .reason)
+        }
+    }
+}
+
+public extension PiHookPayload {
+    var workspaceName: String {
+        WorkspaceNameResolver.workspaceName(for: cwd)
+    }
+
+    var sessionTitle: String {
+        "Pi · \(workspaceName)"
+    }
+
+    var defaultJumpTarget: JumpTarget {
+        JumpTarget(
+            terminalApp: terminalApp ?? "Terminal",
+            workspaceName: workspaceName,
+            paneTitle: terminalTitle ?? "Pi \(sessionID.prefix(8))",
+            workingDirectory: cwd,
+            terminalSessionID: terminalSessionID,
+            terminalTTY: terminalTTY
+        )
+    }
+
+    var implicitStartSummary: String {
+        "Started Pi session in \(workspaceName)."
+    }
+
+    var promptPreview: String? {
+        clipped(prompt)
+    }
+
+    var assistantMessagePreview: String? {
+        clipped(lastAssistantMessage)
+    }
+
+    var toolInputPreview: String? {
+        clipped(toolInput, limit: 160)
+    }
+
+    var toolActivitySummary: String {
+        let base = toolName.map { "Running \($0)" } ?? "Running Pi tool"
+        return toolInputPreview.map { "\(base): \($0)" } ?? base
+    }
+
+    private func clipped(_ value: String?, limit: Int = 240) -> String? {
+        guard let value else {
+            return nil
+        }
+
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return nil
+        }
+
+        if trimmed.count <= limit {
+            return trimmed
+        }
+
+        return "\(trimmed.prefix(limit))…"
+    }
+}

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -243,6 +243,8 @@ public struct SessionState: Equatable, Sendable {
                 session.summary = "Permission approved. \(session.tool.displayName) continued the tool."
             case .openCode:
                 session.summary = "Permission approved. OpenCode continued the tool."
+            case .pi:
+                session.summary = "Permission approved. Pi continued the tool."
             default:
                 session.summary = "Permission approved. Agent resumed work."
             }
@@ -252,6 +254,8 @@ public struct SessionState: Equatable, Sendable {
             case .claudeCode, .geminiCLI, .qoder, .qwenCode, .factory, .codebuddy, .kimiCLI:
                 session.summary = "Permission denied in Open Island."
             case .openCode:
+                session.summary = "Permission denied in Open Island."
+            case .pi:
                 session.summary = "Permission denied in Open Island."
             default:
                 session.summary = "Permission denied. Review the session in the terminal."

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -384,6 +384,16 @@ public struct SessionState: Equatable, Sendable {
                     continue
                 }
 
+                // Pi is extension/heartbeat-managed and has no app-side
+                // process/session ID that process polling can match. Do not
+                // let the generic hook fallback mark it ended between
+                // heartbeats; SessionEnd still closes it when Pi shuts down.
+                if session.tool == .pi {
+                    session.processNotSeenCount = 0
+                    upsert(session)
+                    continue
+                }
+
                 // When a Codex session reached .completed via hooks (.stop)
                 // and Codex.app is still running, don't kill it through
                 // process polling — the CLI subprocess exits after each turn

--- a/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
+++ b/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
@@ -111,6 +111,7 @@ struct AgentSessionPresentationTests {
             (.codebuddy, "CodeBuddy"),
             (.cursor, "Cursor"),
             (.kimiCLI, "Kimi"),
+            (.pi, "Pi"),
         ]
         #expect(expectedNames.map { $0.0.rawValue }.sorted() == AgentTool.allCases.map(\.rawValue).sorted())
 

--- a/Tests/OpenIslandCoreTests/PiHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/PiHooksTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import OpenIslandCore
+import Testing
+
+struct PiHooksTests {
+    @Test
+    func piHookPayloadDecodesFromExtensionShape() throws {
+        let json = #"""
+        {
+          "hook_event_name": "PreToolUse",
+          "session_id": "pi-session-1",
+          "cwd": "/tmp/worktree",
+          "transcript_path": "/Users/me/.pi/agent/sessions/session.jsonl",
+          "model": "anthropic/claude-sonnet-4-5",
+          "tool_name": "bash",
+          "tool_use_id": "tool-1",
+          "tool_input": "{\"command\":\"swift test\"}",
+          "terminal_app": "Ghostty",
+          "terminal_tty": "/dev/ttys001"
+        }
+        """#.data(using: .utf8)!
+
+        let payload = try JSONDecoder().decode(PiHookPayload.self, from: json)
+
+        #expect(payload.hookEventName == .preToolUse)
+        #expect(payload.sessionID == "pi-session-1")
+        #expect(payload.sessionTitle == "Pi · worktree")
+        #expect(payload.toolActivitySummary.contains("Running bash"))
+        #expect(payload.defaultJumpTarget.terminalApp == "Ghostty")
+    }
+
+    @Test
+    func piPreToolUseWaitsForApprovalAndReturnsDenyDirective() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let payload = PiHookPayload(
+            hookEventName: .preToolUse,
+            sessionID: "pi-approval-1",
+            cwd: "/tmp/worktree",
+            toolName: "bash",
+            toolInput: "{\"command\":\"rm -rf build\"}",
+            toolUseID: "tool-1"
+        )
+
+        async let responseTask = sendPiOnGCDThread(.processPiHook(payload), socketURL: socketURL)
+
+        var iterator = stream.makeAsyncIterator()
+        let startedEvent = try await nextPiEvent(from: &iterator)
+        let permissionEvent = try await nextPiEvent(from: &iterator)
+
+        #expect(startedEvent.isPiSessionStarted)
+        #expect(permissionEvent.piPermissionRequest?.request.toolName == "bash")
+        #expect(permissionEvent.piPermissionRequest?.request.summary.contains("rm -rf build") == true)
+
+        try await observer.send(
+            .resolvePermission(
+                sessionID: "pi-approval-1",
+                resolution: .deny(message: "Use the project cleanup script instead.")
+            )
+        )
+
+        let completedEvent = try await nextPiEvent(from: &iterator)
+        let response = try await responseTask
+
+        #expect(completedEvent.piCompletion?.summary == "Use the project cleanup script instead.")
+        #expect(response == .piHookDirective(.deny(reason: "Use the project cleanup script instead.")))
+    }
+}
+
+private enum PiHookTestError: Error {
+    case streamEnded
+}
+
+private func nextPiEvent(
+    from iterator: inout AsyncThrowingStream<AgentEvent, Error>.AsyncIterator
+) async throws -> AgentEvent {
+    guard let event = try await iterator.next() else {
+        throw PiHookTestError.streamEnded
+    }
+
+    return event
+}
+
+private extension AgentEvent {
+    var isPiSessionStarted: Bool {
+        if case let .sessionStarted(payload) = self {
+            payload.tool == .pi
+        } else {
+            false
+        }
+    }
+
+    var piPermissionRequest: PermissionRequested? {
+        if case let .permissionRequested(payload) = self {
+            payload
+        } else {
+            nil
+        }
+    }
+
+    var piCompletion: SessionCompleted? {
+        if case let .sessionCompleted(payload) = self {
+            payload
+        } else {
+            nil
+        }
+    }
+}
+
+private func sendPiOnGCDThread(
+    _ command: BridgeCommand,
+    socketURL: URL
+) async throws -> BridgeResponse? {
+    try await withCheckedThrowingContinuation { continuation in
+        DispatchQueue.global().async {
+            do {
+                let response = try BridgeCommandClient(socketURL: socketURL).send(command)
+                continuation.resume(returning: response)
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+}

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -327,6 +327,7 @@ Pi has no native Open Island hook or approval system. Open Island support is imp
 | Pi extension event | Open Island event | Behavior |
 |---|---|---|
 | `session_start` | `SessionStart` | Creates or restores a Pi session row |
+| timer while Pi is alive | `Heartbeat` | Recreates the row after Open Island restarts without guessing from process lists |
 | `input` | `UserPromptSubmit` | Marks the session running with prompt preview |
 | `agent_start` | `AgentStart` | Marks the session running |
 | `tool_call` | `PreToolUse` | For `bash`, `edit`, and `write`, blocks until Open Island returns allow/deny |

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -349,16 +349,16 @@ The extension talks directly to `OPEN_ISLAND_SOCKET_PATH` when set, otherwise to
 
 ### Directive response
 
-For blocking `PreToolUse` events, BridgeServer returns a Pi directive:
+For blocking `PreToolUse` events, BridgeServer returns a normal bridge response envelope. The Pi extension reads `response.response.type === "piHookDirective"` and then applies `response.response.directive`:
 
 ```json
-{"type":"piHookDirective","directive":{"type":"allow"}}
+{"type":"response","response":{"type":"piHookDirective","directive":{"type":"allow"}}}
 ```
 
 or:
 
 ```json
-{"type":"piHookDirective","directive":{"type":"deny","reason":"Denied by Open Island"}}
+{"type":"response","response":{"type":"piHookDirective","directive":{"type":"deny","reason":"Denied by Open Island"}}}
 ```
 
 The extension maps a deny directive to Pi's blocking extension return value:
@@ -378,6 +378,8 @@ return { block: true, reason: "Denied by Open Island" }
 | Claude Code | `PermissionRequest` | **24 hours** (awaits human approval) |
 | Claude Code | All other events | **45 seconds** |
 | Gemini CLI | All events | Bridge default |
+| Pi Extension | `PreToolUse` for blocking approval tools | **24 hours** (awaits human approval) |
+| Pi Extension | All other events | Bridge default |
 
 ---
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,6 +1,6 @@
 # Hook System
 
-OpenIsland receives hook events from AI agents (Codex / Claude Code / Gemini CLI) via the `OpenIslandHooks` CLI. The CLI forwards payloads to the app over a Unix socket and, when necessary, writes a directive back to stdout so the agent can act on it (e.g. block a tool call).
+OpenIsland receives hook events from AI agents (Codex / Claude Code / Gemini CLI) via the `OpenIslandHooks` CLI, and from Pi via the official Pi Extension API. The hook CLI or extension forwards payloads to the app over a Unix socket and, when necessary, writes a directive back so the agent can act on it (e.g. block a tool call).
 
 ## Architecture
 
@@ -9,6 +9,14 @@ Agent (Codex / Claude Code / Gemini CLI)
   │  stdin: JSON payload
   ▼
 OpenIslandHooks CLI  (--source codex | --source claude | --source gemini)
+  │  Unix socket
+  ▼
+BridgeServer → AppModel → UI
+
+Pi
+  │  TypeScript Extension API events
+  ▼
+open-island-pi.ts extension
   │  Unix socket
   ▼
 BridgeServer → AppModel → UI
@@ -304,6 +312,59 @@ Setting `interrupt: true` terminates the current agent turn immediately.
 - Gemini hooks are currently treated as fire-and-forget. OpenIsland does not send Gemini-specific approval or modification directives back to stdout.
 - Gemini hook payloads sometimes include a duplicated copy of the final response body, often with whitespace-only differences. OpenIsland applies a best-effort compatibility pass before rendering completion content, but the result is not guaranteed to be perfect for every response shape.
 - Gemini support is currently limited to the hook events and UI/session behaviors listed above. It does not yet match the richer permission / interaction flows available for Claude Code or OpenCode.
+
+---
+
+## Pi Extension
+
+**Payload type**: `PiHookPayload`  
+**Source**: [`Sources/OpenIslandCore/PiHooks.swift`](../Sources/OpenIslandCore/PiHooks.swift) and [`Sources/OpenIslandApp/Resources/open-island-pi.ts`](../Sources/OpenIslandApp/Resources/open-island-pi.ts)
+
+Pi has no native Open Island hook or approval system. Open Island support is implemented through Pi's official TypeScript Extension API and does not patch Pi internals.
+
+### Events
+
+| Pi extension event | Open Island event | Behavior |
+|---|---|---|
+| `session_start` | `SessionStart` | Creates or restores a Pi session row |
+| `input` | `UserPromptSubmit` | Marks the session running with prompt preview |
+| `agent_start` | `AgentStart` | Marks the session running |
+| `tool_call` | `PreToolUse` | For `bash`, `edit`, and `write`, blocks until Open Island returns allow/deny |
+| `tool_result` | `PostToolUse` | Updates activity after tool completion |
+| `agent_end` | `Stop` | Marks the turn completed |
+| `session_shutdown` | `SessionEnd` | Marks the Pi session ended |
+
+### Install
+
+Copy the bundled extension to Pi's global extension directory and reload Pi:
+
+```bash
+mkdir -p ~/.pi/agent/extensions
+cp Sources/OpenIslandApp/Resources/open-island-pi.ts ~/.pi/agent/extensions/open-island.ts
+# inside Pi: /reload
+```
+
+The extension talks directly to `OPEN_ISLAND_SOCKET_PATH` when set, otherwise to Open Island's stable per-user socket at `~/Library/Application Support/OpenIsland/bridge.sock`.
+
+### Directive response
+
+For blocking `PreToolUse` events, BridgeServer returns a Pi directive:
+
+```json
+{"type":"piHookDirective","directive":{"type":"allow"}}
+```
+
+or:
+
+```json
+{"type":"piHookDirective","directive":{"type":"deny","reason":"Denied by Open Island"}}
+```
+
+The extension maps a deny directive to Pi's blocking extension return value:
+
+```ts
+return { block: true, reason: "Denied by Open Island" }
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- add Pi extension hook parsing and bridge handling
- add bundled Pi extension resource and install/status management
- surface Pi extension setup in settings and docs

## Verification
- `swift test --filter PiHooksTests` built successfully, but local test launch failed because this machine could not load `libsqlite3-1.dylib` from the Xcode/macOS runtime search paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Pi as a supported agent with UI integration, install/uninstall controls, and tool-labeling ("Pi")
  * Desktop bridge integration to connect Pi sessions to the app via a shipped extension and Unix socket
  * Pi tool approval/deny workflow for blocking tool calls

* **Bug Fixes**
  * Improved Pi session liveness and heartbeat handling to prevent premature session termination

* **Documentation**
  * Docs updated with Pi architecture, install instructions, event mapping, and directive format

* **Tests**
  * Added tests validating Pi hook payloads and approval flow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->