### PR TITLE
feat: surface subagent permission prompts on the parent session

### DIFF
--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -202,6 +202,7 @@
 
 /* Island Panel - Approval */
 "approval.toolPermissionRequested" = "Tool permission requested";
+"approval.subagentAsking" = "Subagent asking";
 "approval.deny" = "No";
 "approval.allowOnce" = "Yes";
 "approval.alwaysAllow" = "Always Allow (%@)";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -202,6 +202,7 @@
 
 /* Island Panel - Approval */
 "approval.toolPermissionRequested" = "请求工具权限";
+"approval.subagentAsking" = "子代理请求中";
 "approval.deny" = "拒绝";
 "approval.allowOnce" = "允许一次";
 "approval.alwaysAllow" = "始终允许（%@）";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -202,6 +202,7 @@
 
 /* Island Panel - Approval */
 "approval.toolPermissionRequested" = "請求工具權限";
+"approval.subagentAsking" = "子代理請求中";
 "approval.deny" = "拒絕";
 "approval.allowOnce" = "允許一次";
 "approval.alwaysAllow" = "始終允許（%@）";

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1343,15 +1343,23 @@ private struct IslandSessionRow: View {
                 .foregroundStyle(.cyan.opacity(0.8))
 
                 ForEach(subagents, id: \.agentID) { sub in
+                    let isAsking = sub.agentID == session.permissionRequest?.originatingAgentID
                     HStack(spacing: 6) {
                         Circle()
-                            .fill(sub.summary != nil
-                                ? IslandDesignPalette.Status.completed
-                                : IslandDesignPalette.Status.running)
-                            .frame(width: 6, height: 6)
+                            .fill(isAsking
+                                ? Color.cyan
+                                : (sub.summary != nil
+                                    ? IslandDesignPalette.Status.completed
+                                    : IslandDesignPalette.Status.running))
+                            .frame(width: isAsking ? 7 : 6, height: isAsking ? 7 : 6)
+                            .overlay(
+                                isAsking
+                                    ? Circle().stroke(.cyan.opacity(0.4), lineWidth: 1).padding(2)
+                                    : nil
+                            )
                         Text(sub.agentType ?? sub.agentID)
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundStyle(.white.opacity(0.8))
+                            .font(.system(size: 11, weight: isAsking ? .semibold : .medium))
+                            .foregroundStyle(.white.opacity(isAsking ? 1.0 : 0.8))
                             .lineLimit(1)
                         if let desc = sub.taskDescription {
                             Text("(\(desc))")
@@ -1360,7 +1368,11 @@ private struct IslandSessionRow: View {
                                 .lineLimit(1)
                         }
                         Spacer(minLength: 0)
-                        if sub.summary != nil {
+                        if isAsking {
+                            Image(systemName: "hand.raised.fill")
+                                .font(.system(size: 9, weight: .medium))
+                                .foregroundStyle(.cyan.opacity(0.9))
+                        } else if sub.summary != nil {
                             Text(lang.t("subagents.completed"))
                                 .font(.system(size: 10, weight: .medium))
                                 .foregroundStyle(.white.opacity(0.4))
@@ -1640,11 +1652,34 @@ private struct IslandSessionRow: View {
 
     // MARK: - Approval action area
 
+    /// Human-readable label for the subagent whose permission request is
+    /// currently surfaced, or `nil` for ordinary parent-origin requests.
+    /// Prefers `originatingAgentType`; falls back to a truncated agent id.
+    private var subagentOriginLabel: String? {
+        guard let id = session.permissionRequest?.originatingAgentID else {
+            return nil
+        }
+        return session.permissionRequest?.originatingAgentType ?? String(id.prefix(8))
+    }
+
     private var approvalActionBody: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(lang.t("approval.toolPermissionRequested"))
                 .font(.system(size: 12.5, weight: .semibold))
                 .foregroundStyle(V6Palette.paper.opacity(0.86))
+
+            if let originLabel = subagentOriginLabel {
+                HStack(spacing: 5) {
+                    Image(systemName: "arrow.triangle.branch")
+                        .font(.system(size: 9, weight: .medium))
+                    Text(lang.t("approval.subagentAsking"))
+                        .font(.system(size: 10, weight: .medium))
+                    Text(originLabel)
+                        .font(.system(size: 10.5, weight: .semibold))
+                        .lineLimit(1)
+                }
+                .foregroundStyle(.cyan.opacity(0.85))
+            }
 
             VStack(alignment: .leading, spacing: 8) {
                 Text(commandPreviewText)

--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -186,6 +186,12 @@ public struct PermissionRequest: Equatable, Identifiable, Codable, Sendable {
     public var toolUseID: String?
     public var suggestedUpdates: [ClaudePermissionUpdate]
     public var requiresTerminalApproval: Bool
+    /// The `agent_id` of the subagent whose hook originated this request.
+    /// `nil` for ordinary parent-origin requests. Set by the bridge when a
+    /// subagent's `PermissionRequest` is surfaced on the parent session.
+    public var originatingAgentID: String?
+    /// The `agent_type` of the originating subagent, for human display.
+    public var originatingAgentType: String?
 
     public init(
         id: UUID = UUID(),
@@ -197,7 +203,9 @@ public struct PermissionRequest: Equatable, Identifiable, Codable, Sendable {
         toolName: String? = nil,
         toolUseID: String? = nil,
         suggestedUpdates: [ClaudePermissionUpdate] = [],
-        requiresTerminalApproval: Bool = false
+        requiresTerminalApproval: Bool = false,
+        originatingAgentID: String? = nil,
+        originatingAgentType: String? = nil
     ) {
         self.id = id
         self.title = title
@@ -209,6 +217,8 @@ public struct PermissionRequest: Equatable, Identifiable, Codable, Sendable {
         self.toolUseID = toolUseID
         self.suggestedUpdates = suggestedUpdates
         self.requiresTerminalApproval = requiresTerminalApproval
+        self.originatingAgentID = originatingAgentID
+        self.originatingAgentType = originatingAgentType
     }
 }
 

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -68,6 +68,11 @@ public final class BridgeServer: @unchecked Sendable {
     private var pendingApprovals: [String: PendingApproval] = [:]
     private var pendingClaudeToolContexts: [String: PendingClaudeToolContext] = [:]
     private var pendingClaudeInteractions: [String: PendingClaudeInteraction] = [:]
+    /// Per-session FIFO of interactions that arrived while another interaction
+    /// was already active for that session. Bridge-internal: the single active
+    /// slot in `pendingClaudeInteractions` is the only thing the UI/AppModel
+    /// ever sees. Queued interactions are emitted only when they become active.
+    private var queuedClaudeInteractions: [String: [PendingClaudeInteraction]] = [:]
     private var pendingOpenCodeInteractions: [String: PendingOpenCodeInteraction] = [:]
     private var pendingCursorInteractions: [String: PendingCursorInteraction] = [:]
     /// Caches Agent tool description from preToolUse for use by the next subagentStart.
@@ -181,6 +186,7 @@ public final class BridgeServer: @unchecked Sendable {
     private func stopLocked() {
         pendingApprovals.removeAll()
         pendingClaudeInteractions.removeAll()
+        queuedClaudeInteractions.removeAll()
         pendingClaudeToolContexts.removeAll()
         pendingAgentDescriptions.removeAll()
         pendingTaskCreations.removeAll()
@@ -615,9 +621,13 @@ public final class BridgeServer: @unchecked Sendable {
         // Subagent processes fire their own hooks with agentID set.
         // The parent session already receives SubagentStart/SubagentStop events,
         // so we suppress subagent hooks to avoid creating duplicate sessions.
+        // PermissionRequest is exempted so a subagent's permission prompt (and
+        // AskUserQuestion, which shares the same hook event) surfaces on the
+        // parent session instead of being silently acknowledged.
         if payload.agentID != nil,
            payload.hookEventName != .subagentStart,
-           payload.hookEventName != .subagentStop {
+           payload.hookEventName != .subagentStop,
+           payload.hookEventName != .permissionRequest {
             send(.response(.acknowledged), to: clientID)
             return
         }
@@ -717,48 +727,30 @@ public final class BridgeServer: @unchecked Sendable {
             synchronizeClaudeJumpTarget(for: payload)
             synchronizeClaudeMetadata(for: payload)
 
+            let interaction: PendingClaudeInteraction
             if let prompt = payload.questionPrompt {
-                emit(
-                    .questionAsked(
-                        QuestionAsked(
-                            sessionID: payload.sessionID,
-                            prompt: prompt,
-                            timestamp: .now
-                        )
-                    )
-                )
-
-                pendingClaudeInteractions[payload.sessionID] = PendingClaudeInteraction(
+                interaction = PendingClaudeInteraction(
                     clientID: clientID,
                     kind: .question(payload, prompt)
                 )
             } else {
-                let suggestions = payload.permissionSuggestions ?? []
-
-                emit(
-                    .permissionRequested(
-                        PermissionRequested(
-                            sessionID: payload.sessionID,
-                            request: PermissionRequest(
-                                title: payload.permissionRequestTitle,
-                                summary: payload.permissionRequestSummary,
-                                affectedPath: payload.permissionAffectedPath,
-                                primaryActionTitle: "Allow Once",
-                                secondaryActionTitle: "Deny",
-                                toolName: payload.toolName,
-                                toolUseID: claudeToolUseID(for: payload),
-                                suggestedUpdates: suggestions
-                            ),
-                            timestamp: .now
-                        )
-                    )
-                )
-
-                pendingClaudeInteractions[payload.sessionID] = PendingClaudeInteraction(
+                interaction = PendingClaudeInteraction(
                     clientID: clientID,
                     kind: .permission(payload)
                 )
             }
+
+            // If an interaction is already active for this session, queue this
+            // one without emitting. The single active slot must not be
+            // overwritten, or the in-flight hook connection would lose its
+            // directive. The queued hook connection stays blocked until it is
+            // promoted and later resolved.
+            if pendingClaudeInteractions[payload.sessionID] != nil {
+                queuedClaudeInteractions[payload.sessionID, default: []].append(interaction)
+                return
+            }
+
+            activateClaudeInteraction(interaction, for: payload.sessionID)
 
         case .postToolUse:
             clearStaleClaudeInteractionIfNeeded(for: payload.sessionID)
@@ -2177,6 +2169,10 @@ public final class BridgeServer: @unchecked Sendable {
             pending.sessionID != sessionID
         }
         pendingAgentDescriptions.removeValue(forKey: sessionID)
+        // The session is ending; any queued interactions it still holds can
+        // never be promoted, so drop them. (The active slot, if any, was
+        // already cleared by `clearStaleClaudeInteractionIfNeeded`.)
+        queuedClaudeInteractions.removeValue(forKey: sessionID)
     }
 
     struct PendingClaudeStateSnapshot: Sendable, Equatable {
@@ -2197,6 +2193,24 @@ public final class BridgeServer: @unchecked Sendable {
                 toolContextCount: pendingClaudeToolContexts.count,
                 agentDescriptionCount: pendingAgentDescriptions.count,
                 taskCreationCount: pendingTaskCreations.count
+            )
+        }
+    }
+
+    struct PendingClaudeInteractionSnapshot: Sendable, Equatable {
+        /// Number of sessions with an active (surfaced) interaction.
+        let activeCount: Int
+        /// Total queued interactions across all sessions.
+        let queuedCount: Int
+    }
+
+    /// Test-only accessor for the Claude interaction slot/queue. Goes through
+    /// the bridge's serial queue so the read is consistent.
+    func pendingClaudeInteractionSnapshotForTests() -> PendingClaudeInteractionSnapshot {
+        queue.sync {
+            PendingClaudeInteractionSnapshot(
+                activeCount: pendingClaudeInteractions.count,
+                queuedCount: queuedClaudeInteractions.values.reduce(0) { $0 + $1.count }
             )
         }
     }
@@ -2399,6 +2413,70 @@ public final class BridgeServer: @unchecked Sendable {
         send(.response(response), to: pendingApproval.clientID)
     }
 
+    /// Emits the appropriate event for `interaction` and stores it as the
+    /// single active interaction for `sessionID`. Called both on first
+    /// arrival and when a queued interaction is promoted after the previous
+    /// one was resolved.
+    private func activateClaudeInteraction(
+        _ interaction: PendingClaudeInteraction,
+        for sessionID: String
+    ) {
+        switch interaction.kind {
+        case let .question(_, prompt):
+            emit(
+                .questionAsked(
+                    QuestionAsked(
+                        sessionID: sessionID,
+                        prompt: prompt,
+                        timestamp: .now
+                    )
+                )
+            )
+
+        case let .permission(payload):
+            let suggestions = payload.permissionSuggestions ?? []
+
+            emit(
+                .permissionRequested(
+                    PermissionRequested(
+                        sessionID: sessionID,
+                        request: PermissionRequest(
+                            title: payload.permissionRequestTitle,
+                            summary: payload.permissionRequestSummary,
+                            affectedPath: payload.permissionAffectedPath,
+                            primaryActionTitle: "Allow Once",
+                            secondaryActionTitle: "Deny",
+                            toolName: payload.toolName,
+                            toolUseID: claudeToolUseID(for: payload),
+                            suggestedUpdates: suggestions,
+                            originatingAgentID: payload.agentID,
+                            originatingAgentType: payload.agentType
+                        ),
+                        timestamp: .now
+                    )
+                )
+            )
+        }
+
+        pendingClaudeInteractions[sessionID] = interaction
+    }
+
+    /// After the active interaction for `sessionID` was resolved, promote the
+    /// next queued interaction (if any) to active and emit its event. If the
+    /// queue is empty, the slot simply stays clear.
+    private func promoteNextQueuedClaudeInteraction(for sessionID: String) {
+        guard var queue = queuedClaudeInteractions[sessionID], let next = queue.first else {
+            return
+        }
+        queue.removeFirst()
+        if queue.isEmpty {
+            queuedClaudeInteractions.removeValue(forKey: sessionID)
+        } else {
+            queuedClaudeInteractions[sessionID] = queue
+        }
+        activateClaudeInteraction(next, for: sessionID)
+    }
+
     private func resolvePendingClaudeInteraction(
         sessionID: String,
         resolution: PermissionResolution
@@ -2464,6 +2542,8 @@ public final class BridgeServer: @unchecked Sendable {
         )
 
         send(.response(.claudeHookDirective(directive)), to: pendingInteraction.clientID)
+
+        promoteNextQueuedClaudeInteraction(for: sessionID)
     }
 
     private func resolvePendingClaudeQuestion(
@@ -2506,6 +2586,8 @@ public final class BridgeServer: @unchecked Sendable {
             ),
             to: pendingInteraction.clientID
         )
+
+        promoteNextQueuedClaudeInteraction(for: sessionID)
     }
 
     private func claudeToolUseID(for payload: ClaudeHookPayload) -> String? {
@@ -2633,6 +2715,19 @@ public final class BridgeServer: @unchecked Sendable {
                 )
             )
         }
+
+        // Purge any queued (not-yet-active) interactions owned by the
+        // disconnecting connection so they can never be promoted onto a dead
+        // connection. Queued interactions were never surfaced, so no event is
+        // emitted for them — they simply vanish from the queue.
+        var purgedQueuedClaudeInteractions: [String: [PendingClaudeInteraction]] = [:]
+        for (sessionID, queue) in queuedClaudeInteractions {
+            let filtered = queue.filter { $0.clientID != clientID }
+            if !filtered.isEmpty {
+                purgedQueuedClaudeInteractions[sessionID] = filtered
+            }
+        }
+        queuedClaudeInteractions = purgedQueuedClaudeInteractions
 
         let pendingOpenCodeSessionIDs = pendingOpenCodeInteractions.compactMap { entry -> String? in
             let (sessionID, pendingInteraction) = entry

--- a/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
@@ -529,6 +529,444 @@ struct ClaudeHooksTests {
     }
 
     @Test
+    func claudeSubagentPermissionRequestSurfacesOnParentSession() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let parentSessionID = "claude-subagent-permission-parent"
+        let subagentID = "subagent-alpha"
+        let subagentType = "general-purpose"
+
+        // Register the subagent on the parent so the card can label it.
+        let subagentStartPayload = ClaudeHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .subagentStart,
+            sessionID: parentSessionID,
+            agentID: subagentID,
+            agentType: subagentType
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(.processClaudeHook(subagentStartPayload))
+
+        let toolInput: ClaudeHookJSONValue = .object(["command": .string("rm -rf /tmp/scratch")])
+        let permissionPayload = ClaudeHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .permissionRequest,
+            sessionID: parentSessionID,
+            agentID: subagentID,
+            agentType: subagentType,
+            toolName: "Bash",
+            toolInput: toolInput,
+            toolUseID: "subagent-tool-use-1"
+        )
+
+        async let responseTask = sendOnGCDThread(.processClaudeHook(permissionPayload), socketURL: socketURL)
+
+        var iterator = stream.makeAsyncIterator()
+        let permissionEvent = try await nextMatchingEvent(from: &iterator, maxEvents: 8) { event in
+            if case .permissionRequested = event {
+                return true
+            }
+            return false
+        }
+
+        if case let .permissionRequested(payload) = permissionEvent {
+            #expect(payload.sessionID == parentSessionID)
+            #expect(payload.request.originatingAgentID == subagentID)
+            #expect(payload.request.originatingAgentType == subagentType)
+            #expect(payload.request.toolName == "Bash")
+            #expect(payload.request.toolUseID == "subagent-tool-use-1")
+        } else {
+            Issue.record("Expected a subagent permission request event on the parent session")
+        }
+
+        let pendingSnapshot = server.pendingClaudeInteractionSnapshotForTests()
+        #expect(pendingSnapshot.activeCount == 1)
+        #expect(pendingSnapshot.queuedCount == 0)
+
+        try await observer.send(.resolvePermission(sessionID: parentSessionID, resolution: .allowOnce()))
+
+        let response = try await responseTask
+        guard case let .some(.claudeHookDirective(.permissionRequest(.allow(updatedInput, updatedPermissions)))) = response else {
+            Issue.record("Expected an allow directive routed to the subagent's hook connection")
+            return
+        }
+        #expect(updatedPermissions.isEmpty)
+        #expect(updatedInput == toolInput)
+
+        let drainedSnapshot = server.pendingClaudeInteractionSnapshotForTests()
+        #expect(drainedSnapshot.activeCount == 0)
+        #expect(drainedSnapshot.queuedCount == 0)
+    }
+
+    @Test
+    func claudeConcurrentSubagentPermissionRequestsAreQueuedInArrivalOrder() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let collector = AgentEventCollector()
+        let collectionTask = Task {
+            do { for try await event in stream { await collector.append(event) } } catch {}
+        }
+        defer { collectionTask.cancel() }
+
+        let parentSessionID = "claude-subagent-queue-parent"
+        let alphaToolInput: ClaudeHookJSONValue = .object(["command": .string("alpha-cmd")])
+        let betaToolInput: ClaudeHookJSONValue = .object(["command": .string("beta-cmd")])
+
+        func subagentPermissionPayload(agentID: String, toolInput: ClaudeHookJSONValue) -> ClaudeHookPayload {
+            ClaudeHookPayload(
+                cwd: "/tmp/worktree",
+                hookEventName: .permissionRequest,
+                sessionID: parentSessionID,
+                agentID: agentID,
+                agentType: "general-purpose",
+                toolName: "Bash",
+                toolInput: toolInput,
+                toolUseID: "tool-use-\(agentID)"
+            )
+        }
+
+        // A arrives first and becomes active; B arrives while A is active.
+        async let responseTaskA = sendOnGCDThread(
+            .processClaudeHook(subagentPermissionPayload(agentID: "subagent-alpha", toolInput: alphaToolInput)),
+            socketURL: socketURL
+        )
+        let alphaEvent = try await waitForPermissionRequestedEvent(
+            originatingAgentID: "subagent-alpha",
+            collector: collector
+        )
+        #expect(alphaEvent != nil)
+
+        async let responseTaskB = sendOnGCDThread(
+            .processClaudeHook(subagentPermissionPayload(agentID: "subagent-beta", toolInput: betaToolInput)),
+            socketURL: socketURL
+        )
+
+        // B must be queued, not emitted: exactly one permission request so far.
+        try await Task.sleep(for: .milliseconds(60))
+        let preResolveCount = await collector.snapshot().filter {
+            if case .permissionRequested = $0 { return true }
+            return false
+        }.count
+        #expect(preResolveCount == 1)
+
+        let queuedSnapshot = server.pendingClaudeInteractionSnapshotForTests()
+        #expect(queuedSnapshot.activeCount == 1)
+        #expect(queuedSnapshot.queuedCount == 1)
+
+        // Resolving A routes the directive to A's connection AND promotes B.
+        try await observer.send(.resolvePermission(sessionID: parentSessionID, resolution: .allowOnce()))
+
+        let responseA = try await responseTaskA
+        guard case let .some(.claudeHookDirective(.permissionRequest(.allow(inputA, _)))) = responseA,
+              inputA == alphaToolInput else {
+            Issue.record("Expected A's allow directive routed to A's hook connection")
+            return
+        }
+
+        let betaEvent = try await waitForPermissionRequestedEvent(
+            originatingAgentID: "subagent-beta",
+            collector: collector
+        )
+        #expect(betaEvent != nil)
+        let promotedSnapshot = server.pendingClaudeInteractionSnapshotForTests()
+        #expect(promotedSnapshot.activeCount == 1)
+        #expect(promotedSnapshot.queuedCount == 0)
+
+        // Resolving B routes to B's connection; the slot clears.
+        try await observer.send(.resolvePermission(sessionID: parentSessionID, resolution: .deny(message: nil, interrupt: false)))
+
+        let responseB = try await responseTaskB
+        guard case .some(.claudeHookDirective(.permissionRequest(.deny))) = responseB else {
+            Issue.record("Expected B's deny directive routed to B's hook connection")
+            return
+        }
+
+        let drainedSnapshot = server.pendingClaudeInteractionSnapshotForTests()
+        #expect(drainedSnapshot.activeCount == 0)
+        #expect(drainedSnapshot.queuedCount == 0)
+    }
+
+    @Test
+    func claudeSubagentAskUserQuestionIsQueuedBehindPermission() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let collector = AgentEventCollector()
+        let collectionTask = Task {
+            do { for try await event in stream { await collector.append(event) } } catch {}
+        }
+        defer { collectionTask.cancel() }
+
+        let parentSessionID = "claude-subagent-question-parent"
+        let alphaToolInput: ClaudeHookJSONValue = .object(["command": .string("alpha-cmd")])
+        let questionToolInput: ClaudeHookJSONValue = .object([
+            "questions": .array([
+                .object([
+                    "question": .string("Which environment?"),
+                    "header": .string("Env"),
+                    "options": .array([
+                        option(label: "Production", description: "Use production"),
+                        option(label: "Staging", description: "Use staging"),
+                    ]),
+                    "multiSelect": .boolean(false),
+                ]),
+            ]),
+        ])
+
+        // A: a subagent permission request (active).
+        async let responseTaskA = sendOnGCDThread(
+            .processClaudeHook(ClaudeHookPayload(
+                cwd: "/tmp/worktree",
+                hookEventName: .permissionRequest,
+                sessionID: parentSessionID,
+                agentID: "subagent-alpha",
+                agentType: "general-purpose",
+                toolName: "Bash",
+                toolInput: alphaToolInput,
+                toolUseID: "tool-use-alpha"
+            )),
+            socketURL: socketURL
+        )
+        let alphaEvent = try await waitForPermissionRequestedEvent(
+            originatingAgentID: "subagent-alpha",
+            collector: collector
+        )
+        #expect(alphaEvent != nil)
+
+        // B: a subagent AskUserQuestion (queued behind A; no event yet).
+        async let responseTaskB = sendOnGCDThread(
+            .processClaudeHook(ClaudeHookPayload(
+                cwd: "/tmp/worktree",
+                hookEventName: .permissionRequest,
+                sessionID: parentSessionID,
+                agentID: "subagent-beta",
+                agentType: "general-purpose",
+                toolName: "AskUserQuestion",
+                toolInput: questionToolInput,
+                toolUseID: "tool-use-beta"
+            )),
+            socketURL: socketURL
+        )
+
+        try await Task.sleep(for: .milliseconds(60))
+        let preResolveQuestionCount = await collector.snapshot().filter {
+            if case .questionAsked = $0 { return true }
+            return false
+        }.count
+        #expect(preResolveQuestionCount == 0)
+
+        let queuedSnapshot = server.pendingClaudeInteractionSnapshotForTests()
+        #expect(queuedSnapshot.activeCount == 1)
+        #expect(queuedSnapshot.queuedCount == 1)
+
+        // Resolving A promotes B: B's AskUserQuestion is now surfaced.
+        try await observer.send(.resolvePermission(sessionID: parentSessionID, resolution: .allowOnce()))
+
+        let responseA = try await responseTaskA
+        guard case .some(.claudeHookDirective(.permissionRequest(.allow))) = responseA else {
+            Issue.record("Expected A's allow directive routed to A's hook connection")
+            return
+        }
+
+        let questionEvent = try await waitForQuestionAskedEvent(collector: collector)
+        #expect(questionEvent != nil)
+        #expect(questionEvent?.sessionID == parentSessionID)
+        let promotedSnapshot = server.pendingClaudeInteractionSnapshotForTests()
+        #expect(promotedSnapshot.activeCount == 1)
+        #expect(promotedSnapshot.queuedCount == 0)
+
+        // Answering B routes the directive to B's connection; the slot clears.
+        try await observer.send(
+            .answerQuestion(
+                sessionID: parentSessionID,
+                response: QuestionPromptResponse(answers: ["Which environment?": "Staging"])
+            )
+        )
+
+        let responseB = try await responseTaskB
+        guard case let .some(.claudeHookDirective(.permissionRequest(.allow(updatedInput, _)))) = responseB,
+              case let .object(root)? = updatedInput,
+              case let .object(answers)? = root["answers"] else {
+            Issue.record("Expected B's AskUserQuestion answers to round-trip through updatedInput")
+            return
+        }
+        #expect(answers["Which environment?"] == .string("Staging"))
+
+        let drainedSnapshot = server.pendingClaudeInteractionSnapshotForTests()
+        #expect(drainedSnapshot.activeCount == 0)
+        #expect(drainedSnapshot.queuedCount == 0)
+    }
+
+    @Test
+    func claudeSubagentQueuedRequestPurgedOnHookDisconnect() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let collector = AgentEventCollector()
+        let collectionTask = Task {
+            do { for try await event in stream { await collector.append(event) } } catch {}
+        }
+        defer { collectionTask.cancel() }
+
+        let parentSessionID = "claude-subagent-disconnect-parent"
+
+        func subagentPermissionPayload(agentID: String) -> ClaudeHookPayload {
+            ClaudeHookPayload(
+                cwd: "/tmp/worktree",
+                hookEventName: .permissionRequest,
+                sessionID: parentSessionID,
+                agentID: agentID,
+                agentType: "general-purpose",
+                toolName: "Bash",
+                toolInput: .object(["command": .string("\(agentID)-cmd")]),
+                toolUseID: "tool-use-\(agentID)"
+            )
+        }
+
+        // Retain the hook clients' event streams for the lifetime of the test
+        // so their connections are not torn down by AsyncThrowingStream
+        // deallocation before we explicitly disconnect them.
+        var retainedHookStreams: [AsyncThrowingStream<AgentEvent, Error>] = []
+
+        // A is active (kept open via a persistent client; no blocking send).
+        let aClient = LocalBridgeClient(socketURL: socketURL)
+        retainedHookStreams.append(try aClient.connect())
+        defer { aClient.disconnect() }
+        try await aClient.send(.processClaudeHook(subagentPermissionPayload(agentID: "subagent-alpha")))
+
+        let alphaEvent = try await waitForPermissionRequestedEvent(
+            originatingAgentID: "subagent-alpha",
+            collector: collector
+        )
+        #expect(alphaEvent != nil)
+
+        // B arrives while A is active and is queued.
+        let bClient = LocalBridgeClient(socketURL: socketURL)
+        retainedHookStreams.append(try bClient.connect())
+        try await bClient.send(.processClaudeHook(subagentPermissionPayload(agentID: "subagent-beta")))
+
+        try await waitForQueuedClaudeInteractionCount(1, server: server)
+        #expect(server.pendingClaudeInteractionSnapshotForTests().activeCount == 1)
+
+        // B's hook process dies (socket closes without resolving). The queued
+        // interaction must be purged so it can never become active later.
+        bClient.disconnect()
+
+        try await waitForQueuedClaudeInteractionCount(0, server: server)
+        let afterDisconnect = server.pendingClaudeInteractionSnapshotForTests()
+        #expect(afterDisconnect.activeCount == 1)
+        #expect(afterDisconnect.queuedCount == 0)
+
+        // Resolving A must NOT promote B (it was purged): no beta event appears.
+        try await observer.send(.resolvePermission(sessionID: parentSessionID, resolution: .allowOnce()))
+
+        let betaEvent = try await waitForPermissionRequestedEvent(
+            originatingAgentID: "subagent-beta",
+            collector: collector
+        )
+        #expect(betaEvent == nil)
+
+        let drainedSnapshot = server.pendingClaudeInteractionSnapshotForTests()
+        #expect(drainedSnapshot.activeCount == 0)
+        #expect(drainedSnapshot.queuedCount == 0)
+    }
+
+    @Test
+    func claudeSubagentQueuedRequestClearedOnSessionEnd() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let collector = AgentEventCollector()
+        let collectionTask = Task {
+            do { for try await event in stream { await collector.append(event) } } catch {}
+        }
+        defer { collectionTask.cancel() }
+
+        let parentSessionID = "claude-subagent-sessionend-parent"
+
+        func subagentPermissionPayload(agentID: String) -> ClaudeHookPayload {
+            ClaudeHookPayload(
+                cwd: "/tmp/worktree",
+                hookEventName: .permissionRequest,
+                sessionID: parentSessionID,
+                agentID: agentID,
+                agentType: "general-purpose",
+                toolName: "Bash",
+                toolInput: .object(["command": .string("\(agentID)-cmd")]),
+                toolUseID: "tool-use-\(agentID)"
+            )
+        }
+
+        var retainedHookStreams: [AsyncThrowingStream<AgentEvent, Error>] = []
+
+        let aClient = LocalBridgeClient(socketURL: socketURL)
+        retainedHookStreams.append(try aClient.connect())
+        defer { aClient.disconnect() }
+        try await aClient.send(.processClaudeHook(subagentPermissionPayload(agentID: "subagent-alpha")))
+
+        _ = try await waitForPermissionRequestedEvent(
+            originatingAgentID: "subagent-alpha",
+            collector: collector
+        )
+
+        let bClient = LocalBridgeClient(socketURL: socketURL)
+        retainedHookStreams.append(try bClient.connect())
+        defer { bClient.disconnect() }
+        try await bClient.send(.processClaudeHook(subagentPermissionPayload(agentID: "subagent-beta")))
+
+        try await waitForQueuedClaudeInteractionCount(1, server: server)
+
+        // The parent session ends: both the active slot and the queue must clear.
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processClaudeHook(ClaudeHookPayload(
+                cwd: "/tmp/worktree",
+                hookEventName: .sessionEnd,
+                sessionID: parentSessionID
+            ))
+        )
+
+        let drainedSnapshot = server.pendingClaudeInteractionSnapshotForTests()
+        #expect(drainedSnapshot.activeCount == 0)
+        #expect(drainedSnapshot.queuedCount == 0)
+    }
+
+    @Test
     func claudeAwaySummaryNotificationCompletesRunningSessionWhenStopWasMissed() async throws {
         let socketURL = BridgeSocketLocation.uniqueTestURL()
         let server = BridgeServer(socketURL: socketURL)
@@ -802,6 +1240,59 @@ private func waitForCompletedSessionEvent(
     }
 
     return await collector.snapshot()
+}
+
+private func waitForPermissionRequestedEvent(
+    originatingAgentID: String,
+    collector: AgentEventCollector
+) async throws -> PermissionRequested? {
+    for _ in 0..<100 {
+        let events = await collector.snapshot()
+        if let match = events.last(where: { event in
+            if case let .permissionRequested(payload) = event {
+                return payload.request.originatingAgentID == originatingAgentID
+            }
+            return false
+        }) {
+            if case let .permissionRequested(payload) = match {
+                return payload
+            }
+        }
+        try? await Task.sleep(for: .milliseconds(10))
+    }
+    return nil
+}
+
+private func waitForQuestionAskedEvent(
+    collector: AgentEventCollector
+) async throws -> QuestionAsked? {
+    for _ in 0..<100 {
+        let events = await collector.snapshot()
+        if let match = events.last(where: { event in
+            if case .questionAsked = event { return true }
+            return false
+        }) {
+            if case let .questionAsked(payload) = match {
+                return payload
+            }
+        }
+        try? await Task.sleep(for: .milliseconds(10))
+    }
+    return nil
+}
+
+private func waitForQueuedClaudeInteractionCount(
+    _ expected: Int,
+    server: BridgeServer
+) async throws {
+    for _ in 0..<100 {
+        if server.pendingClaudeInteractionSnapshotForTests().queuedCount == expected {
+            return
+        }
+        try? await Task.sleep(for: .milliseconds(10))
+    }
+    // One final read so a failing assertion reports the actual value.
+    _ = server.pendingClaudeInteractionSnapshotForTests()
 }
 
 private func nextEvent(


### PR DESCRIPTION
Subagent PermissionRequest hooks (carrying agent_id) were acknowledged and dropped by the Claude subagent guard before reaching the UI, so a blocked subagent left the parent session sitting idle on the Agent tool with no way to approve from the island.

Changes:
- Exempt .permissionRequest from the subagent guard so subagent permission and AskUserQuestion prompts surface on the parent session.
- Add a bridge-internal per-session FIFO queue alongside the unchanged single active slot: a second concurrent interaction is queued without emitting, then promoted when the active one is resolved. AppModel/UI resolution path is untouched.
- Purge queued interactions on hook disconnect (removeClient) and on session/turn end (dropPendingClaudeContexts).
- Add backward-compatible PermissionRequest.originatingAgentID / originatingAgentType for subagent labeling.
- UI: subagent badge on the permission card + highlight of the matching row in activeSubagents (en/zh-Hans/zh-Hant strings).
- Tests: 5 end-to-end BridgeServer tests over the real-socket seam covering surfacing, queue ordering, AskUserQuestion discipline, disconnect purge, and session-end cleanup. Adds a test-only pendingClaudeInteractionSnapshotForTests() count accessor.

Claude-only; non-Claude agents unaffected (full hook suites pass).

Not yet merge-ready: the assumption that a subagent PermissionRequest carries the parent session_id is inferred and needs manual dev-app verification before merge. The documented remap fallback is deferred until that verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer approval prompts for subagent-originated requests, including a more descriptive label in the approval view.
  * Improved subagent indicators so the requesting subagent is easier to spot in the session panel.

* **Bug Fixes**
  * Fixed handling of overlapping approval and question prompts so requests are shown in the right order instead of being lost.
  * Ensured subagent-related approval prompts appear on the parent session and are cleaned up correctly when sessions end or disconnect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->