### PR TITLE
fix: reduce idle cpu usage

### DIFF
--- a/Sources/OpenIslandApp/AppModelTypes.swift
+++ b/Sources/OpenIslandApp/AppModelTypes.swift
@@ -77,6 +77,11 @@ enum IslandSessionStateIndicator: String, CaseIterable, Identifiable, Sendable {
     case tint
 
     var id: String { rawValue }
+
+    func timelineInterval(presence: IslandSessionPresence, isActionable: Bool) -> TimeInterval? {
+        guard self == .animatedDot else { return nil }
+        return presence == .running || isActionable ? 1.0 / 15.0 : nil
+    }
 }
 
 enum IslandSessionGroup: String, CaseIterable, Identifiable, Sendable {

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -45,6 +45,7 @@ final class ProcessMonitoringCoordinator {
     private var wasCodexAppRunning = false
 
     private static let startupPollInterval: TimeInterval = 2
+    private static let codexAppRunningProbeInterval: TimeInterval = 2
     private static let activePollInterval: TimeInterval = 60
     private static let idlePollInterval: TimeInterval = 300
     private static let cursorStalenessTimeout: TimeInterval = 600  // 10 minutes
@@ -58,6 +59,35 @@ final class ProcessMonitoringCoordinator {
         }
 
         return hasTrackedLiveSessions ? activePollInterval : idlePollInterval
+    }
+
+    static func monitoringWakeInterval(
+        isResolvingInitialLiveSessions: Bool,
+        hasTrackedLiveSessions: Bool
+    ) -> TimeInterval {
+        min(
+            codexAppRunningProbeInterval,
+            monitoringPollInterval(
+                isResolvingInitialLiveSessions: isResolvingInitialLiveSessions,
+                hasTrackedLiveSessions: hasTrackedLiveSessions
+            )
+        )
+    }
+
+    static func shouldPerformFullMonitorReconcile(
+        now: Date,
+        nextFullReconcileAt: Date,
+        isResolvingInitialLiveSessions: Bool,
+        hasTrackedLiveSessions: Bool,
+        hadTrackedLiveSessions: Bool
+    ) -> Bool {
+        if isResolvingInitialLiveSessions {
+            return true
+        }
+        if hasTrackedLiveSessions, !hadTrackedLiveSessions {
+            return true
+        }
+        return now >= nextFullReconcileAt
     }
 
     private var state: SessionState {
@@ -77,43 +107,78 @@ final class ProcessMonitoringCoordinator {
                 return
             }
 
+            var nextFullReconcileAt = Date.distantPast
+            var hadTrackedLiveSessions = false
+
             while !Task.isCancelled {
-                let discovery = self.activeAgentProcessDiscovery
-                let probe = self.terminalSessionAttachmentProbe
-                let resolver = self.terminalJumpTargetResolver
                 let liveSessions = self.state.sessions.filter(\.isTrackedLiveSession)
-                let shouldResolveTerminals = !liveSessions.isEmpty
-                let (snapshots, ghosttyAvail, terminalAvail, jumpTargets) = await Task.detached(priority: .utility) {
-                    let s = discovery.discover()
-                    let g: TerminalSessionAttachmentProbe.SnapshotAvailability<TerminalSessionAttachmentProbe.GhosttyTerminalSnapshot>
-                    let t: TerminalSessionAttachmentProbe.SnapshotAvailability<TerminalSessionAttachmentProbe.TerminalTabSnapshot>
-                    let j: [String: JumpTarget]
-
-                    if shouldResolveTerminals {
-                        g = probe.ghosttySnapshotAvailability()
-                        t = probe.terminalSnapshotAvailability()
-                        j = resolver.resolveJumpTargets(for: liveSessions, activeProcesses: s)
-                    } else {
-                        g = .available([], appIsRunning: false)
-                        t = .available([], appIsRunning: false)
-                        j = [:]
-                    }
-
-                    return (s, g, t, j)
-                }.value
-                self.reconcileSessionAttachments(
-                    activeProcesses: snapshots,
-                    ghosttyAvailability: ghosttyAvail,
-                    terminalAvailability: terminalAvail,
-                    preResolvedJumpTargets: jumpTargets
+                let hasTrackedLiveSessions = !liveSessions.isEmpty
+                let shouldRunFullReconcile = Self.shouldPerformFullMonitorReconcile(
+                    now: Date(),
+                    nextFullReconcileAt: nextFullReconcileAt,
+                    isResolvingInitialLiveSessions: self.isResolvingInitialLiveSessions,
+                    hasTrackedLiveSessions: hasTrackedLiveSessions,
+                    hadTrackedLiveSessions: hadTrackedLiveSessions
                 )
-                let pollInterval = Self.monitoringPollInterval(
+
+                if shouldRunFullReconcile {
+                    let discovery = self.activeAgentProcessDiscovery
+                    let probe = self.terminalSessionAttachmentProbe
+                    let resolver = self.terminalJumpTargetResolver
+                    let shouldResolveTerminals = hasTrackedLiveSessions
+                    let (snapshots, ghosttyAvail, terminalAvail, jumpTargets) = await Task.detached(priority: .utility) {
+                        let s = discovery.discover()
+                        let g: TerminalSessionAttachmentProbe.SnapshotAvailability<TerminalSessionAttachmentProbe.GhosttyTerminalSnapshot>
+                        let t: TerminalSessionAttachmentProbe.SnapshotAvailability<TerminalSessionAttachmentProbe.TerminalTabSnapshot>
+                        let j: [String: JumpTarget]
+
+                        if shouldResolveTerminals {
+                            g = probe.ghosttySnapshotAvailability()
+                            t = probe.terminalSnapshotAvailability()
+                            j = resolver.resolveJumpTargets(for: liveSessions, activeProcesses: s)
+                        } else {
+                            g = .available([], appIsRunning: false)
+                            t = .available([], appIsRunning: false)
+                            j = [:]
+                        }
+
+                        return (s, g, t, j)
+                    }.value
+                    self.reconcileSessionAttachments(
+                        activeProcesses: snapshots,
+                        ghosttyAvailability: ghosttyAvail,
+                        terminalAvailability: terminalAvail,
+                        preResolvedJumpTargets: jumpTargets
+                    )
+
+                    let pollInterval = Self.monitoringPollInterval(
+                        isResolvingInitialLiveSessions: self.isResolvingInitialLiveSessions,
+                        hasTrackedLiveSessions: self.state.sessions.contains(where: \.isTrackedLiveSession)
+                    )
+                    nextFullReconcileAt = Date().addingTimeInterval(pollInterval)
+                    hadTrackedLiveSessions = self.state.sessions.contains(where: \.isTrackedLiveSession)
+                } else {
+                    self.reconcileCodexAppRunningState()
+                    hadTrackedLiveSessions = hasTrackedLiveSessions
+                }
+
+                let wakeInterval = Self.monitoringWakeInterval(
                     isResolvingInitialLiveSessions: self.isResolvingInitialLiveSessions,
                     hasTrackedLiveSessions: self.state.sessions.contains(where: \.isTrackedLiveSession)
                 )
-                try? await Task.sleep(for: .milliseconds(Int(pollInterval * 1_000)))
+                try? await Task.sleep(for: .milliseconds(Int(wakeInterval * 1_000)))
             }
         }
+    }
+
+    @discardableResult
+    private func reconcileCodexAppRunningState() -> Bool {
+        let isCodexAppRunning = Self.isCodexDesktopAppRunning()
+        if isCodexAppRunning != wasCodexAppRunning {
+            wasCodexAppRunning = isCodexAppRunning
+            onCodexAppRunningChanged?(isCodexAppRunning)
+        }
+        return isCodexAppRunning
     }
 
     // MARK: - Reconciliation
@@ -151,11 +216,7 @@ final class ProcessMonitoringCoordinator {
         // return — we need to fire the callback on a brand-new Codex.app
         // launch even when no sessions exist yet, so the app-server
         // coordinator can connect and report threads.
-        let isCodexAppRunning = Self.isCodexDesktopAppRunning()
-        if isCodexAppRunning != wasCodexAppRunning {
-            wasCodexAppRunning = isCodexAppRunning
-            onCodexAppRunningChanged?(isCodexAppRunning)
-        }
+        let isCodexAppRunning = reconcileCodexAppRunningState()
         let sessions = local.sessions.filter(\.isTrackedLiveSession)
         guard !sessions.isEmpty else {
             // Flush local changes only if something actually changed.

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -44,7 +44,21 @@ final class ProcessMonitoringCoordinator {
     @ObservationIgnored
     private var wasCodexAppRunning = false
 
+    private static let startupPollInterval: TimeInterval = 2
+    private static let activePollInterval: TimeInterval = 60
+    private static let idlePollInterval: TimeInterval = 300
     private static let cursorStalenessTimeout: TimeInterval = 600  // 10 minutes
+
+    static func monitoringPollInterval(
+        isResolvingInitialLiveSessions: Bool,
+        hasTrackedLiveSessions: Bool
+    ) -> TimeInterval {
+        if isResolvingInitialLiveSessions {
+            return startupPollInterval
+        }
+
+        return hasTrackedLiveSessions ? activePollInterval : idlePollInterval
+    }
 
     private var state: SessionState {
         get { stateAccessor?() ?? SessionState() }
@@ -68,11 +82,23 @@ final class ProcessMonitoringCoordinator {
                 let probe = self.terminalSessionAttachmentProbe
                 let resolver = self.terminalJumpTargetResolver
                 let liveSessions = self.state.sessions.filter(\.isTrackedLiveSession)
+                let shouldResolveTerminals = !liveSessions.isEmpty
                 let (snapshots, ghosttyAvail, terminalAvail, jumpTargets) = await Task.detached(priority: .utility) {
                     let s = discovery.discover()
-                    let g = probe.ghosttySnapshotAvailability()
-                    let t = probe.terminalSnapshotAvailability()
-                    let j = resolver.resolveJumpTargets(for: liveSessions, activeProcesses: s)
+                    let g: TerminalSessionAttachmentProbe.SnapshotAvailability<TerminalSessionAttachmentProbe.GhosttyTerminalSnapshot>
+                    let t: TerminalSessionAttachmentProbe.SnapshotAvailability<TerminalSessionAttachmentProbe.TerminalTabSnapshot>
+                    let j: [String: JumpTarget]
+
+                    if shouldResolveTerminals {
+                        g = probe.ghosttySnapshotAvailability()
+                        t = probe.terminalSnapshotAvailability()
+                        j = resolver.resolveJumpTargets(for: liveSessions, activeProcesses: s)
+                    } else {
+                        g = .available([], appIsRunning: false)
+                        t = .available([], appIsRunning: false)
+                        j = [:]
+                    }
+
                     return (s, g, t, j)
                 }.value
                 self.reconcileSessionAttachments(
@@ -81,7 +107,11 @@ final class ProcessMonitoringCoordinator {
                     terminalAvailability: terminalAvail,
                     preResolvedJumpTargets: jumpTargets
                 )
-                try? await Task.sleep(for: .seconds(2))
+                let pollInterval = Self.monitoringPollInterval(
+                    isResolvingInitialLiveSessions: self.isResolvingInitialLiveSessions,
+                    hasTrackedLiveSessions: self.state.sessions.contains(where: \.isTrackedLiveSession)
+                )
+                try? await Task.sleep(for: .milliseconds(Int(pollInterval * 1_000)))
             }
         }
     }

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1877,18 +1877,16 @@ private struct IslandSessionRow: View {
         let tint = statusTint(for: presence)
         switch stateIndicator {
         case .animatedDot:
-            TimelineView(.periodic(from: .now, by: 1.0 / 30.0)) { context in
-                let pulse = presence == .running || isActionable
-                    ? (sin(context.date.timeIntervalSinceReferenceDate * 3.2) + 1) / 2
-                    : 0
-                Circle()
-                    .fill(tint)
-                    .frame(width: 9, height: 9)
-                    .scaleEffect(1 + (pulse * 0.18))
-                    .shadow(color: tint.opacity(presence == .inactive ? 0 : 0.36 + (pulse * 0.26)), radius: 4 + (pulse * 3))
-                    .padding(.top, 6)
+            if let interval = stateIndicator.timelineInterval(presence: presence, isActionable: isActionable) {
+                TimelineView(.periodic(from: .now, by: interval)) { context in
+                    let pulse = (sin(context.date.timeIntervalSinceReferenceDate * 3.2) + 1) / 2
+                    statusDot(tint: tint, presence: presence, pulse: pulse)
+                }
+                .frame(width: 10, height: 24, alignment: .top)
+            } else {
+                statusDot(tint: tint, presence: presence, pulse: 0)
+                    .frame(width: 10, height: 24, alignment: .top)
             }
-            .frame(width: 10, height: 24, alignment: .top)
         case .bar:
             RoundedRectangle(cornerRadius: 2.5, style: .continuous)
                 .fill(tint)
@@ -1906,6 +1904,15 @@ private struct IslandSessionRow: View {
                 .frame(width: 8, height: 8)
                 .padding(.top, 6)
         }
+    }
+
+    private func statusDot(tint: Color, presence: IslandSessionPresence, pulse: Double) -> some View {
+        Circle()
+            .fill(tint)
+            .frame(width: 9, height: 9)
+            .scaleEffect(1 + (pulse * 0.18))
+            .shadow(color: tint.opacity(presence == .inactive ? 0 : 0.36 + (pulse * 0.26)), radius: 4 + (pulse * 3))
+            .padding(.top, 6)
     }
 
     private func rowFillColor(for presence: IslandSessionPresence) -> Color {

--- a/Sources/OpenIslandApp/Views/UnifiedBars.swift
+++ b/Sources/OpenIslandApp/Views/UnifiedBars.swift
@@ -1,8 +1,9 @@
+import AppKit
 import SwiftUI
 
 /// v6 `UnifiedBars` glyph — three vertical bars that share the same geometry
-/// across all three notch states (idle / running / waiting), so state changes
-/// animate bar heights smoothly instead of driving a continuous timeline.
+/// across all three notch states (idle / running / waiting). Active states are
+/// animated by Core Animation layers so SwiftUI does not invalidate every frame.
 ///
 /// Canonical geometry (from the design handoff): 24×24 box, 3 bars of width
 /// 2.5 centered on columns x = 5.25 / 10.75 / 16.25, rounded to a pill.
@@ -16,12 +17,12 @@ struct UnifiedBars: View {
             nil
         }
 
-        var staticRenderTime: TimeInterval {
+        var usesLayerAnimation: Bool {
             switch self {
-            case .idle, .waiting:
-                0
-            case .running:
-                0.45
+            case .idle:
+                false
+            case .running, .waiting:
+                true
             }
         }
     }
@@ -43,87 +44,167 @@ struct UnifiedBars: View {
 
     @ViewBuilder
     var body: some View {
-        barsCanvas(time: mode.staticRenderTime)
+        LayerRepresentable(mode: mode, tint: tint)
+            .frame(width: size, height: size)
     }
 
-    private func barsCanvas(time: TimeInterval) -> some View {
-        Canvas { context, canvasSize in
-            withScaledContext(context, canvasSize) { ctx in
-                drawBars(context: ctx, time: time)
-            }
+    private struct LayerRepresentable: NSViewRepresentable {
+        let mode: Mode
+        let tint: Color
+
+        func makeNSView(context: Context) -> LayerView {
+            let view = LayerView()
+            view.update(mode: mode, tint: NSColor(tint))
+            return view
         }
-        .frame(width: size, height: size)
-    }
 
-    // MARK: - Drawing
-
-    private func withScaledContext(
-        _ context: GraphicsContext,
-        _ canvasSize: CGSize,
-        body: (GraphicsContext) -> Void
-    ) {
-        var ctx = context
-        let side = min(canvasSize.width, canvasSize.height)
-        let scale = side / Self.box
-        let dx = (canvasSize.width - side) / 2
-        let dy = (canvasSize.height - side) / 2
-        ctx.translateBy(x: dx, y: dy)
-        ctx.scaleBy(x: scale, y: scale)
-        body(ctx)
-    }
-
-    private func drawBars(context: GraphicsContext, time: TimeInterval) {
-        for column in Self.columns {
-            let (height, y, opacity) = barGeometry(for: column, time: time)
-            guard opacity > 0, height > 0 else { continue }
-            let rect = CGRect(
-                x: column.x,
-                y: y,
-                width: Self.barWidth,
-                height: height
-            )
-            let path = Path(
-                roundedRect: rect,
-                cornerSize: CGSize(width: Self.barWidth / 2, height: Self.barWidth / 2)
-            )
-            context.fill(path, with: .color(tint.opacity(opacity)))
+        func updateNSView(_ nsView: LayerView, context: Context) {
+            nsView.update(mode: mode, tint: NSColor(tint))
         }
     }
 
-    private func barGeometry(
-        for column: Column,
-        time: TimeInterval
-    ) -> (height: CGFloat, y: CGFloat, opacity: Double) {
-        switch mode {
-        case .idle:
-            let h = column.idleH
-            return (h, Self.center - h / 2, 1.0)
-        case .running:
-            let cycle = column.waveCycle
-            let period: TimeInterval = 0.9
-            let raw = (time - column.waveDelay)
-                .truncatingRemainder(dividingBy: period) / period
-            let phase = raw < 0 ? raw + 1 : raw
-            let h: CGFloat
-            if phase < 0.5 {
-                let t = phase / 0.5
-                h = cycle[0] + (cycle[1] - cycle[0]) * t
-            } else {
-                let t = (phase - 0.5) / 0.5
-                h = cycle[1] + (cycle[2] - cycle[1]) * t
+    private final class LayerView: NSView {
+        private let barLayers = [CAShapeLayer(), CAShapeLayer(), CAShapeLayer()]
+        private var mode: Mode = .idle
+        private var tintColor = NSColor.white
+
+        override init(frame frameRect: NSRect) {
+            super.init(frame: frameRect)
+            wantsLayer = true
+            layer = CALayer()
+            layer?.masksToBounds = false
+            barLayers.forEach { barLayer in
+                barLayer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
+                barLayer.contentsScale = NSScreen.main?.backingScaleFactor ?? 2
+                layer?.addSublayer(barLayer)
             }
-            return (h, Self.center - h / 2, 1.0)
-        case .waiting:
-            let h = column.waitH
-            guard h > 0 else { return (0, Self.center, 0) }
-            let isLeading = column.x < Self.center
-            let period: TimeInterval = 1.8
-            let offset = isLeading ? 0.0 : period / 2
-            let progress = ((time + offset)
-                .truncatingRemainder(dividingBy: period)) / period
-            let wave = 0.5 - 0.5 * cos(progress * 2 * .pi)
-            let opacity = 0.55 + 0.45 * wave
-            return (h, Self.center - h / 2, opacity)
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        func update(mode: Mode, tint: NSColor) {
+            self.mode = mode
+            tintColor = tint
+            needsLayout = true
+        }
+
+        override func layout() {
+            super.layout()
+            configureLayers()
+        }
+
+        private func configureLayers() {
+            let side = min(bounds.width, bounds.height)
+            guard side > 0 else { return }
+
+            let scale = side / UnifiedBars.box
+            let dx = (bounds.width - side) / 2
+            let dy = (bounds.height - side) / 2
+
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            for (index, column) in UnifiedBars.columns.enumerated() {
+                let barLayer = barLayers[index]
+                let baseHeight = self.baseHeight(for: column)
+                let width = UnifiedBars.barWidth * scale
+                let height = baseHeight * scale
+                let center = CGPoint(
+                    x: dx + ((column.x + UnifiedBars.barWidth / 2) * scale),
+                    y: dy + (UnifiedBars.center * scale)
+                )
+
+                barLayer.isHidden = baseHeight <= 0
+                barLayer.bounds = CGRect(x: 0, y: 0, width: width, height: height)
+                barLayer.position = center
+                barLayer.fillColor = tintColor.cgColor
+                barLayer.path = CGPath(
+                    roundedRect: CGRect(x: 0, y: 0, width: width, height: height),
+                    cornerWidth: width / 2,
+                    cornerHeight: width / 2,
+                    transform: nil
+                )
+                barLayer.transform = CATransform3DMakeScale(1, initialScaleY(for: column), 1)
+                barLayer.opacity = initialOpacity(for: column)
+                configureAnimations(for: barLayer, column: column)
+            }
+            CATransaction.commit()
+        }
+
+        private func baseHeight(for column: Column) -> CGFloat {
+            switch mode {
+            case .idle:
+                column.idleH
+            case .running:
+                column.waveCycle.max() ?? column.idleH
+            case .waiting:
+                column.waitH
+            }
+        }
+
+        private func initialScaleY(for column: Column) -> CGFloat {
+            guard mode == .running,
+                  let maxHeight = column.waveCycle.max(),
+                  maxHeight > 0 else {
+                return 1
+            }
+            return column.waveCycle[0] / maxHeight
+        }
+
+        private func initialOpacity(for column: Column) -> Float {
+            switch mode {
+            case .idle, .running:
+                1
+            case .waiting:
+                column.waitH > 0 ? 0.55 : 0
+            }
+        }
+
+        private func configureAnimations(for barLayer: CAShapeLayer, column: Column) {
+            barLayer.removeAllAnimations()
+            guard mode.usesLayerAnimation, !barLayer.isHidden else { return }
+
+            switch mode {
+            case .idle:
+                return
+            case .running:
+                addRunningAnimation(to: barLayer, column: column)
+            case .waiting:
+                addWaitingAnimation(to: barLayer, column: column)
+            }
+        }
+
+        private func addRunningAnimation(to barLayer: CAShapeLayer, column: Column) {
+            let maxHeight = column.waveCycle.max() ?? column.idleH
+            guard maxHeight > 0 else { return }
+
+            let animation = CAKeyframeAnimation(keyPath: "transform.scale.y")
+            animation.values = column.waveCycle.map { $0 / maxHeight }
+            animation.keyTimes = [0, 0.5, 1]
+            animation.duration = 0.9
+            animation.beginTime = CACurrentMediaTime() + column.waveDelay
+            animation.repeatCount = .infinity
+            animation.timingFunctions = [
+                CAMediaTimingFunction(name: .easeInEaseOut),
+                CAMediaTimingFunction(name: .easeInEaseOut),
+            ]
+            barLayer.add(animation, forKey: "running-scale-y")
+        }
+
+        private func addWaitingAnimation(to barLayer: CAShapeLayer, column: Column) {
+            let animation = CAKeyframeAnimation(keyPath: "opacity")
+            animation.values = [0.55, 1.0, 0.55]
+            animation.keyTimes = [0, 0.5, 1]
+            animation.duration = 1.8
+            animation.beginTime = CACurrentMediaTime() + (column.x < UnifiedBars.center ? 0 : 0.9)
+            animation.repeatCount = .infinity
+            animation.timingFunctions = [
+                CAMediaTimingFunction(name: .easeInEaseOut),
+                CAMediaTimingFunction(name: .easeInEaseOut),
+            ]
+            barLayer.add(animation, forKey: "waiting-opacity")
         }
     }
 

--- a/Sources/OpenIslandApp/Views/UnifiedBars.swift
+++ b/Sources/OpenIslandApp/Views/UnifiedBars.swift
@@ -1,16 +1,29 @@
 import SwiftUI
 
 /// v6 `UnifiedBars` glyph — three vertical bars that share the same geometry
-/// across all three notch states (idle / running / waiting), so transitions
-/// animate bar heights smoothly instead of swapping glyphs.
+/// across all three notch states (idle / running / waiting), so state changes
+/// animate bar heights smoothly instead of driving a continuous timeline.
 ///
 /// Canonical geometry (from the design handoff): 24×24 box, 3 bars of width
 /// 2.5 centered on columns x = 5.25 / 10.75 / 16.25, rounded to a pill.
 struct UnifiedBars: View {
     enum Mode: Equatable {
-        case idle       // rest — 3 short bars, middle breathes
-        case running    // wave — heights 4→12→4, stagger 0.15s
-        case waiting    // pause — outer bars tall, middle hidden, cross-pulse
+        case idle       // rest — 3 short static bars
+        case running    // active — static tall wave frame
+        case waiting    // pause — static outer bars, middle hidden
+
+        var timelineInterval: TimeInterval? {
+            nil
+        }
+
+        var staticRenderTime: TimeInterval {
+            switch self {
+            case .idle, .waiting:
+                0
+            case .running:
+                0.45
+            }
+        }
     }
 
     var mode: Mode
@@ -28,12 +41,15 @@ struct UnifiedBars: View {
         Column(x: 16.25, idleH: 3, waveCycle: [4, 10, 4], waveDelay: 0.30, waitH: 10),
     ]
 
+    @ViewBuilder
     var body: some View {
-        TimelineView(.animation) { timeline in
-            Canvas { context, canvasSize in
-                withScaledContext(context, canvasSize) { ctx in
-                    drawBars(context: ctx, time: timeline.date.timeIntervalSinceReferenceDate)
-                }
+        barsCanvas(time: mode.staticRenderTime)
+    }
+
+    private func barsCanvas(time: TimeInterval) -> some View {
+        Canvas { context, canvasSize in
+            withScaledContext(context, canvasSize) { ctx in
+                drawBars(context: ctx, time: time)
             }
         }
         .frame(width: size, height: size)
@@ -81,11 +97,7 @@ struct UnifiedBars: View {
         switch mode {
         case .idle:
             let h = column.idleH
-            let isMiddle = column.x == Self.columns[1].x
-            let breath = isMiddle
-                ? 0.7 + 0.3 * abs(sin(time * 2 * .pi / 2.8))
-                : 1.0
-            return (h, Self.center - h / 2, breath)
+            return (h, Self.center - h / 2, 1.0)
         case .running:
             let cycle = column.waveCycle
             let period: TimeInterval = 0.9

--- a/Tests/OpenIslandAppTests/PerformancePolicyTests.swift
+++ b/Tests/OpenIslandAppTests/PerformancePolicyTests.swift
@@ -31,6 +31,41 @@ struct PerformancePolicyTests {
         ) == 300)
     }
 
+    @MainActor
+    @Test
+    func codexDesktopProbeKeepsShortWakeCadenceWhileFullReconcileBacksOff() {
+        #expect(ProcessMonitoringCoordinator.monitoringWakeInterval(
+            isResolvingInitialLiveSessions: false,
+            hasTrackedLiveSessions: false
+        ) == 2)
+        #expect(ProcessMonitoringCoordinator.monitoringWakeInterval(
+            isResolvingInitialLiveSessions: false,
+            hasTrackedLiveSessions: true
+        ) == 2)
+    }
+
+    @MainActor
+    @Test
+    func trackedSessionTransitionForcesFullReconcileBeforeIdleDeadline() {
+        let now = Date(timeIntervalSinceReferenceDate: 1_000)
+        let idleDeadline = now.addingTimeInterval(300)
+
+        #expect(!ProcessMonitoringCoordinator.shouldPerformFullMonitorReconcile(
+            now: now,
+            nextFullReconcileAt: idleDeadline,
+            isResolvingInitialLiveSessions: false,
+            hasTrackedLiveSessions: false,
+            hadTrackedLiveSessions: false
+        ))
+        #expect(ProcessMonitoringCoordinator.shouldPerformFullMonitorReconcile(
+            now: now,
+            nextFullReconcileAt: idleDeadline,
+            isResolvingInitialLiveSessions: false,
+            hasTrackedLiveSessions: true,
+            hadTrackedLiveSessions: false
+        ))
+    }
+
     @Test
     func inactiveSessionDotDoesNotRequireAnimationTimeline() {
         #expect(IslandSessionStateIndicator.animatedDot.timelineInterval(

--- a/Tests/OpenIslandAppTests/PerformancePolicyTests.swift
+++ b/Tests/OpenIslandAppTests/PerformancePolicyTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+@testable import OpenIslandApp
+
+struct PerformancePolicyTests {
+    @Test
+    func idleUnifiedBarsDoesNotRequireAnimationTimeline() {
+        #expect(UnifiedBars.Mode.idle.timelineInterval == nil)
+    }
+
+    @Test
+    func activeUnifiedBarsDoNotRequireAnimationTimeline() {
+        #expect(UnifiedBars.Mode.running.timelineInterval == nil)
+        #expect(UnifiedBars.Mode.waiting.timelineInterval == nil)
+    }
+
+    @MainActor
+    @Test
+    func monitoringPollIntervalBacksOffOutsideStartupResolution() {
+        #expect(ProcessMonitoringCoordinator.monitoringPollInterval(
+            isResolvingInitialLiveSessions: true,
+            hasTrackedLiveSessions: false
+        ) == 2)
+        #expect(ProcessMonitoringCoordinator.monitoringPollInterval(
+            isResolvingInitialLiveSessions: false,
+            hasTrackedLiveSessions: true
+        ) == 60)
+        #expect(ProcessMonitoringCoordinator.monitoringPollInterval(
+            isResolvingInitialLiveSessions: false,
+            hasTrackedLiveSessions: false
+        ) == 300)
+    }
+
+    @Test
+    func inactiveSessionDotDoesNotRequireAnimationTimeline() {
+        #expect(IslandSessionStateIndicator.animatedDot.timelineInterval(
+            presence: .inactive,
+            isActionable: false
+        ) == nil)
+        #expect(IslandSessionStateIndicator.animatedDot.timelineInterval(
+            presence: .active,
+            isActionable: false
+        ) == nil)
+        #expect(IslandSessionStateIndicator.animatedDot.timelineInterval(
+            presence: .running,
+            isActionable: false
+        ) == 1.0 / 15.0)
+        #expect(IslandSessionStateIndicator.animatedDot.timelineInterval(
+            presence: .inactive,
+            isActionable: true
+        ) == 1.0 / 15.0)
+    }
+}

--- a/Tests/OpenIslandAppTests/PerformancePolicyTests.swift
+++ b/Tests/OpenIslandAppTests/PerformancePolicyTests.swift
@@ -14,6 +14,13 @@ struct PerformancePolicyTests {
         #expect(UnifiedBars.Mode.waiting.timelineInterval == nil)
     }
 
+    @Test
+    func activeUnifiedBarsUseCoreAnimationLayerAnimation() {
+        #expect(!UnifiedBars.Mode.idle.usesLayerAnimation)
+        #expect(UnifiedBars.Mode.running.usesLayerAnimation)
+        #expect(UnifiedBars.Mode.waiting.usesLayerAnimation)
+    }
+
     @MainActor
     @Test
     func monitoringPollIntervalBacksOffOutsideStartupResolution() {


### PR DESCRIPTION
## Summary

Fixes #553.

This reduces Open Island idle CPU usage by removing high-frequency SwiftUI-driven redraw paths and backing off expensive process discovery while keeping Codex Desktop detection responsive.

## Changes

- Replaced closed island `UnifiedBars` `TimelineView(.animation) + Canvas` rendering with Core Animation layer animations.
- Kept session row status dots static unless the row is `running` or `actionable`.
- Backed off expensive process discovery:
  - startup resolution: 2s
  - active tracked sessions: 60s
  - idle/no tracked sessions: 300s
- Kept cheap Codex Desktop running detection on a short 2s cadence so app-server sync is not delayed.
- Skips terminal snapshot and jump-target resolver work when there are no live tracked sessions.
- Added performance policy tests to prevent regressions.

## Verification

- `swift test --filter PerformancePolicyTests`
- `swift test`
- Runtime check with `Open Island Dev.app`: `top` showed OpenIslandApp around `0.0% / 0.3%` CPU after startup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance & Optimization**
  * Optimized status indicator animation with configurable timing intervals to reduce rendering overhead
  * Refactored bars animation to use more efficient Core Animation layer-based rendering instead of time-sampled drawing
  * Enhanced process monitoring scheduling for improved system responsiveness

* **Tests**
  * Added performance policy validation tests to ensure animation and monitoring behavior meets performance standards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->