### PR TITLE
Fix stale completed Claude sessions in island list

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1691,7 +1691,7 @@ final class AppModel {
         var primary: [AgentSession] = []
         var claimedLiveAttachmentKeys: Set<String> = []
 
-        for session in rankedSessions where session.isVisibleInIsland {
+        for session in rankedSessions where shouldSurfaceInPrimaryList(session, now: now) {
             guard !session.isSubagentSession else { continue }
 
             if let liveAttachmentKey = monitoring.liveAttachmentKey(for: session) {
@@ -1706,6 +1706,17 @@ final class AppModel {
         let primaryIDs = Set(primary.map(\.id))
         let overflow = rankedSessions.filter { !primaryIDs.contains($0.id) && !$0.isSubagentSession }
         return (primary, overflow)
+    }
+
+    private func shouldSurfaceInPrimaryList(_ session: AgentSession, now: Date) -> Bool {
+        guard session.isVisibleInIsland else {
+            return false
+        }
+
+        return !session.isStaleCompletedForIsland(
+            at: now,
+            threshold: completedStaleThreshold.seconds
+        )
     }
 
     private func displayPriority(for session: AgentSession, now: Date) -> Int {

--- a/Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift
+++ b/Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift
@@ -11,7 +11,7 @@ struct AgentsGridRightSlotTests {
     @Test
     func bulkFirstObservationOrdersByHistoricalFirstSeenAt() {
         let model = AppModel()
-        model.islandRightSlot = .agents
+        configureAgentsSlot(model)
 
         let now = Date(timeIntervalSince1970: 100_000)
         let sessionA = makeSession(id: "A", firstSeenAt: now,                       updatedAt: now.addingTimeInterval(60))
@@ -46,7 +46,7 @@ struct AgentsGridRightSlotTests {
     @Test
     func newlyObservedSessionAlwaysLandsAtTheEndRegardlessOfHistoricalTime() {
         let model = AppModel()
-        model.islandRightSlot = .agents
+        configureAgentsSlot(model)
 
         let now = Date(timeIntervalSince1970: 200_000)
         let sessionA = makeSession(id: "A", firstSeenAt: now,                       updatedAt: now)
@@ -79,7 +79,7 @@ struct AgentsGridRightSlotTests {
     @Test
     func returningSessionKeepsItsOriginalSlot() {
         let model = AppModel()
-        model.islandRightSlot = .agents
+        configureAgentsSlot(model)
 
         let now = Date(timeIntervalSince1970: 300_000)
         let sessionA = makeSession(id: "A", firstSeenAt: now,                       updatedAt: now)
@@ -110,7 +110,7 @@ struct AgentsGridRightSlotTests {
     @Test
     func moreThanNineSessionsFoldIntoOverflow() {
         let model = AppModel()
-        model.islandRightSlot = .agents
+        configureAgentsSlot(model)
         let now = Date(timeIntervalSince1970: 200_000)
 
         var sessions: [AgentSession] = []
@@ -141,7 +141,7 @@ struct AgentsGridRightSlotTests {
     @Test
     func cellStateReflectsSessionPhase() {
         let model = AppModel()
-        model.islandRightSlot = .agents
+        configureAgentsSlot(model, completedStaleThreshold: .never)
         let now = Date(timeIntervalSince1970: 300_000)
 
         let running  = makeSession(id: "r", firstSeenAt: now,                         updatedAt: now, phase: .running)
@@ -223,5 +223,17 @@ struct AgentsGridRightSlotTests {
         session.isProcessAlive = true
         session.isHookManaged = true
         return session
+    }
+
+    private func configureAgentsSlot(
+        _ model: AppModel,
+        completedStaleThreshold: IslandCompletedStaleThreshold = .fiveMinutes
+    ) {
+        for profile in IslandAppearanceDisplayProfile.allCases {
+            model.updateAppearancePreferences(for: profile) {
+                $0.rightSlot = .agents
+                $0.completedStaleThreshold = completedStaleThreshold
+            }
+        }
     }
 }

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -94,6 +94,7 @@ struct AppModelSessionListTests {
     func islandListDeduplicatesSessionsSharingTheSameLiveGhosttyTerminal() {
         let now = Date(timeIntervalSince1970: 2_000)
         let model = AppModel()
+        updateAllAppearanceProfiles(model) { $0.completedStaleThreshold = .never }
 
         var runningLive = AgentSession(
             id: "running-live",
@@ -167,6 +168,7 @@ struct AppModelSessionListTests {
     func islandListKeepsDistinctCodexAppThreadsInTheSameWorkspace() {
         let now = Date(timeIntervalSince1970: 2_000)
         let model = AppModel()
+        updateAllAppearanceProfiles(model) { $0.completedStaleThreshold = .never }
 
         var firstThread = AgentSession(
             id: "codex-app-thread-1",
@@ -263,9 +265,10 @@ struct AppModelSessionListTests {
     }
 
     @Test
-    func freshCompletedSessionsSortAheadOfV8StaleCompletedSessions() {
+    func freshCompletedSessionsStayVisibleWhenStaleCompletedFallsToRecent() {
         let now = Date()
         let model = AppModel()
+        updateAllAppearanceProfiles(model) { $0.completedStaleThreshold = .fiveMinutes }
 
         var staleCompleted = AgentSession(
             id: "stale-completed",
@@ -307,15 +310,45 @@ struct AppModelSessionListTests {
 
         model.state = SessionState(sessions: [staleCompleted, freshCompleted])
 
-        #expect(model.islandListSessions.map(\.id) == ["fresh-completed", "stale-completed"])
+        #expect(model.islandListSessions.map(\.id) == ["fresh-completed"])
+        #expect(model.recentSessions.map(\.id).contains("stale-completed"))
+    }
+
+    @Test
+    func staleCompletedSessionsWithLiveProcessesStayOutOfPrimaryIslandList() {
+        let now = Date()
+        let model = AppModel()
+        updateAllAppearanceProfiles(model) { $0.completedStaleThreshold = .fiveMinutes }
+
+        var staleCompleted = listSession(
+            id: "stale-completed",
+            phase: .completed,
+            updatedAt: now.addingTimeInterval(-360)
+        )
+        staleCompleted.isProcessAlive = true
+
+        var freshCompleted = listSession(
+            id: "fresh-completed",
+            phase: .completed,
+            updatedAt: now.addingTimeInterval(-60)
+        )
+        freshCompleted.isProcessAlive = true
+
+        model.state = SessionState(sessions: [staleCompleted, freshCompleted])
+
+        #expect(model.islandListSessions.map(\.id) == ["fresh-completed"])
+        #expect(model.recentSessions.map(\.id).contains("stale-completed"))
+        #expect(model.liveSessionCount == 1)
     }
 
     @Test
     func islandSessionSectionsGroupStaleCompletedIntoIdle() {
         let now = Date()
         let model = AppModel()
-        model.islandSessionGroup = .state
-        model.completedStaleThreshold = .fiveMinutes
+        updateAllAppearanceProfiles(model) {
+            $0.sessionGroup = .state
+            $0.completedStaleThreshold = .fiveMinutes
+        }
 
         var approval = listSession(id: "approval", phase: .waitingForApproval, updatedAt: now)
         approval.permissionRequest = PermissionRequest(
@@ -332,16 +365,19 @@ struct AppModelSessionListTests {
 
         model.state = SessionState(sessions: [stale, done, approval])
 
-        #expect(model.islandSessionSections.map(\.id) == ["state-approval", "state-done", "state-idle"])
-        #expect(model.islandSessionSections.map(\.sessions.first?.id) == ["approval", "done", "stale"])
+        #expect(model.islandSessionSections.map(\.id) == ["state-approval", "state-done"])
+        #expect(model.islandSessionSections.map(\.sessions.first?.id) == ["approval", "done"])
+        #expect(model.recentSessions.map(\.id).contains("stale"))
     }
 
     @Test
     func islandSessionSectionsKeepCompletedInDoneWhenStaleThresholdIsNever() {
         let now = Date()
         let model = AppModel()
-        model.islandSessionGroup = .state
-        model.completedStaleThreshold = .never
+        updateAllAppearanceProfiles(model) {
+            $0.sessionGroup = .state
+            $0.completedStaleThreshold = .never
+        }
 
         var oldDone = listSession(id: "old-done", phase: .completed, updatedAt: now.addingTimeInterval(-86_400))
         oldDone.isProcessAlive = true
@@ -355,7 +391,7 @@ struct AppModelSessionListTests {
     func islandSessionListCanSortByLastUpdate() {
         let now = Date()
         let model = AppModel()
-        model.islandSessionSort = .lastUpdate
+        updateAllAppearanceProfiles(model) { $0.sessionSort = .lastUpdate }
 
         var olderRunning = listSession(id: "older-running", phase: .running, updatedAt: now.addingTimeInterval(-120))
         var newerCompleted = listSession(id: "newer-completed", phase: .completed, updatedAt: now.addingTimeInterval(-10))
@@ -1396,5 +1432,14 @@ struct AppModelSessionListTests {
             safeAreaInsets: NSEdgeInsets(top: mode == .notch ? 37 : 0, left: 0, bottom: 0, right: 0),
             overlayFrame: NSRect(x: 400, y: 820, width: 700, height: 160)
         )
+    }
+
+    private func updateAllAppearanceProfiles(
+        _ model: AppModel,
+        _ update: (inout IslandAppearancePreferences) -> Void
+    ) {
+        for profile in IslandAppearanceDisplayProfile.allCases {
+            model.updateAppearancePreferences(for: profile, update)
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #576.

This PR keeps stale completed Claude sessions out of the primary island list after the configured completed-stale threshold, even when the Claude daemon / background process is still alive.

## Root Cause

The primary island list used every session where `session.isVisibleInIsland` was true. For non-hook Claude sessions, that can remain true while `isProcessAlive` is true. If a Claude daemon process stays alive after a task completes, old completed rows can continue to show in Idle and inflate the total / idle counters.

## Changes

- Adds a primary-list filter in `AppModel` for stale completed sessions.
- Keeps stale completed sessions available in recent / overflow history instead of deleting their liveness state.
- Preserves `.never` completed-stale threshold behavior for users who explicitly want completed rows to remain visible.
- Adds regression coverage for live-process stale completed sessions and for related right-slot ordering behavior.

## Verification

- `swift test`
  - XCTest: 24 passed, 1 skipped live Ghostty integration test
  - Swift Testing: 315 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session visibility so completed sessions marked as stale no longer appear in the primary surfaced list.
  * Refined list and section behavior to better match freshness settings, including cases with live processes and completed items.
  * Fixed several session-list edge cases so sorting, deduplication, and grouped sections behave more consistently across appearance settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->