### PR TITLE
feat: add Codex SSH remote setup

### DIFF
--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -346,6 +346,14 @@ extension AgentSession {
             && referenceDate.timeIntervalSince(islandActivityDate) >= threshold
     }
 
+    func isHiddenIdleIslandSession(
+        at referenceDate: Date,
+        threshold: TimeInterval = Self.staleCompletedDisplayThreshold
+    ) -> Bool {
+        phase == .completed
+            && isStaleCompletedForIsland(at: referenceDate, threshold: threshold)
+    }
+
     private var spotlightRunningActivityText: String? {
         guard let currentTool = currentToolName?.trimmedForSurface,
               !currentTool.isEmpty else {

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1679,6 +1679,7 @@ final class AppModel {
 
         for session in rankedSessions where session.isVisibleInIsland {
             guard !session.isSubagentSession else { continue }
+            guard !session.isHiddenIdleIslandSession(at: now, threshold: completedStaleThreshold.seconds) else { continue }
 
             if let liveAttachmentKey = monitoring.liveAttachmentKey(for: session) {
                 guard claimedLiveAttachmentKeys.insert(liveAttachmentKey).inserted else {

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1527,7 +1527,8 @@ final class AppModel {
             scheduleNotificationSurfacePresentationIfNeeded(
                 surface,
                 wasAlreadyCompleted: wasAlreadyCompleted,
-                ingress: ingress
+                ingress: ingress,
+                bypassFrontmostSuppression: event.isRunningActivityUpdate
             )
         }
     }
@@ -1535,7 +1536,8 @@ final class AppModel {
     private func scheduleNotificationSurfacePresentationIfNeeded(
         _ surface: IslandSurface,
         wasAlreadyCompleted: Bool,
-        ingress: TrackedEventIngress
+        ingress: TrackedEventIngress,
+        bypassFrontmostSuppression: Bool = false
     ) {
         guard !wasAlreadyCompleted,
               notificationSurfaceIsEligibleForPresentation(surface, ingress: ingress),
@@ -1544,7 +1546,7 @@ final class AppModel {
             return
         }
 
-        guard suppressFrontmostNotifications else {
+        guard suppressFrontmostNotifications, !bypassFrontmostSuppression else {
             presentNotificationSurface(surface)
             return
         }
@@ -1799,6 +1801,15 @@ final class AppModel {
         NSApplication.shared.terminate(nil)
     }
 
+}
+
+private extension AgentEvent {
+    var isRunningActivityUpdate: Bool {
+        guard case let .activityUpdated(payload) = self else {
+            return false
+        }
+        return payload.phase == .running
+    }
 }
 
 // MARK: - Hex color helpers

--- a/Sources/OpenIslandApp/IslandSurface.swift
+++ b/Sources/OpenIslandApp/IslandSurface.swift
@@ -22,6 +22,8 @@ enum IslandSurface: Equatable {
 
     static func notificationSurface(for event: AgentEvent) -> IslandSurface? {
         switch event {
+        case let .activityUpdated(payload) where payload.phase == .running:
+            .sessionList(actionableSessionID: payload.sessionID)
         case let .permissionRequested(payload):
             .sessionList(actionableSessionID: payload.sessionID)
         case let .questionAsked(payload):
@@ -50,7 +52,7 @@ enum IslandSurface: Equatable {
         case .completed:
             return true
         case .running:
-            return false
+            return true
         }
     }
 }

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1207,6 +1207,7 @@ private struct IslandSessionRow: View {
     @State private var isHighlighted = false
     @State private var detailOverride: Bool?
     @State private var replyText: String = ""
+    @State private var isShowingFullReply = false
 
     var body: some View {
         rowBody(referenceDate: referenceDate)
@@ -1322,13 +1323,33 @@ private struct IslandSessionRow: View {
     private func rowAuxiliaryDetails(presence: IslandSessionPresence) -> some View {
         if !shouldShowEmbeddedDetailBody,
            let activityLine = session.spotlightActivityLineText ?? expandedActivityLineText {
-            Text(activityLine)
-                .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(activityColor(for: presence).opacity(0.94))
-                .lineLimit(2)
-                .padding(.leading, detailLeadingInset)
-                .padding(.trailing, sideInset)
-                .padding(.bottom, 10)
+            Button {
+                guard isInteractive, fullReplyMessageText != nil else { return }
+                isShowingFullReply = true
+            } label: {
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Text(activityLine)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(activityColor(for: presence).opacity(0.94))
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+
+                    if fullReplyMessageText != nil {
+                        Image(systemName: "doc.text.magnifyingglass")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(.white.opacity(0.42))
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .buttonStyle(.plain)
+            .disabled(fullReplyMessageText == nil)
+            .popover(isPresented: $isShowingFullReply, arrowEdge: .top) {
+                fullReplyPopover
+            }
+            .padding(.leading, detailLeadingInset)
+            .padding(.trailing, sideInset)
+            .padding(.bottom, 10)
         }
 
         if let subagents = session.claudeMetadata?.activeSubagents,
@@ -1802,6 +1823,51 @@ private struct IslandSessionRow: View {
         }
         let summary = session.summary.trimmedForNotificationCard
         return summary == SessionPhase.completed.displayName ? "" : summary
+    }
+
+    private var fullReplyMessageText: String? {
+        if let text = session.completionAssistantMessageText?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !text.isEmpty {
+            return text
+        }
+
+        let summary = session.summary.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !summary.isEmpty, summary != SessionPhase.completed.displayName else { return nil }
+        return summary
+    }
+
+    private var fullReplyPopover: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 8) {
+                Text(session.tool.displayName)
+                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(.white.opacity(0.56))
+                Spacer(minLength: 0)
+                Button {
+                    isShowingFullReply = false
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.45))
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+
+            Divider().overlay(.white.opacity(0.08))
+
+            ScrollView(.vertical) {
+                Markdown(fullReplyMessageText ?? "")
+                    .markdownTheme(.completionCard)
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
+                    .padding(14)
+            }
+            .frame(width: 420, height: 320)
+        }
+        .background(V6Palette.ink)
+        .preferredColorScheme(.dark)
     }
 
     private var commandLabel: String {

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -523,6 +523,21 @@ public final class BridgeServer: @unchecked Sendable {
 
             let command = payload.commandPreview ?? "Bash command"
 
+            if payload.openIslandNotifyOnly == true {
+                emit(
+                    .activityUpdated(
+                        SessionActivityUpdated(
+                            sessionID: payload.sessionID,
+                            summary: "Running: \(command)",
+                            phase: .running,
+                            timestamp: .now
+                        )
+                    )
+                )
+                send(.response(.acknowledged), to: clientID)
+                return
+            }
+
             let approvalEvent = AgentEvent.permissionRequested(
                 PermissionRequested(
                     sessionID: payload.sessionID,

--- a/Sources/OpenIslandCore/CodexHooks.swift
+++ b/Sources/OpenIslandCore/CodexHooks.swift
@@ -141,6 +141,7 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
     public var prompt: String?
     public var stopHookActive: Bool?
     public var lastAssistantMessage: String?
+    public var openIslandNotifyOnly: Bool?
 
     private enum CodingKeys: String, CodingKey {
         case cwd
@@ -163,6 +164,7 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
         case prompt
         case stopHookActive = "stop_hook_active"
         case lastAssistantMessage = "last_assistant_message"
+        case openIslandNotifyOnly = "open_island_notify_only"
     }
 
     public init(
@@ -185,7 +187,8 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
         toolResponse: CodexHookJSONValue? = nil,
         prompt: String? = nil,
         stopHookActive: Bool? = nil,
-        lastAssistantMessage: String? = nil
+        lastAssistantMessage: String? = nil,
+        openIslandNotifyOnly: Bool? = nil
     ) {
         self.cwd = cwd
         self.hookEventName = hookEventName
@@ -207,6 +210,7 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
         self.prompt = prompt
         self.stopHookActive = stopHookActive
         self.lastAssistantMessage = lastAssistantMessage
+        self.openIslandNotifyOnly = openIslandNotifyOnly
     }
 
     public init(from decoder: any Decoder) throws {
@@ -231,6 +235,7 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
         prompt = try container.decodeIfPresent(String.self, forKey: .prompt)
         stopHookActive = try container.decodeIfPresent(Bool.self, forKey: .stopHookActive)
         lastAssistantMessage = try container.decodeIfPresent(String.self, forKey: .lastAssistantMessage)
+        openIslandNotifyOnly = try container.decodeIfPresent(Bool.self, forKey: .openIslandNotifyOnly)
     }
 }
 

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -477,6 +477,46 @@ struct AppModelSessionListTests {
     }
 
     @Test
+    func bridgeRunningActivityPresentsPersistentNotificationSurface() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let model = AppModel()
+        model.notchStatus = .closed
+        model.notchOpenReason = nil
+        model.state = SessionState(
+            sessions: [
+                AgentSession(
+                    id: "remote-codex",
+                    title: "Codex · wins",
+                    tool: .codex,
+                    origin: .live,
+                    attachmentState: .attached,
+                    phase: .completed,
+                    summary: "Ready",
+                    updatedAt: now
+                ),
+            ]
+        )
+
+        model.applyTrackedEvent(
+            .activityUpdated(
+                SessionActivityUpdated(
+                    sessionID: "remote-codex",
+                    summary: "Running: pwd",
+                    phase: .running,
+                    timestamp: now.addingTimeInterval(1)
+                )
+            ),
+            updateLastActionMessage: false,
+            ingress: .bridge
+        )
+
+        #expect(model.notchStatus == .opened)
+        #expect(model.notchOpenReason == .notification)
+        #expect(model.islandSurface == .sessionList(actionableSessionID: "remote-codex"))
+        #expect(!model.hasPendingNotificationAutoCollapse)
+    }
+
+    @Test
     func rolloutCompletionDoesNotPresentNotificationDuringColdStart() {
         let now = Date(timeIntervalSince1970: 2_000)
         let model = AppModel()

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -212,7 +212,7 @@ struct AppModelSessionListTests {
     }
 
     @Test
-    func freshCompletedSessionsSortAheadOfV8StaleCompletedSessions() {
+    func islandListHidesStaleCompletedSessions() {
         let now = Date()
         let model = AppModel()
 
@@ -256,11 +256,12 @@ struct AppModelSessionListTests {
 
         model.state = SessionState(sessions: [staleCompleted, freshCompleted])
 
-        #expect(model.islandListSessions.map(\.id) == ["fresh-completed", "stale-completed"])
+        #expect(model.islandListSessions.map(\.id) == ["fresh-completed"])
+        #expect(model.recentSessions.map(\.id).contains("stale-completed"))
     }
 
     @Test
-    func islandSessionSectionsGroupStaleCompletedIntoIdle() {
+    func islandSessionSectionsHideStaleCompletedSessions() {
         let now = Date()
         let model = AppModel()
         model.islandSessionGroup = .state
@@ -281,8 +282,9 @@ struct AppModelSessionListTests {
 
         model.state = SessionState(sessions: [stale, done, approval])
 
-        #expect(model.islandSessionSections.map(\.id) == ["state-approval", "state-done", "state-idle"])
-        #expect(model.islandSessionSections.map(\.sessions.first?.id) == ["approval", "done", "stale"])
+        #expect(model.islandSessionSections.map(\.id) == ["state-approval", "state-done"])
+        #expect(model.islandSessionSections.map(\.sessions.first?.id) == ["approval", "done"])
+        #expect(model.recentSessions.map(\.id).contains("stale"))
     }
 
     @Test

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -528,6 +528,45 @@ struct SessionStateTests {
     }
 
     @Test
+    func codexNotifyOnlyPreToolUseUpdatesActivityWithoutWaitingForApproval() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let payload = CodexHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .preToolUse,
+            model: "gpt-5-codex",
+            permissionMode: .default,
+            sessionID: "codex-notify-only",
+            transcriptPath: nil,
+            turnID: "turn-1",
+            toolName: "Bash",
+            toolUseID: "tool-use-1",
+            toolInput: CodexHookToolInput(command: "swift test"),
+            openIslandNotifyOnly: true
+        )
+
+        async let responseTask = sendOnGCDThread(.processCodexHook(payload), socketURL: socketURL)
+
+        var iterator = stream.makeAsyncIterator()
+        let startedEvent = try await nextEvent(from: &iterator)
+        let activityEvent = try await nextEvent(from: &iterator)
+        let response = try await responseTask
+
+        #expect(startedEvent.isSessionStarted)
+        #expect(activityEvent.activityUpdate?.summary == "Running: swift test")
+        #expect(activityEvent.activityUpdate?.phase == .running)
+        #expect(response == .acknowledged)
+    }
+
+    @Test
     func codexPermissionRequestReturnsAllowDirectiveAfterApproval() async throws {
         let socketURL = BridgeSocketLocation.uniqueTestURL()
         let server = BridgeServer(socketURL: socketURL)

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ This index is the repository map for humans and coding agents. Read these files 
 
 ## Remote / SSH
 
-- [docs/ssh-setup.md](./ssh-setup.md) for connecting Open Island to Claude Code running on remote servers via SSH socket forwarding
+- [docs/ssh-setup.md](./ssh-setup.md) for connecting Open Island to Claude Code or Codex CLI running on remote servers via SSH socket forwarding
 
 ## Release
 

--- a/docs/ssh-setup.md
+++ b/docs/ssh-setup.md
@@ -126,6 +126,28 @@ Edit `~/.codex/hooks.json` on the remote server:
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-1000.sock OPEN_ISLAND_NOTIFY_ONLY=1 OPEN_ISLAND_NOTIFY_TIMEOUT=2 python3 ~/.local/bin/open-island-hooks.py --source codex",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-1000.sock OPEN_ISLAND_NOTIFY_ONLY=1 OPEN_ISLAND_NOTIFY_TIMEOUT=2 python3 ~/.local/bin/open-island-hooks.py --source codex",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/docs/ssh-setup.md
+++ b/docs/ssh-setup.md
@@ -1,6 +1,6 @@
-# SSH Remote Claude Code Setup
+# SSH Remote Agent Setup
 
-Connect Open Island to Claude Code running on a remote server over SSH.
+Connect Open Island to Claude Code or Codex CLI running on a remote server over SSH.
 
 ## How it works
 
@@ -14,7 +14,8 @@ macOS (local)                         Remote server
                                    │  hooks.py          │
                                    │        ▲           │
                                    │        │           │
-                                   │  Claude Code       │
+                                   │  Claude Code /     │
+                                   │  Codex CLI         │
                                    └────────────────────┘
 ```
 
@@ -25,11 +26,11 @@ SSH's `RemoteForward` tunnels the Unix socket from your Mac to the remote server
 - Open Island running on your Mac
 - SSH access to the remote server
 - Python 3.6+ on the remote server
-- Claude Code installed on the remote server
+- Claude Code or Codex CLI installed on the remote server
 
 ## Quick setup
 
-Run the automated setup script:
+For Claude Code, run:
 
 ```bash
 ./scripts/remote-setup.sh user@myserver
@@ -40,6 +41,20 @@ This will:
 2. Configure Claude Code hooks in `~/.claude/settings.json` on the remote
 3. Print the SSH config snippet you need
 
+For Codex CLI, run:
+
+```bash
+./scripts/remote-setup-codex.sh user@myserver
+```
+
+This will:
+1. Copy `open-island-hooks.py` to the remote server (`~/.local/bin/`)
+2. Configure Codex hooks in `~/.codex/hooks.json` on the remote
+3. Enable `[features].hooks = true` in `~/.codex/config.toml`
+4. Print the SSH config snippet you need
+
+After installing Codex hooks, open `/hooks` inside Codex CLI on the remote and approve the Open Island hook entries if Codex asks for trust review.
+
 ## Manual setup
 
 ### 1. Deploy the hook script
@@ -49,7 +64,7 @@ scp scripts/open-island-hooks.py user@myserver:~/.local/bin/
 ssh user@myserver chmod +x ~/.local/bin/open-island-hooks.py
 ```
 
-### 2. Configure Claude Code hooks on the remote
+### 2a. Configure Claude Code hooks on the remote
 
 Edit `~/.claude/settings.json` on the remote server:
 
@@ -70,6 +85,93 @@ Edit `~/.claude/settings.json` on the remote server:
 }
 ```
 
+### 2b. Configure Codex CLI hooks on the remote
+
+Edit `~/.codex/hooks.json` on the remote server:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-1000.sock python3 ~/.local/bin/open-island-hooks.py --source codex",
+            "timeout": 45
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-1000.sock python3 ~/.local/bin/open-island-hooks.py --source codex",
+            "timeout": 45
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-1000.sock python3 ~/.local/bin/open-island-hooks.py --source codex",
+            "timeout": 3600
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-1000.sock python3 ~/.local/bin/open-island-hooks.py --source codex",
+            "timeout": 45
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-1000.sock python3 ~/.local/bin/open-island-hooks.py --source codex",
+            "timeout": 45
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-1000.sock python3 ~/.local/bin/open-island-hooks.py --source codex",
+            "timeout": 45
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Replace `1000` with the remote user's UID (`ssh user@myserver id -u`) and make sure `[features].hooks = true` is present in `~/.codex/config.toml`:
+
+```toml
+[features]
+hooks = true
+```
+
+Codex may require a manual trust review before running new hooks. Open `/hooks` inside Codex CLI and approve the Open Island entries.
+
 ### 3. Configure SSH socket forwarding
 
 Add to your local `~/.ssh/config`:
@@ -78,22 +180,22 @@ Add to your local `~/.ssh/config`:
 Host myserver
     HostName myserver.example.com
     User youruser
-    RemoteForward /tmp/open-island-501.sock /tmp/open-island-501.sock
+    RemoteForward /tmp/open-island-1000.sock /tmp/open-island-501.sock
 ```
 
-Replace `501` with your local UID (`id -u`).
+Replace `501` with your local UID (`id -u`) and `1000` with your remote UID (`ssh myserver id -u`).
 
 Or connect directly with:
 
 ```bash
-ssh -R /tmp/open-island-$(id -u).sock:/tmp/open-island-$(id -u).sock user@myserver
+ssh -R /tmp/open-island-<remote-uid>.sock:/tmp/open-island-<local-uid>.sock user@myserver
 ```
 
 ### 4. Verify
 
 1. Make sure Open Island is running on your Mac
 2. SSH to the remote with socket forwarding enabled
-3. Run Claude Code on the remote — sessions should appear in the Open Island overlay
+3. Run Claude Code or Codex CLI on the remote — sessions should appear in the Open Island overlay
 
 ## Important: sshd configuration
 

--- a/docs/ssh-setup.md
+++ b/docs/ssh-setup.md
@@ -126,28 +126,6 @@ Edit `~/.codex/hooks.json` on the remote server:
         ]
       }
     ],
-    "PreToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-1000.sock python3 ~/.local/bin/open-island-hooks.py --source codex",
-            "timeout": 45
-          }
-        ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-1000.sock python3 ~/.local/bin/open-island-hooks.py --source codex",
-            "timeout": 45
-          }
-        ]
-      }
-    ],
     "Stop": [
       {
         "hooks": [

--- a/scripts/open-island-hooks.py
+++ b/scripts/open-island-hooks.py
@@ -205,6 +205,16 @@ def encode_codex_stdout(response):
         output = {"decision": "block", "reason": directive.get("reason", "")}
         return json.dumps(output, sort_keys=True) + "\n"
 
+    if dtype == "permissionRequest":
+        output = {
+            "continue": True,
+            "hookSpecificOutput": {
+                "hookEventName": "PermissionRequest",
+                "decision": directive.get("decision", {}),
+            },
+        }
+        return json.dumps(output, sort_keys=True) + "\n"
+
     return None
 
 
@@ -269,7 +279,7 @@ def main():
             encoder = encode_opencode_stdout
         else:
             command = {"type": "processCodexHook", "codexHook": payload}
-            timeout = 45
+            timeout = 3600 if payload.get("hook_event_name") == "PermissionRequest" else 45
             encoder = encode_codex_stdout
 
         envelope = json.dumps({"type": "command", "command": command})

--- a/scripts/open-island-hooks.py
+++ b/scripts/open-island-hooks.py
@@ -125,7 +125,12 @@ def enrich_payload(payload, env):
 # Bridge socket communication
 # ---------------------------------------------------------------------------
 
-def send_command(envelope_json, timeout):
+def env_flag(env, name):
+    """Return whether an environment flag is enabled."""
+    return (env.get(name) or "").lower() in ("1", "true", "yes", "on")
+
+
+def send_command(envelope_json, timeout, wait_response=True):
     """Connect to bridge socket, send JSON line, return parsed response."""
     path = socket_path()
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -133,6 +138,8 @@ def send_command(envelope_json, timeout):
     try:
         sock.connect(path)
         sock.sendall(envelope_json.encode("utf-8") + b"\n")
+        if not wait_response:
+            return None
 
         buf = b""
         while True:
@@ -272,6 +279,9 @@ def main():
 
         # Mark as remote so the UI can distinguish SSH sessions.
         payload["remote"] = True
+        notify_only = env_flag(env, "OPEN_ISLAND_NOTIFY_ONLY")
+        if notify_only:
+            payload["open_island_notify_only"] = True
 
         # Build bridge envelope
         if source == "claude":
@@ -289,7 +299,10 @@ def main():
 
         envelope = json.dumps({"type": "command", "command": command})
 
-        response = send_command(envelope, timeout)
+        if notify_only:
+            timeout = int(env.get("OPEN_ISLAND_NOTIFY_TIMEOUT", "2"))
+
+        response = send_command(envelope, timeout, wait_response=not notify_only)
         if response is None:
             return
 

--- a/scripts/open-island-hooks.py
+++ b/scripts/open-island-hooks.py
@@ -22,6 +22,7 @@ import sys
 # ---------------------------------------------------------------------------
 
 def socket_path():
+    """Return the Unix socket path used to reach the local Open Island bridge."""
     path = os.environ.get("OPEN_ISLAND_SOCKET_PATH") or \
            os.environ.get("VIBE_ISLAND_SOCKET_PATH")
     if path:
@@ -33,6 +34,7 @@ def socket_path():
 # ---------------------------------------------------------------------------
 
 def infer_terminal_app(env):
+    """Infer the terminal app from environment variables available on the remote."""
     if env.get("ITERM_SESSION_ID") or env.get("LC_TERMINAL") == "iTerm2":
         return "iTerm"
     if env.get("CMUX_WORKSPACE_ID") or env.get("CMUX_SOCKET_PATH"):
@@ -54,6 +56,7 @@ def infer_terminal_app(env):
 
 
 def current_tty():
+    """Best-effort TTY detection for Linux and macOS remote hook processes."""
     # Try /proc (Linux) first — no subprocess needed.
     try:
         tty = os.ttyname(0)
@@ -244,6 +247,7 @@ def encode_opencode_stdout(response):
 # ---------------------------------------------------------------------------
 
 def parse_source(args):
+    """Parse the hook source from command-line arguments."""
     i = 0
     while i < len(args):
         if args[i] == "--source" and i + 1 < len(args):
@@ -253,6 +257,7 @@ def parse_source(args):
 
 
 def main():
+    """Read a hook payload from stdin, forward it to the bridge, and emit a directive."""
     try:
         raw = sys.stdin.buffer.read()
         if not raw:

--- a/scripts/remote-setup-codex.sh
+++ b/scripts/remote-setup-codex.sh
@@ -57,8 +57,6 @@ event_specs = {
     "SessionStart": {"matcher": "startup|resume", "timeout": 45},
     "UserPromptSubmit": {"matcher": None, "timeout": 45},
     "PermissionRequest": {"matcher": None, "timeout": 3600},
-    "PreToolUse": {"matcher": None, "timeout": 45},
-    "PostToolUse": {"matcher": None, "timeout": 45},
     "Stop": {"matcher": None, "timeout": 45},
 }
 

--- a/scripts/remote-setup-codex.sh
+++ b/scripts/remote-setup-codex.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+#
+# Open Island — remote SSH setup for Codex CLI
+#
+# Deploys the portable Python hook client to a remote server and configures
+# Codex CLI to use it. Also prints the SSH config snippet needed for Unix
+# socket forwarding.
+#
+# Usage:
+#   ./scripts/remote-setup-codex.sh user@host
+#
+# Prerequisites:
+#   - SSH access to the remote host
+#   - Python 3.6+ on the remote host
+#   - Codex CLI installed on the remote host
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK_SCRIPT="$SCRIPT_DIR/open-island-hooks.py"
+REMOTE_BIN_DIR=".local/bin"
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 user@host"
+    exit 1
+fi
+
+REMOTE="$1"
+LOCAL_UID="$(id -u)"
+REMOTE_UID="$(ssh "$REMOTE" "id -u")"
+LOCAL_SOCKET_NAME="open-island-${LOCAL_UID}.sock"
+REMOTE_SOCKET_NAME="open-island-${REMOTE_UID}.sock"
+
+echo "==> Deploying open-island-hooks.py to $REMOTE ..."
+ssh "$REMOTE" "mkdir -p ~/$REMOTE_BIN_DIR"
+scp "$HOOK_SCRIPT" "$REMOTE:~/$REMOTE_BIN_DIR/open-island-hooks.py"
+ssh "$REMOTE" "chmod +x ~/$REMOTE_BIN_DIR/open-island-hooks.py"
+
+echo ""
+echo "==> Configuring Codex hooks on $REMOTE ..."
+ssh "$REMOTE" "OPEN_ISLAND_REMOTE_SOCKET=/tmp/$REMOTE_SOCKET_NAME python3 -" <<'PY'
+import json
+import os
+from pathlib import Path
+
+socket_path = os.environ["OPEN_ISLAND_REMOTE_SOCKET"]
+hook_cmd = (
+    f"OPEN_ISLAND_SOCKET_PATH={socket_path} "
+    "python3 ~/.local/bin/open-island-hooks.py --source codex"
+)
+
+event_specs = {
+    "SessionStart": {"matcher": "startup|resume", "timeout": 45},
+    "UserPromptSubmit": {"matcher": None, "timeout": 45},
+    "PermissionRequest": {"matcher": None, "timeout": 3600},
+    "PreToolUse": {"matcher": None, "timeout": 45},
+    "PostToolUse": {"matcher": None, "timeout": 45},
+    "Stop": {"matcher": None, "timeout": 45},
+}
+
+hooks_path = Path.home() / ".codex" / "hooks.json"
+hooks_path.parent.mkdir(parents=True, exist_ok=True)
+
+root = {}
+if hooks_path.exists():
+    with hooks_path.open() as f:
+        root = json.load(f)
+
+hooks = root.get("hooks")
+if not isinstance(hooks, dict):
+    hooks = {}
+
+
+def group_for(spec):
+    group = {
+        "hooks": [{
+            "type": "command",
+            "command": hook_cmd,
+            "timeout": spec["timeout"],
+        }]
+    }
+    if spec["matcher"]:
+        group["matcher"] = spec["matcher"]
+    return group
+
+
+def group_contains_command(group, command):
+    nested = group.get("hooks")
+    if not isinstance(nested, list):
+        return False
+    return any(isinstance(hook, dict) and hook.get("command") == command for hook in nested)
+
+
+for event, spec in event_specs.items():
+    existing_groups = hooks.get(event, [])
+    if not isinstance(existing_groups, list):
+        existing_groups = []
+
+    cleaned_groups = [
+        group
+        for group in existing_groups
+        if isinstance(group, dict) and not group_contains_command(group, hook_cmd)
+    ]
+    cleaned_groups.append(group_for(spec))
+    hooks[event] = cleaned_groups
+
+root["hooks"] = hooks
+with hooks_path.open("w") as f:
+    json.dump(root, f, indent=2)
+    f.write("\n")
+
+print(f"Updated {hooks_path}")
+PY
+
+echo ""
+echo "==> Enabling Codex hooks feature flag on $REMOTE ..."
+ssh "$REMOTE" "python3 -" <<'PY'
+from pathlib import Path
+
+config_path = Path.home() / ".codex" / "config.toml"
+config_path.parent.mkdir(parents=True, exist_ok=True)
+text = config_path.read_text() if config_path.exists() else ""
+lines = text.splitlines()
+out = []
+in_features = False
+has_features = False
+has_hooks = False
+
+for line in lines:
+    stripped = line.strip()
+    if stripped == "[features]":
+        in_features = True
+        has_features = True
+        out.append(line)
+        continue
+
+    if in_features and stripped.startswith("[") and stripped.endswith("]"):
+        if not has_hooks:
+            out.append("hooks = true")
+            has_hooks = True
+        in_features = False
+        out.append(line)
+        continue
+
+    if in_features and stripped.startswith("codex_hooks"):
+        continue
+
+    if in_features and stripped.startswith("hooks"):
+        out.append("hooks = true")
+        has_hooks = True
+        continue
+
+    out.append(line)
+
+if not has_features:
+    if out and out[-1] != "":
+        out.append("")
+    out.extend(["[features]", "hooks = true"])
+elif in_features and not has_hooks:
+    out.append("hooks = true")
+
+config_path.write_text("\n".join(out) + "\n")
+print(f"Updated {config_path}")
+PY
+
+echo ""
+echo "==> Done!"
+echo ""
+echo "IMPORTANT: Ensure the remote sshd has 'StreamLocalBindUnlink yes' in"
+echo "/etc/ssh/sshd_config — otherwise reconnecting can fail with"
+echo "'Address already in use' when the old socket file is still on disk."
+echo ""
+echo "Add the following to your local ~/.ssh/config to enable socket forwarding:"
+echo ""
+echo "  Host ${REMOTE##*@}"
+echo "      RemoteForward /tmp/$REMOTE_SOCKET_NAME /tmp/$LOCAL_SOCKET_NAME"
+echo ""
+echo "Or connect directly with:"
+echo ""
+echo "  ssh -R /tmp/$REMOTE_SOCKET_NAME:/tmp/$LOCAL_SOCKET_NAME $REMOTE"
+echo ""
+echo "After connecting, run Codex on the remote. If Codex asks for hook trust,"
+echo "open /hooks inside Codex CLI and approve the Open Island entries."

--- a/scripts/remote-setup-codex.sh
+++ b/scripts/remote-setup-codex.sh
@@ -27,7 +27,11 @@ fi
 
 REMOTE="$1"
 LOCAL_UID="$(id -u)"
-REMOTE_UID="$(ssh "$REMOTE" "id -u")"
+REMOTE_UID="$(ssh "$REMOTE" "id -u" | tr -d '\r' | awk 'NR==1{print $1}')"
+if ! [[ "$REMOTE_UID" =~ ^[0-9]+$ ]]; then
+    echo "Failed to resolve numeric remote UID from '$REMOTE' (got: '$REMOTE_UID')." >&2
+    exit 1
+fi
 LOCAL_SOCKET_NAME="open-island-${LOCAL_UID}.sock"
 REMOTE_SOCKET_NAME="open-island-${REMOTE_UID}.sock"
 
@@ -145,10 +149,12 @@ for line in lines:
     if in_features and stripped.startswith("codex_hooks"):
         continue
 
-    if in_features and stripped.startswith("hooks"):
-        out.append("hooks = true")
-        has_hooks = True
-        continue
+    if in_features:
+        key = stripped.split("=", 1)[0].strip() if "=" in stripped else ""
+        if key == "hooks":
+            out.append("hooks = true")
+            has_hooks = True
+            continue
 
     out.append(line)
 

--- a/scripts/remote-setup-codex.sh
+++ b/scripts/remote-setup-codex.sh
@@ -52,12 +52,20 @@ hook_cmd = (
     f"OPEN_ISLAND_SOCKET_PATH={socket_path} "
     "python3 ~/.local/bin/open-island-hooks.py --source codex"
 )
+notify_hook_cmd = (
+    f"OPEN_ISLAND_SOCKET_PATH={socket_path} "
+    "OPEN_ISLAND_NOTIFY_ONLY=1 "
+    "OPEN_ISLAND_NOTIFY_TIMEOUT=2 "
+    "python3 ~/.local/bin/open-island-hooks.py --source codex"
+)
 
 event_specs = {
-    "SessionStart": {"matcher": "startup|resume", "timeout": 45},
-    "UserPromptSubmit": {"matcher": None, "timeout": 45},
-    "PermissionRequest": {"matcher": None, "timeout": 3600},
-    "Stop": {"matcher": None, "timeout": 45},
+    "SessionStart": {"matcher": "startup|resume", "timeout": 45, "command": hook_cmd},
+    "UserPromptSubmit": {"matcher": None, "timeout": 45, "command": hook_cmd},
+    "PermissionRequest": {"matcher": None, "timeout": 3600, "command": hook_cmd},
+    "PreToolUse": {"matcher": None, "timeout": 5, "command": notify_hook_cmd},
+    "PostToolUse": {"matcher": None, "timeout": 5, "command": notify_hook_cmd},
+    "Stop": {"matcher": None, "timeout": 45, "command": hook_cmd},
 }
 
 hooks_path = Path.home() / ".codex" / "hooks.json"
@@ -78,7 +86,7 @@ def group_for(spec):
     group = {
         "hooks": [{
             "type": "command",
-            "command": hook_cmd,
+            "command": spec["command"],
             "timeout": spec["timeout"],
         }]
     }
@@ -103,7 +111,9 @@ for event, spec in event_specs.items():
     cleaned_groups = [
         group
         for group in existing_groups
-        if isinstance(group, dict) and not group_contains_command(group, hook_cmd)
+        if isinstance(group, dict)
+        and not group_contains_command(group, hook_cmd)
+        and not group_contains_command(group, notify_hook_cmd)
     ]
     cleaned_groups.append(group_for(spec))
     hooks[event] = cleaned_groups

--- a/scripts/remote-setup-codex.sh
+++ b/scripts/remote-setup-codex.sh
@@ -76,6 +76,7 @@ if not isinstance(hooks, dict):
 
 
 def group_for(spec):
+    """Build one Codex hook matcher group for the managed Open Island command."""
     group = {
         "hooks": [{
             "type": "command",
@@ -89,6 +90,7 @@ def group_for(spec):
 
 
 def group_contains_command(group, command):
+    """Return whether a Codex hook group already contains the given command."""
     nested = group.get("hooks")
     if not isinstance(nested, list):
         return False


### PR DESCRIPTION
## Summary
- add a Codex-specific SSH remote setup script that deploys the portable Python hook client and configures ~/.codex/hooks.json
- enable the Codex hooks feature flag in remote ~/.codex/config.toml during setup
- extend the remote Python hook client to return Codex PermissionRequest decisions and wait for remote approvals
- update SSH docs to cover both Claude Code and Codex CLI remote setup

## Verification
- bash -n scripts/remote-setup-codex.sh
- python3 -m py_compile scripts/open-island-hooks.py

## Notes
- The setup script preserves existing Codex hook groups and only de-duplicates the Open Island command it manages.
- Codex may still require users to open /hooks and approve the new hook entries before they run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support Codex CLI as an alternative to Claude Code for remote SSH workflows.
  * Added automated remote setup for deploying hooks and configuring SSH socket forwarding.
  * New “notify-only” mode: remote tool invocations can show running activity without awaiting approval.

* **UI**
  * Full-reply popover to view expanded assistant responses.
  * Stale completed sessions are hidden from the main island list.

* **Documentation**
  * Updated setup guides and diagrams to cover Claude Code / Codex CLI, UID-mapped SSH forwarding, and verification steps.

* **Tests**
  * Added coverage for notify-only hook behavior and session filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->