### PR TITLE
fix: keep Qoder sessions alive while a qoder process exists

### DIFF
--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -211,6 +211,23 @@ struct ActiveAgentProcessDiscovery {
                 ))
                 continue
             }
+
+            if isQoderProcess(command: process.command) {
+                let claimKey = "qoder:\(process.pid)"
+                guard claimedKeys.insert(claimKey).inserted else {
+                    continue
+                }
+
+                let lsofOutput = lsofOutput(pid: process.pid)
+                snapshots.append(ProcessSnapshot(
+                    tool: .qoder,
+                    sessionID: nil,
+                    workingDirectory: lsofOutput.flatMap(workingDirectory(from:)),
+                    terminalTTY: process.terminalTTY,
+                    terminalApp: terminalApp(for: process, processesByPID: processesByPID)
+                ))
+                continue
+            }
         }
 
         return snapshots
@@ -763,6 +780,23 @@ struct ActiveAgentProcessDiscovery {
         }
 
         return firstToken == "kimi" || firstToken.hasSuffix("/kimi")
+    }
+
+    /// Matches the `qoder` CLI entry-point. Qoder is a Claude Code fork that
+    /// ships its own `qoder` binary (installed by `@qoder-ai/qodercli`), so
+    /// `isClaudeProcess` does not pick it up.
+    private func isQoderProcess(command: String) -> Bool {
+        let lowered = command.lowercased()
+        guard let firstToken = lowered.split(separator: " ").first.map(String.init) else {
+            return false
+        }
+
+        let binaryName = (firstToken as NSString).lastPathComponent
+        guard binaryName == "qoder" else {
+            return false
+        }
+
+        return firstToken == "qoder" || firstToken.hasSuffix("/qoder")
     }
 
     /// Returns `true` when the given `ps` command string belongs to a Claude Code process.

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -509,6 +509,18 @@ final class ProcessMonitoringCoordinator {
             }
         }
 
+        // Qoder sessions are hook-managed (Claude Code fork) and use UUIDs
+        // that Open Island cannot recover from ps/lsof. As long as any
+        // qoder process exists, keep every tracked Qoder session alive so
+        // Stop/completed sessions don't get evicted by the hook-managed
+        // liveness fallback in SessionState.markProcessLiveness.
+        let hasQoderProcess = activeProcesses.contains { $0.tool == .qoder }
+        if hasQoderProcess {
+            for session in sessions where session.tool == .qoder && !session.isDemoSession {
+                aliveIDs.insert(session.id)
+            }
+        }
+
         // Cursor sessions: prefer concrete cursor-agent processes when they
         // are visible (Cursor CLI / integrated terminal), then fall back to
         // app-level liveness for IDE-only hook sessions where there is no

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -510,13 +510,19 @@ final class ProcessMonitoringCoordinator {
         }
 
         // Qoder sessions are hook-managed (Claude Code fork) and use UUIDs
-        // that Open Island cannot recover from ps/lsof. As long as any
-        // qoder process exists, keep every tracked Qoder session alive so
-        // Stop/completed sessions don't get evicted by the hook-managed
-        // liveness fallback in SessionState.markProcessLiveness.
+        // that Open Island cannot recover from ps/lsof. Two liveness signals:
+        // 1. A qoder CLI process is running (standalone CLI usage)
+        // 2. Qoder.app is running (IDE usage - the CLI is spawned per task
+        //    and exits when the task completes, but the session should
+        //    persist as long as the IDE is open, matching Claude Code
+        //    behavior where sessions persist until SessionEnd)
         let hasQoderProcess = activeProcesses.contains { $0.tool == .qoder }
-        if hasQoderProcess {
+        let isQoderAppRunning = !NSRunningApplication.runningApplications(
+            withBundleIdentifier: "com.qoder.ide"
+        ).isEmpty
+        if hasQoderProcess || isQoderAppRunning {
             for session in sessions where session.tool == .qoder && !session.isDemoSession {
+                if session.isSessionEnded { continue }
                 aliveIDs.insert(session.id)
             }
         }

--- a/Tests/OpenIslandAppTests/ActiveAgentProcessDiscoveryTests.swift
+++ b/Tests/OpenIslandAppTests/ActiveAgentProcessDiscoveryTests.swift
@@ -257,4 +257,44 @@ struct ActiveAgentProcessDiscoveryTests {
             ),
         ])
     }
+
+    @Test
+    func discoverDetectsQoderCLIProcess() {
+        let discovery = ActiveAgentProcessDiscovery { executablePath, arguments in
+            if executablePath == "/bin/ps" {
+                return """
+                  102 301 ttys002 qoder
+                  301 900 ttys002 -/opt/homebrew/bin/fish
+                  900 1 ?? /Applications/Ghostty.app/Contents/MacOS/ghostty
+                """
+            }
+
+            guard executablePath == "/usr/sbin/lsof",
+                  let pid = arguments.dropFirst(2).first else {
+                return nil
+            }
+
+            switch pid {
+            case "102":
+                return """
+                fcwd
+                n/tmp/open-island
+                """
+            default:
+                Issue.record("unexpected lsof lookup for pid \(pid)")
+                return nil
+            }
+        }
+
+        let snapshots = discovery.discover()
+
+        #expect(snapshots.count == 1)
+        #expect(snapshots.contains(.init(
+            tool: .qoder,
+            sessionID: nil,
+            workingDirectory: "/tmp/open-island",
+            terminalTTY: "/dev/ttys002",
+            terminalApp: "Ghostty"
+        )))
+    }
 }


### PR DESCRIPTION
ProcessMonitoringCoordinator.sessionIDsWithAliveProcesses had explicit liveness strategies for every supported agent except Qoder. Because Qoder sessions are hook-managed (Claude Code fork, same hook format at ~/.qoder/settings.json), the default 'not in aliveSessionIDs' path incremented processNotSeenCount on every poll and flipped isSessionEnded=true after two polls. Result: the Qoder session vanished from the island within ~2-4 seconds, even while the qoder CLI was still running.

Additionally, ActiveAgentProcessDiscovery had no isQoderProcess matcher, so the qoder binary (installed by @qoder-ai/qodercli) was never discovered as an active agent process.

Adopt the same strategy used for Kimi CLI (commit 201f2b1): as long as any qoder process is observed by ActiveAgentProcessDiscovery, mark every tracked Qoder session as alive. Qoder's UUID session IDs are not recoverable from ps/lsof, and assuming one agent-per-process is good enough for v1.

Related to #507.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for detecting Qoder CLI processes and capturing their session details.
  * Qoder sessions can now be recognized as active when only related processes are available.

* **Bug Fixes**
  * Improved process matching so Qoder is correctly identified and not misclassified as other supported tools.
  * Enhanced Qoder session liveness tracking to reduce false “inactive” states.

* **Tests**
  * Added coverage for discovering Qoder CLI processes and validating the resulting snapshot details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->