### PR TITLE
feat: add menu bar status item mode

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -17,6 +17,7 @@ extension Notification.Name {
 final class AppModel {
     private static let soundMutedDefaultsKey = "overlay.sound.muted"
     private static let showDockIconDefaultsKey = "app.showDockIcon"
+    private static let menuBarStatusItemDefaultsKey = "app.menuBarStatusItem"
     private static let hapticFeedbackEnabledDefaultsKey = "app.hapticFeedbackEnabled"
     private static let islandRightSlotDefaultsKey = "appearance.island.v6.rightSlot"
     private static let islandCenterLabelDefaultsKey = "appearance.island.v6.centerLabel"
@@ -49,6 +50,7 @@ final class AppModel {
             _cachedSessionBuckets = nil
             pruneAgentsGridObservationTicketsIfNeeded()
             bridgeServer.updateStateSnapshot(state)
+            statusItemController?.refreshStatus()
         }
     }
     @ObservationIgnored private var _cachedSessionBuckets: (primary: [AgentSession], overflow: [AgentSession])?
@@ -240,6 +242,17 @@ final class AppModel {
             }
         }
     }
+    /// Prototype: show a standard menu bar icon and drop the overlay down
+    /// underneath it instead of floating at the notch / top-bar center.
+    var menuBarStatusItemEnabled: Bool = false {
+        didSet {
+            guard hasFinishedInit, menuBarStatusItemEnabled != oldValue else { return }
+            UserDefaults.standard.set(menuBarStatusItemEnabled, forKey: Self.menuBarStatusItemDefaultsKey)
+            applyMenuBarStatusItemState()
+        }
+    }
+    @ObservationIgnored
+    private var statusItemController: StatusItemController?
     var hapticFeedbackEnabled: Bool = false {
         didSet {
             guard hasFinishedInit, hapticFeedbackEnabled != oldValue else { return }
@@ -595,6 +608,7 @@ final class AppModel {
         isSoundMuted = UserDefaults.standard.bool(forKey: Self.soundMutedDefaultsKey)
         selectedSoundName = NotificationSoundService.selectedSoundName
         showDockIcon = UserDefaults.standard.bool(forKey: Self.showDockIconDefaultsKey)
+        menuBarStatusItemEnabled = UserDefaults.standard.bool(forKey: Self.menuBarStatusItemDefaultsKey)
         hapticFeedbackEnabled = UserDefaults.standard.bool(forKey: Self.hapticFeedbackEnabledDefaultsKey)
         suppressFrontmostNotifications = UserDefaults.standard.bool(forKey: Self.suppressFrontmostNotificationsDefaultsKey)
         if UserDefaults.standard.object(forKey: Self.showCodexUsageDefaultsKey) != nil {
@@ -706,6 +720,18 @@ final class AppModel {
         didSet {
             let delta = abs(measuredNotificationContentHeight - oldValue)
             if delta >= 2, measuredNotificationContentHeight > 0 {
+                overlay.refreshOverlayPlacementIfVisible()
+            }
+        }
+    }
+
+    /// Measured natural height of the opened content in menu bar mode, so the
+    /// dropped-down panel hugs its real content instead of an over-estimate.
+    /// Same 2pt tolerance as above to avoid layout-measurement loops.
+    var measuredMenuBarContentHeight: CGFloat = 0 {
+        didSet {
+            let delta = abs(measuredMenuBarContentHeight - oldValue)
+            if delta >= 2, measuredMenuBarContentHeight > 0 {
                 overlay.refreshOverlayPlacementIfVisible()
             }
         }
@@ -862,6 +888,63 @@ final class AppModel {
             }
             return session.tool.displayName
         }
+    }
+
+    /// Aggregate session state powering the menu bar status dot's color.
+    var menuBarStatusLevel: MenuBarStatusLevel {
+        guard !surfacedSessions.isEmpty else { return .none }
+        switch islandClosedMode {
+        case .waiting: return .waiting
+        case .running: return .running
+        case .idle: return .idle
+        }
+    }
+
+    /// Per-state counts for the menu bar breakdown — mirrors the opened
+    /// panel's session overview (`sessionOverviewItems`) so the two agree.
+    var menuBarStateCounts: MenuBarStateCounts {
+        let sessions = islandListSessions
+        let now = Date.now
+        let threshold = completedStaleThreshold.seconds
+
+        func isIdle(_ s: AgentSession) -> Bool {
+            s.phase == .completed
+                && (s.isStaleCompletedForIsland(at: now, threshold: threshold)
+                    || s.islandPresence(at: now) == .inactive)
+        }
+
+        return MenuBarStateCounts(
+            total: sessions.count,
+            waiting: sessions.filter(\.phase.requiresAttention).count,
+            running: sessions.filter { $0.phase == .running }.count,
+            done: sessions.filter { $0.phase == .completed && !isIdle($0) }.count,
+            idle: sessions.filter(isIdle).count
+        )
+    }
+
+    /// Compact status string shown directly in the menu bar (menu bar mode),
+    /// so the current session state previews without opening the panel.
+    /// Empty when there are no surfaced sessions (icon shows alone).
+    var menuBarStatusSummary: String {
+        let sessions = surfacedSessions
+        guard !sessions.isEmpty else { return "" }
+
+        let count = sessions.count
+        guard let spotlight = islandClosedSpotlight else {
+            return "×\(count)"
+        }
+
+        let name: String
+        if let action = spotlight.displayCurrentToolName, !action.isEmpty {
+            name = action
+        } else if !spotlight.title.isEmpty {
+            name = spotlight.title
+        } else {
+            name = spotlight.tool.displayName
+        }
+
+        let trimmed = name.count > 16 ? String(name.prefix(15)) + "…" : name
+        return count > 1 ? "\(trimmed) ×\(count)" : trimmed
     }
 
     /// Right-slot payload derived from the user's `islandRightSlot`
@@ -1087,6 +1170,7 @@ final class AppModel {
         }
         refreshOverlayDisplayConfiguration()
         ensureOverlayPanel()
+        applyMenuBarStatusItemState()
         if shouldPerformBootAnimation {
             performBootAnimation()
         }
@@ -1193,6 +1277,37 @@ final class AppModel {
 
     func select(sessionID: String) {
         selectedSessionID = sessionID
+    }
+
+    // MARK: - Menu bar status item (prototype)
+
+    func applyMenuBarStatusItemState() {
+        let panelController = overlay.overlayPanelController
+        panelController.menuBarMode = menuBarStatusItemEnabled
+
+        if menuBarStatusItemEnabled {
+            if statusItemController == nil {
+                let controller = StatusItemController(model: self)
+                controller.install()
+                statusItemController = controller
+                panelController.menuBarAnchorProvider = { [weak self] in
+                    self?.statusItemController?.anchorScreenX
+                }
+                panelController.menuBarButtonFrameProvider = { [weak self] in
+                    self?.statusItemController?.buttonScreenFrame
+                }
+            }
+            // Collapse any visible overlay so only the icon represents the
+            // closed state, then hide the floating pill.
+            overlay.notchClose()
+        } else {
+            statusItemController?.remove()
+            statusItemController = nil
+            panelController.menuBarAnchorProvider = nil
+            panelController.menuBarButtonFrameProvider = nil
+        }
+
+        panelController.applyMenuBarModeVisibility()
     }
 
     // MARK: - Overlay forwarding

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -604,6 +604,7 @@ final class AppModel {
             Self.hapticFeedbackEnabledDefaultsKey: false,
             Self.completionReplyEnabledDefaultsKey: false,
             Self.suppressFrontmostNotificationsDefaultsKey: true,
+            Self.menuBarStatusItemDefaultsKey: false,
         ])
         isSoundMuted = UserDefaults.standard.bool(forKey: Self.soundMutedDefaultsKey)
         selectedSoundName = NotificationSoundService.selectedSoundName
@@ -943,7 +944,10 @@ final class AppModel {
             name = spotlight.tool.displayName
         }
 
-        let trimmed = name.count > 16 ? String(name.prefix(15)) + "…" : name
+        let maxMenuBarSummaryCharacters = 16
+        let trimmed = name.count > maxMenuBarSummaryCharacters
+            ? String(name.prefix(maxMenuBarSummaryCharacters)) + "…"
+            : name
         return count > 1 ? "\(trimmed) ×\(count)" : trimmed
     }
 
@@ -1364,6 +1368,8 @@ final class AppModel {
             NSApp.sendAction(NSSelectorFromString("showSettingsWindow:"), to: nil, from: nil)
         }
         bringSettingsWindowToFront()
+        // Re-apply on the next run-loop after SwiftUI/AppKit finishes creating
+        // or reordering the settings window; otherwise focus can be stolen back.
         DispatchQueue.main.async { [weak self] in
             self?.bringSettingsWindowToFront()
         }

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1363,6 +1363,13 @@ final class AppModel {
             // the `CommandGroup(.appSettings)` button that opens the window.
             NSApp.sendAction(NSSelectorFromString("showSettingsWindow:"), to: nil, from: nil)
         }
+        bringSettingsWindowToFront()
+        DispatchQueue.main.async { [weak self] in
+            self?.bringSettingsWindowToFront()
+        }
+    }
+
+    func bringSettingsWindowToFront() {
         if let window = NSApp.windows.first(where: { $0.title == "Open Island Settings" }) {
             window.orderFrontRegardless()
             window.makeKey()

--- a/Sources/OpenIslandApp/OpenIslandApp.swift
+++ b/Sources/OpenIslandApp/OpenIslandApp.swift
@@ -104,6 +104,8 @@ struct OpenIslandApp: App {
                 Button("Settings…") {
                     openWindow(id: "settings")
                     appDelegate.model.bringSettingsWindowToFront()
+                    // Re-apply on the next run-loop after `openWindow` creates
+                    // or reorders the SwiftUI settings window.
                     DispatchQueue.main.async {
                         appDelegate.model.bringSettingsWindowToFront()
                     }

--- a/Sources/OpenIslandApp/OpenIslandApp.swift
+++ b/Sources/OpenIslandApp/OpenIslandApp.swift
@@ -103,7 +103,10 @@ struct OpenIslandApp: App {
             CommandGroup(replacing: .appSettings) {
                 Button("Settings…") {
                     openWindow(id: "settings")
-                    appDelegate.model.showSettings()
+                    appDelegate.model.bringSettingsWindowToFront()
+                    DispatchQueue.main.async {
+                        appDelegate.model.bringSettingsWindowToFront()
+                    }
                 }
                 .keyboardShortcut(",", modifiers: .command)
             }

--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -38,6 +38,17 @@ final class OverlayPanelController {
     weak var model: AppModel?
     private(set) var notchRect: NSRect = .zero
 
+    /// When true, the overlay behaves as a menu bar drop-down: the closed pill
+    /// is hidden (the `NSStatusItem` is the closed state) and the opened panel
+    /// is anchored under the icon via `menuBarAnchorProvider`.
+    var menuBarMode = false
+    /// Returns the desired horizontal screen center for the opened panel, or
+    /// nil to fall back to the default (screen-centered) placement.
+    var menuBarAnchorProvider: (() -> CGFloat?)?
+    /// Returns the status item button's screen frame, so outside-click
+    /// dismissal can ignore clicks the button's own action already handles.
+    var menuBarButtonFrameProvider: (() -> NSRect?)?
+
     var isVisible: Bool {
         panel?.isVisible == true
     }
@@ -55,7 +66,12 @@ final class OverlayPanelController {
         let panel = self.panel ?? makePanel(model: model)
         self.panel = panel
         positionPanel(panel, preferredScreenID: preferredScreenID, animated: false)
-        panel.orderFrontRegardless()
+        if menuBarMode {
+            // The status item is the closed state — keep the floating pill hidden.
+            panel.orderOut(nil)
+        } else {
+            panel.orderFrontRegardless()
+        }
         panel.ignoresMouseEvents = true
         panel.acceptsMouseMovedEvents = false
         startEventMonitoring()
@@ -88,6 +104,21 @@ final class OverlayPanelController {
 
         if interactive {
             presentPanel(panel, activates: Self.shouldActivatePanel(for: model?.notchOpenReason))
+        } else if menuBarMode {
+            // Closed: in menu bar mode there is no visible pill to fall back to.
+            panel.orderOut(nil)
+        }
+    }
+
+    /// Reconcile panel visibility after `menuBarMode` is toggled at runtime.
+    func applyMenuBarModeVisibility() {
+        guard let panel else { return }
+        if menuBarMode {
+            if model?.notchStatus == .closed {
+                panel.orderOut(nil)
+            }
+        } else {
+            panel.orderFrontRegardless()
         }
     }
 
@@ -241,12 +272,16 @@ final class OverlayPanelController {
     private func handleMouseMoved(_ screenLocation: NSPoint) {
         guard let model else { return }
 
-        let inClosedSurfaceArea = isPointInClosedSurfaceArea(screenLocation)
+        // In menu bar mode the closed state is the status item — there is no
+        // floating pill to hover, so skip hover-open entirely (click-driven).
+        if !menuBarMode {
+            let inClosedSurfaceArea = isPointInClosedSurfaceArea(screenLocation)
 
-        if model.notchStatus == .closed && inClosedSurfaceArea {
-            scheduleHoverOpen()
-        } else if model.notchStatus == .closed && !inClosedSurfaceArea {
-            cancelHoverOpen()
+            if model.notchStatus == .closed && inClosedSurfaceArea {
+                scheduleHoverOpen()
+            } else if model.notchStatus == .closed && !inClosedSurfaceArea {
+                cancelHoverOpen()
+            }
         }
 
         let shouldTrackNotificationPointer = model.notchStatus == .opened
@@ -264,6 +299,21 @@ final class OverlayPanelController {
 
     private func handleMouseDown(_ screenLocation: NSPoint) {
         guard let model else { return }
+
+        if menuBarMode {
+            // Opening is owned by the status item button's action. Here we only
+            // dismiss on clicks outside the opened panel — and ignore clicks on
+            // the button itself, which the action already toggles.
+            guard model.notchStatus == .opened else { return }
+            if let buttonFrame = menuBarButtonFrameProvider?(),
+               Self.rectContainsIncludingEdges(buttonFrame, point: screenLocation) {
+                return
+            }
+            if !isPointInExpandedArea(screenLocation) {
+                model.notchClose()
+            }
+            return
+        }
 
         let inClosedSurfaceArea = isPointInClosedSurfaceArea(screenLocation)
 
@@ -453,13 +503,27 @@ final class OverlayPanelController {
 
     private func panelFrame(for model: AppModel?, on screen: NSScreen) -> NSRect {
         let size = panelSize(for: model, on: screen)
-        return NSRect(
-            x: screen.frame.midX - size.width / 2,
-            y: screen.frame.maxY - size.height,
-            width: size.width,
-            height: size.height
-        )
+        let x: CGFloat
+        let y: CGFloat
+        if menuBarMode, let anchorX = menuBarAnchorProvider?() {
+            // Center the panel under the icon, clamped to stay on-screen.
+            let margin: CGFloat = 8
+            let minX = screen.frame.minX + margin
+            let maxX = screen.frame.maxX - size.width - margin
+            x = min(max(anchorX - size.width / 2, minX), maxX)
+            // Drop the panel just below the menu bar. `visibleFrame.maxY` sits
+            // under the menu bar; subtracting the height puts the panel's top
+            // there, with a small gap so the flat surface tucks under the bar.
+            y = screen.visibleFrame.maxY - size.height - Self.menuBarPanelTopGap
+        } else {
+            x = screen.frame.midX - size.width / 2
+            y = screen.frame.maxY - size.height
+        }
+        return NSRect(x: x, y: y, width: size.width, height: size.height)
     }
+
+    /// Small breathing gap between the menu bar and the dropped-down panel.
+    private static let menuBarPanelTopGap: CGFloat = 2
 
     /// Always returns the maximum (opened) panel size so the window never
     /// needs to resize.  All visual transitions are driven purely by SwiftUI
@@ -510,6 +574,16 @@ final class OverlayPanelController {
             sessions: model.islandListSessions
         )
 
+        // Menu bar mode hugs the SwiftUI-measured natural content height once
+        // it's available, avoiding the estimate's slack (e.g. an expanded
+        // session reserving more than it renders).
+        if menuBarMode,
+           !visibleSessions.isEmpty,
+           model.notchOpenReason != .notification,
+           model.measuredMenuBarContentHeight > 0 {
+            return model.measuredMenuBarContentHeight
+        }
+
         if visibleSessions.isEmpty {
             return Self.openedEmptyStateHeight
         }
@@ -548,8 +622,16 @@ final class OverlayPanelController {
         let listHeight = rowsHeight + spacingHeight
         // Cap to match AutoHeightScrollView's maxHeight in IslandPanelView.
         let cappedListHeight = min(listHeight, Self.maxSessionListHeight)
-        return cappedListHeight + Self.openedContentVerticalInsets
+        // Menu bar mode hides the standalone list header (36pt row + 1pt
+        // divider) — its overview moved into the control strip — so reclaim
+        // that height to avoid an empty strip at the panel's bottom.
+        let headerSaving = menuBarMode ? Self.menuBarListHeaderSaving : 0
+        return cappedListHeight + Self.openedContentVerticalInsets - headerSaving
     }
+
+    /// Height reclaimed in menu bar mode where the standalone session-list
+    /// header is hidden (matches `sessionPanelHeader`'s 36pt + 1pt divider).
+    private static let menuBarListHeaderSaving: CGFloat = 37
 
     /// Additional height for the actionable session's inline action area.
     private func actionableBodyHeight(for session: AgentSession, model: AppModel) -> CGFloat {

--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -138,6 +138,7 @@ final class OverlayUICoordinator {
                 self?.autoCollapseSurfaceHasBeenEntered = false
                 self?.isPointerInsideIslandSurface = false
                 self?.appModel?.measuredNotificationContentHeight = 0
+                self?.appModel?.measuredMenuBarContentHeight = 0
             }
         )
     }

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -24,6 +24,8 @@
 "settings.general.autoHideNoSessions" = "Auto-hide without active sessions";
 "settings.general.autoCollapse" = "Auto-collapse on mouse exit";
 "settings.general.showDockIcon" = "Show icon in Dock";
+"settings.general.menuBarIcon" = "Show icon in menu bar (drops down from the icon)";
+"settings.menuBarMode.notApplicable" = "Not applicable in menu bar mode.";
 "settings.general.hapticFeedback" = "Haptic feedback on hover";
 "settings.general.suppressFrontmostNotifications" = "Suppress notifications for focused sessions";
 "settings.general.showCodexUsage" = "Show Codex usage";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -24,6 +24,8 @@
 "settings.general.autoHideNoSessions" = "无活跃会话时自动隐藏";
 "settings.general.autoCollapse" = "鼠标离开时自动收起";
 "settings.general.showDockIcon" = "在 Dock 中显示图标";
+"settings.general.menuBarIcon" = "在菜单栏显示图标（面板从图标下方展开）";
+"settings.menuBarMode.notApplicable" = "菜单栏模式下不适用。";
 "settings.general.hapticFeedback" = "悬停时震动反馈";
 "settings.general.suppressFrontmostNotifications" = "前台会话不弹出通知";
 "settings.general.showCodexUsage" = "显示 Codex 用量";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -24,6 +24,8 @@
 "settings.general.autoHideNoSessions" = "無活躍工作階段時自動隱藏";
 "settings.general.autoCollapse" = "滑鼠離開時自動收起";
 "settings.general.showDockIcon" = "在 Dock 中顯示圖示";
+"settings.general.menuBarIcon" = "在選單列顯示圖示（面板從圖示下方展開）";
+"settings.menuBarMode.notApplicable" = "選單列模式下不適用。";
 "settings.general.hapticFeedback" = "懸停時震動回饋";
 "settings.general.suppressFrontmostNotifications" = "前台工作階段不彈出通知";
 "settings.general.showCodexUsage" = "顯示 Codex 用量";

--- a/Sources/OpenIslandApp/StatusItemController.swift
+++ b/Sources/OpenIslandApp/StatusItemController.swift
@@ -1,0 +1,178 @@
+import AppKit
+
+/// Per-state session counts for the menu bar breakdown.
+struct MenuBarStateCounts {
+    var total: Int
+    var waiting: Int
+    var running: Int
+    var done: Int
+    var idle: Int
+}
+
+/// Aggregate session state shown as a colored dot in the menu bar.
+enum MenuBarStatusLevel {
+    case none      // no surfaced sessions
+    case idle      // sessions present, none running or needing attention
+    case running   // at least one running
+    case waiting   // at least one needs attention (approval / answer)
+
+    /// Dot color, matching `IslandDesignPalette.Status`.
+    var dotColor: NSColor {
+        switch self {
+        case .waiting:
+            return NSColor(srgbRed: 231 / 255, green: 167 / 255, blue: 98 / 255, alpha: 1)
+        case .running:
+            return NSColor(srgbRed: 110 / 255, green: 167 / 255, blue: 255 / 255, alpha: 1)
+        case .idle:
+            return NSColor(srgbRed: 111 / 255, green: 185 / 255, blue: 130 / 255, alpha: 1)
+        case .none:
+            return NSColor.tertiaryLabelColor
+        }
+    }
+}
+
+/// Minimal-validation menu bar entry point.
+///
+/// Adds a standard `NSStatusItem` to the system menu bar. The button shows a
+/// state-colored dot plus a compact live status string (e.g. "bash ×3"), so the
+/// current session state previews without opening anything. Clicking it toggles
+/// the existing overlay panel, which drops down underneath the icon.
+///
+/// This deliberately reuses the whole `IslandPanelView` / `OverlayUICoordinator`
+/// stack — it is a prototype to feel out the "menu bar icon" placement, not a
+/// full second presentation path.
+@MainActor
+final class StatusItemController {
+    private var statusItem: NSStatusItem?
+    weak var model: AppModel?
+
+    init(model: AppModel) {
+        self.model = model
+    }
+
+    /// The status item button's frame in global screen coordinates.
+    var buttonScreenFrame: NSRect? {
+        guard let button = statusItem?.button, let window = button.window else {
+            return nil
+        }
+        let rectInWindow = button.convert(button.bounds, to: nil)
+        return window.convertToScreen(rectInWindow)
+    }
+
+    /// Horizontal center of the status item button in global screen
+    /// coordinates, used to anchor the dropped-down panel under the icon.
+    var anchorScreenX: CGFloat? {
+        buttonScreenFrame?.midX
+    }
+
+    func install() {
+        guard statusItem == nil else { return }
+
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        if let button = item.button {
+            button.imageHugsTitle = true
+            button.target = self
+            button.action = #selector(handleClick)
+            button.toolTip = "Open Island"
+        }
+        statusItem = item
+
+        refreshStatus()
+    }
+
+    func remove() {
+        if let item = statusItem {
+            NSStatusBar.system.removeStatusItem(item)
+        }
+        statusItem = nil
+    }
+
+    @objc private func handleClick() {
+        model?.toggleOverlay()
+    }
+
+    // MARK: - Live status
+
+    /// Refresh the button title from the model's current status summary.
+    /// Pushed by `AppModel` whenever session state changes (the `state`
+    /// mutation funnel) — reliable, unlike observing the cached buckets.
+    func refreshStatus() {
+        guard let button = statusItem?.button else { return }
+
+        let level = model?.menuBarStatusLevel ?? .none
+        button.image = Self.makeStatusDot(color: level.dotColor)
+
+        let counts = model?.menuBarStateCounts ?? MenuBarStateCounts(total: 0, waiting: 0, running: 0, done: 0, idle: 0)
+        if counts.total == 0 {
+            button.attributedTitle = NSAttributedString(string: "")
+            button.imagePosition = .imageOnly
+        } else {
+            button.attributedTitle = Self.makeBreakdownTitle(counts)
+            button.imagePosition = .imageLeading
+            button.imageHugsTitle = true
+        }
+        let summary = model?.menuBarStatusSummary ?? ""
+        button.toolTip = summary.isEmpty ? "Open Island" : "Open Island — \(summary)"
+    }
+
+    // MARK: - Breakdown title
+
+    private static let breakdownTextColor = NSColor.labelColor
+    // Chip colors match IslandDesignPalette.Status (and the panel overview).
+    private static let waitingColor = NSColor(srgbRed: 231 / 255, green: 167 / 255, blue: 98 / 255, alpha: 1)
+    private static let runningColor = NSColor(srgbRed: 110 / 255, green: 167 / 255, blue: 255 / 255, alpha: 1)
+    private static let doneColor = NSColor(srgbRed: 111 / 255, green: 185 / 255, blue: 130 / 255, alpha: 1)
+    private static let idleColor = NSColor.tertiaryLabelColor
+
+    /// "3   ●1 ●1 ●1" — total in label color, then a colored dot + count for
+    /// each non-zero state (waiting, running, done, idle), ordered by urgency.
+    private static func makeBreakdownTitle(_ counts: MenuBarStateCounts) -> NSAttributedString {
+        let textFont = NSFont.systemFont(ofSize: 12, weight: .medium)
+        let dotFont = NSFont.systemFont(ofSize: 8, weight: .black)
+
+        let title = NSMutableAttributedString()
+        title.append(NSAttributedString(
+            string: " \(counts.total)",
+            attributes: [.font: textFont, .foregroundColor: breakdownTextColor]
+        ))
+
+        func appendChip(_ count: Int, _ color: NSColor) {
+            guard count > 0 else { return }
+            title.append(NSAttributedString(
+                string: "   ",
+                attributes: [.font: textFont]
+            ))
+            title.append(NSAttributedString(
+                string: "●",
+                attributes: [.font: dotFont, .foregroundColor: color, .baselineOffset: 1]
+            ))
+            title.append(NSAttributedString(
+                string: " \(count)",
+                attributes: [.font: textFont, .foregroundColor: breakdownTextColor]
+            ))
+        }
+
+        appendChip(counts.waiting, waitingColor)
+        appendChip(counts.running, runningColor)
+        appendChip(counts.done, doneColor)
+        appendChip(counts.idle, idleColor)
+
+        return title
+    }
+
+    // MARK: - Icon
+
+    /// A filled colored circle. Non-template so the state color is preserved
+    /// (template images get tinted monochrome by the menu bar).
+    private static func makeStatusDot(color: NSColor) -> NSImage {
+        let diameter: CGFloat = 9
+        let size = NSSize(width: diameter, height: diameter)
+        let image = NSImage(size: size)
+        image.lockFocus()
+        color.setFill()
+        NSBezierPath(ovalIn: NSRect(origin: .zero, size: size)).fill()
+        image.unlockFocus()
+        image.isTemplate = false
+        return image
+    }
+}

--- a/Sources/OpenIslandApp/StatusItemController.swift
+++ b/Sources/OpenIslandApp/StatusItemController.swift
@@ -1,7 +1,7 @@
 import AppKit
 
 /// Per-state session counts for the menu bar breakdown.
-struct MenuBarStateCounts {
+struct MenuBarStateCounts: Sendable, Codable {
     var total: Int
     var waiting: Int
     var running: Int
@@ -10,7 +10,7 @@ struct MenuBarStateCounts {
 }
 
 /// Aggregate session state shown as a colored dot in the menu bar.
-enum MenuBarStatusLevel {
+enum MenuBarStatusLevel: Sendable, Codable {
     case none      // no surfaced sessions
     case idle      // sessions present, none running or needing attention
     case running   // at least one running
@@ -120,11 +120,6 @@ final class StatusItemController {
     // MARK: - Breakdown title
 
     private static let breakdownTextColor = NSColor.labelColor
-    // Chip colors match IslandDesignPalette.Status (and the panel overview).
-    private static let waitingColor = NSColor(srgbRed: 231 / 255, green: 167 / 255, blue: 98 / 255, alpha: 1)
-    private static let runningColor = NSColor(srgbRed: 110 / 255, green: 167 / 255, blue: 255 / 255, alpha: 1)
-    private static let doneColor = NSColor(srgbRed: 111 / 255, green: 185 / 255, blue: 130 / 255, alpha: 1)
-    private static let idleColor = NSColor.tertiaryLabelColor
 
     /// "●1 ●1 ●1" — a colored dot + count for each non-zero state (waiting,
     /// running, done, idle), ordered by urgency. The aggregate total is omitted:
@@ -152,10 +147,10 @@ final class StatusItemController {
             ))
         }
 
-        appendChip(counts.waiting, waitingColor)
-        appendChip(counts.running, runningColor)
-        appendChip(counts.done, doneColor)
-        appendChip(counts.idle, idleColor)
+        appendChip(counts.waiting, MenuBarStatusLevel.waiting.dotColor)
+        appendChip(counts.running, MenuBarStatusLevel.running.dotColor)
+        appendChip(counts.done, MenuBarStatusLevel.idle.dotColor)
+        appendChip(counts.idle, MenuBarStatusLevel.none.dotColor)
 
         return title
     }
@@ -167,11 +162,11 @@ final class StatusItemController {
     private static func makeStatusDot(color: NSColor) -> NSImage {
         let diameter: CGFloat = 9
         let size = NSSize(width: diameter, height: diameter)
-        let image = NSImage(size: size)
-        image.lockFocus()
-        color.setFill()
-        NSBezierPath(ovalIn: NSRect(origin: .zero, size: size)).fill()
-        image.unlockFocus()
+        let image = NSImage(size: size, flipped: false) { rect in
+            color.setFill()
+            NSBezierPath(ovalIn: rect).fill()
+            return true
+        }
         image.isTemplate = false
         return image
     }

--- a/Sources/OpenIslandApp/StatusItemController.swift
+++ b/Sources/OpenIslandApp/StatusItemController.swift
@@ -99,17 +99,19 @@ final class StatusItemController {
     func refreshStatus() {
         guard let button = statusItem?.button else { return }
 
-        let level = model?.menuBarStatusLevel ?? .none
-        button.image = Self.makeStatusDot(color: level.dotColor)
-
         let counts = model?.menuBarStateCounts ?? MenuBarStateCounts(total: 0, waiting: 0, running: 0, done: 0, idle: 0)
         if counts.total == 0 {
+            // No sessions: show a single neutral dot as the clickable icon.
+            let level = model?.menuBarStatusLevel ?? .none
+            button.image = Self.makeStatusDot(color: level.dotColor)
             button.attributedTitle = NSAttributedString(string: "")
             button.imagePosition = .imageOnly
         } else {
+            // The per-state chips already carry their own colored dots, so the
+            // aggregate status dot would just be a redundant leading dot.
+            button.image = nil
             button.attributedTitle = Self.makeBreakdownTitle(counts)
-            button.imagePosition = .imageLeading
-            button.imageHugsTitle = true
+            button.imagePosition = .noImage
         }
         let summary = model?.menuBarStatusSummary ?? ""
         button.toolTip = summary.isEmpty ? "Open Island" : "Open Island — \(summary)"
@@ -124,22 +126,20 @@ final class StatusItemController {
     private static let doneColor = NSColor(srgbRed: 111 / 255, green: 185 / 255, blue: 130 / 255, alpha: 1)
     private static let idleColor = NSColor.tertiaryLabelColor
 
-    /// "3   ●1 ●1 ●1" — total in label color, then a colored dot + count for
-    /// each non-zero state (waiting, running, done, idle), ordered by urgency.
+    /// "●1 ●1 ●1" — a colored dot + count for each non-zero state (waiting,
+    /// running, done, idle), ordered by urgency. The aggregate total is omitted:
+    /// it's redundant with the leading status dot and the per-state breakdown.
     private static func makeBreakdownTitle(_ counts: MenuBarStateCounts) -> NSAttributedString {
         let textFont = NSFont.systemFont(ofSize: 12, weight: .medium)
         let dotFont = NSFont.systemFont(ofSize: 8, weight: .black)
 
         let title = NSMutableAttributedString()
-        title.append(NSAttributedString(
-            string: " \(counts.total)",
-            attributes: [.font: textFont, .foregroundColor: breakdownTextColor]
-        ))
 
         func appendChip(_ count: Int, _ color: NSColor) {
             guard count > 0 else { return }
+            // No leading pad on the first chip (no icon precedes it); gap between.
             title.append(NSAttributedString(
-                string: "   ",
+                string: title.length == 0 ? "" : "   ",
                 attributes: [.font: textFont]
             ))
             title.append(NSAttributedString(

--- a/Sources/OpenIslandApp/Views/AppearanceSettingsPane.swift
+++ b/Sources/OpenIslandApp/Views/AppearanceSettingsPane.swift
@@ -29,8 +29,15 @@ struct AppearanceSettingsPane: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 32) {
+                if model.menuBarStatusItemEnabled {
+                    MenuBarNotApplicableNote(lang: lang)
+                }
                 displayProfilePart
+                    .disabled(model.menuBarStatusItemEnabled)
+                    .opacity(model.menuBarStatusItemEnabled ? 0.45 : 1)
                 notchPersonalizationPart
+                    .disabled(model.menuBarStatusItemEnabled)
+                    .opacity(model.menuBarStatusItemEnabled ? 0.45 : 1)
                 sessionListPersonalizationPart
             }
             .padding(24)

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -16,6 +16,13 @@ private struct ContentHeightKey: PreferenceKey {
     }
 }
 
+private struct MenuBarContentHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
 /// Auto-height container: renders content directly (auto-sizing).
 /// When content exceeds maxHeight, wraps in ScrollView at fixed maxHeight.
 private struct AutoHeightScrollView<Content: View>: View {
@@ -144,7 +151,9 @@ struct IslandPanelView: View {
     }
 
     private var usesNotchAwareOpenedHeader: Bool {
-        model.overlayPlacementDiagnostics?.mode == .notch
+        // Menu bar mode drops a flat panel under the icon — never notch-shaped.
+        if model.menuBarStatusItemEnabled { return false }
+        return model.overlayPlacementDiagnostics?.mode == .notch
             || targetOverlayScreen?.safeAreaInsets.top ?? 0 > 0
     }
 
@@ -152,6 +161,8 @@ struct IslandPanelView: View {
     /// The central black rectangle is otherwise aligned with the physical
     /// notch, so center content is only useful here.
     private var isExternalDisplayPlacement: Bool {
+        // Menu bar mode is always treated as flat / non-notch placement.
+        if model.menuBarStatusItemEnabled { return true }
         if let mode = model.overlayPlacementDiagnostics?.mode {
             return mode == .topBar
         }
@@ -212,13 +223,19 @@ struct IslandPanelView: View {
             ZStack(alignment: .top) {
                 if shouldRenderOpenedSurface {
                     openedSurface(width: openedWidth, height: openedHeight)
-                        .opacity(usesOpenedVisualState ? 1 : 0)
+                        // In menu bar mode the panel is hidden while closed and
+                        // the status item is the closed state, so show the
+                        // opened surface immediately — no closed→opened
+                        // crossfade that would flash the pill content.
+                        .opacity(usesOpenedVisualState || model.menuBarStatusItemEnabled ? 1 : 0)
                         .allowsHitTesting(usesOpenedVisualState)
                 }
 
-                v6ClosedSurface()
-                    .opacity(usesOpenedVisualState ? 0 : 1)
-                    .allowsHitTesting(!usesOpenedVisualState)
+                if !model.menuBarStatusItemEnabled {
+                    v6ClosedSurface()
+                        .opacity(usesOpenedVisualState ? 0 : 1)
+                        .allowsHitTesting(!usesOpenedVisualState)
+                }
             }
             .frame(maxWidth: .infinity, alignment: .top)
         }
@@ -363,8 +380,16 @@ struct IslandPanelView: View {
             }
         } else {
             HStack(spacing: 12) {
-                openedUsageSummary
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                if model.menuBarStatusItemEnabled {
+                    // Menu bar mode: the session overview lives here, sharing
+                    // the row with the buttons (the standalone list header is
+                    // hidden), so there's no empty band above the list.
+                    sessionOverviewHeaderContent(referenceDate: .now)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else {
+                    openedUsageSummary
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
 
                 openedHeaderButtons
             }
@@ -551,6 +576,27 @@ struct IslandPanelView: View {
                             model.measuredNotificationContentHeight = height
                         }
                     }
+            } else if model.menuBarStatusItemEnabled {
+                // Menu bar mode: hug the content (no greedy ScrollView, no
+                // duplicate header) so the dropped-down panel sizes to fit.
+                VStack(spacing: 0) {
+                    AutoHeightScrollView(maxHeight: Self.maxSessionListHeight) {
+                        sessionRowsContent(referenceDate: referenceDate)
+                    }
+                    sessionPanelFooter
+                }
+                .padding(.vertical, 2)
+                .background(
+                    GeometryReader { geo in
+                        Color.clear.preference(
+                            key: MenuBarContentHeightKey.self,
+                            value: geo.size.height
+                        )
+                    }
+                )
+                .onPreferenceChange(MenuBarContentHeightKey.self) { height in
+                    if height > 0 { model.measuredMenuBarContentHeight = height }
+                }
             } else {
                 VStack(spacing: 0) {
                     sessionPanelHeader(referenceDate: referenceDate)
@@ -690,7 +736,10 @@ struct IslandPanelView: View {
         }
     }
 
-    private func sessionPanelHeader(referenceDate: Date) -> some View {
+    /// Title ("SESSIONS") + state overview counts. Shared by the standalone
+    /// list header and, in menu bar mode, the top control strip (so the
+    /// overview and the sound/settings/quit buttons share one row).
+    private func sessionOverviewHeaderContent(referenceDate: Date) -> some View {
         let overview = sessionOverviewItems(referenceDate: referenceDate)
 
         return HStack(spacing: 8) {
@@ -703,7 +752,12 @@ struct IslandPanelView: View {
                 sessionOverviewView(overview, compact: false)
                 sessionOverviewView(overview, compact: true)
             }
+        }
+    }
 
+    private func sessionPanelHeader(referenceDate: Date) -> some View {
+        HStack(spacing: 8) {
+            sessionOverviewHeaderContent(referenceDate: referenceDate)
             Spacer(minLength: 0)
         }
         .padding(.leading, sessionListSideInset)

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -167,6 +167,20 @@ struct SettingsView: View {
     }
 }
 
+// MARK: - Menu bar mode note
+
+/// Caption shown under settings that have no effect while the menu bar
+/// status item is the active presentation (closed pill / hover are gone).
+struct MenuBarNotApplicableNote: View {
+    let lang: LanguageManager
+
+    var body: some View {
+        Text(lang.t("settings.menuBarMode.notApplicable"))
+            .font(.caption)
+            .foregroundStyle(.secondary)
+    }
+}
+
 // MARK: - General
 
 struct GeneralSettingsPane: View {
@@ -191,6 +205,10 @@ struct GeneralSettingsPane: View {
                         Text(option.title).tag(option.id)
                     }
                 }
+                .disabled(model.menuBarStatusItemEnabled)
+                if model.menuBarStatusItemEnabled {
+                    MenuBarNotApplicableNote(lang: lang)
+                }
             }
 
             Section(lang.t("settings.general.language")) {
@@ -207,9 +225,17 @@ struct GeneralSettingsPane: View {
 
             Section(lang.t("settings.general.behavior")) {
                 Toggle(lang.t("settings.general.autoCollapse"), isOn: .constant(true))
+                    .disabled(model.menuBarStatusItemEnabled)
+                if model.menuBarStatusItemEnabled {
+                    MenuBarNotApplicableNote(lang: lang)
+                }
                 Toggle(lang.t("settings.general.showDockIcon"), isOn: Binding(
                     get: { model.showDockIcon },
                     set: { model.showDockIcon = $0 }
+                ))
+                Toggle(lang.t("settings.general.menuBarIcon"), isOn: Binding(
+                    get: { model.menuBarStatusItemEnabled },
+                    set: { model.menuBarStatusItemEnabled = $0 }
                 ))
                 Toggle(lang.t("settings.general.hapticFeedback"), isOn: Binding(
                     get: { model.hapticFeedbackEnabled },
@@ -249,6 +275,10 @@ struct DisplaySettingsPane: View {
                     ForEach(model.overlayDisplayOptions) { option in
                         Text(option.title).tag(option.id)
                     }
+                }
+                .disabled(model.menuBarStatusItemEnabled)
+                if model.menuBarStatusItemEnabled {
+                    MenuBarNotApplicableNote(lang: lang)
                 }
             }
 


### PR DESCRIPTION
## Summary
- add an optional menu bar status item mode as an alternative to the notch/top-bar overlay
- render live session state chips in the menu bar and anchor the existing island panel below the status item
- grey out notch-only settings while menu bar mode is enabled and avoid recursive settings reopening

## Verification
- `swift build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Menu bar status item showing session counts/status with color indicators and toggling the overlay
  * Settings toggle to enable/disable the menu bar icon; settings UI shows a note and disables conflicted options when enabled
  * Menu-bar mode: compact header, adjusted panel positioning and sizing for menu bar placement

* **Bug Fixes**
  * Settings window reliably brought to the front after opening

* **Localization**
  * Added English, Simplified Chinese, and Traditional Chinese strings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->