### PR TITLE
fix: end completed non-Codex.app Codex sessions

### DIFF
--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -380,15 +380,10 @@ public struct SessionState: Equatable, Sendable {
                     continue
                 }
 
-                // When a Codex session reached .completed via hooks (.stop)
-                // and Codex.app is still running, don't kill it through
-                // process polling — the CLI subprocess exits after each turn
-                // but the desktop app session is still valid.  The session
-                // stays visible as "Completed" and fades via island presence.
-                if session.tool == .codex && session.phase == .completed && isCodexAppRunning {
-                    upsert(session)
-                    continue
-                }
+                // Codex.app sessions are handled by the app-level liveness branch
+                // above.  Other Codex hook sessions, such as VS Code / Claude
+                // plugin sessions, must still age out when their CLI process is
+                // gone even if Codex.app itself is running.
 
                 if aliveSessionIDs.contains(id) {
                     session.processNotSeenCount = 0

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -3,7 +3,50 @@ import Foundation
 import Testing
 @testable import OpenIslandCore
 
+/// Regression coverage for core session lifecycle and visibility behavior.
 struct SessionStateTests {
+    /// Completed Codex CLI sessions outside Codex.app should age out even while Codex.app is running.
+    @Test
+    func completedCodexCLISessionEndsEvenWhenCodexAppIsRunning() {
+        let startedAt = Date(timeIntervalSince1970: 7_000)
+        var state = SessionState()
+
+        state.apply(
+            .sessionStarted(
+                SessionStarted(
+                    sessionID: "codex-vscode-review",
+                    title: "Codex · jobfeed",
+                    tool: .codex,
+                    origin: .live,
+                    summary: "Reviewing code",
+                    timestamp: startedAt,
+                    jumpTarget: JumpTarget(
+                        terminalApp: "VS Code",
+                        workspaceName: "jobfeed",
+                        paneTitle: "Codex 019e9716",
+                        workingDirectory: "/Users/example/jobfeed"
+                    )
+                )
+            )
+        )
+        state.apply(
+            .sessionCompleted(
+                SessionCompleted(
+                    sessionID: "codex-vscode-review",
+                    summary: "no issues found",
+                    timestamp: startedAt.addingTimeInterval(10)
+                )
+            )
+        )
+
+        _ = state.markProcessLiveness(aliveSessionIDs: [], isCodexAppRunning: true)
+        _ = state.markProcessLiveness(aliveSessionIDs: [], isCodexAppRunning: true)
+
+        #expect(state.session(id: "codex-vscode-review")?.isSessionEnded == true)
+        #expect(state.liveSessionCount == 0)
+    }
+
+    /// Verifies permission and question events update an already-tracked session.
     @Test
     func appliesPermissionAndQuestionEventsToExistingSessions() {
         let startedAt = Date(timeIntervalSince1970: 1_000)


### PR DESCRIPTION
Fixes #542

Summary:
- Stop using Codex.app process liveness as a keepalive for every completed Codex hook session.
- Let non-Codex.app Codex hook sessions, such as VS Code / Claude plugin sessions, age out when their CLI process is gone.
- Add a regression test for a completed VS Code Codex session while Codex.app is still running.

Verification:
- Xcode 26.5 (17F42), Swift 6.3.2.
- `git diff --check` passed.
- `swift build` passed. It still emits the existing `@discardableResult` on `Void` warning in `SessionState.swift`.
- `swift test --filter SessionStateTests/completedCodexCLISessionEndsEvenWhenCodexAppIsRunning` passed: 1 Swift Testing test executed.
- `swift test --filter SessionStateTests` passed: 36 Swift Testing tests executed.
- Full `swift test` is not clean in this local environment. The relevant pre-existing AppModel failure reproduces on a clean `origin/main` checkout with `swift test --filter AppModelSessionListTests/islandSessionSectionsGroupStaleCompletedIntoIdle`; it returns `[`all`]` instead of the expected state-grouped sections. A full-suite run also surfaced `AgentsGridRightSlotTests/newlyObservedSessionAlwaysLandsAtTheEndRegardlessOfHistoricalTime`, but that test passes in isolation on both `origin/main` and this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session lifecycle so completed Codex CLI sessions are reliably ended and cleaned up even when the Codex app is running.

* **Tests**
  * Added a test that verifies completed Codex CLI sessions are terminated and removed from live counts while the Codex app is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->