### PR TITLE
fix: install Codex PreToolUse hooks

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -234,6 +234,8 @@ final class AppModel {
             refreshOverlayPlacementIfVisible()
         }
     }
+    /// Which edge the island panel is docked to. Driven by OverlayPanelController on drag.
+    var dockEdge: IslandDockEdge = .top
     var islandPixelShapeStyle: IslandPixelShapeStyle = .bars {
         didSet {
             guard islandPixelShapeStyle != oldValue else { return }

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -39,10 +39,23 @@ final class AppModel {
     var state = SessionState() {
         didSet {
             _cachedSessionBuckets = nil
+            if !acknowledgedEndedSessionIDs.isEmpty {
+                // Drop acknowledgements for sessions that are gone or have
+                // restarted (no longer ended), so a session's next completion
+                // re-surfaces as unseen.
+                let stillEnded = Set(state.sessions.filter(\.isSessionEnded).map(\.id))
+                acknowledgedEndedSessionIDs.formIntersection(stillEnded)
+            }
             bridgeServer.updateStateSnapshot(state)
         }
     }
     @ObservationIgnored private var _cachedSessionBuckets: (primary: [AgentSession], overflow: [AgentSession])?
+    /// Hook-managed sessions that have ended and that the user has already seen
+    /// in an island they actively opened. Keeps a completed Claude Code task in
+    /// the pending badge after it finishes — until the user opens the island and
+    /// sees it — instead of vanishing when its notification card collapses.
+    /// See `shouldSurfaceInIsland(_:)`.
+    @ObservationIgnored private var acknowledgedEndedSessionIDs: Set<String> = []
     var selectedSessionID: String?
     let hooks = HookInstallationCoordinator()
     let overlay = OverlayUICoordinator()
@@ -483,6 +496,7 @@ final class AppModel {
         monitoring.syntheticClaudeSessionPrefix = Self.syntheticClaudeSessionPrefix
         monitoring.stateAccessor = { [weak self] in self?.state ?? SessionState() }
         monitoring.stateUpdater = { [weak self] in self?.state = $0 }
+        monitoring.acknowledgedEndedSessionIDsAccessor = { [weak self] in self?.acknowledgedEndedSessionIDs ?? [] }
         monitoring.onSessionsReconciled = { [weak self] in
             self?.synchronizeSelection()
             self?.refreshOverlayPlacementIfVisible()
@@ -1191,7 +1205,7 @@ final class AppModel {
         var primary: [AgentSession] = []
         var claimedLiveAttachmentKeys: Set<String> = []
 
-        for session in rankedSessions where session.isVisibleInIsland {
+        for session in rankedSessions where shouldSurfaceInIsland(session) {
             guard !session.isSubagentSession else { continue }
 
             if let liveAttachmentKey = monitoring.liveAttachmentKey(for: session) {
@@ -1206,6 +1220,37 @@ final class AppModel {
         let primaryIDs = Set(primary.map(\.id))
         let overflow = rankedSessions.filter { !primaryIDs.contains($0.id) && !$0.isSubagentSession }
         return (primary, overflow)
+    }
+
+    /// Like `AgentSession.isVisibleInIsland`, but also keeps a completed
+    /// hook-managed (e.g. Claude Code) session surfaced after it ends until the
+    /// user has opened the island and seen it. Stops a finished CC task from
+    /// disappearing from the pending badge the moment its notification card
+    /// auto-collapses.
+    private func shouldSurfaceInIsland(_ session: AgentSession) -> Bool {
+        session.isVisibleInIsland || isUnseenEndedHookSession(session)
+    }
+
+    private func isUnseenEndedHookSession(_ session: AgentSession) -> Bool {
+        session.isHookManaged
+            && session.isSessionEnded
+            && !acknowledgedEndedSessionIDs.contains(session.id)
+    }
+
+    /// Marks every currently-surfaced ended hook session as seen. Called when the
+    /// user closes an island they actively opened (hover/click), so a completed
+    /// task's badge clears only after they've had a chance to look — not when a
+    /// passive notification card auto-collapses.
+    func markSurfacedEndedSessionsSeen() {
+        let endedIDs = surfacedSessions
+            .filter { $0.isHookManaged && $0.isSessionEnded }
+            .map(\.id)
+        guard !endedIDs.isEmpty else { return }
+        let before = acknowledgedEndedSessionIDs.count
+        acknowledgedEndedSessionIDs.formUnion(endedIDs)
+        if acknowledgedEndedSessionIDs.count != before {
+            _cachedSessionBuckets = nil
+        }
     }
 
     private func displayPriority(for session: AgentSession, now: Date) -> Int {

--- a/Sources/OpenIslandApp/AppModelTypes.swift
+++ b/Sources/OpenIslandApp/AppModelTypes.swift
@@ -44,3 +44,14 @@ enum IslandPixelShapeStyle: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 }
+
+/// Which screen edge the island panel is docked to.
+enum IslandDockEdge: String, CaseIterable, Identifiable {
+    case top
+    case left
+    case right
+
+    var id: String { rawValue }
+
+    var isVertical: Bool { self == .left || self == .right }
+}

--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -30,12 +30,103 @@ final class OverlayPanelController {
     private static let completionCardMaxHeight: CGFloat = 400
     private static let hiddenIdleEdgeHoverHitHeight: CGFloat = 8
 
+    private static let customPositionXKey = "islandCustomPositionX"
+    private static let customPositionYKey = "islandCustomPositionY"
+    private static let useCustomPositionKey = "islandUseCustomPosition"
+
     private var panel: NotchPanel?
     private var eventMonitors = NotchEventMonitors()
     private var hoverTimer: DispatchWorkItem?
     private var hoverCancelGrace: DispatchWorkItem?
     weak var model: AppModel?
     private(set) var notchRect: NSRect = .zero
+
+    /// Whether the user has dragged the panel to a custom position.
+    var useCustomPosition: Bool {
+        get { UserDefaults.standard.bool(forKey: Self.useCustomPositionKey) }
+        set { UserDefaults.standard.set(newValue, forKey: Self.useCustomPositionKey) }
+    }
+
+    /// The user's custom panel origin, persisted across launches.
+    var customPosition: NSPoint? {
+        get {
+            guard useCustomPosition else { return nil }
+            let x = UserDefaults.standard.double(forKey: Self.customPositionXKey)
+            let y = UserDefaults.standard.double(forKey: Self.customPositionYKey)
+            return NSPoint(x: x, y: y)
+        }
+        set {
+            if let p = newValue {
+                UserDefaults.standard.set(p.x, forKey: Self.customPositionXKey)
+                UserDefaults.standard.set(p.y, forKey: Self.customPositionYKey)
+                useCustomPosition = true
+            } else {
+                useCustomPosition = false
+            }
+        }
+    }
+
+    /// Distance from screen edge to trigger snap (in points).
+    private static let edgeSnapThreshold: CGFloat = 80
+    /// Width of the vertical sidebar when docked to left/right edge.
+    private static let verticalPanelWidth: CGFloat = 320
+    /// Key for persisting dock edge.
+    private static let dockEdgeKey = "islandDockEdge"
+
+    var dockEdge: IslandDockEdge {
+        get {
+            let raw = UserDefaults.standard.string(forKey: Self.dockEdgeKey) ?? "top"
+            return IslandDockEdge(rawValue: raw) ?? .top
+        }
+        set {
+            UserDefaults.standard.set(newValue.rawValue, forKey: Self.dockEdgeKey)
+            model?.dockEdge = newValue
+        }
+    }
+
+    /// Reset the panel back to the notch position.
+    func resetToNotch() {
+        customPosition = nil
+        dockEdge = .top
+        guard let panel, let screen = resolveTargetScreen() else { return }
+        let frame = panelFrame(for: model, on: screen)
+        panel.setFrame(frame, display: true)
+        computeNotchRect(screen: screen)
+    }
+
+    /// Called when the user finishes dragging the panel. Detects edge proximity and snaps.
+    func panelDidMove() {
+        guard let panel, let screen = resolveTargetScreen() else { return }
+        let panelFrame = panel.frame
+        let screenFrame = screen.frame
+
+        let distToLeft = panelFrame.minX - screenFrame.minX
+        let distToRight = screenFrame.maxX - panelFrame.maxX
+        let distToTop = screenFrame.maxY - panelFrame.maxY
+
+        let newEdge: IslandDockEdge
+        if distToTop < Self.edgeSnapThreshold && distToTop <= distToLeft && distToTop <= distToRight {
+            newEdge = .top
+        } else if distToLeft < Self.edgeSnapThreshold && distToLeft <= distToRight {
+            newEdge = .left
+        } else if distToRight < Self.edgeSnapThreshold {
+            newEdge = .right
+        } else {
+            // Not near any edge — keep as free-floating at current position.
+            customPosition = panel.frame.origin
+            return
+        }
+
+        dockEdge = newEdge
+        // Snap to edge — compute the snapped frame and apply.
+        if newEdge == .top {
+            customPosition = nil
+        } else {
+            customPosition = nil  // Edge-docked positions are computed, not stored.
+        }
+        let snappedFrame = self.panelFrame(for: model, on: screen)
+        panel.setFrame(snappedFrame, display: true, animate: true)
+    }
 
     var isVisible: Bool {
         panel?.isVisible == true
@@ -51,12 +142,21 @@ final class OverlayPanelController {
 
     func ensurePanel(model: AppModel, preferredScreenID: String?) {
         self.model = model
+        // Sync persisted dock edge to model.
+        model.dockEdge = dockEdge
         let panel = self.panel ?? makePanel(model: model)
         self.panel = panel
         positionPanel(panel, preferredScreenID: preferredScreenID, animated: false)
         panel.orderFrontRegardless()
-        panel.ignoresMouseEvents = true
-        panel.acceptsMouseMovedEvents = false
+        if dockEdge.isVertical {
+            // Side-docked: always interactive, always visible as opened.
+            panel.ignoresMouseEvents = false
+            panel.acceptsMouseMovedEvents = true
+            model.notchOpen(reason: .click)
+        } else {
+            panel.ignoresMouseEvents = true
+            panel.acceptsMouseMovedEvents = false
+        }
         startEventMonitoring()
     }
 
@@ -73,6 +173,8 @@ final class OverlayPanelController {
     }
 
     func hide() {
+        // Sidebar mode: never hide — panel stays visible and interactive.
+        if dockEdge.isVertical { return }
         panel?.ignoresMouseEvents = true
         panel?.acceptsMouseMovedEvents = false
     }
@@ -123,7 +225,7 @@ final class OverlayPanelController {
         panel.backgroundColor = .clear
         panel.isOpaque = false
         panel.hasShadow = false
-        panel.isMovable = false
+        panel.isMovable = true
         panel.hidesOnDeactivate = false
         panel.acceptsMouseMovedEvents = false
         panel.collectionBehavior = [.fullScreenAuxiliary, .stationary, .canJoinAllSpaces, .ignoresCycle]
@@ -131,9 +233,20 @@ final class OverlayPanelController {
         panel.titlebarAppearsTransparent = true
         panel.ignoresMouseEvents = true
 
+        panel.overlayController = self
+
         let hostingView = NotchHostingView(rootView: IslandPanelView(model: model))
         hostingView.notchController = self
         panel.contentView = hostingView
+
+        // Listen for drag-end from SwiftUI DragGripButton.
+        NotificationCenter.default.addObserver(
+            forName: .islandPanelDragEnded,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.panelDidMove() }
+        }
 
         computeNotchRect(screen: resolveTargetScreen())
         return panel
@@ -151,7 +264,14 @@ final class OverlayPanelController {
             return nil
         }
 
-        let windowFrame = panelFrame(for: model, on: screen)
+        let windowFrame: NSRect
+        if let custom = customPosition, !dockEdge.isVertical {
+            // Preserve user-dragged origin, only update size (free-floating mode).
+            let size = panelSize(for: model, on: screen)
+            windowFrame = NSRect(origin: custom, size: size)
+        } else {
+            windowFrame = panelFrame(for: model, on: screen)
+        }
 
         // Always set the panel frame instantly — no AppKit animation.
         // All visual transitions (shape, size, opacity, corner radius) are
@@ -234,6 +354,9 @@ final class OverlayPanelController {
     private func handleMouseMoved(_ screenLocation: NSPoint) {
         guard let model else { return }
 
+        // Sidebar mode: always stay opened, no hover open/close logic.
+        if dockEdge.isVertical { return }
+
         let inClosedSurfaceArea = isPointInClosedSurfaceArea(screenLocation)
 
         if model.notchStatus == .closed && inClosedSurfaceArea {
@@ -253,6 +376,9 @@ final class OverlayPanelController {
 
     private func handleMouseDown(_ screenLocation: NSPoint) {
         guard let model else { return }
+
+        // Sidebar mode: never close on outside click. Panel stays open.
+        if dockEdge.isVertical { return }
 
         let inClosedSurfaceArea = isPointInClosedSurfaceArea(screenLocation)
 
@@ -342,6 +468,12 @@ final class OverlayPanelController {
     func isPointInClosedSurfaceArea(_ screenPoint: NSPoint) -> Bool {
         guard let model else { return false }
 
+        // When using a custom position, use the panel frame directly for hit testing.
+        if useCustomPosition, let panel {
+            let expandedFrame = panel.frame.insetBy(dx: -20, dy: -10)
+            return expandedFrame.contains(screenPoint)
+        }
+
         if let closedSurfaceRect = closedSurfaceRect(for: model) {
             return closedSurfaceRect.contains(screenPoint)
         }
@@ -385,6 +517,10 @@ final class OverlayPanelController {
     }
 
     func contentRect(for model: AppModel, in bounds: NSRect) -> NSRect? {
+        // Sidebar mode: the entire panel is content, no shadow insets.
+        if dockEdge.isVertical {
+            return bounds
+        }
         let insets = panelShadowInsets
         return NSRect(
             x: bounds.minX + insets.horizontal,
@@ -471,18 +607,46 @@ final class OverlayPanelController {
 
     private func panelFrame(for model: AppModel?, on screen: NSScreen) -> NSRect {
         let size = panelSize(for: model, on: screen)
-        return NSRect(
-            x: screen.frame.midX - size.width / 2,
-            y: screen.frame.maxY - size.height,
-            width: size.width,
-            height: size.height
-        )
+        if let custom = customPosition {
+            return NSRect(origin: custom, size: size)
+        }
+
+        let edge = dockEdge
+        switch edge {
+        case .top:
+            return NSRect(
+                x: screen.frame.midX - size.width / 2,
+                y: screen.frame.maxY - size.height,
+                width: size.width,
+                height: size.height
+            )
+        case .left:
+            return NSRect(
+                x: screen.frame.minX,
+                y: screen.frame.midY - size.height / 2,
+                width: size.width,
+                height: size.height
+            )
+        case .right:
+            return NSRect(
+                x: screen.frame.maxX - size.width,
+                y: screen.frame.midY - size.height / 2,
+                width: size.width,
+                height: size.height
+            )
+        }
     }
 
     /// Always returns the maximum (opened) panel size so the window never
     /// needs to resize.  All visual transitions are driven purely by SwiftUI
     /// inside this fixed-size window.
     private func panelSize(for model: AppModel?, on screen: NSScreen) -> CGSize {
+        // Vertical sidebar mode for left/right docking.
+        if dockEdge.isVertical {
+            let height = min(screen.visibleFrame.height * 0.85, 800)
+            return CGSize(width: Self.verticalPanelWidth, height: height)
+        }
+
         let insets = panelShadowInsets
 
         guard let model else {
@@ -674,6 +838,8 @@ final class OverlayPanelController {
 // MARK: - NotchPanel
 
 private final class NotchPanel: NSPanel {
+    weak var overlayController: OverlayPanelController?
+
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { false }
 }

--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -125,6 +125,12 @@ final class OverlayUICoordinator {
             beforeTransition: { [weak self] in
                 self?.notificationAutoCollapseTask?.cancel()
                 self?.notificationAutoCollapseTask = nil
+                // Only an island the user actively opened (hover/click) counts as
+                // "seen" — passive notification cards must not clear the pending
+                // badge when they auto-collapse.
+                if let self, self.notchOpenReason == .click || self.notchOpenReason == .hover {
+                    self.appModel?.markSurfacedEndedSessionsSeen()
+                }
             },
             afterStateChange: { [weak self] in
                 self?.autoCollapseSurfaceHasBeenEntered = false

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -20,6 +20,11 @@ final class ProcessMonitoringCoordinator {
     @ObservationIgnored
     var stateUpdater: ((SessionState) -> Void)?
 
+    /// Returns the IDs of ended hook sessions the user has already seen, so the
+    /// reconciliation purge keeps unseen completed tasks alive in the island.
+    @ObservationIgnored
+    var acknowledgedEndedSessionIDsAccessor: (() -> Set<String>)?
+
     @ObservationIgnored
     var onSessionsReconciled: (() -> Void)?
 
@@ -162,8 +167,11 @@ final class ProcessMonitoringCoordinator {
             _ = local.reconcileJumpTargets(resolverJumpTargets)
         }
 
-        // Phase 4: remove sessions that are no longer visible.
-        _ = local.removeInvisibleSessions()
+        // Phase 4: remove sessions that are no longer visible (but keep ended
+        // hook sessions the user hasn't seen yet).
+        _ = local.removeInvisibleSessions(
+            acknowledgedEndedSessionIDs: acknowledgedEndedSessionIDsAccessor?() ?? []
+        )
 
         // Single state assignment — triggers didSet exactly once.
         // Compare against the original snapshot to catch all mutations

--- a/Sources/OpenIslandApp/UpdateChecker.swift
+++ b/Sources/OpenIslandApp/UpdateChecker.swift
@@ -34,6 +34,10 @@ final class UpdateChecker: NSObject {
     /// Start Sparkle's automatic update checking schedule.
     /// Call once after app launch.
     func startIfNeeded() {
+        // Disabled for dev builds — Sparkle signature mismatch causes errors.
+        print("[UpdateChecker] Skipping Sparkle updater for dev build.")
+        return
+
         let updater = updaterController.updater
         updater.automaticallyChecksForUpdates = true
         updater.updateCheckInterval = 60 * 60 // 1 hour

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -572,6 +572,13 @@ struct IslandPanelView: View {
 
     private static let maxSessionListHeight: CGFloat = 560
 
+    /// Above this row count, the list stops giving each row its own
+    /// `.drawingGroup()`. Per-row Metal offscreen rasterization is fine for a
+    /// handful of rows but becomes a main-thread throughput cliff on a long
+    /// list — the cause of the "white screen / freeze when many sessions"
+    /// hang. Short lists keep it for smoother animation.
+    private static let maxDrawingGroupRowCount = 8
+
     private var sessionList: some View {
         TimelineView(.periodic(from: .now, by: 30)) { context in
             if isNotificationMode {
@@ -636,7 +643,8 @@ struct IslandPanelView: View {
                         session: session,
                         referenceDate: context.date,
                         isActionable: session.phase.requiresAttention || session.id == actionableSessionID,
-                        useDrawingGroup: model.notchStatus == .opened,
+                        useDrawingGroup: model.notchStatus == .opened
+                            && model.islandListSessions.count <= Self.maxDrawingGroupRowCount,
                         isInteractive: model.notchStatus == .opened,
                         lang: model.lang,
                         onApprove: { model.approvePermission(for: session.id, action: $0) },

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1,6 +1,45 @@
 import SwiftUI
+import AppKit
 @preconcurrency import MarkdownUI
 import OpenIslandCore
+
+// MARK: - Window drag handle (pure SwiftUI gesture)
+
+/// Notification posted when the user finishes dragging the panel.
+extension Notification.Name {
+    static let islandPanelDragEnded = Notification.Name("islandPanelDragEnded")
+}
+
+/// A drag grip that moves the window via SwiftUI DragGesture.
+private struct DragGripButton: View {
+    @State private var dragStartOrigin: CGPoint? = nil
+
+    var body: some View {
+        Image(systemName: "line.3.horizontal")
+            .font(.system(size: 9, weight: .bold))
+            .foregroundStyle(.white.opacity(0.35))
+            .frame(width: 28, height: 22)
+            .background(.white.opacity(0.06), in: RoundedRectangle(cornerRadius: 5))
+            .help("Drag to reposition")
+            .gesture(
+                DragGesture(coordinateSpace: .global)
+                    .onChanged { value in
+                        guard let window = NSApp.windows.first(where: { $0.title == "" && $0.level == .statusBar && $0.isVisible }) else { return }
+                        if dragStartOrigin == nil {
+                            dragStartOrigin = CGPoint(x: window.frame.origin.x, y: window.frame.origin.y)
+                        }
+                        guard let start = dragStartOrigin else { return }
+                        let newX = start.x + value.translation.width
+                        let newY = start.y - value.translation.height
+                        window.setFrameOrigin(NSPoint(x: newX, y: newY))
+                    }
+                    .onEnded { _ in
+                        dragStartOrigin = nil
+                        NotificationCenter.default.post(name: .islandPanelDragEnded, object: nil)
+                    }
+            )
+    }
+}
 
 private struct NotificationContentHeightKey: PreferenceKey {
     static let defaultValue: CGFloat = 0
@@ -218,16 +257,28 @@ struct IslandPanelView: View {
 
     var body: some View {
         GeometryReader { geometry in
-            ZStack(alignment: .top) {
-                Color.clear
+            if model.dockEdge.isVertical {
+                sidebarContent(availableSize: geometry.size)
+            } else {
+                ZStack(alignment: .top) {
+                    Color.clear
 
-                notchContent(availableSize: geometry.size)
-                    .frame(maxWidth: .infinity, alignment: .top)
+                    notchContent(availableSize: geometry.size)
+                        .frame(maxWidth: .infinity, alignment: .top)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .ignoresSafeArea()
         .preferredColorScheme(.dark)
+    }
+
+    // MARK: - Sidebar (vertical) layout for left/right docking
+
+    @ViewBuilder
+    private func sidebarContent(availableSize: CGSize) -> some View {
+        IslandSidebarView(model: model)
+            .frame(width: availableSize.width, height: availableSize.height)
     }
 
     @ViewBuilder
@@ -431,6 +482,8 @@ struct IslandPanelView: View {
 
     private var openedHeaderButtons: some View {
         HStack(spacing: Self.headerControlSpacing) {
+            DragGripButton()
+
             headerIconButton(
                 systemName: model.isSoundMuted ? "speaker.slash.fill" : "speaker.wave.2.fill",
                 tint: model.isSoundMuted ? .orange.opacity(0.92) : .white.opacity(0.62)
@@ -1970,5 +2023,156 @@ private struct DismissButton: View {
         }
         .buttonStyle(.plain)
         .onHover { isHovered = $0 }
+    }
+}
+
+// MARK: - Sidebar view (vertical, for left/right edge docking)
+
+private struct IslandSidebarView: View {
+    var model: AppModel
+
+    private var scoutTint: Color {
+        let sessions = model.surfacedSessions
+        if sessions.contains(where: { $0.phase == .running }) {
+            return Color(red: 0.43, green: 0.62, blue: 1.0)
+        }
+        if !sessions.isEmpty {
+            return Color(red: 0.26, green: 0.91, blue: 0.42)
+        }
+        return Color.white.opacity(0.4)
+    }
+
+    var body: some View {
+        let isLeft = model.dockEdge == .left
+        let cr: CGFloat = 14
+
+        VStack(spacing: 0) {
+            sidebarHeader
+            sidebarDivider
+            sidebarSessionList
+        }
+        .background(sidebarBackground(isLeft: isLeft, cornerRadius: cr))
+        .shadow(color: .black.opacity(0.4), radius: 20, x: isLeft ? 4 : -4, y: 0)
+    }
+
+    private var sidebarHeader: some View {
+        HStack(spacing: 8) {
+            sidebarIcon
+            Text("Open Island")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.white.opacity(0.85))
+            Spacer()
+            sidebarHeaderButtons
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+    }
+
+    @ViewBuilder
+    private var sidebarIcon: some View {
+        if model.isCustomAppearance {
+            IslandPixelGlyph(
+                tint: scoutTint,
+                style: model.islandPixelShapeStyle,
+                isAnimating: model.surfacedSessions.contains(where: { $0.phase == .running }),
+                customAvatarImage: model.customAvatarImage
+            )
+        } else {
+            OpenIslandIcon(
+                size: 14,
+                isAnimating: model.surfacedSessions.contains(where: { $0.phase == .running }),
+                tint: scoutTint
+            )
+        }
+    }
+
+    private var sidebarHeaderButtons: some View {
+        HStack(spacing: 8) {
+            DragGripButton()
+
+            headerButton(systemName: model.isSoundMuted ? "speaker.slash.fill" : "speaker.wave.2.fill",
+                         tint: model.isSoundMuted ? .orange.opacity(0.92) : .white.opacity(0.62)) {
+                model.toggleSoundMuted()
+            }
+            headerButton(systemName: "gearshape.fill", tint: .white.opacity(0.62)) {
+                model.showSettings()
+            }
+        }
+    }
+
+    private func headerButton(systemName: String, tint: Color, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(tint)
+                .frame(width: 22, height: 22)
+                .background(.white.opacity(0.08), in: Circle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var sidebarDivider: some View {
+        Rectangle()
+            .fill(Color.white.opacity(0.08))
+            .frame(height: 0.5)
+    }
+
+    private var sidebarSessionList: some View {
+        ScrollView(.vertical) {
+            if model.islandListSessions.isEmpty {
+                sidebarEmptyState
+            } else {
+                let now = Date.now
+                LazyVStack(spacing: 6) {
+                    ForEach(model.islandListSessions, id: \.id) { session in
+                        IslandSessionRow(
+                            session: session,
+                            referenceDate: now,
+                            isActionable: session.phase.requiresAttention || session.id == model.islandSurface.sessionID,
+                            useDrawingGroup: true,
+                            isInteractive: true,
+                            lang: model.lang,
+                            onApprove: { model.approvePermission(for: session.id, action: $0) },
+                            onAnswer: { model.answerQuestion(for: session.id, answer: $0) },
+                            onJump: { model.jumpToSession(session) },
+                            onDismiss: session.isRemote ? { model.dismissSession(session.id) } : nil
+                        )
+                    }
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+            }
+        }
+        .scrollIndicators(.hidden)
+    }
+
+    private var sidebarEmptyState: some View {
+        VStack(spacing: 8) {
+            Spacer(minLength: 40)
+            Text(model.lang.t("island.noSessions"))
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.white.opacity(0.4))
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func sidebarBackground(isLeft: Bool, cornerRadius cr: CGFloat) -> some View {
+        UnevenRoundedRectangle(
+            topLeadingRadius: isLeft ? 0 : cr,
+            bottomLeadingRadius: isLeft ? 0 : cr,
+            bottomTrailingRadius: isLeft ? cr : 0,
+            topTrailingRadius: isLeft ? cr : 0
+        )
+        .fill(Color.black.opacity(0.92))
+        .overlay(
+            UnevenRoundedRectangle(
+                topLeadingRadius: isLeft ? 0 : cr,
+                bottomLeadingRadius: isLeft ? 0 : cr,
+                bottomTrailingRadius: isLeft ? cr : 0,
+                topTrailingRadius: isLeft ? cr : 0
+            )
+            .stroke(Color.white.opacity(0.07), lineWidth: 1)
+        )
     }
 }

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -240,6 +240,26 @@ struct DisplaySettingsPane: View {
                 }
             }
 
+            Section("Position") {
+                let edge = model.dockEdge
+                let edgeLabel = switch edge {
+                case .top: "Top (Notch)"
+                case .left: "Left Sidebar"
+                case .right: "Right Sidebar"
+                }
+                LabeledContent("Docked", value: edgeLabel)
+
+                Text("Drag the panel to a screen edge to snap: top → notch, left/right → vertical sidebar")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+
+                if edge != .top || model.overlay.overlayPanelController.useCustomPosition {
+                    Button("Reset to Notch") {
+                        model.overlay.overlayPanelController.resetToNotch()
+                    }
+                }
+            }
+
             if let diag = model.overlayPlacementDiagnostics {
                 Section(lang.t("settings.display.diagnostics")) {
                     LabeledContent(lang.t("settings.display.currentScreen"), value: diag.targetScreenName)

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -477,6 +477,21 @@ public final class BridgeServer: @unchecked Sendable {
 
             let command = payload.commandPreview ?? "Bash command"
 
+            guard payload.permissionMode.requiresOpenIslandApproval else {
+                emit(
+                    .activityUpdated(
+                        SessionActivityUpdated(
+                            sessionID: payload.sessionID,
+                            summary: "Codex is running \(command).",
+                            phase: .running,
+                            timestamp: .now
+                        )
+                    )
+                )
+                send(.response(.acknowledged), to: clientID)
+                return
+            }
+
             let approvalEvent = AgentEvent.permissionRequested(
                 PermissionRequested(
                     sessionID: payload.sessionID,

--- a/Sources/OpenIslandCore/CodexHookInstaller.swift
+++ b/Sources/OpenIslandCore/CodexHookInstaller.swift
@@ -60,11 +60,9 @@ public enum CodexHookInstaller {
     public static let legacyManagedStatusMessage = "Managed by Vibe Island"
     public static let managedTimeout = 45
 
-    // Keep the managed Codex install aligned with the original app's low-noise footprint.
-    // The bridge still understands richer hook events, but we do not install them by default
-    // because per-command Bash hooks produce a large amount of terminal log spam.
     private static let eventSpecs: [(name: String, matcher: String?)] = [
         ("SessionStart", "startup|resume"),
+        ("PreToolUse", nil),
         ("UserPromptSubmit", nil),
         ("Stop", nil),
     ]

--- a/Sources/OpenIslandCore/CodexHooks.swift
+++ b/Sources/OpenIslandCore/CodexHooks.swift
@@ -14,6 +14,15 @@ public enum CodexPermissionMode: String, Codable, Sendable {
     case plan
     case dontAsk
     case bypassPermissions
+
+    public var requiresOpenIslandApproval: Bool {
+        switch self {
+        case .default, .acceptEdits, .plan:
+            true
+        case .dontAsk, .bypassPermissions:
+            false
+        }
+    }
 }
 
 

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -368,9 +368,6 @@ public struct SessionState: Equatable, Sendable {
         return changed
     }
 
-    /// Remove sessions that are no longer visible in the island.
-    /// Returns `true` if any sessions were removed.
-    @discardableResult
     /// Manually mark a session as completed and ended.
     /// Intended for remote sessions whose SSH tunnel dropped without a
     /// SessionEnd hook.
@@ -382,10 +379,17 @@ public struct SessionState: Equatable, Sendable {
         upsert(session)
     }
 
-    public mutating func removeInvisibleSessions() -> Bool {
+    /// Remove sessions that are no longer visible in the island.
+    /// Returns `true` if any sessions were removed.
+    @discardableResult
+    public mutating func removeInvisibleSessions(acknowledgedEndedSessionIDs: Set<String> = []) -> Bool {
         let before = sessionsByID.count
-        sessionsByID = sessionsByID.filter { _, session in
-            session.isVisibleInIsland
+        sessionsByID = sessionsByID.filter { id, session in
+            if session.isVisibleInIsland { return true }
+            // Keep an ended hook session (e.g. a finished Claude Code task) until
+            // the user has seen it in the island, so its pending badge survives
+            // until acknowledged.
+            return session.isHookManaged && session.isSessionEnded && !acknowledgedEndedSessionIDs.contains(id)
         }
         return sessionsByID.count != before
     }

--- a/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
+++ b/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
@@ -50,7 +50,7 @@ struct OpenIslandHooksCLI {
                 }
 
                 if let output = try CodexHookOutputEncoder.standardOutput(for: response) {
-                    FileHandle.standardOutput.write(output)
+                    try? FileHandle.standardOutput.write(contentsOf: output)
                 }
             case .claude, .qoder, .qwen, .factory, .droid, .codebuddy:
                 var payload = try decoder
@@ -68,7 +68,7 @@ struct OpenIslandHooksCLI {
                 }
 
                 if let output = try ClaudeHookOutputEncoder.standardOutput(for: response) {
-                    FileHandle.standardOutput.write(output)
+                    try? FileHandle.standardOutput.write(contentsOf: output)
                 }
             case .cursor:
                 let payload = try decoder.decode(CursorHookPayload.self, from: input)
@@ -84,8 +84,8 @@ struct OpenIslandHooksCLI {
                 if case let .cursorHookDirective(directive) = response {
                     let encoder = JSONEncoder()
                     let output = try encoder.encode(directive)
-                    FileHandle.standardOutput.write(output)
-                    FileHandle.standardOutput.write(Data("\n".utf8))
+                    try? FileHandle.standardOutput.write(contentsOf: output)
+                    try? FileHandle.standardOutput.write(contentsOf: Data("\n".utf8))
                 }
             }
         } catch {
@@ -96,7 +96,7 @@ struct OpenIslandHooksCLI {
 
     private static func logStderr(_ message: String) {
         guard let data = "[OpenIslandHooks] \(message)\n".data(using: .utf8) else { return }
-        FileHandle.standardError.write(data)
+        try? FileHandle.standardError.write(contentsOf: data)
     }
 
     private static func hookSource(arguments: [String]) -> HookSource {

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -721,4 +721,68 @@ struct AppModelSessionListTests {
         let claudeSessions = model.state.sessions.filter { $0.tool == .claudeCode }
         #expect(claudeSessions.count == 2)
     }
+
+    /// A finished Claude Code task must stay in the pending badge after its
+    /// notification collapses — until the user actively opens the island and
+    /// sees it — then clear.
+    @Test
+    func completedHookSessionStaysSurfacedUntilSeen() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let model = AppModel()
+
+        var ended = AgentSession(
+            id: "cc-ended",
+            title: "Claude · open-island",
+            tool: .claudeCode,
+            origin: .live,
+            attachmentState: .stale,
+            phase: .completed,
+            summary: "Done",
+            updatedAt: now
+        )
+        ended.isHookManaged = true
+        ended.isSessionEnded = true
+
+        model.state = SessionState(sessions: [ended])
+
+        // Unseen finished task is retained in the badge.
+        #expect(model.liveSessionCount == 1)
+
+        // User actively opens the island (click) and then closes it → seen.
+        model.notchOpen(reason: .click)
+        model.notchClose()
+
+        // Once seen, it clears.
+        #expect(model.liveSessionCount == 0)
+    }
+
+    /// A passive notification card auto-collapsing must NOT count as "seen", so
+    /// the finished task survives in the badge for the user to find later.
+    @Test
+    func completedHookSessionPersistsWhenOnlyNotificationCardCollapses() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let model = AppModel()
+
+        var ended = AgentSession(
+            id: "cc-ended",
+            title: "Claude · open-island",
+            tool: .claudeCode,
+            origin: .live,
+            attachmentState: .stale,
+            phase: .completed,
+            summary: "Done",
+            updatedAt: now
+        )
+        ended.isHookManaged = true
+        ended.isSessionEnded = true
+
+        model.state = SessionState(sessions: [ended])
+        #expect(model.liveSessionCount == 1)
+
+        // Notification popup opening and auto-collapsing does not acknowledge it.
+        model.notchOpen(reason: .notification)
+        model.notchClose()
+
+        #expect(model.liveSessionCount == 1)
+    }
 }

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -462,7 +462,7 @@ struct SessionStateTests {
     }
 
     @Test
-    func codexPreToolUseStillRequiresResolutionWhenHookArrivesInDontAskMode() async throws {
+    func codexPreToolUseAcknowledgesWithoutApprovalWhenHookArrivesInDontAskMode() async throws {
         let socketURL = BridgeSocketLocation.uniqueTestURL()
         let server = BridgeServer(socketURL: socketURL)
         try server.start()
@@ -492,17 +492,49 @@ struct SessionStateTests {
 
         var iterator = stream.makeAsyncIterator()
         let startedEvent = try await nextEvent(from: &iterator)
-        let permissionEvent = try await nextEvent(from: &iterator)
+        let activityEvent = try await nextEvent(from: &iterator)
 
         #expect(startedEvent.isSessionStarted)
-        #expect(permissionEvent.isPermissionRequested)
+        let response = try await responseTask
 
-        try await observer.send(.resolvePermission(sessionID: "codex-session-no-ask", resolution: .allowOnce()))
+        #expect(activityEvent.activityUpdate?.summary == "Codex is running ls.")
+        #expect(response == .acknowledged)
+    }
 
+    @Test
+    func codexPreToolUseAcknowledgesWithoutApprovalWhenBypassingPermissions() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let payload = CodexHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .preToolUse,
+            model: "gpt-5-codex",
+            permissionMode: .bypassPermissions,
+            sessionID: "codex-session-bypass",
+            transcriptPath: nil,
+            turnID: "turn-1",
+            toolName: "Bash",
+            toolUseID: "tool-use-1",
+            toolInput: CodexHookToolInput(command: "pwd")
+        )
+
+        async let responseTask = sendOnGCDThread(.processCodexHook(payload), socketURL: socketURL)
+
+        var iterator = stream.makeAsyncIterator()
+        let startedEvent = try await nextEvent(from: &iterator)
         let activityEvent = try await nextEvent(from: &iterator)
         let response = try await responseTask
 
-        #expect(activityEvent.activityUpdate?.summary == "Permission approved. Codex continued the command.")
+        #expect(startedEvent.isSessionStarted)
+        #expect(activityEvent.activityUpdate?.summary == "Codex is running pwd.")
         #expect(response == .acknowledged)
     }
 
@@ -699,7 +731,12 @@ struct SessionStateTests {
 
         let sessionStartGroups = hooks?["SessionStart"] as? [[String: Any]]
         #expect(sessionStartGroups?.contains(where: { $0["matcher"] as? String == "startup|resume" }) == true)
-        #expect(hooks?["PreToolUse"] == nil)
+        let preToolGroups = hooks?["PreToolUse"] as? [[String: Any]]
+        let preToolCommands = preToolGroups?
+            .compactMap { $0["hooks"] as? [[String: Any]] }
+            .flatMap { $0 }
+            .compactMap { $0["command"] as? String } ?? []
+        #expect(preToolCommands.contains("'/tmp/OpenIslandHooks'"))
         #expect(hooks?["PostToolUse"] == nil)
     }
 
@@ -765,7 +802,7 @@ struct SessionStateTests {
             .flatMap { $0 }
             .compactMap { $0["command"] as? String } ?? []
 
-        #expect(preToolCommands == ["/usr/bin/printf"])
+        #expect(preToolCommands == ["/usr/bin/printf", "'/tmp/new-release/OpenIslandHooks'"])
         #expect(hooks?["PostToolUse"] == nil)
         #expect(stopCommands.contains("/usr/bin/true"))
         #expect(stopCommands.contains("'/tmp/new-release/OpenIslandHooks'"))


### PR DESCRIPTION
## Summary
- install managed Codex `PreToolUse` hooks so Open Island can receive approval requests
- keep `PostToolUse` uninstalled to avoid extra hook noise
- respect Codex auto-approval modes: `dontAsk` and `bypassPermissions` now acknowledge without showing Open Island approval UI
- update Codex hook installer and PreToolUse behavior tests

## Verification
- `swift test --filter codexHookInstaller`
- `swift test --filter codexPreToolUse`

## Notes
On the local machine, `PreToolUse` was temporarily removed from `~/.codex/hooks.json` while validating a Codex restart white-screen issue. Before enabling this by default, we should confirm restart behavior and consider making Codex approval hooks opt-in if app-server hook event volume remains a problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a docked sidebar mode with left/right positioning and a persisted custom panel position.
  * Added a Settings “Position” section to show the current dock edge and reset back to the notch.
* **Bug Fixes**
  * Completed hook-managed items now remain in the pending badge until the island is explicitly opened and the user has seen them (avoids marking as seen after auto-collapse).
* **Improvements**
  * Dev builds no longer start the Sparkle updater.
  * Codex now supports an additional `PreToolUse` phase and can acknowledge immediately when approval isn’t required.
* **Tests**
  * Added/updated coverage for the badge and Codex behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->