### PR TITLE
feat: add custom Claude-compatible CLI support with settings UI

### DIFF
--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -50,9 +50,14 @@ struct ActiveAgentProcessDiscovery {
     typealias CommandRunner = @Sendable (_ executablePath: String, _ arguments: [String]) -> String?
 
     private let commandRunner: CommandRunner
+    private let customClaudeProfileStore: ClaudeCompatibleCLIProfileStore
 
-    init(commandRunner: @escaping CommandRunner = Self.commandOutput) {
+    init(
+        commandRunner: @escaping CommandRunner = Self.commandOutput,
+        customClaudeProfileStore: ClaudeCompatibleCLIProfileStore = ClaudeCompatibleCLIProfileStore()
+    ) {
         self.commandRunner = commandRunner
+        self.customClaudeProfileStore = customClaudeProfileStore
     }
 
     func discover() -> [ProcessSnapshot] {
@@ -65,6 +70,7 @@ struct ActiveAgentProcessDiscovery {
 
         var snapshots: [ProcessSnapshot] = []
         var claimedKeys: Set<String> = []
+        let customClaudeProfiles = customClaudeProfileStore.load()
 
         for process in processes {
             guard process.terminalTTY != nil else {
@@ -85,7 +91,11 @@ struct ActiveAgentProcessDiscovery {
                 continue
             }
 
-            if isClaudeProcess(command: process.command) {
+            if isClaudeProcess(command: process.command)
+                || matchesCustomClaudeCompatibleProcess(
+                    command: process.command,
+                    profiles: customClaudeProfiles
+                ) {
                 guard let snapshot = claudeSnapshot(for: process, processesByPID: processesByPID) else {
                     continue
                 }
@@ -690,6 +700,13 @@ struct ActiveAgentProcessDiscovery {
 
         return firstToken == "claude"
             || firstToken.hasSuffix("/claude")
+    }
+
+    private func matchesCustomClaudeCompatibleProcess(
+        command: String,
+        profiles: [ClaudeCompatibleCLIProfile]
+    ) -> Bool {
+        profiles.contains { $0.matches(command: command) }
     }
 
     private static func commandOutput(executablePath: String, arguments: [String]) -> String? {

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -236,10 +236,8 @@
 "settings.customCLI.edit" = "Edit Custom CLI";
 "settings.customCLI.displayName" = "Display Name";
 "settings.customCLI.executablePath" = "Executable Path";
-"settings.customCLI.hookSource" = "Hook Source";
 "settings.customCLI.browse" = "Browse…";
 "settings.customCLI.save" = "Save";
 "settings.customCLI.delete" = "Delete";
 "settings.customCLI.deleteConfirm" = "Are you sure you want to remove \"%@\"?";
 "settings.customCLI.errorRequired" = "This field is required.";
-"settings.customCLI.errorHookSource" = "Only letters, numbers, dots, underscores, and hyphens are allowed.";

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -240,4 +240,5 @@
 "settings.customCLI.save" = "Save";
 "settings.customCLI.delete" = "Delete";
 "settings.customCLI.deleteConfirm" = "Are you sure you want to remove \"%@\"?";
+"settings.customCLI.deleteConfirmTitle" = "Remove Custom CLI?";
 "settings.customCLI.errorRequired" = "This field is required.";

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -225,3 +225,21 @@
 
 /* Window Titles */
 "window.settings" = "Open Island Settings";
+
+/* Custom CLI Settings */
+"settings.tab.customCLI" = "Custom CLI";
+"settings.customCLI.section" = "Custom CLIs";
+"settings.customCLI.footer" = "Configure additional Claude Code-compatible CLI wrappers so Open Island can recognize their sessions.";
+"settings.customCLI.empty" = "No custom CLIs configured.";
+"settings.customCLI.add" = "Add Custom CLI…";
+"settings.customCLI.addTitle" = "Add Custom CLI";
+"settings.customCLI.edit" = "Edit Custom CLI";
+"settings.customCLI.displayName" = "Display Name";
+"settings.customCLI.executablePath" = "Executable Path";
+"settings.customCLI.hookSource" = "Hook Source";
+"settings.customCLI.browse" = "Browse…";
+"settings.customCLI.save" = "Save";
+"settings.customCLI.delete" = "Delete";
+"settings.customCLI.deleteConfirm" = "Are you sure you want to remove \"%@\"?";
+"settings.customCLI.errorRequired" = "This field is required.";
+"settings.customCLI.errorHookSource" = "Only letters, numbers, dots, underscores, and hyphens are allowed.";

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -242,3 +242,4 @@
 "settings.customCLI.deleteConfirm" = "Are you sure you want to remove \"%@\"?";
 "settings.customCLI.deleteConfirmTitle" = "Remove Custom CLI?";
 "settings.customCLI.errorRequired" = "This field is required.";
+"settings.customCLI.errorReservedSource" = "The executable name collides with a built-in agent source. Rename or use a wrapper script.";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -242,3 +242,4 @@
 "settings.customCLI.deleteConfirm" = "确定要移除此“%@”配置吗？";
 "settings.customCLI.deleteConfirmTitle" = "移除自定义 CLI？";
 "settings.customCLI.errorRequired" = "此字段为必填项。";
+"settings.customCLI.errorReservedSource" = "可执行文件名与内置代理源冲突。请重命名或使用包装脚本。";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -225,3 +225,21 @@
 
 /* Window Titles */
 "window.settings" = "Open Island 设置";
+
+/* Custom CLI Settings */
+"settings.tab.customCLI" = "自定义 CLI";
+"settings.customCLI.section" = "自定义 CLI";
+"settings.customCLI.footer" = "配置其他兼容 Claude Code 的 CLI 包装工具，让 Open Island 能识别它们的会话。";
+"settings.customCLI.empty" = "尚未配置自定义 CLI。";
+"settings.customCLI.add" = "添加自定义 CLI…";
+"settings.customCLI.addTitle" = "添加自定义 CLI";
+"settings.customCLI.edit" = "编辑自定义 CLI";
+"settings.customCLI.displayName" = "显示名称";
+"settings.customCLI.executablePath" = "可执行文件路径";
+"settings.customCLI.hookSource" = "Hook 标识";
+"settings.customCLI.browse" = "选择…";
+"settings.customCLI.save" = "保存";
+"settings.customCLI.delete" = "删除";
+"settings.customCLI.deleteConfirm" = "确定要移除此“%@”配置吗？";
+"settings.customCLI.errorRequired" = "此字段为必填项。";
+"settings.customCLI.errorHookSource" = "仅允许字母、数字、点、下划线和短横线。";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -240,4 +240,5 @@
 "settings.customCLI.save" = "保存";
 "settings.customCLI.delete" = "删除";
 "settings.customCLI.deleteConfirm" = "确定要移除此“%@”配置吗？";
+"settings.customCLI.deleteConfirmTitle" = "移除自定义 CLI？";
 "settings.customCLI.errorRequired" = "此字段为必填项。";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -236,10 +236,8 @@
 "settings.customCLI.edit" = "编辑自定义 CLI";
 "settings.customCLI.displayName" = "显示名称";
 "settings.customCLI.executablePath" = "可执行文件路径";
-"settings.customCLI.hookSource" = "Hook 标识";
 "settings.customCLI.browse" = "选择…";
 "settings.customCLI.save" = "保存";
 "settings.customCLI.delete" = "删除";
 "settings.customCLI.deleteConfirm" = "确定要移除此“%@”配置吗？";
 "settings.customCLI.errorRequired" = "此字段为必填项。";
-"settings.customCLI.errorHookSource" = "仅允许字母、数字、点、下划线和短横线。";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -241,3 +241,4 @@
 "settings.customCLI.deleteConfirm" = "確定要移除此「%@」配置嗎？";
 "settings.customCLI.deleteConfirmTitle" = "移除自訂 CLI？";
 "settings.customCLI.errorRequired" = "此欄位為必填項。";
+"settings.customCLI.errorReservedSource" = "可執行檔名稱與內建代理來源衝突。請重新命名或使用包裝腳本。";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -235,10 +235,8 @@
 "settings.customCLI.edit" = "編輯自訂 CLI";
 "settings.customCLI.displayName" = "顯示名稱";
 "settings.customCLI.executablePath" = "可執行檔路徑";
-"settings.customCLI.hookSource" = "Hook 識別碼";
 "settings.customCLI.browse" = "選擇…";
 "settings.customCLI.save" = "儲存";
 "settings.customCLI.delete" = "刪除";
 "settings.customCLI.deleteConfirm" = "確定要移除此「%@」配置嗎？";
 "settings.customCLI.errorRequired" = "此欄位為必填項。";
-"settings.customCLI.errorHookSource" = "僅允許字母、數字、點、底線和連字號。";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -239,4 +239,5 @@
 "settings.customCLI.save" = "儲存";
 "settings.customCLI.delete" = "刪除";
 "settings.customCLI.deleteConfirm" = "確定要移除此「%@」配置嗎？";
+"settings.customCLI.deleteConfirmTitle" = "移除自訂 CLI？";
 "settings.customCLI.errorRequired" = "此欄位為必填項。";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -224,3 +224,21 @@
 
 /* Window Titles */
 "window.settings" = "Open Island 設定";
+
+/* Custom CLI Settings */
+"settings.tab.customCLI" = "自訂 CLI";
+"settings.customCLI.section" = "自訂 CLI";
+"settings.customCLI.footer" = "設定其他與 Claude Code 相容的 CLI 包裝工具，讓 Open Island 能識別它們的連線階段。";
+"settings.customCLI.empty" = "尚未配置自訂 CLI。";
+"settings.customCLI.add" = "加入自訂 CLI…";
+"settings.customCLI.addTitle" = "加入自訂 CLI";
+"settings.customCLI.edit" = "編輯自訂 CLI";
+"settings.customCLI.displayName" = "顯示名稱";
+"settings.customCLI.executablePath" = "可執行檔路徑";
+"settings.customCLI.hookSource" = "Hook 識別碼";
+"settings.customCLI.browse" = "選擇…";
+"settings.customCLI.save" = "儲存";
+"settings.customCLI.delete" = "刪除";
+"settings.customCLI.deleteConfirm" = "確定要移除此「%@」配置嗎？";
+"settings.customCLI.errorRequired" = "此欄位為必填項。";
+"settings.customCLI.errorHookSource" = "僅允許字母、數字、點、底線和連字號。";

--- a/Sources/OpenIslandApp/Views/CustomCLISettingsPane.swift
+++ b/Sources/OpenIslandApp/Views/CustomCLISettingsPane.swift
@@ -274,10 +274,16 @@ private struct EditCLIProfileSheet: View {
 
         guard nameError == nil, pathError == nil else { return }
 
+        let derivedSource = Self.deriveHookSource(from: trimmedPath)
+        if !HookSourceClassification.classify(derivedSource).isClaudeFormat {
+            pathError = lang("settings.customCLI.errorReservedSource")
+            return
+        }
+
         onSave(ClaudeCompatibleCLIProfile(
             id: profile.id,
             displayName: trimmedName,
-            hookSource: Self.deriveHookSource(from: trimmedPath),
+            hookSource: derivedSource,
             executablePath: trimmedPath
         ))
     }

--- a/Sources/OpenIslandApp/Views/CustomCLISettingsPane.swift
+++ b/Sources/OpenIslandApp/Views/CustomCLISettingsPane.swift
@@ -1,0 +1,310 @@
+import SwiftUI
+import OpenIslandCore
+
+// MARK: - Custom CLI Settings Pane
+
+struct CustomCLISettingsPane: View {
+    var model: AppModel
+
+    @State private var profiles: [ClaudeCompatibleCLIProfile] = []
+    @State private var showEditSheet = false
+    @State private var editingProfile: ClaudeCompatibleCLIProfile?
+    @State private var deleteConfirm: ClaudeCompatibleCLIProfile?
+
+    private let store = ClaudeCompatibleCLIProfileStore()
+    private var lang: LanguageManager { model.lang }
+
+    var body: some View {
+        Form {
+            Section {
+                Text(lang.t("settings.customCLI.footer"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section(lang.t("settings.customCLI.section")) {
+                if profiles.isEmpty {
+                    Text(lang.t("settings.customCLI.empty"))
+                        .foregroundStyle(.tertiary)
+                }
+
+                ForEach(profiles) { profile in
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(profile.displayName)
+                                .font(.body)
+                            Text(profile.executablePath)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+
+                        Spacer()
+
+                        Button {
+                            deleteConfirm = profile
+                        } label: {
+                            Image(systemName: "trash")
+                                .foregroundStyle(.red)
+                        }
+                        .buttonStyle(.plain)
+                        .help(lang.t("settings.customCLI.delete"))
+                    }
+                }
+
+                Button {
+                    editingProfile = ClaudeCompatibleCLIProfile(
+                        displayName: "",
+                        hookSource: "",
+                        executablePath: ""
+                    )
+                    showEditSheet = true
+                } label: {
+                    Label(lang.t("settings.customCLI.add"), systemImage: "plus")
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle(lang.t("settings.tab.customCLI"))
+        .onAppear(perform: loadProfiles)
+        .sheet(isPresented: $showEditSheet) {
+            if let profile = editingProfile {
+                EditCLIProfileSheet(
+                    profile: profile,
+                    isPresented: $showEditSheet,
+                    onSave: { updated in
+                        saveProfile(updated)
+                        showEditSheet = false
+                    },
+                    onCancel: { showEditSheet = false }
+                )
+            }
+        }
+        .alert(lang.t("settings.general.uninstallConfirmTitle"),
+               isPresented: Binding(
+                get: { deleteConfirm != nil },
+                set: { if !$0 { deleteConfirm = nil } }
+               )) {
+            Button(lang.t("settings.customCLI.delete"), role: .destructive) {
+                if let profile = deleteConfirm {
+                    deleteProfile(profile)
+                }
+                deleteConfirm = nil
+            }
+            Button(lang.t("settings.general.cancel"), role: .cancel) {
+                deleteConfirm = nil
+            }
+        } message: {
+            if let profile = deleteConfirm {
+                Text(String(format: lang.t("settings.customCLI.deleteConfirm"), profile.displayName))
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func loadProfiles() {
+        profiles = store.load()
+    }
+
+    private func saveProfile(_ profile: ClaudeCompatibleCLIProfile) {
+        var updated = profiles
+        if let index = updated.firstIndex(where: { $0.id == profile.id }) {
+            updated[index] = profile
+        } else {
+            updated.append(profile)
+        }
+        profiles = updated
+        try? store.save(updated)
+    }
+
+    private func deleteProfile(_ profile: ClaudeCompatibleCLIProfile) {
+        profiles.removeAll { $0.id == profile.id }
+        try? store.save(profiles)
+    }
+}
+
+// MARK: - Edit Profile Sheet
+
+private struct EditCLIProfileSheet: View {
+    @State var profile: ClaudeCompatibleCLIProfile
+    @Binding var isPresented: Bool
+    var onSave: (ClaudeCompatibleCLIProfile) -> Void
+    var onCancel: () -> Void
+
+    @State private var displayName: String = ""
+    @State private var executablePath: String = ""
+    @State private var hookSource: String = ""
+    @State private var nameError: String? = nil
+    @State private var pathError: String? = nil
+    @State private var hookSourceError: String? = nil
+
+    private var isEditing: Bool {
+        !profile.displayName.isEmpty
+    }
+
+    private var isValid: Bool {
+        ClaudeCompatibleCLIProfile(
+            displayName: displayName,
+            hookSource: hookSource,
+            executablePath: executablePath
+        ).isValid
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Form {
+                Section {
+                    LabeledContent(lang("settings.customCLI.displayName")) {
+                        VStack(alignment: .trailing) {
+                            TextField("", text: $displayName)
+                                .textFieldStyle(.roundedBorder)
+                                .frame(width: 280)
+                                .onChange(of: displayName) { _, _ in
+                                    nameError = nil
+                                }
+                            if let error = nameError {
+                                Text(error)
+                                    .font(.caption)
+                                    .foregroundStyle(.red)
+                            }
+                        }
+                    }
+
+                    LabeledContent(lang("settings.customCLI.executablePath")) {
+                        VStack(alignment: .trailing) {
+                            HStack(spacing: 6) {
+                                TextField("", text: $executablePath)
+                                    .textFieldStyle(.roundedBorder)
+                                    .frame(width: 220)
+                                    .onChange(of: executablePath) { _, newPath in
+                                        pathError = nil
+                                        autoFillHookSource(from: newPath)
+                                    }
+
+                                Button(lang("settings.customCLI.browse")) {
+                                    browseFile()
+                                }
+                                .buttonStyle(.bordered)
+                                .controlSize(.small)
+                            }
+                            if let error = pathError {
+                                Text(error)
+                                    .font(.caption)
+                                    .foregroundStyle(.red)
+                            }
+                        }
+                    }
+
+                    LabeledContent(lang("settings.customCLI.hookSource")) {
+                        VStack(alignment: .trailing) {
+                            TextField("", text: $hookSource)
+                                .textFieldStyle(.roundedBorder)
+                                .frame(width: 200)
+                                .onChange(of: hookSource) { _, _ in
+                                    hookSourceError = nil
+                                }
+                            if let error = hookSourceError {
+                                Text(error)
+                                    .font(.caption)
+                                    .foregroundStyle(.red)
+                            }
+                        }
+                    }
+                } header: {
+                    Text(isEditing
+                         ? lang("settings.customCLI.edit")
+                         : lang("settings.customCLI.addTitle"))
+                }
+            }
+            .formStyle(.grouped)
+
+            Divider()
+
+            HStack {
+                Spacer()
+                Button(lang("settings.general.cancel")) {
+                    onCancel()
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Button(isEditing
+                       ? lang("settings.customCLI.save")
+                       : lang("settings.customCLI.add")) {
+                    commit()
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(!isValid)
+            }
+            .padding()
+        }
+        .frame(width: 480)
+        .onAppear {
+            displayName = profile.displayName
+            executablePath = profile.executablePath
+            hookSource = profile.hookSource
+            if hookSource.isEmpty {
+                autoFillHookSource(from: executablePath)
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func browseFile() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.canCreateDirectories = false
+        panel.showsHiddenFiles = true
+        panel.prompt = lang("settings.customCLI.browse")
+        if panel.runModal() == .OK, let url = panel.url {
+            executablePath = url.path
+            pathError = nil
+            autoFillHookSource(from: executablePath)
+        }
+    }
+
+    private func autoFillHookSource(from path: String) {
+        guard !path.isEmpty else { return }
+        let basename = URL(fileURLWithPath: path).deletingPathExtension().lastPathComponent
+        if !basename.isEmpty {
+            hookSource = basename
+        }
+    }
+
+    private func commit() {
+        let trimmedName = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedPath = executablePath.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedSource = hookSource.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Validate
+        nameError = trimmedName.isEmpty ? lang("settings.customCLI.errorRequired") : nil
+        pathError = trimmedPath.isEmpty ? lang("settings.customCLI.errorRequired") : nil
+        if !ClaudeCompatibleCLIProfile.isValidHookSource(trimmedSource) {
+            hookSourceError = lang("settings.customCLI.errorHookSource")
+        } else {
+            hookSourceError = nil
+        }
+
+        guard nameError == nil, pathError == nil, hookSourceError == nil else {
+            return
+        }
+
+        let updated = ClaudeCompatibleCLIProfile(
+            id: profile.id,
+            displayName: trimmedName,
+            hookSource: trimmedSource,
+            executablePath: trimmedPath
+        )
+
+        onSave(updated)
+    }
+
+    private func lang(_ key: String) -> String {
+        // Access language via shared instance; model is not available in sheet.
+        // Use explicit NSLocalizedString with Bundle lookup via LanguageManager.
+        LanguageManager.shared.t(key)
+    }
+}

--- a/Sources/OpenIslandApp/Views/CustomCLISettingsPane.swift
+++ b/Sources/OpenIslandApp/Views/CustomCLISettingsPane.swift
@@ -3,6 +3,11 @@ import OpenIslandCore
 
 // MARK: - Custom CLI Settings Pane
 
+/// Settings pane for managing custom Claude-compatible CLI profiles.
+///
+/// Shows a list of configured profiles (display name + executable path),
+/// with add and delete actions. The add/edit sheet auto-derives the
+/// ``ClaudeCompatibleCLIProfile/hookSource`` from the executable path basename.
 struct CustomCLISettingsPane: View {
     var model: AppModel
 
@@ -101,10 +106,12 @@ struct CustomCLISettingsPane: View {
 
     // MARK: - Helpers
 
+    /// Reload profiles from the store.
     private func loadProfiles() {
         profiles = store.load()
     }
 
+    /// Insert or replace a profile in the local list and persist.
     private func saveProfile(_ profile: ClaudeCompatibleCLIProfile) {
         var updated = profiles
         if let index = updated.firstIndex(where: { $0.id == profile.id }) {
@@ -116,6 +123,7 @@ struct CustomCLISettingsPane: View {
         try? store.save(updated)
     }
 
+    /// Remove a profile from the local list and persist.
     private func deleteProfile(_ profile: ClaudeCompatibleCLIProfile) {
         profiles.removeAll { $0.id == profile.id }
         try? store.save(profiles)
@@ -124,6 +132,11 @@ struct CustomCLISettingsPane: View {
 
 // MARK: - Edit Profile Sheet
 
+/// Modal sheet for adding or editing a single custom CLI profile.
+///
+/// Shows two fields: display name and executable path. The executable path
+/// can be chosen via an ``NSOpenPanel`` file browser. The ``hookSource``
+/// is auto-derived from the path basename when the user saves.
 private struct EditCLIProfileSheet: View {
     var profile: ClaudeCompatibleCLIProfile
     var onSave: (ClaudeCompatibleCLIProfile) -> Void
@@ -193,6 +206,14 @@ private struct EditCLIProfileSheet: View {
 
     // MARK: - Field row helper
 
+    /// Build a labelled row suitable for a settings form, with optional
+    /// error text shown below the content.
+    ///
+    /// - Parameters:
+    ///   - label: The right-aligned label text.
+    ///   - content: The input control(s) for this field.
+    ///   - error: An optional error string; when non-nil, alignment shifts
+    ///     to top-of-text and the error is rendered in red below the content.
     @ViewBuilder
     private func fieldRow(_ label: String, @ViewBuilder content: () -> some View, error: () -> String?) -> some View {
         HStack(alignment: error() != nil ? .top : .firstTextBaseline) {
@@ -213,6 +234,7 @@ private struct EditCLIProfileSheet: View {
 
     // MARK: - Actions
 
+    /// Present an ``NSOpenPanel`` for choosing the CLI executable.
     private func browseFile() {
         let panel = NSOpenPanel()
         panel.canChooseDirectories = false
@@ -226,11 +248,23 @@ private struct EditCLIProfileSheet: View {
         }
     }
 
-    /// Derive hookSource from the executable path's basename (without extension).
+    /// Derive the hook source identifier from an executable path.
+    ///
+    /// Takes the last path component without its file extension.
+    /// For example:
+    /// - `/opt/company/bin/acme-claude` → `acme-claude`
+    /// - `/usr/local/bin/my-cc-wrapper` → `my-cc-wrapper`
+    ///
+    /// - Parameter path: The full executable path.
+    /// - Returns: The basename without extension.
     private static func deriveHookSource(from path: String) -> String {
         URL(fileURLWithPath: path).deletingPathExtension().lastPathComponent
     }
 
+    /// Validate fields and call back the save action.
+    ///
+    /// Trims input, sets inline errors for empty fields, and only calls
+    /// ``onSave`` when both fields are non-empty.
     private func commit() {
         let trimmedName = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedPath = executablePath.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/OpenIslandApp/Views/CustomCLISettingsPane.swift
+++ b/Sources/OpenIslandApp/Views/CustomCLISettingsPane.swift
@@ -83,7 +83,7 @@ struct CustomCLISettingsPane: View {
                 }
             )
         }
-        .alert(lang.t("settings.general.uninstallConfirmTitle"),
+        .alert(lang.t("settings.customCLI.deleteConfirmTitle"),
                isPresented: Binding(
                 get: { deleteConfirm != nil },
                 set: { if !$0 { deleteConfirm = nil } }

--- a/Sources/OpenIslandApp/Views/CustomCLISettingsPane.swift
+++ b/Sources/OpenIslandApp/Views/CustomCLISettingsPane.swift
@@ -7,7 +7,6 @@ struct CustomCLISettingsPane: View {
     var model: AppModel
 
     @State private var profiles: [ClaudeCompatibleCLIProfile] = []
-    @State private var showEditSheet = false
     @State private var editingProfile: ClaudeCompatibleCLIProfile?
     @State private var deleteConfirm: ClaudeCompatibleCLIProfile?
 
@@ -59,7 +58,6 @@ struct CustomCLISettingsPane: View {
                         hookSource: "",
                         executablePath: ""
                     )
-                    showEditSheet = true
                 } label: {
                     Label(lang.t("settings.customCLI.add"), systemImage: "plus")
                 }
@@ -68,18 +66,17 @@ struct CustomCLISettingsPane: View {
         .formStyle(.grouped)
         .navigationTitle(lang.t("settings.tab.customCLI"))
         .onAppear(perform: loadProfiles)
-        .sheet(isPresented: $showEditSheet) {
-            if let profile = editingProfile {
-                EditCLIProfileSheet(
-                    profile: profile,
-                    isPresented: $showEditSheet,
-                    onSave: { updated in
-                        saveProfile(updated)
-                        showEditSheet = false
-                    },
-                    onCancel: { showEditSheet = false }
-                )
-            }
+        .sheet(item: $editingProfile) { profile in
+            EditCLIProfileSheet(
+                profile: profile,
+                onSave: { updated in
+                    saveProfile(updated)
+                    editingProfile = nil
+                },
+                onCancel: {
+                    editingProfile = nil
+                }
+            )
         }
         .alert(lang.t("settings.general.uninstallConfirmTitle"),
                isPresented: Binding(
@@ -128,94 +125,47 @@ struct CustomCLISettingsPane: View {
 // MARK: - Edit Profile Sheet
 
 private struct EditCLIProfileSheet: View {
-    @State var profile: ClaudeCompatibleCLIProfile
-    @Binding var isPresented: Bool
+    var profile: ClaudeCompatibleCLIProfile
     var onSave: (ClaudeCompatibleCLIProfile) -> Void
     var onCancel: () -> Void
 
     @State private var displayName: String = ""
     @State private var executablePath: String = ""
-    @State private var hookSource: String = ""
     @State private var nameError: String? = nil
     @State private var pathError: String? = nil
-    @State private var hookSourceError: String? = nil
 
-    private var isEditing: Bool {
-        !profile.displayName.isEmpty
-    }
-
-    private var isValid: Bool {
-        ClaudeCompatibleCLIProfile(
-            displayName: displayName,
-            hookSource: hookSource,
-            executablePath: executablePath
-        ).isValid
+    private var isEditing: Bool { !profile.displayName.isEmpty }
+    private var fieldsValid: Bool {
+        !displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !executablePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     var body: some View {
         VStack(spacing: 0) {
             Form {
                 Section {
-                    LabeledContent(lang("settings.customCLI.displayName")) {
-                        VStack(alignment: .trailing) {
-                            TextField("", text: $displayName)
+                    fieldRow(lang("settings.customCLI.displayName")) {
+                        TextField("", text: $displayName)
+                            .textFieldStyle(.roundedBorder)
+                            .onChange(of: displayName) { _, _ in nameError = nil }
+                    } error: {
+                        nameError
+                    }
+
+                    fieldRow(lang("settings.customCLI.executablePath")) {
+                        HStack(spacing: 6) {
+                            TextField("", text: $executablePath)
                                 .textFieldStyle(.roundedBorder)
-                                .frame(width: 280)
-                                .onChange(of: displayName) { _, _ in
-                                    nameError = nil
-                                }
-                            if let error = nameError {
-                                Text(error)
-                                    .font(.caption)
-                                    .foregroundStyle(.red)
+                            Button(lang("settings.customCLI.browse")) {
+                                browseFile()
                             }
                         }
+                    } error: {
+                        pathError
                     }
 
-                    LabeledContent(lang("settings.customCLI.executablePath")) {
-                        VStack(alignment: .trailing) {
-                            HStack(spacing: 6) {
-                                TextField("", text: $executablePath)
-                                    .textFieldStyle(.roundedBorder)
-                                    .frame(width: 220)
-                                    .onChange(of: executablePath) { _, newPath in
-                                        pathError = nil
-                                        autoFillHookSource(from: newPath)
-                                    }
-
-                                Button(lang("settings.customCLI.browse")) {
-                                    browseFile()
-                                }
-                                .buttonStyle(.bordered)
-                                .controlSize(.small)
-                            }
-                            if let error = pathError {
-                                Text(error)
-                                    .font(.caption)
-                                    .foregroundStyle(.red)
-                            }
-                        }
-                    }
-
-                    LabeledContent(lang("settings.customCLI.hookSource")) {
-                        VStack(alignment: .trailing) {
-                            TextField("", text: $hookSource)
-                                .textFieldStyle(.roundedBorder)
-                                .frame(width: 200)
-                                .onChange(of: hookSource) { _, _ in
-                                    hookSourceError = nil
-                                }
-                            if let error = hookSourceError {
-                                Text(error)
-                                    .font(.caption)
-                                    .foregroundStyle(.red)
-                            }
-                        }
-                    }
                 } header: {
-                    Text(isEditing
-                         ? lang("settings.customCLI.edit")
-                         : lang("settings.customCLI.addTitle"))
+                    Text(isEditing ? lang("settings.customCLI.edit") : lang("settings.customCLI.addTitle"))
                 }
             }
             .formStyle(.grouped)
@@ -224,28 +174,39 @@ private struct EditCLIProfileSheet: View {
 
             HStack {
                 Spacer()
-                Button(lang("settings.general.cancel")) {
-                    onCancel()
-                }
-                .keyboardShortcut(.cancelAction)
-
-                Button(isEditing
-                       ? lang("settings.customCLI.save")
-                       : lang("settings.customCLI.add")) {
+                Button(lang("settings.general.cancel")) { onCancel() }
+                    .keyboardShortcut(.cancelAction)
+                Button(isEditing ? lang("settings.customCLI.save") : lang("settings.customCLI.add")) {
                     commit()
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(!isValid)
+                .disabled(!fieldsValid)
             }
             .padding()
         }
-        .frame(width: 480)
+        .frame(width: 460)
         .onAppear {
             displayName = profile.displayName
             executablePath = profile.executablePath
-            hookSource = profile.hookSource
-            if hookSource.isEmpty {
-                autoFillHookSource(from: executablePath)
+        }
+    }
+
+    // MARK: - Field row helper
+
+    @ViewBuilder
+    private func fieldRow(_ label: String, @ViewBuilder content: () -> some View, error: () -> String?) -> some View {
+        HStack(alignment: error() != nil ? .top : .firstTextBaseline) {
+            Text(label)
+                .frame(width: 100, alignment: .trailing)
+                .foregroundStyle(.secondary)
+
+            VStack(alignment: .leading, spacing: 4) {
+                content()
+                if let err = error() {
+                    Text(err)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
             }
         }
     }
@@ -262,49 +223,32 @@ private struct EditCLIProfileSheet: View {
         if panel.runModal() == .OK, let url = panel.url {
             executablePath = url.path
             pathError = nil
-            autoFillHookSource(from: executablePath)
         }
     }
 
-    private func autoFillHookSource(from path: String) {
-        guard !path.isEmpty else { return }
-        let basename = URL(fileURLWithPath: path).deletingPathExtension().lastPathComponent
-        if !basename.isEmpty {
-            hookSource = basename
-        }
+    /// Derive hookSource from the executable path's basename (without extension).
+    private static func deriveHookSource(from path: String) -> String {
+        URL(fileURLWithPath: path).deletingPathExtension().lastPathComponent
     }
 
     private func commit() {
         let trimmedName = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedPath = executablePath.trimmingCharacters(in: .whitespacesAndNewlines)
-        let trimmedSource = hookSource.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        // Validate
         nameError = trimmedName.isEmpty ? lang("settings.customCLI.errorRequired") : nil
         pathError = trimmedPath.isEmpty ? lang("settings.customCLI.errorRequired") : nil
-        if !ClaudeCompatibleCLIProfile.isValidHookSource(trimmedSource) {
-            hookSourceError = lang("settings.customCLI.errorHookSource")
-        } else {
-            hookSourceError = nil
-        }
 
-        guard nameError == nil, pathError == nil, hookSourceError == nil else {
-            return
-        }
+        guard nameError == nil, pathError == nil else { return }
 
-        let updated = ClaudeCompatibleCLIProfile(
+        onSave(ClaudeCompatibleCLIProfile(
             id: profile.id,
             displayName: trimmedName,
-            hookSource: trimmedSource,
+            hookSource: Self.deriveHookSource(from: trimmedPath),
             executablePath: trimmedPath
-        )
-
-        onSave(updated)
+        ))
     }
 
     private func lang(_ key: String) -> String {
-        // Access language via shared instance; model is not available in sheet.
-        // Use explicit NSLocalizedString with Bundle lookup via LanguageManager.
         LanguageManager.shared.t(key)
     }
 }

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -13,6 +13,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     case watch
     case shortcuts
     case lab
+    case customCLI
     case about
 
     var id: String { rawValue }
@@ -27,6 +28,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .watch:      "Watch"
         case .shortcuts:  lang.t("settings.tab.shortcuts")
         case .lab:        lang.t("settings.tab.lab")
+        case .customCLI:  lang.t("settings.tab.customCLI")
         case .about:      lang.t("settings.tab.about")
         }
     }
@@ -41,6 +43,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .watch:      "applewatch"
         case .shortcuts:  "keyboard.fill"
         case .lab:        "flask.fill"
+        case .customCLI:  "terminal.fill"
         case .about:      "info.circle.fill"
         }
     }
@@ -55,6 +58,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .watch:      .cyan
         case .shortcuts:  .gray
         case .lab:        .pink
+        case .customCLI:  .green
         case .about:      .blue
         }
     }
@@ -62,7 +66,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     var section: SettingsSection {
         switch self {
         case .general, .setup, .display, .sound, .appearance, .watch: .system
-        case .shortcuts, .lab:                                        .advanced
+        case .shortcuts, .lab, .customCLI:                          .advanced
         case .about:                                                  .app
         }
     }
@@ -152,6 +156,8 @@ struct SettingsView: View {
                 PlaceholderSettingsPane(model: model, titleKey: "settings.tab.shortcuts", subtitleKey: "settings.shortcuts.comingSoon")
             case .lab:
                 PlaceholderSettingsPane(model: model, titleKey: "settings.tab.lab", subtitleKey: "settings.lab.comingSoon")
+            case .customCLI:
+                CustomCLISettingsPane(model: model)
             case .about:
                 AboutSettingsPane(model: model)
             }

--- a/Sources/OpenIslandCore/ClaudeCompatibleCLIProfile.swift
+++ b/Sources/OpenIslandCore/ClaudeCompatibleCLIProfile.swift
@@ -89,10 +89,9 @@ public struct ClaudeCompatibleCLIProfile: Codable, Equatable, Identifiable, Send
 
     /// Check whether a command line matches this profile.
     ///
-    /// Matching uses three strategies derived from ``executablePath``:
-    /// 1. The full path appears as a substring of the command.
-    /// 2. A whitespace-delimited token equals the full path.
-    /// 3. A token's last path component equals the executable's basename.
+    /// Matching uses two strategies derived from ``executablePath``:
+    /// 1. A whitespace-delimited token equals the full path.
+    /// 2. A token's last path component equals the executable's basename.
     ///
     /// - Parameter command: The raw command line (e.g. the ``command`` field
     ///   from a ``ProcessInfo``-style snapshot).
@@ -104,10 +103,6 @@ public struct ClaudeCompatibleCLIProfile: Codable, Equatable, Identifiable, Send
         guard isValid else { return false }
 
         let path = normalizedExecutablePath
-        if command.contains(path) {
-            return true
-        }
-
         let tokens = command.split(whereSeparator: \.isWhitespace).map(String.init)
         return tokens.contains { token in
             token == path || URL(fileURLWithPath: token).lastPathComponent == executableBasename

--- a/Sources/OpenIslandCore/ClaudeCompatibleCLIProfile.swift
+++ b/Sources/OpenIslandCore/ClaudeCompatibleCLIProfile.swift
@@ -1,11 +1,37 @@
 import Foundation
 
+/// A user-defined profile for a Claude Code-compatible CLI wrapper.
+///
+/// Each profile holds a display name, the identifier passed as ``--source``
+/// in the hook invocation, and the path to the CLI executable. Process
+/// detection auto-derives matching strategies from the executable path:
+///
+/// - The full path appears anywhere in the command line.
+/// - A token in the command equals the full path.
+/// - A token's last path component matches the executable's basename.
+///
+/// - Note: Whitespace trimming is centralised in ``init(displayName:hookSource:executablePath:)``
+///   and the ``Codable`` decoder, so consumers never need to trim manually.
 public struct ClaudeCompatibleCLIProfile: Codable, Equatable, Identifiable, Sendable {
+    /// Stable identifier used for equality and UI identity.
     public var id: UUID
+    /// Human-readable name shown in the settings list (e.g. "Company Claude").
     public var displayName: String
+    /// Value passed as ``--source`` when the hook CLI invokes OpenIslandHooks.
+    /// Only ``[A-Za-z0-9._-]`` characters are allowed — validated by ``isValidHookSource(_:)``.
     public var hookSource: String
+    /// Absolute path to the CLI executable. Auto-derives process matching
+    /// strategies; a leading tilde is not expanded, so prefer an absolute path.
     public var executablePath: String
 
+    /// Creates a profile with trimming of all string fields.
+    ///
+    /// - Parameters:
+    ///   - id: Stable identifier. Defaults to a new UUID.
+    ///   - displayName: Human-readable name for the settings UI.
+    ///   - hookSource: Identifier for the ``--source`` hook argument. Must match
+    ///     ``isValidHookSource(_:)`` for the profile to be considered valid.
+    ///   - executablePath: Absolute path to the CLI executable.
     public init(
         id: UUID = UUID(),
         displayName: String,
@@ -24,11 +50,23 @@ public struct ClaudeCompatibleCLIProfile: Codable, Equatable, Identifiable, Send
         executablePath.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// The last path component of ``normalizedExecutablePath``.
+    ///
+    /// Used internally by ``matches(command:)`` to compare against command
+    /// tokens by basename alone.
     public var executableBasename: String {
         URL(fileURLWithPath: normalizedExecutablePath).lastPathComponent
     }
 
     /// Whether the profile has all required fields filled in and valid.
+    ///
+    /// A profile is valid when:
+    /// - ``displayName`` is non-empty after trimming.
+    /// - ``hookSource`` is non-empty and matches ``isValidHookSource(_:)``.
+    /// - ``executablePath`` is non-empty after trimming.
+    /// - ``executableBasename`` is non-empty.
+    ///
+    /// Invalid profiles are filtered out on load (see ``ClaudeCompatibleCLIProfileStore.load()``).
     public var isValid: Bool {
         !displayName.isEmpty
             && Self.isValidHookSource(hookSource)
@@ -36,11 +74,32 @@ public struct ClaudeCompatibleCLIProfile: Codable, Equatable, Identifiable, Send
             && !executableBasename.isEmpty
     }
 
+    /// Validate a hook-source string.
+    ///
+    /// Accepted characters: ``[A-Za-z0-9._-]``. This guarantees the source
+    /// can safely appear on a command line without quoting issues.
+    ///
+    /// - Parameter source: The raw source string to validate.
+    /// - Returns: ``true`` when the source is non-empty and matches the
+    ///   allowed character set.
     public static func isValidHookSource(_ source: String) -> Bool {
         guard !source.isEmpty else { return false }
         return source.range(of: #"^[A-Za-z0-9._-]+$"#, options: .regularExpression) != nil
     }
 
+    /// Check whether a command line matches this profile.
+    ///
+    /// Matching uses three strategies derived from ``executablePath``:
+    /// 1. The full path appears as a substring of the command.
+    /// 2. A whitespace-delimited token equals the full path.
+    /// 3. A token's last path component equals the executable's basename.
+    ///
+    /// - Parameter command: The raw command line (e.g. the ``command`` field
+    ///   from a ``ProcessInfo``-style snapshot).
+    /// - Returns: ``true`` if the command appears to have been launched via
+    ///   this profile's executable.
+    ///
+    /// - Note: Returns ``false`` immediately when ``isValid`` is false.
     public func matches(command: String) -> Bool {
         guard isValid else { return false }
 
@@ -71,12 +130,28 @@ public struct ClaudeCompatibleCLIProfile: Codable, Equatable, Identifiable, Send
     }
 }
 
+/// Persists an array of ``ClaudeCompatibleCLIProfile`` values via `UserDefaults`.
+///
+/// Profiles are serialised as JSON. On load, invalid profiles (see
+/// ``ClaudeCompatibleCLIProfile/isValid``) are silently filtered out so
+/// that a corrupt or manually edited defaults entry degrades gracefully.
+///
+/// - Note: This class is ``@unchecked Sendable`` because ``UserDefaults``
+///   is thread-safe on the platforms we target, even though the compiler
+///   cannot prove it.
 public final class ClaudeCompatibleCLIProfileStore: @unchecked Sendable {
+    /// The default `UserDefaults` key used when no custom key is provided.
     public static let defaultKey = "customClaudeCompatibleCLIProfiles"
 
     private let userDefaults: UserDefaults
     private let key: String
 
+    /// Create a store backed by a specific `UserDefaults` and key pair.
+    ///
+    /// - Parameters:
+    ///   - userDefaults: The `UserDefaults` instance to use. Defaults to ``.standard``.
+    ///   - key: The key under which the encoded profile array is stored.
+    ///     Defaults to ``defaultKey``.
     public init(
         userDefaults: UserDefaults = .standard,
         key: String = ClaudeCompatibleCLIProfileStore.defaultKey
@@ -85,6 +160,10 @@ public final class ClaudeCompatibleCLIProfileStore: @unchecked Sendable {
         self.key = key
     }
 
+    /// Load all stored profiles, filtering out any that are invalid.
+    ///
+    /// - Returns: An array of valid profiles, or an empty array when no
+    ///   data exists or decoding fails.
     public func load() -> [ClaudeCompatibleCLIProfile] {
         guard let data = userDefaults.data(forKey: key),
               let profiles = try? JSONDecoder().decode([ClaudeCompatibleCLIProfile].self, from: data) else {
@@ -93,6 +172,12 @@ public final class ClaudeCompatibleCLIProfileStore: @unchecked Sendable {
         return profiles.filter(\.isValid)
     }
 
+    /// Encode and persist the given profiles.
+    ///
+    /// - Parameter profiles: The profiles to store. Invalid profiles are
+    ///   persisted as-is; filtering to only valid entries is the caller's
+    ///   responsibility if desired.
+    /// - Throws: ``EncodingError`` if JSON encoding fails.
     public func save(_ profiles: [ClaudeCompatibleCLIProfile]) throws {
         let data = try JSONEncoder().encode(profiles)
         userDefaults.set(data, forKey: key)

--- a/Sources/OpenIslandCore/ClaudeCompatibleCLIProfile.swift
+++ b/Sources/OpenIslandCore/ClaudeCompatibleCLIProfile.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+public struct ClaudeCompatibleCLIProfile: Codable, Equatable, Identifiable, Sendable {
+    public var id: UUID
+    public var displayName: String
+    public var hookSource: String
+    public var executablePath: String
+
+    public init(
+        id: UUID = UUID(),
+        displayName: String,
+        hookSource: String,
+        executablePath: String
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.hookSource = hookSource
+        self.executablePath = executablePath
+    }
+
+    public var normalizedExecutablePath: String {
+        executablePath.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public var executableBasename: String {
+        URL(fileURLWithPath: normalizedExecutablePath).lastPathComponent
+    }
+
+    public var isValid: Bool {
+        !displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && Self.isValidHookSource(hookSource)
+            && !normalizedExecutablePath.isEmpty
+            && !executableBasename.isEmpty
+    }
+
+    public static func isValidHookSource(_ source: String) -> Bool {
+        guard !source.isEmpty else { return false }
+        return source.range(of: #"^[A-Za-z0-9._-]+$"#, options: .regularExpression) != nil
+    }
+
+    public func matches(command: String) -> Bool {
+        guard isValid else { return false }
+
+        let path = normalizedExecutablePath
+        if command.contains(path) {
+            return true
+        }
+
+        return Self.commandTokens(from: command).contains { token in
+            token == path || URL(fileURLWithPath: token).lastPathComponent == executableBasename
+        }
+    }
+
+    public static func commandTokens(from command: String) -> [String] {
+        command.split(whereSeparator: \.isWhitespace).map(String.init)
+    }
+}
+
+public final class ClaudeCompatibleCLIProfileStore: @unchecked Sendable {
+    public static let defaultKey = "customClaudeCompatibleCLIProfiles"
+
+    private let userDefaults: UserDefaults
+    private let key: String
+
+    public init(
+        userDefaults: UserDefaults = .standard,
+        key: String = ClaudeCompatibleCLIProfileStore.defaultKey
+    ) {
+        self.userDefaults = userDefaults
+        self.key = key
+    }
+
+    public func load() -> [ClaudeCompatibleCLIProfile] {
+        guard let data = userDefaults.data(forKey: key),
+              let profiles = try? JSONDecoder().decode([ClaudeCompatibleCLIProfile].self, from: data) else {
+            return []
+        }
+        return profiles.filter(\.isValid)
+    }
+
+    public func save(_ profiles: [ClaudeCompatibleCLIProfile]) throws {
+        let data = try JSONEncoder().encode(profiles)
+        userDefaults.set(data, forKey: key)
+    }
+}

--- a/Sources/OpenIslandCore/ClaudeCompatibleCLIProfile.swift
+++ b/Sources/OpenIslandCore/ClaudeCompatibleCLIProfile.swift
@@ -13,11 +13,13 @@ public struct ClaudeCompatibleCLIProfile: Codable, Equatable, Identifiable, Send
         executablePath: String
     ) {
         self.id = id
-        self.displayName = displayName
-        self.hookSource = hookSource
-        self.executablePath = executablePath
+        self.displayName = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.hookSource = hookSource.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.executablePath = executablePath.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// Normalized path, always trimmed. Internal consumers should use this
+    /// rather than accessing `executablePath` directly.
     public var normalizedExecutablePath: String {
         executablePath.trimmingCharacters(in: .whitespacesAndNewlines)
     }
@@ -26,8 +28,9 @@ public struct ClaudeCompatibleCLIProfile: Codable, Equatable, Identifiable, Send
         URL(fileURLWithPath: normalizedExecutablePath).lastPathComponent
     }
 
+    /// Whether the profile has all required fields filled in and valid.
     public var isValid: Bool {
-        !displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        !displayName.isEmpty
             && Self.isValidHookSource(hookSource)
             && !normalizedExecutablePath.isEmpty
             && !executableBasename.isEmpty
@@ -46,13 +49,25 @@ public struct ClaudeCompatibleCLIProfile: Codable, Equatable, Identifiable, Send
             return true
         }
 
-        return Self.commandTokens(from: command).contains { token in
+        let tokens = command.split(whereSeparator: \.isWhitespace).map(String.init)
+        return tokens.contains { token in
             token == path || URL(fileURLWithPath: token).lastPathComponent == executableBasename
         }
     }
 
-    public static func commandTokens(from command: String) -> [String] {
-        command.split(whereSeparator: \.isWhitespace).map(String.init)
+    // MARK: - Codable
+
+    /// Trim whitespace on decode, matching the init behaviour so that
+    /// profiles persisted via JSON (UserDefaults) are always normalized.
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(UUID.self, forKey: .id)
+        self.displayName = (try container.decode(String.self, forKey: .displayName))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        self.hookSource = (try container.decode(String.self, forKey: .hookSource))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        self.executablePath = (try container.decode(String.self, forKey: .executablePath))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
 

--- a/Sources/OpenIslandCore/HookSourceClassification.swift
+++ b/Sources/OpenIslandCore/HookSourceClassification.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public enum HookSourceClassification: Equatable, Sendable {
+    case codex
+    case cursor
+    case gemini
+    case claudeFormat(String)
+
+    public var isClaudeFormat: Bool {
+        switch self {
+        case .claudeFormat(_):
+            true
+        case .codex, .cursor, .gemini:
+            false
+        }
+    }
+
+    public static func classify(_ rawSource: String?) -> HookSourceClassification {
+        guard let rawSource, !rawSource.isEmpty else {
+            return .codex
+        }
+
+        switch rawSource {
+        case "codex":
+            return .codex
+        case "cursor":
+            return .cursor
+        case "gemini":
+            return .gemini
+        default:
+            return .claudeFormat(rawSource)
+        }
+    }
+}

--- a/Sources/OpenIslandCore/HookSourceClassification.swift
+++ b/Sources/OpenIslandCore/HookSourceClassification.swift
@@ -1,20 +1,44 @@
 import Foundation
 
+/// Classifies a hook `--source` argument into a known payload-protocol case.
+///
+/// This replaces per-agent if-else chains so that the hook CLI (``OpenIslandHooksCLI``)
+/// and any code that inspects source identifiers can share one classification table.
+/// Unknown non-empty sources are treated as Claude-format, which is the most common
+/// pattern for custom or company-wrapped Claude Code-compatible CLIs.
+///
+/// - Note: Empty or missing source falls back to ``codex`` for backward compatibility.
 public enum HookSourceClassification: Equatable, Sendable {
+    /// Codex (Amazon Q Developer) agent protocol.
     case codex
+    /// Cursor agent protocol.
     case cursor
+    /// Gemini agent protocol.
     case gemini
+    /// Claude-format payload, identified by the raw source string.
     case claudeFormat(String)
 
+    /// Whether the classification represents a Claude-format payload.
+    ///
+    /// Use this for quick checks without pattern matching:
+    /// ```swift
+    /// if HookSourceClassification.classify(raw).isClaudeFormat { ... }
+    /// ```
     public var isClaudeFormat: Bool {
         switch self {
-        case .claudeFormat(_):
+        case .claudeFormat:
             true
         case .codex, .cursor, .gemini:
             false
         }
     }
 
+    /// Classify a raw ``--source`` argument string.
+    ///
+    /// - Parameter rawSource: The raw `--source` value from the hook CLI invocation,
+    ///   or `nil` if the flag was omitted.
+    /// - Returns: A ``HookSourceClassification`` matching the known source, or
+    ///   ``claudeFormat(_:)`` if the source is unrecognised.
     public static func classify(_ rawSource: String?) -> HookSourceClassification {
         guard let rawSource, !rawSource.isEmpty else {
             return .codex

--- a/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
+++ b/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
@@ -7,28 +7,6 @@ struct OpenIslandHooksCLI {
     private static let interactiveCodexHookTimeout =
         TimeInterval(CodexHookInstaller.managedInteractiveTimeout)
 
-    private enum HookSource: String {
-        case codex
-        case claude
-        case qoder
-        case qwen
-        case factory
-        case droid
-        case codebuddy
-        case cursor
-        case gemini
-        case kimi
-
-        var isClaudeFormat: Bool {
-            switch self {
-            case .claude, .qoder, .qwen, .factory, .droid, .codebuddy, .kimi:
-                return true
-            case .codex, .cursor, .gemini:
-                return false
-            }
-        }
-    }
-
     static func main() {
         do {
             // Allow wrappers to delegate one child process away from Open Island without changing global hook installation.
@@ -66,7 +44,7 @@ struct OpenIslandHooksCLI {
                 if let output = try CodexHookOutputEncoder.standardOutput(for: response) {
                     FileHandle.standardOutput.write(output)
                 }
-            case .claude, .qoder, .qwen, .factory, .droid, .codebuddy, .kimi:
+            case .claudeFormat(_):
                 var payload = try decoder
                     .decode(ClaudeHookPayload.self, from: input)
                     .withRuntimeContext(environment: ProcessInfo.processInfo.environment)
@@ -119,17 +97,8 @@ struct OpenIslandHooksCLI {
         FileHandle.standardError.write(data)
     }
 
-    private static func hookSource(arguments: [String]) -> HookSource {
-        var index = 0
-        while index < arguments.count {
-            if arguments[index] == "--source", index + 1 < arguments.count {
-                return HookSource(rawValue: arguments[index + 1]) ?? .codex
-            }
-
-            index += 1
-        }
-
-        return .codex
+    private static func hookSource(arguments: [String]) -> HookSourceClassification {
+        HookSourceClassification.classify(rawSourceString(arguments: arguments))
     }
 
     private static func rawSourceString(arguments: [String]) -> String? {

--- a/Tests/OpenIslandCoreTests/ClaudeCompatibleCLIProfileStoreTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeCompatibleCLIProfileStoreTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import OpenIslandCore
+
+final class ClaudeCompatibleCLIProfileStoreTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private let suiteName = "ClaudeCompatibleCLIProfileStoreTests"
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    func testSaveAndLoadProfiles() throws {
+        let store = ClaudeCompatibleCLIProfileStore(userDefaults: defaults, key: "profiles")
+        let profile = ClaudeCompatibleCLIProfile(
+            displayName: "Company Claude",
+            hookSource: "company-cc",
+            executablePath: "/opt/company-ai/bin/acme-claude"
+        )
+
+        try store.save([profile])
+
+        XCTAssertEqual(store.load(), [profile])
+    }
+
+    func testLoadFiltersInvalidProfiles() throws {
+        let store = ClaudeCompatibleCLIProfileStore(userDefaults: defaults, key: "profiles")
+        let valid = ClaudeCompatibleCLIProfile(
+            displayName: "Company Claude",
+            hookSource: "company-cc",
+            executablePath: "/opt/company-ai/bin/acme-claude"
+        )
+        let invalid = ClaudeCompatibleCLIProfile(
+            displayName: "Invalid",
+            hookSource: "company cc",
+            executablePath: "/opt/company-ai/bin/acme-claude"
+        )
+
+        try store.save([valid, invalid])
+
+        XCTAssertEqual(store.load(), [valid])
+    }
+}

--- a/Tests/OpenIslandCoreTests/ClaudeCompatibleCLIProfileTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeCompatibleCLIProfileTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import OpenIslandCore
+
+final class ClaudeCompatibleCLIProfileTests: XCTestCase {
+    func testValidatesHookSource() {
+        XCTAssertTrue(ClaudeCompatibleCLIProfile.isValidHookSource("ducc"))
+        XCTAssertTrue(ClaudeCompatibleCLIProfile.isValidHookSource("company-cc_1.0"))
+        XCTAssertFalse(ClaudeCompatibleCLIProfile.isValidHookSource(""))
+        XCTAssertFalse(ClaudeCompatibleCLIProfile.isValidHookSource("company cc"))
+        XCTAssertFalse(ClaudeCompatibleCLIProfile.isValidHookSource("company;cc"))
+    }
+
+    func testMatchesWrapperCommandByExecutablePath() {
+        let profile = ClaudeCompatibleCLIProfile(
+            displayName: "Company Claude",
+            hookSource: "company-cc",
+            executablePath: "/opt/company-ai/bin/acme-claude"
+        )
+
+        XCTAssertTrue(profile.matches(command: "/bin/sh /opt/company-ai/bin/acme-claude"))
+    }
+
+    func testMatchesWrapperCommandByExecutableBasename() {
+        let profile = ClaudeCompatibleCLIProfile(
+            displayName: "Company Claude",
+            hookSource: "company-cc",
+            executablePath: "/opt/company-ai/bin/acme-claude"
+        )
+
+        XCTAssertTrue(profile.matches(command: "/usr/bin/env acme-claude"))
+    }
+
+    func testDoesNotMatchInvalidProfile() {
+        let profile = ClaudeCompatibleCLIProfile(
+            displayName: "Invalid",
+            hookSource: "company cc",
+            executablePath: "/opt/company-ai/bin/acme-claude"
+        )
+
+        XCTAssertFalse(profile.matches(command: "/bin/sh /opt/company-ai/bin/acme-claude"))
+    }
+}

--- a/Tests/OpenIslandCoreTests/HookSourceClassificationTests.swift
+++ b/Tests/OpenIslandCoreTests/HookSourceClassificationTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import OpenIslandCore
+
+final class HookSourceClassificationTests: XCTestCase {
+    func testMissingSourceDefaultsToCodex() {
+        XCTAssertEqual(HookSourceClassification.classify(nil), .codex)
+        XCTAssertEqual(HookSourceClassification.classify(""), .codex)
+    }
+
+    func testKnownNonClaudeSourcesKeepTheirProtocol() {
+        XCTAssertEqual(HookSourceClassification.classify("codex"), .codex)
+        XCTAssertEqual(HookSourceClassification.classify("cursor"), .cursor)
+        XCTAssertEqual(HookSourceClassification.classify("gemini"), .gemini)
+    }
+
+    func testKnownClaudeSourcesUseClaudeFormat() {
+        XCTAssertEqual(HookSourceClassification.classify("claude"), .claudeFormat("claude"))
+        XCTAssertEqual(HookSourceClassification.classify("qoder"), .claudeFormat("qoder"))
+        XCTAssertEqual(HookSourceClassification.classify("kimi"), .claudeFormat("kimi"))
+    }
+
+    func testUnknownNonEmptySourceUsesClaudeFormat() {
+        XCTAssertEqual(HookSourceClassification.classify("acme-cc"), .claudeFormat("acme-cc"))
+        XCTAssertTrue(HookSourceClassification.classify("company-cc").isClaudeFormat)
+    }
+}


### PR DESCRIPTION
## Summary

Add support for custom Claude Code-compatible CLI wrappers so Open Island can recognize their sessions, decode their hook payloads correctly, and prevent sessions from prematurely disappearing.

## Root cause

Two gaps combined:

1. **Wrong hook decoder** — Unknown `--source` values (e.g. company-wrapped Claude Code CLIs) fell through to the Codex decoder instead of being treated as Claude-format.
2. **No process detection** — `ActiveAgentProcessDiscovery` had matchers for built-in agents only. Wrapper processes that show a shell or launcher as the first token (e.g. `/bin/sh /path/to/wrapper`) were never identified as Claude-compatible.

## Changes

### Backend

- **`ClaudeCompatibleCLIProfile`** — New model with `displayName`, `hookSource`, `executablePath`. Auto-derives process matching from the executable path (contains/basename/token equality). Whitespace trimming centralized in init and Codable decoder.
- **`ClaudeCompatibleCLIProfileStore`** — Persists profiles via UserDefaults.
- **`HookSourceClassification`** — Classifies `--source` arguments: known non-Claude sources keep their protocol; unknown non-empty sources are treated as Claude-format.
- **`ActiveAgentProcessDiscovery`** — Loads custom profiles and matches them against running processes, reusing the Claude `ProcessSnapshot` path.

### UI

- **`CustomCLISettingsPane`** — Full settings pane with profile list (display name + executable path), delete with confirmation, and add/edit sheet.
- **Edit sheet** — Display name and executable path fields with NSOpenPanel for file browsing. `hookSource` auto-derived from path basename.
- New settings tab (`.terminal.fill` icon).
- Localized strings (en, zh-Hans, zh-Hant).

### Testing

- Unit tests for HookSource classification, profile validation/matching/Codable round-trip, and profile store load/save.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “Custom CLI” settings tab to create and manage Claude-compatible CLI profiles (add/edit/browse/save/delete).
  * Added multilingual UI, confirmations, and validation for custom CLI profile setup.
  * Agent process discovery now detects additional Claude-compatible sessions using the saved profiles.
* **Bug Fixes**
  * Improved consistency of Claude-format hook source handling via unified classification logic.
* **Tests**
  * Added unit tests for profile persistence/validation, command matching, and hook source classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->