### PR TITLE
fix: keep Codex.app threads distinct in island counts

### DIFF
--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -99,6 +99,32 @@ struct ActiveAgentProcessDiscovery {
                 continue
             }
 
+            if isCursorAgentProcess(command: process.command) {
+                guard let snapshot = cursorSnapshot(for: process, processesByPID: processesByPID) else {
+                    continue
+                }
+
+                let claimKey: String
+                if let sessionID = snapshot.sessionID {
+                    claimKey = "cursor:\(sessionID)"
+                } else {
+                    claimKey = [
+                        "cursor",
+                        snapshot.terminalTTY,
+                        snapshot.workingDirectory,
+                        process.pid,
+                    ]
+                    .compactMap { $0 }
+                    .joined(separator: ":")
+                }
+                guard claimedKeys.insert(claimKey).inserted else {
+                    continue
+                }
+
+                snapshots.append(snapshot)
+                continue
+            }
+
             if isOpenCodeProcess(command: process.command) {
                 let lsofOutput = lsofOutput(pid: process.pid)
                 let cwd = lsofOutput.flatMap(workingDirectory(from:))
@@ -254,6 +280,41 @@ struct ActiveAgentProcessDiscovery {
         return snapshot
     }
 
+    private func cursorSnapshot(
+        for process: RunningProcess,
+        processesByPID: [String: RunningProcess]
+    ) -> ProcessSnapshot? {
+        let lsofOutput = lsofOutput(pid: process.pid)
+        let workingDirectory = lsofOutput.flatMap(workingDirectory(from:))
+        let sessionID = lsofOutput.flatMap(cursorConversationID(in:))
+
+        guard workingDirectory != nil || sessionID != nil else {
+            return nil
+        }
+
+        var snapshot = ProcessSnapshot(
+            tool: .cursor,
+            sessionID: sessionID,
+            workingDirectory: workingDirectory,
+            terminalTTY: process.terminalTTY,
+            terminalApp: terminalApp(for: process, processesByPID: processesByPID)
+        )
+
+        if snapshot.terminalApp == nil, let agentTTY = process.terminalTTY {
+            if let (tmuxTarget, hostTerminalApp, socketPath) = resolveTmuxInfo(
+                agentTTY: agentTTY,
+                processes: processesByPID.values.map { $0 },
+                processesByPID: processesByPID
+            ) {
+                snapshot.terminalApp = hostTerminalApp
+                snapshot.tmuxTarget = tmuxTarget
+                snapshot.tmuxSocketPath = socketPath
+            }
+        }
+
+        return snapshot
+    }
+
     private func bestCodexTranscriptPath(in lsofOutput: String) -> String? {
         let paths = allMatchingPaths(in: lsofOutput, containing: "/.codex/sessions/", suffix: ".jsonl")
         guard !paths.isEmpty else {
@@ -357,6 +418,25 @@ struct ActiveAgentProcessDiscovery {
         }
 
         return results
+    }
+
+    private func cursorConversationID(in lsofOutput: String) -> String? {
+        for line in lsofOutput.split(whereSeparator: \.isNewline) {
+            guard line.first == "n" else {
+                continue
+            }
+
+            let value = String(line.dropFirst()).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard value.contains("/.cursor/chats/"),
+                  value.contains("/store.db"),
+                  let conversationID = firstUUID(in: value) else {
+                continue
+            }
+
+            return conversationID
+        }
+
+        return nil
     }
 
     private func terminalApp(
@@ -575,6 +655,16 @@ struct ActiveAgentProcessDiscovery {
         return firstToken == "codex"
             || firstToken.hasSuffix("/codex")
             || lowered.contains("/codex/codex")
+    }
+
+    private func isCursorAgentProcess(command: String) -> Bool {
+        let lowered = command.lowercased()
+        guard let firstToken = lowered.split(separator: " ").first.map(String.init) else {
+            return false
+        }
+
+        return firstToken == "cursor-agent"
+            || firstToken.hasSuffix("/cursor-agent")
     }
 
     private func isOpenCodeProcess(command: String) -> Bool {

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -971,6 +971,18 @@ final class ProcessMonitoringCoordinator {
             return nil
         }
 
+        if session.isCodexAppSession || terminalApp == "Codex.app" {
+            let threadID = jumpTarget.codexThreadID?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let disambiguator: String
+            if let threadID, !threadID.isEmpty {
+                disambiguator = threadID
+            } else {
+                disambiguator = session.id
+            }
+            return "codex.app:thread:\(disambiguator.lowercased())"
+        }
+
         if let terminalSessionID = jumpTarget.terminalSessionID?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !terminalSessionID.isEmpty {

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -216,8 +216,12 @@ final class ProcessMonitoringCoordinator {
             local = SessionState(sessions: sanitizedSessions)
         }
 
-        let mergedSessions = mergedWithSyntheticClaudeSessions(
+        let mergedClaudeSessions = mergedWithSyntheticClaudeSessions(
             existingSessions: local.sessions,
+            activeProcesses: activeProcesses
+        )
+        let mergedSessions = mergedWithSyntheticCursorSessions(
+            existingSessions: mergedClaudeSessions,
             activeProcesses: activeProcesses
         )
         if mergedSessions != local.sessions {
@@ -226,6 +230,7 @@ final class ProcessMonitoringCoordinator {
 
         // Adopt process TTYs inline on local copy.
         adoptProcessTTYsForClaudeSessions(activeProcesses: activeProcesses, sessions: &local)
+        adoptProcessTTYsForCursorSessions(activeProcesses: activeProcesses, sessions: &local)
 
         // Detect Codex.app running state BEFORE the empty-sessions early
         // return — we need to fire the callback on a brand-new Codex.app
@@ -504,18 +509,33 @@ final class ProcessMonitoringCoordinator {
             }
         }
 
-        // Cursor sessions: Cursor is an Electron IDE — we cannot match
-        // individual session IDs from ps/lsof.  Keep Cursor sessions alive
-        // while Cursor.app is running, but let completed sessions expire
-        // after a staleness window so the notch clears when the user is
-        // no longer interacting with the conversation.  Cursor has no
-        // "tab closed" hook, so this timeout is the best available proxy.
+        // Cursor sessions: prefer concrete cursor-agent processes when they
+        // are visible (Cursor CLI / integrated terminal), then fall back to
+        // app-level liveness for IDE-only hook sessions where there is no
+        // stable subprocess to match.
+        let cursorProcesses = activeProcesses.filter { $0.tool == .cursor }
+        let trackedCursorSessions = sessions.filter { $0.tool == .cursor && !$0.isDemoSession }
+        var claimedCursorSessionIDs: Set<String> = []
+        for process in cursorProcesses {
+            guard let matched = uniqueTrackedCursorSession(
+                for: process,
+                sessions: trackedCursorSessions,
+                claimedSessionIDs: claimedCursorSessionIDs
+            ) else {
+                continue
+            }
+
+            aliveIDs.insert(matched.id)
+            claimedCursorSessionIDs.insert(matched.id)
+        }
+
         let isCursorRunning = !NSRunningApplication.runningApplications(
             withBundleIdentifier: "com.todesktop.230313mzl4w4u92"
         ).isEmpty
         if isCursorRunning {
-            for session in sessions where session.tool == .cursor && !session.isDemoSession {
+            for session in trackedCursorSessions where !claimedCursorSessionIDs.contains(session.id) {
                 if session.isSessionEnded { continue }
+                if normalizedTTYForMatching(session.jumpTarget?.terminalTTY) != nil { continue }
                 let isStale = session.phase == .completed
                     && session.updatedAt.addingTimeInterval(Self.cursorStalenessTimeout) < Date.now
                 if !isStale {
@@ -738,7 +758,174 @@ final class ProcessMonitoringCoordinator {
         session.tool == .claudeCode && session.id.hasPrefix(syntheticClaudeSessionPrefix)
     }
 
+    // MARK: - Synthetic Cursor sessions
+
+    func mergedWithSyntheticCursorSessions(
+        existingSessions: [AgentSession],
+        activeProcesses: [ActiveProcessSnapshot],
+        now: Date = .now
+    ) -> [AgentSession] {
+        let activeCursorProcesses = activeProcesses.filter { $0.tool == .cursor }
+        guard !activeCursorProcesses.isEmpty else {
+            return existingSessions
+        }
+
+        let trackedCursorSessions = existingSessions.filter { $0.tool == .cursor && !$0.isDemoSession }
+        let representedProcessKeys = representedCursorProcessKeys(
+            sessions: trackedCursorSessions,
+            activeProcesses: activeCursorProcesses
+        )
+
+        var seenSessionIDs = Set(existingSessions.map(\.id))
+        var syntheticSessions: [AgentSession] = []
+        for process in activeCursorProcesses
+            .filter({ !representedProcessKeys.contains(processIdentityKey($0)) })
+            .sorted(by: { processIdentityKey($0) < processIdentityKey($1) }) {
+            let candidateID = cursorSyntheticSessionID(for: process)
+            guard seenSessionIDs.insert(candidateID).inserted else {
+                continue
+            }
+
+            syntheticSessions.append(syntheticCursorSession(for: process, sessionID: candidateID, now: now))
+        }
+
+        return existingSessions + syntheticSessions
+    }
+
+    private func cursorSyntheticSessionID(for process: ActiveProcessSnapshot) -> String {
+        process.sessionID ?? "cursor-process:\(processIdentityKey(process))"
+    }
+
+    private func syntheticCursorSession(
+        for process: ActiveProcessSnapshot,
+        sessionID: String? = nil,
+        now: Date
+    ) -> AgentSession {
+        let workingDirectory = process.workingDirectory
+        let workspaceName = workingDirectory.map { WorkspaceNameResolver.workspaceName(for: $0) } ?? "Workspace"
+        let terminalApp = supportedTerminalApp(for: process.terminalApp)
+            ?? process.terminalApp?.trimmingCharacters(in: .whitespacesAndNewlines)
+            ?? "Unknown"
+        let sessionID = sessionID ?? cursorSyntheticSessionID(for: process)
+
+        var session = AgentSession(
+            id: sessionID,
+            title: "Cursor · \(workspaceName)",
+            tool: .cursor,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Cursor agent detected from \(terminalApp).",
+            updatedAt: now,
+            jumpTarget: JumpTarget(
+                terminalApp: terminalApp,
+                workspaceName: workspaceName,
+                paneTitle: "Cursor \(sessionID.prefix(8))",
+                workingDirectory: workingDirectory,
+                terminalTTY: process.terminalTTY,
+                tmuxTarget: process.tmuxTarget,
+                tmuxSocketPath: process.tmuxSocketPath
+            ),
+            cursorMetadata: CursorSessionMetadata(
+                conversationId: process.sessionID,
+                workspaceRoots: workingDirectory.map { [$0] }
+            )
+        )
+        session.isProcessAlive = true
+        return session
+    }
+
     // MARK: - Process matching
+
+    private func representedCursorProcessKeys(
+        sessions: [AgentSession],
+        activeProcesses: [ActiveProcessSnapshot]
+    ) -> Set<String> {
+        var representedProcessKeys: Set<String> = []
+        var claimedSessionIDs: Set<String> = []
+
+        for process in activeProcesses {
+            guard let processSessionID = process.sessionID,
+                  sessions.contains(where: {
+                      $0.id == processSessionID
+                          || $0.cursorMetadata?.conversationId == processSessionID
+                  }) else {
+                continue
+            }
+
+            representedProcessKeys.insert(processIdentityKey(process))
+        }
+
+        for process in activeProcesses {
+            let processKey = processIdentityKey(process)
+            guard !representedProcessKeys.contains(processKey) else {
+                continue
+            }
+
+            guard let matchedSession = uniqueTrackedCursorSession(
+                for: process,
+                sessions: sessions,
+                claimedSessionIDs: claimedSessionIDs
+            ) else {
+                continue
+            }
+
+            representedProcessKeys.insert(processKey)
+            claimedSessionIDs.insert(matchedSession.id)
+        }
+
+        return representedProcessKeys
+    }
+
+    private func uniqueTrackedCursorSession(
+        for process: ActiveProcessSnapshot,
+        sessions: [AgentSession],
+        claimedSessionIDs: Set<String>
+    ) -> AgentSession? {
+        let unclaimedSessions = sessions.filter { !claimedSessionIDs.contains($0.id) }
+        guard !unclaimedSessions.isEmpty else {
+            return nil
+        }
+
+        if let processSessionID = process.sessionID {
+            let exactMatches = unclaimedSessions.filter {
+                $0.id == processSessionID
+                    || $0.cursorMetadata?.conversationId == processSessionID
+            }
+            if exactMatches.count == 1 {
+                return exactMatches[0]
+            }
+        }
+
+        if let terminalTTY = normalizedTTYForMatching(process.terminalTTY) {
+            let ttyMatches = unclaimedSessions.filter {
+                normalizedTTYForMatching($0.jumpTarget?.terminalTTY) == terminalTTY
+            }
+            if ttyMatches.count == 1 {
+                return ttyMatches[0]
+            }
+            if ttyMatches.count > 1,
+               let processCWD = normalizedPathForMatching(process.workingDirectory) {
+                let cwdMatches = ttyMatches.filter {
+                    normalizedPathForMatching($0.jumpTarget?.workingDirectory) == processCWD
+                }
+                if cwdMatches.count == 1 {
+                    return cwdMatches[0]
+                }
+            }
+        }
+
+        if let processCWD = normalizedPathForMatching(process.workingDirectory) {
+            let cwdMatches = unclaimedSessions.filter {
+                normalizedPathForMatching($0.jumpTarget?.workingDirectory) == processCWD
+            }
+            if cwdMatches.count == 1 {
+                return cwdMatches[0]
+            }
+        }
+
+        return nil
+    }
 
     private func representedClaudeProcessKeys(
         sessions: [AgentSession],
@@ -930,6 +1117,80 @@ final class ProcessMonitoringCoordinator {
                 changed = true
                 break
             }
+        }
+
+        if changed {
+            localState = SessionState(sessions: sessions)
+        }
+        return changed
+    }
+
+    @discardableResult
+    private func adoptProcessTTYsForCursorSessions(
+        activeProcesses: [ActiveProcessSnapshot],
+        sessions localState: inout SessionState
+    ) -> Bool {
+        let cursorProcesses = activeProcesses.filter { $0.tool == .cursor }
+        guard !cursorProcesses.isEmpty else { return false }
+
+        var sessions = localState.sessions
+        var changed = false
+
+        for process in cursorProcesses {
+            guard let processSessionID = process.sessionID else {
+                continue
+            }
+
+            guard let index = sessions.firstIndex(where: {
+                $0.tool == .cursor
+                    && ($0.id == processSessionID || $0.cursorMetadata?.conversationId == processSessionID)
+            }) else {
+                continue
+            }
+
+            let session = sessions[index]
+            let workingDirectory = process.workingDirectory ?? session.jumpTarget?.workingDirectory
+            let workspaceName = workingDirectory.map { WorkspaceNameResolver.workspaceName(for: $0) }
+                ?? session.jumpTarget?.workspaceName
+                ?? "Workspace"
+            let terminalApp = supportedTerminalApp(for: process.terminalApp)
+                ?? process.terminalApp?.trimmingCharacters(in: .whitespacesAndNewlines)
+                ?? session.jumpTarget?.terminalApp
+                ?? "Unknown"
+            let existingPaneTitle = session.jumpTarget?.paneTitle
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let paneTitle: String
+            if let existingPaneTitle, !existingPaneTitle.isEmpty {
+                paneTitle = existingPaneTitle
+            } else {
+                paneTitle = "Cursor \(processSessionID.prefix(8))"
+            }
+
+            let jumpTarget = JumpTarget(
+                terminalApp: terminalApp,
+                workspaceName: workspaceName,
+                paneTitle: paneTitle,
+                workingDirectory: workingDirectory,
+                terminalSessionID: session.jumpTarget?.terminalSessionID,
+                terminalTTY: process.terminalTTY ?? session.jumpTarget?.terminalTTY,
+                tmuxTarget: process.tmuxTarget ?? session.jumpTarget?.tmuxTarget,
+                tmuxSocketPath: process.tmuxSocketPath ?? session.jumpTarget?.tmuxSocketPath,
+                warpPaneUUID: session.jumpTarget?.warpPaneUUID,
+                codexThreadID: session.jumpTarget?.codexThreadID
+            )
+
+            guard jumpTarget != session.jumpTarget
+                    || session.attachmentState != .attached
+                    || !session.isProcessAlive else {
+                continue
+            }
+
+            sessions[index].jumpTarget = jumpTarget
+            sessions[index].attachmentState = .attached
+            sessions[index].isProcessAlive = true
+            sessions[index].processNotSeenCount = 0
+            sessions[index].updatedAt = .now
+            changed = true
         }
 
         if changed {

--- a/Tests/OpenIslandAppTests/ActiveAgentProcessDiscoveryTests.swift
+++ b/Tests/OpenIslandAppTests/ActiveAgentProcessDiscoveryTests.swift
@@ -137,6 +137,84 @@ struct ActiveAgentProcessDiscoveryTests {
         ])
     }
 
+    @Test
+    func discoverCursorAgentProcessFromOpenChatStore() {
+        let discovery = ActiveAgentProcessDiscovery { executablePath, arguments in
+            if executablePath == "/bin/ps" {
+                return """
+                  302 401 ttys003 /Users/test/.local/bin/cursor-agent --use-system-ca /Users/test/.local/share/cursor-agent/versions/2026.06.26/index.js
+                  401 500 ttys003 -/opt/homebrew/bin/fish
+                  500 900 ttys003 /usr/bin/login -flp test /bin/bash --noprofile --norc -c exec -l /opt/homebrew/bin/fish
+                  900 1 ?? /Applications/Ghostty.app/Contents/MacOS/ghostty
+                """
+            }
+
+            guard executablePath == "/usr/sbin/lsof",
+                  let pid = arguments.dropFirst(2).first else {
+                return nil
+            }
+
+            guard pid == "302" else {
+                Issue.record("unexpected lsof lookup for pid \(pid)")
+                return nil
+            }
+
+            return """
+            fcwd
+            n/tmp/simple-agent-lab
+            n/Users/test/.cursor/chats/cf595f65441221b71014fd6f7b9999b2/6f7b9f8a-2bd0-48b4-a497-9801dd191d03/store.db-shm
+            """
+        }
+
+        let snapshots = discovery.discover()
+
+        #expect(snapshots == [
+            .init(
+                tool: .cursor,
+                sessionID: "6f7b9f8a-2bd0-48b4-a497-9801dd191d03",
+                workingDirectory: "/tmp/simple-agent-lab",
+                terminalTTY: "/dev/ttys003",
+                terminalApp: "Ghostty"
+            ),
+        ])
+    }
+
+    @Test
+    func discoverCursorAgentDeduplicatesProcessesForSameConversation() {
+        let discovery = ActiveAgentProcessDiscovery { executablePath, arguments in
+            if executablePath == "/bin/ps" {
+                return """
+                  302 401 ttys003 /Users/test/.local/bin/cursor-agent --use-system-ca /Users/test/.local/share/cursor-agent/versions/2026.06.26/index.js
+                  303 402 ttys004 /Users/test/.local/bin/cursor-agent --use-system-ca /Users/test/.local/share/cursor-agent/versions/2026.06.26/index.js
+                  401 900 ttys003 -/opt/homebrew/bin/fish
+                  402 900 ttys004 -/opt/homebrew/bin/fish
+                  900 1 ?? /Applications/Ghostty.app/Contents/MacOS/ghostty
+                """
+            }
+
+            guard executablePath == "/usr/sbin/lsof",
+                  let pid = arguments.dropFirst(2).first else {
+                return nil
+            }
+
+            guard pid == "302" || pid == "303" else {
+                Issue.record("unexpected lsof lookup for pid \(pid)")
+                return nil
+            }
+
+            return """
+            fcwd
+            n/tmp/simple-agent-lab
+            n/Users/test/.cursor/chats/cf595f65441221b71014fd6f7b9999b2/6f7b9f8a-2bd0-48b4-a497-9801dd191d03/store.db
+            """
+        }
+
+        let snapshots = discovery.discover()
+
+        #expect(snapshots.count == 1)
+        #expect(snapshots.first?.sessionID == "6f7b9f8a-2bd0-48b4-a497-9801dd191d03")
+    }
+
     /// VS Code forks (Cursor, Windsurf, Trae, Qoder) bundle Electron's "Code
     /// Helper" inside their .app bundles. Their helper paths therefore contain
     /// both "/<fork>.app/" and "/code helper", and Open Island used to match

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -164,6 +164,57 @@ struct AppModelSessionListTests {
     }
 
     @Test
+    func islandListKeepsDistinctCodexAppThreadsInTheSameWorkspace() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let model = AppModel()
+
+        var firstThread = AgentSession(
+            id: "codex-app-thread-1",
+            title: "Codex · open-island",
+            tool: .codex,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .completed,
+            summary: "First Codex.app thread",
+            updatedAt: now,
+            jumpTarget: JumpTarget(
+                terminalApp: "Codex.app",
+                workspaceName: "open-island",
+                paneTitle: "Codex · open-island",
+                workingDirectory: "/tmp/open-island",
+                codexThreadID: "codex-app-thread-1"
+            )
+        )
+        firstThread.isCodexAppSession = true
+        firstThread.isProcessAlive = true
+
+        var secondThread = AgentSession(
+            id: "codex-app-thread-2",
+            title: "Codex · open-island",
+            tool: .codex,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .completed,
+            summary: "Second Codex.app thread",
+            updatedAt: now.addingTimeInterval(-30),
+            jumpTarget: JumpTarget(
+                terminalApp: "Codex.app",
+                workspaceName: "open-island",
+                paneTitle: "Codex · open-island",
+                workingDirectory: "/tmp/open-island",
+                codexThreadID: "codex-app-thread-2"
+            )
+        )
+        secondThread.isCodexAppSession = true
+        secondThread.isProcessAlive = true
+
+        model.state = SessionState(sessions: [firstThread, secondThread])
+
+        #expect(model.surfacedSessions.map(\.id) == ["codex-app-thread-1", "codex-app-thread-2"])
+        #expect(model.liveSessionCount == 2)
+    }
+
+    @Test
     func sessionBootstrapPlaceholderAppearsWhileStartupResolutionIsPending() {
         let now = Date(timeIntervalSince1970: 2_000)
         let model = AppModel()

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -1017,6 +1017,104 @@ struct AppModelSessionListTests {
         #expect(merged.map(\.id) == [existing.id])
     }
 
+    @Test
+    func mergedWithSyntheticCursorSessionsAddsCursorAgentWhenNoTrackedSessionExists() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let model = AppModel()
+
+        let merged = model.monitoring.mergedWithSyntheticCursorSessions(
+            existingSessions: [],
+            activeProcesses: [
+                .init(
+                    tool: .cursor,
+                    sessionID: "6f7b9f8a-2bd0-48b4-a497-9801dd191d03",
+                    workingDirectory: "/tmp/simple-agent-lab",
+                    terminalTTY: "/dev/ttys003",
+                    terminalApp: "Ghostty"
+                ),
+            ],
+            now: now
+        )
+
+        #expect(merged.count == 1)
+        #expect(merged.first?.id == "6f7b9f8a-2bd0-48b4-a497-9801dd191d03")
+        #expect(merged.first?.tool == .cursor)
+        #expect(merged.first?.attachmentState == .attached)
+        #expect(merged.first?.jumpTarget?.terminalApp == "Ghostty")
+        #expect(merged.first?.jumpTarget?.terminalTTY == "/dev/ttys003")
+        #expect(merged.first?.cursorMetadata?.conversationId == "6f7b9f8a-2bd0-48b4-a497-9801dd191d03")
+    }
+
+    @Test
+    func mergedWithSyntheticCursorSessionsSkipsSyntheticWhenHookSessionMatchesConversation() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let model = AppModel()
+        let existing = AgentSession(
+            id: "6f7b9f8a-2bd0-48b4-a497-9801dd191d03",
+            title: "Cursor · simple-agent-lab",
+            tool: .cursor,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Running",
+            updatedAt: now,
+            jumpTarget: JumpTarget(
+                terminalApp: "Cursor",
+                workspaceName: "simple-agent-lab",
+                paneTitle: "Cursor 6f7b9f8a",
+                workingDirectory: "/tmp/simple-agent-lab"
+            ),
+            cursorMetadata: CursorSessionMetadata(
+                conversationId: "6f7b9f8a-2bd0-48b4-a497-9801dd191d03"
+            )
+        )
+
+        let merged = model.monitoring.mergedWithSyntheticCursorSessions(
+            existingSessions: [existing],
+            activeProcesses: [
+                .init(
+                    tool: .cursor,
+                    sessionID: "6f7b9f8a-2bd0-48b4-a497-9801dd191d03",
+                    workingDirectory: "/tmp/simple-agent-lab",
+                    terminalTTY: "/dev/ttys003",
+                    terminalApp: "Ghostty"
+                ),
+            ],
+            now: now
+        )
+
+        #expect(merged.map(\.id) == [existing.id])
+    }
+
+    @Test
+    func mergedWithSyntheticCursorSessionsDeduplicatesRepeatedConversationProcesses() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let model = AppModel()
+
+        let merged = model.monitoring.mergedWithSyntheticCursorSessions(
+            existingSessions: [],
+            activeProcesses: [
+                .init(
+                    tool: .cursor,
+                    sessionID: "6f7b9f8a-2bd0-48b4-a497-9801dd191d03",
+                    workingDirectory: "/tmp/simple-agent-lab",
+                    terminalTTY: "/dev/ttys003",
+                    terminalApp: "Ghostty"
+                ),
+                .init(
+                    tool: .cursor,
+                    sessionID: "6f7b9f8a-2bd0-48b4-a497-9801dd191d03",
+                    workingDirectory: "/tmp/simple-agent-lab",
+                    terminalTTY: "/dev/ttys004",
+                    terminalApp: "Ghostty"
+                ),
+            ],
+            now: now
+        )
+
+        #expect(merged.map(\.id) == ["6f7b9f8a-2bd0-48b4-a497-9801dd191d03"])
+    }
+
 
     /// Regression test: `measuredNotificationContentHeight` MUST be cleared when the
     /// surface changes to a different session, to avoid sizing the new card with stale


### PR DESCRIPTION
## Summary
- give Codex.app sessions a thread-scoped live attachment key instead of reusing terminal pane keys
- add coverage for multiple Codex.app threads in the same workspace staying visible as distinct island sessions

## Verification
- swift build
- swift test --filter AppModelSessionListTests (blocked locally by CommandLineTools missing Swift Testing module; CI covers this)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Live sessions from Codex.app are now tracked separately when they belong to different threads in the same workspace.
  * Session lists and live session counts now keep multiple Codex.app threads distinct instead of merging them together.
  * Improved Cursor (cursor-agent) session detection and reconciliation, reducing duplicate sessions and updating live/attachment state more reliably based on the currently active Cursor processes.
* **Tests**
  * Added regression coverage for distinct Codex.app threads and expanded Cursor synthetic-session discovery/synthesis scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->