### PR TITLE
fix: age completed sessions out of island primary

### DIFF
--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -16,7 +16,7 @@ enum IslandSessionPresence: Equatable {
 
 extension AgentSession {
     private static let collapsedDetailAgeThreshold: TimeInterval = 20 * 60
-    private static let islandActivityThreshold: TimeInterval = 20 * 60
+    static let islandActivityThreshold: TimeInterval = 20 * 60
     static let staleCompletedDisplayThreshold: TimeInterval = 5 * 60
 
     /// Whether this session represents a subagent (worktree agent) that should

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -33,6 +33,13 @@ final class AppModel {
     private static let liveSessionStalenessWindow: TimeInterval = 15 * 60
     private static let jumpOverlayDismissLeadTime: Duration = .milliseconds(20)
     private static let agentsGridObservedSequenceLimit = 512
+    private static let sessionBucketPriorityAgeBoundaries: [TimeInterval] = [
+        120,
+        900,
+        AgentSession.islandActivityThreshold,
+        3_600,
+        21_600,
+    ]
     static let hoverOpenDelay: TimeInterval = 0.15
 
     struct AcceptanceStep: Identifiable {
@@ -42,16 +49,42 @@ final class AppModel {
         let isComplete: Bool
     }
 
+    private struct CachedSessionBuckets {
+        let primary: [AgentSession]
+        let overflow: [AgentSession]
+        let expiresAt: Date?
+        let completedStaleThreshold: IslandCompletedStaleThreshold
+
+        func isValid(
+            at referenceDate: Date,
+            completedStaleThreshold: IslandCompletedStaleThreshold
+        ) -> Bool {
+            guard self.completedStaleThreshold == completedStaleThreshold else {
+                return false
+            }
+
+            if let expiresAt, referenceDate >= expiresAt {
+                return false
+            }
+
+            return true
+        }
+    }
+
     let lang = LanguageManager.shared
 
     var state = SessionState() {
         didSet {
-            _cachedSessionBuckets = nil
+            invalidateSessionBuckets()
             pruneAgentsGridObservationTicketsIfNeeded()
             bridgeServer.updateStateSnapshot(state)
         }
     }
-    @ObservationIgnored private var _cachedSessionBuckets: (primary: [AgentSession], overflow: [AgentSession])?
+    @ObservationIgnored private var _cachedSessionBuckets: CachedSessionBuckets?
+    @ObservationIgnored private var sessionBucketExpiryTask: Task<Void, Never>?
+    @ObservationIgnored var sessionBucketDateProvider: @MainActor () -> Date = { Date.now }
+    /// Observation token for time-only bucket changes, such as a completed row crossing the stale threshold.
+    private var sessionBucketRefreshGeneration = 0
 
     /// Monotonic ticket assigned the first time a session ID shows up in the
     /// closed-island's right-slot surfaced set. Drives the grid's display
@@ -409,7 +442,7 @@ final class AppModel {
         if oldValue.sessionGroup != newValue.sessionGroup ||
             oldValue.sessionSort != newValue.sessionSort ||
             oldValue.completedStaleThreshold != newValue.completedStaleThreshold {
-            _cachedSessionBuckets = nil
+            invalidateSessionBuckets()
         }
         refreshOverlayPlacementIfVisible()
     }
@@ -738,6 +771,7 @@ final class AppModel {
     }
 
     var islandSessionSections: [IslandSessionSection] {
+        let referenceDate = sessionBucketDateProvider()
         let sessions = sortIslandSessions(surfacedSessions)
         switch islandSessionGroup {
         case .none:
@@ -749,7 +783,7 @@ final class AppModel {
                 )
             ]
         case .state:
-            return stateGroupedSections(for: sessions)
+            return stateGroupedSections(for: sessions, referenceDate: referenceDate)
         case .agent:
             return AgentTool.allCases.compactMap { tool in
                 let list = sessions.filter { $0.tool == tool }
@@ -798,18 +832,21 @@ final class AppModel {
         }
     }
 
-    private func stateGroupedSections(for sessions: [AgentSession]) -> [IslandSessionSection] {
+    private func stateGroupedSections(
+        for sessions: [AgentSession],
+        referenceDate: Date
+    ) -> [IslandSessionSection] {
         let definitions: [(id: String, title: String, include: (AgentSession) -> Bool)] = [
             ("approval", "island.section.needsApproval", { $0.phase == .waitingForApproval }),
             ("answer", "island.section.needsAnswer", { $0.phase == .waitingForAnswer }),
             ("running", "island.section.inProgress", { $0.phase == .running }),
             ("done", "island.section.justDone", { [completedStaleThreshold] session in
                 session.phase == .completed
-                    && !session.isStaleCompletedForIsland(at: .now, threshold: completedStaleThreshold.seconds)
+                    && !session.isStaleCompletedForIsland(at: referenceDate, threshold: completedStaleThreshold.seconds)
             }),
             ("idle", "island.section.idle", { [completedStaleThreshold] session in
                 session.phase == .completed
-                    && session.isStaleCompletedForIsland(at: .now, threshold: completedStaleThreshold.seconds)
+                    && session.isStaleCompletedForIsland(at: referenceDate, threshold: completedStaleThreshold.seconds)
             }),
         ]
 
@@ -1663,19 +1700,84 @@ final class AppModel {
 
 
     private var sessionBuckets: (primary: [AgentSession], overflow: [AgentSession]) {
-        if let cached = _cachedSessionBuckets {
-            return cached
+        _ = sessionBucketRefreshGeneration
+        let now = sessionBucketDateProvider()
+        let selectedCompletedStaleThreshold = completedStaleThreshold
+        let staleCompletedThreshold = selectedCompletedStaleThreshold.seconds
+
+        if let cached = _cachedSessionBuckets,
+           cached.isValid(at: now, completedStaleThreshold: selectedCompletedStaleThreshold) {
+            return (cached.primary, cached.overflow)
         }
-        let result = computeSessionBuckets()
-        _cachedSessionBuckets = result
+
+        let result = computeSessionBuckets(
+            now: now,
+            staleCompletedThreshold: staleCompletedThreshold
+        )
+        let expiresAt = nextSessionBucketsCacheExpiry(
+            after: now,
+            staleCompletedThreshold: staleCompletedThreshold
+        )
+        _cachedSessionBuckets = CachedSessionBuckets(
+            primary: result.primary,
+            overflow: result.overflow,
+            expiresAt: expiresAt,
+            completedStaleThreshold: selectedCompletedStaleThreshold
+        )
+        scheduleSessionBucketCacheExpiry(at: expiresAt)
         return result
     }
 
-    private func computeSessionBuckets() -> (primary: [AgentSession], overflow: [AgentSession]) {
-        let now = Date.now
+    private func invalidateSessionBuckets() {
+        _cachedSessionBuckets = nil
+        sessionBucketExpiryTask?.cancel()
+        sessionBucketExpiryTask = nil
+    }
+
+    private func scheduleSessionBucketCacheExpiry(at expiresAt: Date?) {
+        sessionBucketExpiryTask?.cancel()
+        sessionBucketExpiryTask = nil
+
+        guard let expiresAt else {
+            return
+        }
+
+        let delaySeconds = expiresAt.timeIntervalSince(sessionBucketDateProvider())
+        guard delaySeconds.isFinite else {
+            return
+        }
+        let delayMilliseconds = max(0, Int((delaySeconds * 1_000).rounded(.up)))
+
+        sessionBucketExpiryTask = Task { @MainActor [weak self] in
+            if delayMilliseconds > 0 {
+                try? await Task.sleep(for: .milliseconds(delayMilliseconds))
+            }
+
+            guard !Task.isCancelled else {
+                return
+            }
+
+            self?._cachedSessionBuckets = nil
+            self?.sessionBucketExpiryTask = nil
+            self?.sessionBucketRefreshGeneration += 1
+        }
+    }
+
+    private func computeSessionBuckets(
+        now: Date,
+        staleCompletedThreshold: TimeInterval
+    ) -> (primary: [AgentSession], overflow: [AgentSession]) {
         let rankedSessions = state.sessions.sorted { lhs, rhs in
-            let lhsScore = displayPriority(for: lhs, now: now)
-            let rhsScore = displayPriority(for: rhs, now: now)
+            let lhsScore = displayPriority(
+                for: lhs,
+                now: now,
+                staleCompletedThreshold: staleCompletedThreshold
+            )
+            let rhsScore = displayPriority(
+                for: rhs,
+                now: now,
+                staleCompletedThreshold: staleCompletedThreshold
+            )
 
             if lhsScore == rhsScore {
                 if lhs.islandActivityDate == rhs.islandActivityDate {
@@ -1691,7 +1793,11 @@ final class AppModel {
         var primary: [AgentSession] = []
         var claimedLiveAttachmentKeys: Set<String> = []
 
-        for session in rankedSessions where session.isVisibleInIsland {
+        for session in rankedSessions where shouldSurfaceInPrimaryList(
+            session,
+            now: now,
+            staleCompletedThreshold: staleCompletedThreshold
+        ) {
             guard !session.isSubagentSession else { continue }
 
             if let liveAttachmentKey = monitoring.liveAttachmentKey(for: session) {
@@ -1708,7 +1814,52 @@ final class AppModel {
         return (primary, overflow)
     }
 
-    private func displayPriority(for session: AgentSession, now: Date) -> Int {
+    private func shouldSurfaceInPrimaryList(
+        _ session: AgentSession,
+        now: Date,
+        staleCompletedThreshold: TimeInterval
+    ) -> Bool {
+        session.isVisibleInIsland
+            && !session.isStaleCompletedForIsland(at: now, threshold: staleCompletedThreshold)
+    }
+
+    private func nextSessionBucketsCacheExpiry(
+        after now: Date,
+        staleCompletedThreshold: TimeInterval
+    ) -> Date? {
+        var earliestExpiry: Date?
+
+        for session in state.sessions where !session.isSubagentSession {
+            if staleCompletedThreshold.isFinite, session.phase == .completed {
+                let staleAt = session.islandActivityDate.addingTimeInterval(staleCompletedThreshold)
+                if staleAt > now {
+                    earliestExpiry = Self.earlierDate(staleAt, earliestExpiry)
+                }
+            }
+
+            for ageBoundary in Self.sessionBucketPriorityAgeBoundaries {
+                let ageBoundaryDate = session.islandActivityDate.addingTimeInterval(ageBoundary)
+                if ageBoundaryDate > now {
+                    earliestExpiry = Self.earlierDate(ageBoundaryDate, earliestExpiry)
+                }
+            }
+        }
+
+        return earliestExpiry
+    }
+
+    private static func earlierDate(_ candidate: Date, _ current: Date?) -> Date {
+        guard let current else {
+            return candidate
+        }
+        return min(candidate, current)
+    }
+
+    private func displayPriority(
+        for session: AgentSession,
+        now: Date,
+        staleCompletedThreshold: TimeInterval
+    ) -> Int {
         var score = 0
 
         let presence = session.islandPresence(at: now)
@@ -1742,7 +1893,7 @@ final class AppModel {
             score += 600
         }
 
-        if session.isStaleCompletedForIsland(at: now, threshold: completedStaleThreshold.seconds) {
+        if session.isStaleCompletedForIsland(at: now, threshold: staleCompletedThreshold) {
             score -= 900
         }
 

--- a/Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift
+++ b/Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift
@@ -143,6 +143,7 @@ struct AgentsGridRightSlotTests {
         let model = AppModel()
         model.islandRightSlot = .agents
         let now = Date(timeIntervalSince1970: 300_000)
+        model.sessionBucketDateProvider = { now }
 
         let running  = makeSession(id: "r", firstSeenAt: now,                         updatedAt: now, phase: .running)
         let waitingA = makeSession(

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -94,6 +94,7 @@ struct AppModelSessionListTests {
     func islandListDeduplicatesSessionsSharingTheSameLiveGhosttyTerminal() {
         let now = Date(timeIntervalSince1970: 2_000)
         let model = AppModel()
+        model.sessionBucketDateProvider = { now }
 
         var runningLive = AgentSession(
             id: "running-live",
@@ -167,6 +168,7 @@ struct AppModelSessionListTests {
     func islandListKeepsDistinctCodexAppThreadsInTheSameWorkspace() {
         let now = Date(timeIntervalSince1970: 2_000)
         let model = AppModel()
+        model.sessionBucketDateProvider = { now }
 
         var firstThread = AgentSession(
             id: "codex-app-thread-1",
@@ -263,9 +265,10 @@ struct AppModelSessionListTests {
     }
 
     @Test
-    func freshCompletedSessionsSortAheadOfV8StaleCompletedSessions() {
-        let now = Date()
+    func freshCompletedSessionsStayVisibleWhenStaleCompletedFallsToRecent() {
+        let now = Date(timeIntervalSince1970: 10_000)
         let model = AppModel()
+        model.sessionBucketDateProvider = { now }
 
         var staleCompleted = AgentSession(
             id: "stale-completed",
@@ -307,13 +310,42 @@ struct AppModelSessionListTests {
 
         model.state = SessionState(sessions: [staleCompleted, freshCompleted])
 
-        #expect(model.islandListSessions.map(\.id) == ["fresh-completed", "stale-completed"])
+        #expect(model.islandListSessions.map(\.id) == ["fresh-completed"])
+        #expect(model.recentSessions.map(\.id).contains("stale-completed"))
+        #expect(model.liveSessionCount == 1)
     }
 
     @Test
-    func islandSessionSectionsGroupStaleCompletedIntoIdle() {
-        let now = Date()
+    func completedSessionLeavesPrimaryWhenStaleThresholdPassesWithoutStateChange() {
+        var now = Date(timeIntervalSince1970: 20_000)
         let model = AppModel()
+        model.sessionBucketDateProvider = { now }
+        model.completedStaleThreshold = .twoMinutes
+
+        var session = listSession(
+            id: "finishing",
+            phase: .completed,
+            updatedAt: now.addingTimeInterval(-119)
+        )
+        session.isProcessAlive = true
+        model.state = SessionState(sessions: [session])
+
+        #expect(model.islandListSessions.map(\.id) == ["finishing"])
+        #expect(model.liveSessionCount == 1)
+        #expect(model.recentSessions.isEmpty)
+
+        now = now.addingTimeInterval(2)
+
+        #expect(model.islandListSessions.isEmpty)
+        #expect(model.recentSessions.map(\.id) == ["finishing"])
+        #expect(model.liveSessionCount == 0)
+    }
+
+    @Test
+    func islandSessionSectionsExcludeStaleCompletedFromPrimaryAndKeepThemRecent() {
+        let now = Date(timeIntervalSince1970: 30_000)
+        let model = AppModel()
+        model.sessionBucketDateProvider = { now }
         model.islandSessionGroup = .state
         model.completedStaleThreshold = .fiveMinutes
 
@@ -332,14 +364,16 @@ struct AppModelSessionListTests {
 
         model.state = SessionState(sessions: [stale, done, approval])
 
-        #expect(model.islandSessionSections.map(\.id) == ["state-approval", "state-done", "state-idle"])
-        #expect(model.islandSessionSections.map(\.sessions.first?.id) == ["approval", "done", "stale"])
+        #expect(model.islandSessionSections.map(\.id) == ["state-approval", "state-done"])
+        #expect(model.islandSessionSections.map(\.sessions.first?.id) == ["approval", "done"])
+        #expect(model.recentSessions.map(\.id).contains("stale"))
     }
 
     @Test
     func islandSessionSectionsKeepCompletedInDoneWhenStaleThresholdIsNever() {
-        let now = Date()
+        let now = Date(timeIntervalSince1970: 40_000)
         let model = AppModel()
+        model.sessionBucketDateProvider = { now }
         model.islandSessionGroup = .state
         model.completedStaleThreshold = .never
 


### PR DESCRIPTION
## Summary

Fixes #576.

Completed sessions that have crossed the configured stale threshold now leave the primary island session list instead of staying counted as live just because their daemon or terminal process is still alive. They remain available through `recentSessions` / overflow history.

## Root Cause

`AppModel.sessionBuckets` cached the primary/overflow split even though the split depended on wall-clock time through completed-session staleness. A completed session could therefore stay in primary until some unrelated state mutation invalidated the cache.

## Changes

- Filter primary session buckets with the completed-stale threshold, so stale completed rows move to recent history.
- Add a time-aware session bucket cache with an expiry task so closed-island counts and agent slots refresh when a stale boundary is crossed without any state change.
- Use the same reference date for state grouping and bucket filtering.
- Add regression coverage for stale completed sessions leaving primary and preserving recent history.

## Validation

- `git diff --check`
- `swift build`

Targeted `swift test --filter 'AppModelSessionListTests|AgentsGridRightSlotTests'` could not run in this local CLT environment because test targets fail to compile with `no such module 'Testing'`, even with `--enable-swift-testing`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session lists now update more consistently as time passes, so completed items move between active and recent views at the expected threshold.
  * Stale completed sessions are handled more predictably when grouping and sorting islands.
  * Improved internal timing consistency makes session display behavior less likely to shift unexpectedly.

* **Tests**
  * Updated automated checks to use a fixed time reference for more reliable session-list behavior coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->