### PR TITLE
fix: detect OpenCode processes without a TTY

### DIFF
--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -67,7 +67,11 @@ struct ActiveAgentProcessDiscovery {
         var claimedKeys: Set<String> = []
 
         for process in processes {
-            guard process.terminalTTY != nil else {
+            // Most agent detection requires a TTY (terminal-attached process).
+            // OpenCode is an exception: it can run inside IDE integrated terminals
+            // that don't expose a TTY in `ps` output. Let OpenCode processes
+            // through so the liveness fallback can keep their sessions alive.
+            if process.terminalTTY == nil && !isOpenCodeProcess(command: process.command) {
                 continue
             }
 

--- a/Tests/OpenIslandAppTests/ActiveAgentProcessDiscoveryTests.swift
+++ b/Tests/OpenIslandAppTests/ActiveAgentProcessDiscoveryTests.swift
@@ -257,4 +257,38 @@ struct ActiveAgentProcessDiscoveryTests {
             ),
         ])
     }
+
+    @Test
+    func discoverDetectsOpenCodeProcessWithoutTTY() {
+        let discovery = ActiveAgentProcessDiscovery { executablePath, arguments in
+            if executablePath == "/bin/ps" {
+                return """
+                  102 1 ?? opencode
+                """
+            }
+
+            guard executablePath == "/usr/sbin/lsof",
+                  let pid = arguments.dropFirst(2).first else {
+                return nil
+            }
+
+            switch pid {
+            case "102":
+                return """
+                fcwd
+                n/tmp/open-island
+                """
+            default:
+                Issue.record("unexpected lsof lookup for pid \(pid)")
+                return nil
+            }
+        }
+
+        let snapshots = discovery.discover()
+
+        let openCodeSnapshots = snapshots.filter { $0.tool == .openCode }
+        #expect(openCodeSnapshots.count == 1)
+        #expect(openCodeSnapshots.first?.workingDirectory == "/tmp/open-island")
+        #expect(openCodeSnapshots.first?.terminalTTY == nil)
+    }
 }


### PR DESCRIPTION
## Summary

OpenCode sessions were disappearing from the island within 2-4 seconds when running inside IDE integrated terminals that don't expose a TTY in `ps` output. This is a different root cause from #588 and #589 — OpenCode already had process detection and liveness matching, but the TTY requirement prevented detection in IDE environments.

## Root cause

`ActiveAgentProcessDiscovery.discover()` skipped every process without a TTY:

```swift
for process in processes {
    guard process.terminalTTY != nil else {
        continue
    }
    // ... agent detection ...
}
```

This is correct for most agents (Claude Code, Codex, Gemini, etc. always run in a terminal with a TTY). But OpenCode can run inside IDE integrated terminals (VS Code, JetBrains, etc.) that don't expose a TTY in `ps` output. When the OpenCode process was skipped:

1. `activeProcesses` contained no `.openCode` entries
2. `sessionIDsWithAliveProcesses` saw no OpenCode process
3. The hook-managed liveness fallback in `SessionState.markProcessLiveness` evicted the session after ~2-4 seconds (2 polls × 2s)

## Fix

Relax the TTY guard to let OpenCode processes through:

```swift
if process.terminalTTY == nil && !isOpenCodeProcess(command: process.command) {
    continue
}
```

This is safe because:

- The OpenCode detection branch already handles nil TTY — it falls back to PID for deduplication (`ttyId = process.terminalTTY ?? process.pid`)
- The existing unmatched-process fallback in `sessionIDsWithAliveProcesses` keeps all OpenCode sessions alive as long as any opencode process is detected
- Other agents (Claude Code, Codex, Gemini, Kimi, etc.) still require a TTY — only OpenCode is exempted

## Verification

- ✅ `swift build` — 288/288 compiled, 0 errors, 0 warnings
- ✅ `swift test` — 315/315 tests passed (314 existing + 1 new), 0 failures
- ✅ New test: `discoverDetectsOpenCodeProcessWithoutTTY` — verifies an OpenCode process with `??` TTY is detected
- ✅ Only 1 line changed in production code (TTY guard), rest is the test

## Related

- Issue #507 (OpenCode notification cards disappear too fast)
- PR #588 (Qoder fix — different root cause, same symptom)
- PR #589 (Qwen/Factory/CodeBuddy fix — different root cause, same symptom)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process detection so OpenCode sessions can stay active even when no terminal TTY is available.
  * Better support for IDE-integrated terminals where TTY information may be missing.
* **Tests**
  * Added coverage for discovering OpenCode processes without a TTY, including the expected working directory and session state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->