### PR TITLE
feat: display Zellij pane ID badge in island session row

### DIFF
--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -119,6 +119,19 @@ extension AgentSession {
         jumpTarget?.terminalApp
     }
 
+    /// For Zellij sessions, returns "Pane N" extracted from `terminalSessionID`
+    /// (format: "paneID:sessionName"). Returns nil for non-Zellij sessions.
+    var spotlightPaneBadge: String? {
+        guard let jumpTarget,
+              jumpTarget.terminalApp.lowercased() == "zellij",
+              let sessionID = jumpTarget.terminalSessionID else {
+            return nil
+        }
+        let paneID = sessionID.split(separator: ":").first.map(String.init) ?? sessionID
+        guard !paneID.isEmpty else { return nil }
+        return "Pane \(paneID)"
+    }
+
     var spotlightWorkspaceName: String {
         if let workspaceName = jumpTarget?.workspaceName.trimmedForSurface,
            !workspaceName.isEmpty {

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1049,6 +1049,9 @@ private struct IslandSessionRow: View {
                             if let terminalBadge = session.spotlightTerminalBadge {
                                 compactBadge(terminalBadge, presence: presence)
                             }
+                            if let paneBadge = session.spotlightPaneBadge {
+                                compactBadge(paneBadge, presence: presence)
+                            }
                             compactBadge(session.spotlightAgeBadge, presence: presence)
                             if let onDismiss {
                                 DismissButton(action: onDismiss)


### PR DESCRIPTION
## What

When a session runs inside Zellij, display a `Pane N` badge next to the terminal badge in the island session row.

## How

- Add `spotlightPaneBadge` to `AgentSession+Presentation`: for Zellij sessions it extracts the pane ID from the existing `terminalSessionID` field (format `paneID:sessionName`) and returns `Pane N`, `nil` otherwise.
- Render the badge in `IslandSessionRow` right after the existing terminal badge, reusing `compactBadge`.

## Notes

- Zellij only: returns `nil` for every other terminal, so no visible change elsewhere.
- +16 lines across 2 files, no new dependencies.
- This branch is behind upstream `main` and will need a rebase before merge.