### PR TITLE
feat: add herdr terminal multiplexer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Think of it as an open-source [Vibe Island](https://vibeisland.app/) — **free,
 
 **10 agents**: Claude Code, Codex, Cursor, Gemini CLI, Kimi CLI, OpenCode, Qoder, Qwen Code, Factory, CodeBuddy
 
-**15+ terminals & IDEs**: Terminal.app, Ghostty, iTerm2, WezTerm, Zellij, tmux, cmux, Kaku, VS Code, Cursor, Windsurf, Trae, JetBrains IDEs (IDEA, WebStorm, PyCharm, GoLand, CLion, RubyMine, PhpStorm, Rider, RustRover)
+**15+ terminals & IDEs**: Terminal.app, Ghostty, iTerm2, WezTerm, Zellij, herdr, tmux, cmux, Kaku, VS Code, Cursor, Windsurf, Trae, JetBrains IDEs (IDEA, WebStorm, PyCharm, GoLand, CLion, RubyMine, PhpStorm, Rider, RustRover)
 
 <details>
 <summary>Full compatibility table</summary>
@@ -86,6 +86,7 @@ Think of it as an open-source [Vibe Island](https://vibeisland.app/) — **free,
 | **iTerm2** | Full | Jump-back with session ID / TTY matching |
 | **tmux** (multiplexer) | Full | Jump-back with session/window/pane targeting |
 | **Zellij** | Full | Jump-back via CLI pane/tab targeting |
+| **herdr** (multiplexer) | Full | Jump-back via `herdr agent focus` pane targeting |
 | **VS Code** | Workspace | Activate workspace via `code` CLI |
 | **Cursor** | Workspace | Activate workspace via `cursor` CLI |
 | **Windsurf** | Workspace | Activate workspace via `windsurf` CLI |
@@ -281,7 +282,7 @@ Developers who already live in the terminal and want a better way to work with c
 
 ### Terminal Support
 
-- **Terminal.app**, **Ghostty**, **cmux**, **Kaku**, **WezTerm**, **iTerm2**, and **Zellij** — Full jump-back support with session attachment matching (cmux via Unix socket API, Kaku/WezTerm/Zellij via CLI pane targeting, iTerm2 via AppleScript session/TTY probe)
+- **Terminal.app**, **Ghostty**, **cmux**, **Kaku**, **WezTerm**, **iTerm2**, **Zellij**, and **herdr** — Full jump-back support with session attachment matching (cmux via Unix socket API, Kaku/WezTerm/Zellij via CLI pane targeting, herdr via `herdr agent focus`, iTerm2 via AppleScript session/TTY probe)
 - **VS Code**, **VS Code Insiders**, **Cursor**, **Windsurf**, **Trae** — Workspace-level jump via respective CLI (`code -r`, `cursor -r`, etc.)
 - **JetBrains IDEs** (IntelliJ IDEA, WebStorm, PyCharm, GoLand, CLion, RubyMine, PhpStorm, Rider, RustRover) — Workspace-level jump via IDE CLI launcher
 - **Warp** — Precision tab jump via SQLite pane lookup, pid-based sibling-tab disambiguation, and AX menu click

--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -500,6 +500,10 @@ struct ActiveAgentProcessDiscovery {
             return "Zellij"
         }
 
+        if lowered.hasSuffix("/herdr") {
+            return "Herdr"
+        }
+
         // VS Code family — check forks BEFORE plain VS Code so fork apps that
         // retain the upstream "Code Helper" naming inside their Electron
         // framework aren't misidentified as VS Code (#415).

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -1370,6 +1370,8 @@ final class ProcessMonitoringCoordinator {
             return "WezTerm"
         case "zellij":
             return "Zellij"
+        case "herdr":
+            return "Herdr"
         // VS Code family
         case "vscode", "code", "visual studio code":
             return "VS Code"

--- a/Sources/OpenIslandApp/Resources/open-island-opencode.js
+++ b/Sources/OpenIslandApp/Resources/open-island-opencode.js
@@ -83,6 +83,7 @@ const ENV_KEYS = [
   "TMUX", "TMUX_PANE", "KITTY_WINDOW_ID",
   "CMUX_WORKSPACE_ID", "CMUX_SURFACE_ID", "CMUX_SOCKET_PATH",
   "ZELLIJ", "ZELLIJ_PANE_ID", "ZELLIJ_SESSION_NAME",
+  "HERDR_ENV", "HERDR_PANE_ID", "HERDR_SESSION", "HERDR_SOCKET_PATH",
 ];
 
 function collectEnv() {
@@ -105,6 +106,13 @@ function terminalFields() {
     const paneID = env.ZELLIJ_PANE_ID || "";
     const sessionName = env.ZELLIJ_SESSION_NAME || "";
     if (paneID) result.terminal_session_id = `${paneID}:${sessionName}`;
+  } else if (env.HERDR_ENV != null) {
+    result.terminal_app = "Herdr";
+    // herdr pane ids contain a colon (e.g. "w2:p1"), so encode with "|" and
+    // carry the socket so the jump service can focus the right session server.
+    const paneID = env.HERDR_PANE_ID || "";
+    const socketPath = env.HERDR_SOCKET_PATH || "";
+    if (paneID) result.terminal_session_id = socketPath ? `${paneID}|${socketPath}` : paneID;
   } else if (env.GHOSTTY_RESOURCES_DIR || (env.TERM_PROGRAM || "").toLowerCase().includes("ghostty")) {
     result.terminal_app = "Ghostty";
   } else if (env.TERM_PROGRAM === "Apple_Terminal") {

--- a/Sources/OpenIslandApp/TerminalJumpService.swift
+++ b/Sources/OpenIslandApp/TerminalJumpService.swift
@@ -331,6 +331,19 @@ struct TerminalJumpService {
             throw TerminalJumpError.unsupportedTerminal("Zellij (no parent terminal found)")
         }
 
+        // herdr is also a terminal multiplexer with no macOS .app. Focus the
+        // pane directly via the herdr CLI before the descriptor dispatch.
+        if target.terminalApp.lowercased() == "herdr" {
+            if jumpToHerdrPane(target) {
+                return "Focused the matching herdr pane."
+            }
+            if let parentBundleID = Self.zellijParentTerminals.first(where: { appRunningChecker($0) }) {
+                try openAction(["-b", parentBundleID])
+                return "Activated parent terminal. herdr pane targeting could not find the pane."
+            }
+            throw TerminalJumpError.unsupportedTerminal("herdr (no parent terminal found)")
+        }
+
         if let descriptor {
             switch resolvedBundleIdentifier ?? descriptor.bundleIdentifier {
             case "com.openai.codex":
@@ -793,6 +806,70 @@ struct TerminalJumpService {
         }
 
         return panes.first(where: { $0.id == paneID })?.tabPosition
+    }
+
+    // MARK: - herdr CLI-based jump
+
+    /// Parses the encoded `terminalSessionID` (format: `paneID|socketPath`,
+    /// socket optional) and focuses that pane via `herdr agent focus`. Unlike
+    /// Zellij, herdr needs no tab lookup: the pane id addresses the pane
+    /// directly on its session socket.
+    private func jumpToHerdrPane(_ target: JumpTarget) -> Bool {
+        guard let encoded = target.terminalSessionID, !encoded.isEmpty else {
+            return false
+        }
+
+        let parts = encoded.split(separator: "|", maxSplits: 1).map(String.init)
+        let paneID = parts[0]
+        let socketPath = parts.count > 1 ? parts[1] : nil
+
+        guard !paneID.isEmpty, let herdrPath = resolveHerdrPath() else {
+            return false
+        }
+
+        let focus = Process()
+        focus.executableURL = URL(fileURLWithPath: herdrPath)
+        focus.arguments = ["agent", "focus", paneID]
+        if let socketPath, !socketPath.isEmpty {
+            var env = ProcessInfo.processInfo.environment
+            env["HERDR_SOCKET_PATH"] = socketPath
+            focus.environment = env
+        }
+        focus.standardOutput = FileHandle.nullDevice
+        focus.standardError = FileHandle.nullDevice
+        guard (try? focus.run()) != nil else { return false }
+        focus.waitUntilExit()
+
+        // Activate the parent terminal app window hosting herdr.
+        if let parentBundleID = Self.zellijParentTerminals.first(where: { appRunningChecker($0) }) {
+            try? openAction(["-b", parentBundleID])
+        }
+
+        return focus.terminationStatus == 0
+    }
+
+    private func resolveHerdrPath() -> String? {
+        let candidates = [
+            NSHomeDirectory() + "/.local/bin/herdr",
+            "/usr/local/bin/herdr",
+            "/opt/homebrew/bin/herdr",
+        ]
+        if let found = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) {
+            return found
+        }
+
+        let whichTask = Process()
+        whichTask.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        whichTask.arguments = ["herdr"]
+        let pipe = Pipe()
+        whichTask.standardOutput = pipe
+        whichTask.standardError = FileHandle.nullDevice
+        guard (try? whichTask.run()) != nil else { return nil }
+        whichTask.waitUntilExit()
+        guard whichTask.terminationStatus == 0 else { return nil }
+        let path = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return path.isEmpty ? nil : path
     }
 
     private func jumpToGhosttyTerminal(_ target: JumpTarget) throws -> Bool {

--- a/Sources/OpenIslandApp/TerminalJumpService.swift
+++ b/Sources/OpenIslandApp/TerminalJumpService.swift
@@ -178,9 +178,10 @@ struct TerminalJumpService {
     /// `vscodeFamilyCLI` so the two maps cannot drift.
     private static let vscodeFamilyBundleIDs: Set<String> = Set(vscodeFamilyCLI.keys)
 
-    /// Bundle identifiers of terminal emulators that commonly host Zellij,
-    /// derived from `knownApps` so it stays in sync automatically.
-    private static let zellijParentTerminals = knownApps.map(\.bundleIdentifier)
+    /// Bundle identifiers of terminal emulators that commonly host a
+    /// multiplexer (Zellij, herdr), derived from `knownApps` so it stays in
+    /// sync automatically.
+    private static let multiplexerParentTerminals = knownApps.map(\.bundleIdentifier)
 
     private static let ghosttyFocusSettleDelay = 0.08
     private static let ghosttyWindowActivationDelay = 0.04
@@ -324,7 +325,7 @@ struct TerminalJumpService {
                 return "Focused the matching Zellij pane."
             }
             // Fallback: activate whichever parent terminal is running.
-            if let parentBundleID = Self.zellijParentTerminals.first(where: { appRunningChecker($0) }) {
+            if let parentBundleID = Self.multiplexerParentTerminals.first(where: { appRunningChecker($0) }) {
                 try openAction(["-b", parentBundleID])
                 return "Activated parent terminal. Zellij pane targeting could not find the pane."
             }
@@ -337,7 +338,7 @@ struct TerminalJumpService {
             if jumpToHerdrPane(target) {
                 return "Focused the matching herdr pane."
             }
-            if let parentBundleID = Self.zellijParentTerminals.first(where: { appRunningChecker($0) }) {
+            if let parentBundleID = Self.multiplexerParentTerminals.first(where: { appRunningChecker($0) }) {
                 try openAction(["-b", parentBundleID])
                 return "Activated parent terminal. herdr pane targeting could not find the pane."
             }
@@ -666,21 +667,17 @@ struct TerminalJumpService {
         }
     }
 
-    private func resolveTmuxPath() -> String? {
-        let candidates = [
-            "/opt/homebrew/bin/tmux",
-            "/usr/local/bin/tmux",
-            "/usr/bin/tmux",
-        ]
-
+    /// Resolves a CLI executable by checking well-known bin directories, then
+    /// falling back to `which`. Returns nil when the binary can't be found.
+    private func resolveExecutablePath(named name: String, searchDirs: [String]) -> String? {
+        let candidates = searchDirs.map { "\($0)/\(name)" }
         if let found = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) {
             return found
         }
 
-        // Fallback to 'which'
         let whichTask = Process()
         whichTask.executableURL = URL(fileURLWithPath: "/usr/bin/which")
-        whichTask.arguments = ["tmux"]
+        whichTask.arguments = [name]
         let pipe = Pipe()
         whichTask.standardOutput = pipe
         whichTask.standardError = FileHandle.nullDevice
@@ -690,6 +687,13 @@ struct TerminalJumpService {
         let path = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return path.isEmpty ? nil : path
+    }
+
+    private func resolveTmuxPath() -> String? {
+        resolveExecutablePath(
+            named: "tmux",
+            searchDirs: ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin"]
+        )
     }
 
     // MARK: - Zellij CLI-based jump
@@ -736,7 +740,7 @@ struct TerminalJumpService {
         goToTab.waitUntilExit()
 
         // Activate the parent terminal app window.
-        if let parentBundleID = Self.zellijParentTerminals.first(where: { appRunningChecker($0) }) {
+        if let parentBundleID = Self.multiplexerParentTerminals.first(where: { appRunningChecker($0) }) {
             try? openAction(["-b", parentBundleID])
         }
 
@@ -744,28 +748,10 @@ struct TerminalJumpService {
     }
 
     private func resolveZellijPath() -> String? {
-        let candidates = [
-            NSHomeDirectory() + "/.local/bin/zellij",
-            "/usr/local/bin/zellij",
-            "/opt/homebrew/bin/zellij",
-        ]
-        if let found = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) {
-            return found
-        }
-
-        // Fallback: which.
-        let whichTask = Process()
-        whichTask.executableURL = URL(fileURLWithPath: "/usr/bin/which")
-        whichTask.arguments = ["zellij"]
-        let pipe = Pipe()
-        whichTask.standardOutput = pipe
-        whichTask.standardError = FileHandle.nullDevice
-        guard (try? whichTask.run()) != nil else { return nil }
-        whichTask.waitUntilExit()
-        guard whichTask.terminationStatus == 0 else { return nil }
-        let path = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return path.isEmpty ? nil : path
+        resolveExecutablePath(
+            named: "zellij",
+            searchDirs: [NSHomeDirectory() + "/.local/bin", "/usr/local/bin", "/opt/homebrew/bin"]
+        )
     }
 
     private struct ZellijPaneInfo: Decodable {
@@ -823,7 +809,7 @@ struct TerminalJumpService {
         let paneID = parts[0]
         let socketPath = parts.count > 1 ? parts[1] : nil
 
-        guard !paneID.isEmpty, let herdrPath = resolveHerdrPath() else {
+        guard let herdrPath = resolveHerdrPath() else {
             return false
         }
 
@@ -841,7 +827,7 @@ struct TerminalJumpService {
         focus.waitUntilExit()
 
         // Activate the parent terminal app window hosting herdr.
-        if let parentBundleID = Self.zellijParentTerminals.first(where: { appRunningChecker($0) }) {
+        if let parentBundleID = Self.multiplexerParentTerminals.first(where: { appRunningChecker($0) }) {
             try? openAction(["-b", parentBundleID])
         }
 
@@ -849,27 +835,10 @@ struct TerminalJumpService {
     }
 
     private func resolveHerdrPath() -> String? {
-        let candidates = [
-            NSHomeDirectory() + "/.local/bin/herdr",
-            "/usr/local/bin/herdr",
-            "/opt/homebrew/bin/herdr",
-        ]
-        if let found = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) {
-            return found
-        }
-
-        let whichTask = Process()
-        whichTask.executableURL = URL(fileURLWithPath: "/usr/bin/which")
-        whichTask.arguments = ["herdr"]
-        let pipe = Pipe()
-        whichTask.standardOutput = pipe
-        whichTask.standardError = FileHandle.nullDevice
-        guard (try? whichTask.run()) != nil else { return nil }
-        whichTask.waitUntilExit()
-        guard whichTask.terminationStatus == 0 else { return nil }
-        let path = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return path.isEmpty ? nil : path
+        resolveExecutablePath(
+            named: "herdr",
+            searchDirs: [NSHomeDirectory() + "/.local/bin", "/usr/local/bin", "/opt/homebrew/bin"]
+        )
     }
 
     private func jumpToGhosttyTerminal(_ target: JumpTarget) throws -> Bool {

--- a/Sources/OpenIslandApp/TerminalSessionAttachmentProbe.swift
+++ b/Sources/OpenIslandApp/TerminalSessionAttachmentProbe.swift
@@ -731,10 +731,11 @@ struct TerminalSessionAttachmentProbe {
             terminalSessionID: snapshot.sessionID
         )
 
-        // Zellij runs inside Ghostty but has its own jump-back mechanism
-        // via pane IDs. Don't overwrite Zellij's terminal info with
-        // Ghostty's session ID, as it would break Zellij pane targeting.
-        if jumpTarget.terminalApp.lowercased() == "zellij" {
+        // Zellij and herdr run inside Ghostty but have their own jump-back
+        // mechanism via pane IDs. Don't overwrite their terminal info with
+        // Ghostty's session ID, as it would break pane targeting.
+        let multiplexerApp = jumpTarget.terminalApp.lowercased()
+        if multiplexerApp == "zellij" || multiplexerApp == "herdr" {
             return nil
         }
 

--- a/Sources/OpenIslandCore/ClaudeHooks.swift
+++ b/Sources/OpenIslandCore/ClaudeHooks.swift
@@ -1007,13 +1007,31 @@ public extension ClaudeHookPayload {
             }
         }
 
+        // For herdr, encode pane ID and session socket so the jump service can
+        // focus the correct pane via the herdr CLI. herdr pane ids contain a
+        // colon (e.g. "w2:p1"), so use "|" as the separator instead of the
+        // Zellij ":" scheme, and carry the socket so focus targets the right
+        // session server.
+        if isHerdrTerminalApp(payload.terminalApp) {
+            if payload.terminalSessionID == nil {
+                let paneID = environment["HERDR_PANE_ID"] ?? ""
+                let socketPath = environment["HERDR_SOCKET_PATH"] ?? ""
+                if !paneID.isEmpty {
+                    payload.terminalSessionID = socketPath.isEmpty
+                        ? paneID
+                        : "\(paneID)|\(socketPath)"
+                }
+            }
+        }
+
         if payload.terminalTTY == nil {
             payload.terminalTTY = currentTTYProvider()
         }
 
         let useLocator: Bool
-        if isCmuxTerminalApp(payload.terminalApp) || isZellijTerminalApp(payload.terminalApp) {
-            // cmux/Zellij session IDs come from environment variables;
+        if isCmuxTerminalApp(payload.terminalApp) || isZellijTerminalApp(payload.terminalApp)
+            || isHerdrTerminalApp(payload.terminalApp) {
+            // cmux/Zellij/herdr session IDs come from environment variables;
             // no AppleScript locator is available, so skip entirely.
             useLocator = false
         } else if let terminalApp = payload.terminalApp, isGhosttyTerminalApp(terminalApp) {
@@ -1051,7 +1069,7 @@ public extension ClaudeHookPayload {
     }
 
     private static let noLocatorTerminalApps: Set<String> = [
-        "cmux", "kaku", "wezterm", "zellij",
+        "cmux", "kaku", "wezterm", "zellij", "herdr",
         "vs code", "vs code insiders", "cursor", "windsurf", "trae",
         "intellij idea", "webstorm", "pycharm", "goland", "clion",
         "rubymine", "phpstorm", "rider", "rustrover",
@@ -1076,6 +1094,10 @@ public extension ClaudeHookPayload {
 
     private func isZellijTerminalApp(_ terminalApp: String?) -> Bool {
         terminalApp?.lowercased() == "zellij"
+    }
+
+    private func isHerdrTerminalApp(_ terminalApp: String?) -> Bool {
+        terminalApp?.lowercased() == "herdr"
     }
 
     private var extractedPathValue: String? {
@@ -1167,6 +1189,9 @@ public extension ClaudeHookPayload {
         }
         if environment["ZELLIJ"] != nil {
             return "Zellij"
+        }
+        if environment["HERDR_ENV"] != nil {
+            return "Herdr"
         }
 
         // Claude desktop app — Claude Code launched by Claude.app (its "local

--- a/Sources/OpenIslandCore/CodexHooks.swift
+++ b/Sources/OpenIslandCore/CodexHooks.swift
@@ -600,13 +600,31 @@ public extension CodexHookPayload {
             }
         }
 
+        // For herdr, encode pane ID and session socket so the jump service can
+        // focus the correct pane via the herdr CLI. herdr pane ids contain a
+        // colon (e.g. "w2:p1"), so use "|" as the separator instead of the
+        // Zellij ":" scheme, and carry the socket so focus targets the right
+        // session server.
+        if isHerdrTerminalApp(payload.terminalApp) {
+            if payload.terminalSessionID == nil {
+                let paneID = environment["HERDR_PANE_ID"] ?? ""
+                let socketPath = environment["HERDR_SOCKET_PATH"] ?? ""
+                if !paneID.isEmpty {
+                    payload.terminalSessionID = socketPath.isEmpty
+                        ? paneID
+                        : "\(paneID)|\(socketPath)"
+                }
+            }
+        }
+
         if payload.terminalTTY == nil {
             payload.terminalTTY = currentTTYProvider()
         }
 
         let useLocator: Bool
-        if isCmuxTerminalApp(payload.terminalApp) || isZellijTerminalApp(payload.terminalApp) {
-            // cmux/Zellij session IDs come from environment variables;
+        if isCmuxTerminalApp(payload.terminalApp) || isZellijTerminalApp(payload.terminalApp)
+            || isHerdrTerminalApp(payload.terminalApp) {
+            // cmux/Zellij/herdr session IDs come from environment variables;
             // no AppleScript locator is available, so skip entirely.
             useLocator = false
         } else if let terminalApp = payload.terminalApp, isGhosttyTerminalApp(terminalApp) {
@@ -638,7 +656,7 @@ public extension CodexHookPayload {
     }
 
     private static let noLocatorTerminalApps: Set<String> = [
-        "cmux", "codex.app", "kaku", "wezterm", "zellij",
+        "cmux", "codex.app", "kaku", "wezterm", "zellij", "herdr",
         "vs code", "vs code insiders", "cursor", "windsurf", "trae",
         "intellij idea", "webstorm", "pycharm", "goland", "clion",
         "rubymine", "phpstorm", "rider", "rustrover",
@@ -665,6 +683,10 @@ public extension CodexHookPayload {
         terminalApp?.lowercased() == "zellij"
     }
 
+    private func isHerdrTerminalApp(_ terminalApp: String?) -> Bool {
+        terminalApp?.lowercased() == "herdr"
+    }
+
     private func inferTerminalApp(from environment: [String: String]) -> String? {
         // Multiplexers run inside a host terminal but expose their own pane
         // context. Detect them first so the captured jumpTarget points at
@@ -674,6 +696,9 @@ public extension CodexHookPayload {
         }
         if environment["ZELLIJ"] != nil {
             return "Zellij"
+        }
+        if environment["HERDR_ENV"] != nil {
+            return "Herdr"
         }
 
         // Codex desktop app — the hook binary runs as a child of Codex.app,

--- a/Sources/OpenIslandCore/GeminiHooks.swift
+++ b/Sources/OpenIslandCore/GeminiHooks.swift
@@ -225,7 +225,8 @@ public extension GeminiHookPayload {
         }
 
         let useLocator: Bool
-        if isCmuxTerminalApp(payload.terminalApp) || isZellijTerminalApp(payload.terminalApp) {
+        if isCmuxTerminalApp(payload.terminalApp) || isZellijTerminalApp(payload.terminalApp)
+            || isHerdrTerminalApp(payload.terminalApp) {
             useLocator = false
         } else if let terminalApp = payload.terminalApp, isGhosttyTerminalApp(terminalApp) {
             switch payload.hookEventName {
@@ -257,7 +258,7 @@ public extension GeminiHookPayload {
     }
 
     private static let noLocatorTerminalApps: Set<String> = [
-        "cmux", "kaku", "wezterm", "zellij",
+        "cmux", "kaku", "wezterm", "zellij", "herdr",
         "vs code", "vs code insiders", "cursor", "windsurf", "trae",
         "intellij idea", "webstorm", "pycharm", "goland", "clion",
         "rubymine", "phpstorm", "rider", "rustrover"
@@ -329,6 +330,10 @@ public extension GeminiHookPayload {
         terminalApp?.lowercased() == "zellij"
     }
 
+    private func isHerdrTerminalApp(_ terminalApp: String?) -> Bool {
+        terminalApp?.lowercased() == "herdr"
+    }
+
     private func inferTerminalApp(from environment: [String: String]) -> String? {
         if environment["ITERM_SESSION_ID"] != nil || environment["LC_TERMINAL"] == "iTerm2" {
             return "iTerm"
@@ -340,6 +345,10 @@ public extension GeminiHookPayload {
 
         if environment["ZELLIJ"] != nil {
             return "Zellij"
+        }
+
+        if environment["HERDR_ENV"] != nil {
+            return "Herdr"
         }
 
         if environment["GHOSTTY_RESOURCES_DIR"] != nil {

--- a/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
@@ -303,6 +303,52 @@ struct ClaudeHooksTests {
     }
 
     @Test
+    func claudeInferTerminalAppRecognizesHerdrViaEnvVar() {
+        let payload = ClaudeHookPayload(
+            cwd: "/tmp/demo", hookEventName: .sessionStart, sessionID: "s1"
+        ).withRuntimeContext(
+            environment: ["HERDR_ENV": "1", "HERDR_PANE_ID": "w2:p1"],
+            currentTTYProvider: { nil },
+            terminalLocatorProvider: { _ in (sessionID: nil, tty: nil, title: nil) }
+        )
+
+        #expect(payload.terminalApp == "Herdr")
+    }
+
+    @Test
+    func claudeHerdrEncodesPaneAndSocketWithPipeSeparator() {
+        // herdr pane ids contain a colon (e.g. "w2:p1"), so the encoding must
+        // use "|" instead of Zellij's ":" and carry the session socket.
+        let payload = ClaudeHookPayload(
+            cwd: "/tmp/demo", hookEventName: .sessionStart, sessionID: "s1"
+        ).withRuntimeContext(
+            environment: [
+                "HERDR_ENV": "1",
+                "HERDR_PANE_ID": "w2:p1",
+                "HERDR_SOCKET_PATH": "/Users/x/.config/herdr/sessions/main/herdr.sock",
+            ],
+            currentTTYProvider: { nil },
+            terminalLocatorProvider: { _ in (sessionID: nil, tty: nil, title: nil) }
+        )
+
+        #expect(payload.terminalApp == "Herdr")
+        #expect(payload.terminalSessionID == "w2:p1|/Users/x/.config/herdr/sessions/main/herdr.sock")
+    }
+
+    @Test
+    func claudeHerdrEncodesPaneOnlyWhenSocketMissing() {
+        let payload = ClaudeHookPayload(
+            cwd: "/tmp/demo", hookEventName: .sessionStart, sessionID: "s1"
+        ).withRuntimeContext(
+            environment: ["HERDR_ENV": "1", "HERDR_PANE_ID": "w2:p1"],
+            currentTTYProvider: { nil },
+            terminalLocatorProvider: { _ in (sessionID: nil, tty: nil, title: nil) }
+        )
+
+        #expect(payload.terminalSessionID == "w2:p1")
+    }
+
+    @Test
     func claudeDefaultJumpTargetUsesUnknownSentinelForUnrecognizedTerminal() {
         let payload = ClaudeHookPayload(
             cwd: "/tmp/demo", hookEventName: .sessionStart, sessionID: "s1"

--- a/Tests/OpenIslandCoreTests/CodexHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexHooksTests.swift
@@ -42,6 +42,30 @@ struct CodexHooksTests {
     }
 
     @Test
+    func codexHerdrEncodesPaneAndSocketWithPipeSeparator() {
+        let payload = CodexHookPayload(
+            cwd: "/Users/u/demo",
+            hookEventName: .sessionStart,
+            model: "gpt-4o",
+            permissionMode: .default,
+            sessionID: "s1",
+            transcriptPath: nil
+        ).withRuntimeContext(
+            environment: [
+                "HERDR_ENV": "1",
+                "HERDR_PANE_ID": "w2:p1",
+                "HERDR_SOCKET_PATH": "/Users/x/.config/herdr/sessions/main/herdr.sock",
+            ],
+            currentTTYProvider: { nil },
+            terminalLocatorProvider: { _ in (sessionID: nil, tty: nil, title: nil) },
+            warpPaneResolver: { _ in nil }
+        )
+
+        #expect(payload.terminalApp == "Herdr")
+        #expect(payload.terminalSessionID == "w2:p1|/Users/x/.config/herdr/sessions/main/herdr.sock")
+    }
+
+    @Test
     func codexWithRuntimeContextSkipsWarpResolverForNonWarpTerminal() {
         var resolverCalls = 0
         let payload = CodexHookPayload(

--- a/Tests/OpenIslandCoreTests/GeminiHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/GeminiHooksTests.swift
@@ -220,6 +220,21 @@ struct GeminiHooksTests {
     }
 
     @Test
+    func geminiInferTerminalAppRecognizesHerdrViaEnvVar() {
+        let payload = GeminiHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .sessionStart,
+            sessionID: "gemini-session-herdr"
+        ).withRuntimeContext(
+            environment: ["HERDR_ENV": "1", "HERDR_PANE_ID": "w2:p1"],
+            currentTTYProvider: { nil },
+            terminalLocatorProvider: { _ in (sessionID: nil, tty: nil, title: nil) }
+        )
+
+        #expect(payload.terminalApp == "Herdr")
+    }
+
+    @Test
     func geminiGhosttyLocatorScriptSeparatesIDWorkingDirectoryAndTitle() {
         let script = GeminiHookPayload.terminalLocatorAppleScript(for: "Ghostty")
 


### PR DESCRIPTION
## What

Add support for the [herdr](https://github.com/) terminal multiplexer, mirroring the existing Zellij integration. Sessions running inside a herdr pane are now detected, tagged `Herdr`, and jump-back focuses the correct pane.

## How

- **Detection**: recognize herdr via `HERDR_ENV` in the Claude, Codex, and Gemini hooks and in the opencode plugin (`inferTerminalApp` / `terminalFields`), plus the `/herdr` executable suffix in process discovery and the terminal normalization switch in `ProcessMonitoringCoordinator`.
- **Encoding**: herdr pane ids contain a colon (e.g. `w2:p1`), so Zellij's `paneID:sessionName` scheme is ambiguous. Encode `terminalSessionID` as `paneID|socketPath` instead, carrying `HERDR_SOCKET_PATH` so focus targets the right session server.
- **Jump**: `TerminalJumpService` gets a `jumpToHerdrPane` that runs `herdr agent focus <pane>` (with `HERDR_SOCKET_PATH` in env) then activates the parent terminal window. Unlike Zellij, no `list-panes`/`go-to-tab` dance is needed since the pane id addresses the pane directly.
- **Ghostty guard**: `TerminalSessionAttachmentProbe` skips overwriting herdr's terminal info with Ghostty's session id (same as Zellij), so pane targeting survives.
- **Locator skip**: herdr identity comes from env vars, so the AppleScript focused-terminal locator is skipped (added to `noLocatorTerminalApps`).

## Tests

- Hook detection + encoding tests for Claude, Codex, and Gemini (`HERDR_ENV` -> `Herdr`, `paneID|socketPath` encoding, pane-only fallback when the socket is absent).
- Full suite green: 319 tests, 0 failures. `zsh scripts/harness.sh ci` (lint, docs, test, build) passes.
- README support matrix updated.

## Notes

The Gemini path mirrors Zellij exactly (detection + locator skip, no pane encoding block), since Zellij itself does not encode a pane id under Gemini.