### PR TITLE
perf(monitor): reduce idle process polling

### DIFF
--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -9,6 +9,38 @@ struct ActiveAgentProcessDiscovery {
         var data = Data()
     }
 
+    private final class LSOFCacheBox: @unchecked Sendable {
+        private struct Entry {
+            var output: String
+            var expiresAt: Date
+        }
+
+        private let lock = NSLock()
+        private var entries: [String: Entry] = [:]
+
+        func output(for pid: String, now: Date) -> String? {
+            lock.lock()
+            defer { lock.unlock() }
+
+            guard let entry = entries[pid] else {
+                return nil
+            }
+
+            guard entry.expiresAt > now else {
+                entries.removeValue(forKey: pid)
+                return nil
+            }
+
+            return entry.output
+        }
+
+        func store(_ output: String, for pid: String, expiresAt: Date) {
+            lock.lock()
+            entries[pid] = Entry(output: output, expiresAt: expiresAt)
+            lock.unlock()
+        }
+    }
+
     struct ProcessSnapshot: Equatable, Sendable {
         var tool: AgentTool
         var sessionID: String?
@@ -48,11 +80,22 @@ struct ActiveAgentProcessDiscovery {
     }
 
     typealias CommandRunner = @Sendable (_ executablePath: String, _ arguments: [String]) -> String?
+    typealias DateProvider = @Sendable () -> Date
 
     private let commandRunner: CommandRunner
+    private let dateProvider: DateProvider
+    private let lsofCache: LSOFCacheBox
+    private let lsofCacheTTL: TimeInterval
 
-    init(commandRunner: @escaping CommandRunner = Self.commandOutput) {
+    init(
+        commandRunner: @escaping CommandRunner = Self.commandOutput,
+        dateProvider: @escaping DateProvider = { Date() },
+        lsofCacheTTL: TimeInterval = 10
+    ) {
         self.commandRunner = commandRunner
+        self.dateProvider = dateProvider
+        self.lsofCache = LSOFCacheBox()
+        self.lsofCacheTTL = lsofCacheTTL
     }
 
     func discover() -> [ProcessSnapshot] {
@@ -558,7 +601,17 @@ struct ActiveAgentProcessDiscovery {
     }
 
     private func lsofOutput(pid: String) -> String? {
-        commandRunner("/usr/sbin/lsof", ["-a", "-p", pid, "-Fn"])
+        let now = dateProvider()
+        if let cached = lsofCache.output(for: pid, now: now) {
+            return cached
+        }
+
+        guard let output = commandRunner("/usr/sbin/lsof", ["-a", "-p", pid, "-Fn"]) else {
+            return nil
+        }
+
+        lsofCache.store(output, for: pid, expiresAt: now.addingTimeInterval(lsofCacheTTL))
+        return output
     }
 
     private func workingDirectory(from lsofOutput: String) -> String? {

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1502,6 +1502,7 @@ final class AppModel {
         if ingress == .bridge {
             monitoring.markSessionAttached(for: event)
             monitoring.markSessionProcessAlive(for: event)
+            monitoring.scheduleReconcileSoon()
         }
         synchronizeSelection()
         discovery.refreshCodexRolloutTracking()

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -46,12 +46,21 @@ final class ProcessMonitoringCoordinator {
     private var sessionAttachmentMonitorTask: Task<Void, Never>?
 
     @ObservationIgnored
+    private var immediateReconcileTask: Task<Void, Never>?
+
+    @ObservationIgnored
+    private var codexAppObservers: [NSObjectProtocol] = []
+
+    @ObservationIgnored
     private var wasCodexAppRunning = false
 
     private static let startupPollInterval: TimeInterval = 2
     private static let codexAppRunningProbeInterval: TimeInterval = 2
-    private static let activePollInterval: TimeInterval = 60
-    private static let idlePollInterval: TimeInterval = 300
+    private static let activePollInterval: TimeInterval = 2
+    private static let recentPollInterval: TimeInterval = 8
+    private static let idlePollInterval: TimeInterval = 20
+    private static let emptyPollInterval: TimeInterval = 30
+    private static let recentSessionWindow: TimeInterval = 120
     private static let cursorStalenessTimeout: TimeInterval = 600  // 10 minutes
     private static let codexAppStalenessTimeout: TimeInterval = 600  // 10 minutes
     private static let claudeDesktopStalenessTimeout: TimeInterval = 600  // 10 minutes
@@ -64,7 +73,7 @@ final class ProcessMonitoringCoordinator {
             return startupPollInterval
         }
 
-        return hasTrackedLiveSessions ? activePollInterval : idlePollInterval
+        return hasTrackedLiveSessions ? idlePollInterval : emptyPollInterval
     }
 
     static func monitoringWakeInterval(
@@ -104,6 +113,8 @@ final class ProcessMonitoringCoordinator {
     // MARK: - Monitoring lifecycle
 
     func startMonitoringIfNeeded() {
+        startCodexAppObserversIfNeeded()
+
         guard sessionAttachmentMonitorTask == nil else {
             return
         }
@@ -131,43 +142,25 @@ final class ProcessMonitoringCoordinator {
                     let discovery = self.activeAgentProcessDiscovery
                     let probe = self.terminalSessionAttachmentProbe
                     let resolver = self.terminalJumpTargetResolver
-                    let shouldResolveTerminals = hasTrackedLiveSessions
-                    let (snapshots, ghosttyAvail, terminalAvail, jumpTargets) = await Task.detached(priority: .utility) {
-                        let s = discovery.discover()
-                        let g: TerminalSessionAttachmentProbe.SnapshotAvailability<TerminalSessionAttachmentProbe.GhosttyTerminalSnapshot>
-                        let t: TerminalSessionAttachmentProbe.SnapshotAvailability<TerminalSessionAttachmentProbe.TerminalTabSnapshot>
-                        let j: [String: JumpTarget]
-
-                        if shouldResolveTerminals {
-                            g = probe.ghosttySnapshotAvailability()
-                            t = probe.terminalSnapshotAvailability()
-                            j = resolver.resolveJumpTargets(for: liveSessions, activeProcesses: s)
-                        } else {
-                            g = .available([], appIsRunning: false)
-                            t = .available([], appIsRunning: false)
-                            j = [:]
-                        }
-
-                        return (s, g, t, j)
-                    }.value
-                    let isCodexAppRunning = Self.isCodexDesktopAppRunning()
-                    self.reconcileSessionAttachments(
-                        activeProcesses: snapshots,
-                        ghosttyAvailability: ghosttyAvail,
-                        terminalAvailability: terminalAvail,
-                        preResolvedJumpTargets: jumpTargets,
-                        observedCodexAppRunning: isCodexAppRunning
+                    let options = Self.monitoringOptions(
+                        for: liveSessions,
+                        isResolvingInitialLiveSessions: self.isResolvingInitialLiveSessions
                     )
-                    if isCodexAppRunning {
-                        self.onCodexAppMaintenanceTick?()
-                    }
-
-                    let pollInterval = Self.monitoringPollInterval(
-                        isResolvingInitialLiveSessions: self.isResolvingInitialLiveSessions,
-                        hasTrackedLiveSessions: self.state.sessions.contains(where: \.isTrackedLiveSession)
+                    await self.performMonitoringPass(
+                        discovery: discovery,
+                        probe: probe,
+                        resolver: resolver,
+                        liveSessions: liveSessions,
+                        options: options
                     )
-                    nextFullReconcileAt = Date().addingTimeInterval(pollInterval)
-                    hadTrackedLiveSessions = self.state.sessions.contains(where: \.isTrackedLiveSession)
+
+                    let updatedLiveSessions = self.state.sessions.filter(\.isTrackedLiveSession)
+                    let updatedOptions = Self.monitoringOptions(
+                        for: updatedLiveSessions,
+                        isResolvingInitialLiveSessions: self.isResolvingInitialLiveSessions
+                    )
+                    nextFullReconcileAt = Date().addingTimeInterval(updatedOptions.pollInterval)
+                    hadTrackedLiveSessions = !updatedLiveSessions.isEmpty
                 } else {
                     let isCodexAppRunning = self.reconcileCodexAppRunningState()
                     if isCodexAppRunning {
@@ -195,12 +188,119 @@ final class ProcessMonitoringCoordinator {
         return isCodexAppRunning
     }
 
+    func scheduleReconcileSoon() {
+        immediateReconcileTask?.cancel()
+        immediateReconcileTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(500))
+            guard !Task.isCancelled, let self else {
+                return
+            }
+
+            let liveSessions = self.state.sessions.filter(\.isTrackedLiveSession)
+            let options = Self.monitoringOptions(
+                for: liveSessions,
+                isResolvingInitialLiveSessions: self.isResolvingInitialLiveSessions
+            )
+            await self.performMonitoringPass(
+                discovery: self.activeAgentProcessDiscovery,
+                probe: self.terminalSessionAttachmentProbe,
+                resolver: self.terminalJumpTargetResolver,
+                liveSessions: liveSessions,
+                options: options
+            )
+        }
+    }
+
+    @discardableResult
+    private func performMonitoringPass(
+        discovery: ActiveAgentProcessDiscovery,
+        probe: TerminalSessionAttachmentProbe,
+        resolver: TerminalJumpTargetResolver,
+        liveSessions: [AgentSession],
+        options: MonitoringOptions
+    ) async -> Bool {
+        let (snapshots, ghosttyAvail, terminalAvail, itermAvail, jumpTargets) = await Task.detached(priority: .utility) {
+            let s = discovery.discover()
+            let g: TerminalSessionAttachmentProbe.SnapshotAvailability<TerminalSessionAttachmentProbe.GhosttyTerminalSnapshot> = options.probeGhostty
+                ? probe.ghosttySnapshotAvailability()
+                : .available([], appIsRunning: false)
+            let t: TerminalSessionAttachmentProbe.SnapshotAvailability<TerminalSessionAttachmentProbe.TerminalTabSnapshot> = options.probeTerminal
+                ? probe.terminalSnapshotAvailability()
+                : .available([], appIsRunning: false)
+            let i: TerminalSessionAttachmentProbe.SnapshotAvailability<TerminalSessionAttachmentProbe.ITermSessionSnapshot> = options.probeITerm
+                ? probe.itermSnapshotAvailability()
+                : .available([], appIsRunning: false)
+            let j = liveSessions.isEmpty
+                ? [:]
+                : resolver.resolveJumpTargets(for: liveSessions, activeProcesses: s)
+            return (s, g, t, i, j)
+        }.value
+        let isCodexAppRunning = Self.isCodexDesktopAppRunning()
+        reconcileSessionAttachments(
+            activeProcesses: snapshots,
+            ghosttyAvailability: ghosttyAvail,
+            terminalAvailability: terminalAvail,
+            itermAvailability: itermAvail,
+            preResolvedJumpTargets: jumpTargets,
+            observedCodexAppRunning: isCodexAppRunning
+        )
+        if isCodexAppRunning {
+            onCodexAppMaintenanceTick?()
+        }
+        return isCodexAppRunning
+    }
+
+    private func startCodexAppObserversIfNeeded() {
+        guard codexAppObservers.isEmpty else { return }
+
+        let center = NSWorkspace.shared.notificationCenter
+        let launched = center.addObserver(
+            forName: NSWorkspace.didLaunchApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            let bundleIdentifier = (notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication)?
+                .bundleIdentifier
+            Task { @MainActor [weak self, bundleIdentifier] in
+                self?.handleCodexAppWorkspaceNotification(bundleIdentifier: bundleIdentifier)
+            }
+        }
+        let terminated = center.addObserver(
+            forName: NSWorkspace.didTerminateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            let bundleIdentifier = (notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication)?
+                .bundleIdentifier
+            Task { @MainActor [weak self, bundleIdentifier] in
+                self?.handleCodexAppWorkspaceNotification(bundleIdentifier: bundleIdentifier)
+            }
+        }
+        codexAppObservers = [launched, terminated]
+    }
+
+    private func handleCodexAppWorkspaceNotification(bundleIdentifier: String?) {
+        guard bundleIdentifier == "com.openai.codex" else {
+            return
+        }
+
+        let isRunning = Self.isCodexDesktopAppRunning()
+        guard isRunning != wasCodexAppRunning else {
+            return
+        }
+
+        wasCodexAppRunning = isRunning
+        onCodexAppRunningChanged?(isRunning)
+        scheduleReconcileSoon()
+    }
+
     // MARK: - Reconciliation
 
     func reconcileSessionAttachments(
         activeProcesses: [ActiveProcessSnapshot]? = nil,
         ghosttyAvailability: TerminalSessionAttachmentProbe.SnapshotAvailability<TerminalSessionAttachmentProbe.GhosttyTerminalSnapshot>? = nil,
         terminalAvailability: TerminalSessionAttachmentProbe.SnapshotAvailability<TerminalSessionAttachmentProbe.TerminalTabSnapshot>? = nil,
+        itermAvailability: TerminalSessionAttachmentProbe.SnapshotAvailability<TerminalSessionAttachmentProbe.ITermSessionSnapshot>? = nil,
         preResolvedJumpTargets: [String: JumpTarget]? = nil,
         observedCodexAppRunning: Bool? = nil
     ) {
@@ -253,6 +353,7 @@ final class ProcessMonitoringCoordinator {
                 for: sessions,
                 ghosttyAvailability: ghosttyAvailability,
                 terminalAvailability: terminalAvailability,
+                itermAvailability: itermAvailability ?? .available([], appIsRunning: false),
                 activeProcesses: activeProcesses,
                 allowRecentAttachmentGrace: !isResolvingInitialLiveSessions
             )
@@ -321,6 +422,90 @@ final class ProcessMonitoringCoordinator {
         }
         onSessionsReconciled?()
         onPersistenceNeeded?()
+    }
+
+    // MARK: - Monitoring policy
+
+    struct MonitoringOptions: Equatable {
+        var pollInterval: TimeInterval
+        var probeGhostty: Bool
+        var probeTerminal: Bool
+        var probeITerm: Bool
+    }
+
+    static func monitoringOptions(
+        for sessions: [AgentSession],
+        isResolvingInitialLiveSessions: Bool,
+        now: Date = .now
+    ) -> MonitoringOptions {
+        MonitoringOptions(
+            pollInterval: pollingInterval(
+                for: sessions,
+                isResolvingInitialLiveSessions: isResolvingInitialLiveSessions,
+                now: now
+            ),
+            probeGhostty: sessions.contains(where: shouldProbeGhostty),
+            probeTerminal: sessions.contains(where: shouldProbeTerminal),
+            probeITerm: sessions.contains(where: shouldProbeITerm)
+        )
+    }
+
+    static func pollingInterval(
+        for sessions: [AgentSession],
+        isResolvingInitialLiveSessions: Bool,
+        now: Date = .now
+    ) -> TimeInterval {
+        guard !isResolvingInitialLiveSessions else {
+            return startupPollInterval
+        }
+
+        guard !sessions.isEmpty else {
+            return emptyPollInterval
+        }
+
+        if sessions.contains(where: isActiveSession) {
+            return activePollInterval
+        }
+
+        if sessions.contains(where: { now.timeIntervalSince($0.updatedAt) <= recentSessionWindow }) {
+            return recentPollInterval
+        }
+
+        return idlePollInterval
+    }
+
+    private static func isActiveSession(_ session: AgentSession) -> Bool {
+        session.phase == .running || session.phase.requiresAttention
+    }
+
+    private static func shouldProbeGhostty(_ session: AgentSession) -> Bool {
+        switch normalizedTerminalName(for: session.jumpTarget?.terminalApp) {
+        case "ghostty", nil, "unknown":
+            true
+        default:
+            session.jumpTarget == nil
+        }
+    }
+
+    private static func shouldProbeTerminal(_ session: AgentSession) -> Bool {
+        normalizedTerminalName(for: session.jumpTarget?.terminalApp) == "terminal"
+    }
+
+    private static func shouldProbeITerm(_ session: AgentSession) -> Bool {
+        normalizedTerminalName(for: session.jumpTarget?.terminalApp) == "iterm"
+    }
+
+    private static func normalizedTerminalName(for value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+
+        let lowered = trimmed.lowercased()
+        if lowered == "iterm2" || lowered == "iterm.app" {
+            return "iterm"
+        }
+        return lowered
     }
 
     // MARK: - Event helpers

--- a/Tests/OpenIslandAppTests/ActiveAgentProcessDiscoveryTests.swift
+++ b/Tests/OpenIslandAppTests/ActiveAgentProcessDiscoveryTests.swift
@@ -215,6 +215,88 @@ struct ActiveAgentProcessDiscoveryTests {
         #expect(snapshots.first?.sessionID == "6f7b9f8a-2bd0-48b4-a497-9801dd191d03")
     }
 
+    @Test
+    func lsofSuccessOutputIsCachedWithinTTL() {
+        let state = DiscoveryTestState(now: Date(timeIntervalSince1970: 1_000))
+        let discovery = ActiveAgentProcessDiscovery(
+            commandRunner: { executablePath, arguments in
+                if executablePath == "/bin/ps" {
+                    return """
+                      102 301 ttys002 /Users/test/.local/bin/claude
+                      301 900 ttys002 -/opt/homebrew/bin/fish
+                      900 1 ?? /Applications/Ghostty.app/Contents/MacOS/ghostty
+                    """
+                }
+
+                guard executablePath == "/usr/sbin/lsof",
+                      arguments.dropFirst(2).first == "102" else {
+                    return nil
+                }
+
+                state.incrementLSOFLookups()
+                return """
+                fcwd
+                n/tmp/open-island
+                """
+            },
+            dateProvider: { state.now },
+            lsofCacheTTL: 10
+        )
+
+        _ = discovery.discover()
+        _ = discovery.discover()
+        #expect(state.lsofLookups == 1)
+
+        state.advance(by: 11)
+        _ = discovery.discover()
+        #expect(state.lsofLookups == 2)
+    }
+
+    @Test
+    func lsofFailureOutputIsNotCached() {
+        let state = DiscoveryTestState(now: Date(timeIntervalSince1970: 1_000))
+        let discovery = ActiveAgentProcessDiscovery(
+            commandRunner: { executablePath, arguments in
+                if executablePath == "/bin/ps" {
+                    return """
+                      102 301 ttys002 /Users/test/.local/bin/claude
+                      301 900 ttys002 -/opt/homebrew/bin/fish
+                      900 1 ?? /Applications/Ghostty.app/Contents/MacOS/ghostty
+                    """
+                }
+
+                guard executablePath == "/usr/sbin/lsof",
+                      arguments.dropFirst(2).first == "102" else {
+                    return nil
+                }
+
+                let lsofLookups = state.incrementLSOFLookups()
+                guard lsofLookups > 1 else {
+                    return nil
+                }
+
+                return """
+                fcwd
+                n/tmp/open-island
+                """
+            },
+            dateProvider: { state.now },
+            lsofCacheTTL: 10
+        )
+
+        #expect(discovery.discover().isEmpty)
+        #expect(discovery.discover() == [
+            .init(
+                tool: .claudeCode,
+                sessionID: nil,
+                workingDirectory: "/tmp/open-island",
+                terminalTTY: "/dev/ttys002",
+                terminalApp: "Ghostty"
+            ),
+        ])
+        #expect(state.lsofLookups == 2)
+    }
+
     /// VS Code forks (Cursor, Windsurf, Trae, Qoder) bundle Electron's "Code
     /// Helper" inside their .app bundles. Their helper paths therefore contain
     /// both "/<fork>.app/" and "/code helper", and Open Island used to match
@@ -256,5 +338,41 @@ struct ActiveAgentProcessDiscoveryTests {
                 terminalApp: expectedTerminal
             ),
         ])
+    }
+}
+
+private final class DiscoveryTestState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedNow: Date
+    private var storedLSOFLookups = 0
+
+    init(now: Date) {
+        self.storedNow = now
+    }
+
+    var now: Date {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedNow
+    }
+
+    var lsofLookups: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedLSOFLookups
+    }
+
+    func advance(by interval: TimeInterval) {
+        lock.lock()
+        storedNow = storedNow.addingTimeInterval(interval)
+        lock.unlock()
+    }
+
+    @discardableResult
+    func incrementLSOFLookups() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        storedLSOFLookups += 1
+        return storedLSOFLookups
     }
 }

--- a/Tests/OpenIslandAppTests/PerformancePolicyTests.swift
+++ b/Tests/OpenIslandAppTests/PerformancePolicyTests.swift
@@ -31,11 +31,11 @@ struct PerformancePolicyTests {
         #expect(ProcessMonitoringCoordinator.monitoringPollInterval(
             isResolvingInitialLiveSessions: false,
             hasTrackedLiveSessions: true
-        ) == 60)
+        ) == 20)
         #expect(ProcessMonitoringCoordinator.monitoringPollInterval(
             isResolvingInitialLiveSessions: false,
             hasTrackedLiveSessions: false
-        ) == 300)
+        ) == 30)
     }
 
     @MainActor
@@ -55,7 +55,7 @@ struct PerformancePolicyTests {
     @Test
     func trackedSessionTransitionForcesFullReconcileBeforeIdleDeadline() {
         let now = Date(timeIntervalSinceReferenceDate: 1_000)
-        let idleDeadline = now.addingTimeInterval(300)
+        let idleDeadline = now.addingTimeInterval(30)
 
         #expect(!ProcessMonitoringCoordinator.shouldPerformFullMonitorReconcile(
             now: now,

--- a/Tests/OpenIslandAppTests/ProcessMonitoringCoordinatorTests.swift
+++ b/Tests/OpenIslandAppTests/ProcessMonitoringCoordinatorTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+@testable import OpenIslandApp
+import OpenIslandCore
+
+struct ProcessMonitoringCoordinatorTests {
+    @Test
+    @MainActor
+    func pollingIntervalTracksSessionUrgency() {
+        let now = Date(timeIntervalSince1970: 1_000)
+
+        #expect(ProcessMonitoringCoordinator.pollingInterval(
+            for: [],
+            isResolvingInitialLiveSessions: true,
+            now: now
+        ) == 2)
+        #expect(ProcessMonitoringCoordinator.pollingInterval(
+            for: [],
+            isResolvingInitialLiveSessions: false,
+            now: now
+        ) == 30)
+        #expect(ProcessMonitoringCoordinator.pollingInterval(
+            for: [session(phase: .running, updatedAt: now.addingTimeInterval(-600))],
+            isResolvingInitialLiveSessions: false,
+            now: now
+        ) == 2)
+        #expect(ProcessMonitoringCoordinator.pollingInterval(
+            for: [session(phase: .completed, updatedAt: now.addingTimeInterval(-60))],
+            isResolvingInitialLiveSessions: false,
+            now: now
+        ) == 8)
+        #expect(ProcessMonitoringCoordinator.pollingInterval(
+            for: [session(phase: .completed, updatedAt: now.addingTimeInterval(-600))],
+            isResolvingInitialLiveSessions: false,
+            now: now
+        ) == 20)
+    }
+
+    @Test
+    @MainActor
+    func terminalSnapshotsAreGatedByTrackedSessionTargets() {
+        let now = Date(timeIntervalSince1970: 1_000)
+
+        let empty = ProcessMonitoringCoordinator.monitoringOptions(
+            for: [],
+            isResolvingInitialLiveSessions: false,
+            now: now
+        )
+        #expect(empty.probeGhostty == false)
+        #expect(empty.probeTerminal == false)
+        #expect(empty.probeITerm == false)
+
+        let ghostty = ProcessMonitoringCoordinator.monitoringOptions(
+            for: [session(terminalApp: "Ghostty", updatedAt: now)],
+            isResolvingInitialLiveSessions: false,
+            now: now
+        )
+        #expect(ghostty.probeGhostty == true)
+        #expect(ghostty.probeTerminal == false)
+        #expect(ghostty.probeITerm == false)
+
+        let terminal = ProcessMonitoringCoordinator.monitoringOptions(
+            for: [session(terminalApp: "Terminal", updatedAt: now)],
+            isResolvingInitialLiveSessions: false,
+            now: now
+        )
+        #expect(terminal.probeGhostty == false)
+        #expect(terminal.probeTerminal == true)
+        #expect(terminal.probeITerm == false)
+
+        let iterm = ProcessMonitoringCoordinator.monitoringOptions(
+            for: [session(terminalApp: "iTerm", updatedAt: now)],
+            isResolvingInitialLiveSessions: false,
+            now: now
+        )
+        #expect(iterm.probeGhostty == false)
+        #expect(iterm.probeTerminal == false)
+        #expect(iterm.probeITerm == true)
+    }
+
+    private func session(
+        phase: SessionPhase = .completed,
+        terminalApp: String = "Ghostty",
+        updatedAt: Date
+    ) -> AgentSession {
+        AgentSession(
+            id: UUID().uuidString.lowercased(),
+            title: "Codex",
+            tool: .codex,
+            origin: .live,
+            attachmentState: .attached,
+            phase: phase,
+            summary: "Summary",
+            updatedAt: updatedAt,
+            jumpTarget: JumpTarget(
+                terminalApp: terminalApp,
+                workspaceName: "open-island",
+                paneTitle: "codex ~/open-island",
+                workingDirectory: "/tmp/open-island"
+            )
+        )
+    }
+}


### PR DESCRIPTION
- Add adaptive monitor intervals for active, recent, idle, and empty states
- Gate terminal snapshots and jump resolution by tracked live sessions
- Cache successful lsof output briefly to avoid repeated PID lookups
- Wake monitoring on bridge and Codex app lifecycle events
- Cover monitor policy and lsof cache behavior with focused tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved background monitoring for active sessions, with smarter polling based on session activity and recency.
  * Added support for more terminal apps during session detection, including iTerm.

* **Bug Fixes**
  * Reduced repeated process lookups to improve responsiveness and lower system overhead.
  * Monitoring now refreshes sooner when app or workspace state changes, helping session status stay current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->