### PR TITLE
fix: end completed non-Codex.app Codex sessions

### DIFF
--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -380,15 +380,10 @@ public struct SessionState: Equatable, Sendable {
                     continue
                 }
 
-                // When a Codex session reached .completed via hooks (.stop)
-                // and Codex.app is still running, don't kill it through
-                // process polling — the CLI subprocess exits after each turn
-                // but the desktop app session is still valid.  The session
-                // stays visible as "Completed" and fades via island presence.
-                if session.tool == .codex && session.phase == .completed && isCodexAppRunning {
-                    upsert(session)
-                    continue
-                }
+                // Codex.app sessions are handled by the app-level liveness branch
+                // above.  Other Codex hook sessions, such as VS Code / Claude
+                // plugin sessions, must still age out when their CLI process is
+                // gone even if Codex.app itself is running.
 
                 if aliveSessionIDs.contains(id) {
                     session.processNotSeenCount = 0

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -5,6 +5,46 @@ import Testing
 
 struct SessionStateTests {
     @Test
+    func completedCodexCLISessionEndsEvenWhenCodexAppIsRunning() {
+        let startedAt = Date(timeIntervalSince1970: 7_000)
+        var state = SessionState()
+
+        state.apply(
+            .sessionStarted(
+                SessionStarted(
+                    sessionID: "codex-vscode-review",
+                    title: "Codex · jobfeed",
+                    tool: .codex,
+                    origin: .live,
+                    summary: "Reviewing code",
+                    timestamp: startedAt,
+                    jumpTarget: JumpTarget(
+                        terminalApp: "VS Code",
+                        workspaceName: "jobfeed",
+                        paneTitle: "Codex 019e9716",
+                        workingDirectory: "/Users/example/jobfeed"
+                    )
+                )
+            )
+        )
+        state.apply(
+            .sessionCompleted(
+                SessionCompleted(
+                    sessionID: "codex-vscode-review",
+                    summary: "no issues found",
+                    timestamp: startedAt.addingTimeInterval(10)
+                )
+            )
+        )
+
+        _ = state.markProcessLiveness(aliveSessionIDs: [], isCodexAppRunning: true)
+        _ = state.markProcessLiveness(aliveSessionIDs: [], isCodexAppRunning: true)
+
+        #expect(state.session(id: "codex-vscode-review")?.isSessionEnded == true)
+        #expect(state.visibleCount == 0)
+    }
+
+    @Test
     func appliesPermissionAndQuestionEventsToExistingSessions() {
         let startedAt = Date(timeIntervalSince1970: 1_000)
         var state = SessionState()


### PR DESCRIPTION
Fixes #542

Summary:
- Stop using Codex.app process liveness as a keepalive for every completed Codex hook session.
- Let non-Codex.app Codex hook sessions, such as VS Code / Claude plugin sessions, age out when their CLI process is gone.
- Add a regression test for a completed VS Code Codex session while Codex.app is still running.

Verification:
- `git diff --check` passed.
- `swift build` passed.
- `swift test --filter SessionStateTests/completedCodexCLISessionEndsEvenWhenCodexAppIsRunning` did not run to completion in this local Command Line Tools environment because the test targets fail at `import Testing` with no such module Testing.

Note:
- Opened as draft because the targeted test cannot be executed in this local environment until Swift Testing is available, likely via the full Xcode toolchain.