### PR TITLE
Fix Codex hooks feature detection

### DIFF
--- a/Sources/OpenIslandCore/CodexHookInstaller.swift
+++ b/Sources/OpenIslandCore/CodexHookInstaller.swift
@@ -265,6 +265,7 @@ public enum CodexHookInstaller {
             || featureValue(for: legacyFeatureKey, lines: lines) == true
     }
 
+    /// Detects the Codex hook feature flag supported by the installed CLI.
     public static func preferredCodexHooksFeatureKey() -> CodexHooksFeatureFlagKey {
         if let featureKey = commandOutput(arguments: ["features", "list"])
             .flatMap(preferredCodexHooksFeatureKey(fromFeatureList:)) {
@@ -276,7 +277,7 @@ public enum CodexHookInstaller {
             return featureKey
         }
 
-        return .legacy
+        return .current
     }
 
     private static func loadRootObject(from data: Data?) throws -> [String: Any] {
@@ -485,6 +486,7 @@ public enum CodexHookInstaller {
         return (key: parts[0], value: parts[1])
     }
 
+    /// Parses `codex features list` output to find the supported hook feature flag.
     static func preferredCodexHooksFeatureKey(fromFeatureList output: String) -> CodexHooksFeatureFlagKey? {
         let featureNames = Set(output.split(whereSeparator: \.isNewline).compactMap { line -> String? in
             line.split(whereSeparator: \.isWhitespace).first.map(String.init)
@@ -499,6 +501,7 @@ public enum CodexHookInstaller {
         return nil
     }
 
+    /// Infers the hook feature flag from `codex --version` when feature listing is unavailable.
     static func preferredCodexHooksFeatureKey(fromVersionOutput output: String) -> CodexHooksFeatureFlagKey? {
         guard let versionToken = output.split(whereSeparator: \.isWhitespace).first(where: { token in
             token.first?.isNumber == true
@@ -529,12 +532,17 @@ public enum CodexHookInstaller {
         return nil
     }
 
+    /// Returns Codex CLI locations to probe, including app-bundled and shell-installed builds.
     private static func codexCommandCandidates() -> [(executableURL: URL, prefixArguments: [String])] {
         var candidates: [(executableURL: URL, prefixArguments: [String])] = [
             (URL(fileURLWithPath: "/usr/bin/env"), ["codex"]),
         ]
 
-        for path in ["/opt/homebrew/bin/codex", "/usr/local/bin/codex"] {
+        for path in [
+            "/Applications/Codex.app/Contents/Resources/codex",
+            "/opt/homebrew/bin/codex",
+            "/usr/local/bin/codex",
+        ] {
             if FileManager.default.isExecutableFile(atPath: path) {
                 candidates.append((URL(fileURLWithPath: path), []))
             }

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -1102,6 +1102,7 @@ struct SessionStateTests {
         """))
     }
 
+    /// Verifies Codex hook feature detection across current, legacy, and invalid CLI output.
     @Test
     func codexHookInstallerDetectsPreferredFeatureFlagFromCodexOutput() {
         let currentFeatures = """
@@ -1117,6 +1118,8 @@ struct SessionStateTests {
         #expect(CodexHookInstaller.preferredCodexHooksFeatureKey(fromFeatureList: legacyFeatures) == .legacy)
         #expect(CodexHookInstaller.preferredCodexHooksFeatureKey(fromVersionOutput: "codex-cli 0.130.0") == .current)
         #expect(CodexHookInstaller.preferredCodexHooksFeatureKey(fromVersionOutput: "codex-cli 0.129.0") == .legacy)
+        #expect(CodexHookInstaller.preferredCodexHooksFeatureKey(fromFeatureList: "shell_tool stable true") == nil)
+        #expect(CodexHookInstaller.preferredCodexHooksFeatureKey(fromVersionOutput: "not a version") == nil)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #549. Related to #460.

This updates the Codex hook installer so newer Codex installs keep using the canonical `[features].hooks = true` flag even when a stale global `codex` executable prevents feature detection from completing.

Changes:

- Add the Codex.app bundled CLI path, `/Applications/Codex.app/Contents/Resources/codex`, to the feature-detection candidates.
- Default to the current `hooks` feature key when detection fails, instead of falling back to deprecated `codex_hooks`.
- Add parser coverage for unrecognized feature/version output returning `nil`.

## Why

On a local affected machine, `/opt/homebrew/bin/codex` was a stale wrapper that failed with a missing vendored binary, while Codex.app's bundled CLI worked and advertised `hooks stable true`. Open Island therefore installed hooks successfully but left `~/.codex/config.toml` with the deprecated legacy flag:

```toml
[features]
codex_hooks = true
```

Switching the config to:

```toml
[features]
hooks = true
```

and reviewing hooks with `/hooks` restored Open Island hook behavior.

## Verification

- `swift build --target OpenIslandCore`
- Built release `OpenIslandHooks` and `OpenIslandSetup`, installed them locally, and verified:
  - `OpenIslandSetup status` reports `Feature flag enabled: yes` and `Managed hooks present: yes`.
  - Installed `OpenIslandHooks` can process a representative Codex `SessionStart` payload without decode/runtime errors.

Note: `swift test --filter codexHookInstallerDetectsPreferredFeatureFlagFromCodexOutput` could not complete in this local environment because the command-line test build reports `no such module 'Testing'`, which appears unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default to the current Codex feature flag when configuration can’t be determined, reducing incorrect legacy fallbacks.
  * Improved detection of Codex installations by checking additional bundled and standard locations so embedded installs are recognized reliably.

* **Tests**
  * Added tests covering malformed feature-list and non-version CLI outputs to ensure robust behavior with invalid tool output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
