### PR TITLE
fix: keep Qoder sessions alive while Qoder IDE is open

### DIFF
--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -211,6 +211,23 @@ struct ActiveAgentProcessDiscovery {
                 ))
                 continue
             }
+
+            if isQoderProcess(command: process.command) {
+                let claimKey = "qoder:\(process.pid)"
+                guard claimedKeys.insert(claimKey).inserted else {
+                    continue
+                }
+
+                let lsofOutput = lsofOutput(pid: process.pid)
+                snapshots.append(ProcessSnapshot(
+                    tool: .qoder,
+                    sessionID: nil,
+                    workingDirectory: lsofOutput.flatMap(workingDirectory(from:)),
+                    terminalTTY: process.terminalTTY,
+                    terminalApp: terminalApp(for: process, processesByPID: processesByPID)
+                ))
+                continue
+            }
         }
 
         return snapshots
@@ -763,6 +780,23 @@ struct ActiveAgentProcessDiscovery {
         }
 
         return firstToken == "kimi" || firstToken.hasSuffix("/kimi")
+    }
+
+    /// Matches the `qoder` CLI entry-point. Qoder is a Claude Code fork that
+    /// ships its own `qoder` binary (installed by `@qoder-ai/qodercli`), so
+    /// `isClaudeProcess` does not pick it up.
+    private func isQoderProcess(command: String) -> Bool {
+        let lowered = command.lowercased()
+        guard let firstToken = lowered.split(separator: " ").first.map(String.init) else {
+            return false
+        }
+
+        let binaryName = (firstToken as NSString).lastPathComponent
+        guard binaryName == "qoder" else {
+            return false
+        }
+
+        return firstToken == "qoder" || firstToken.hasSuffix("/qoder")
     }
 
     /// Returns `true` when the given `ps` command string belongs to a Claude Code process.

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -509,6 +509,24 @@ final class ProcessMonitoringCoordinator {
             }
         }
 
+        // Qoder sessions are hook-managed (Claude Code fork) and use UUIDs
+        // that Open Island cannot recover from ps/lsof. Two liveness signals:
+        // 1. A qoder CLI process is running (standalone CLI usage)
+        // 2. Qoder.app is running (IDE usage - the CLI is spawned per task
+        //    and exits when the task completes, but the session should
+        //    persist as long as the IDE is open, matching Claude Code
+        //    behavior where sessions persist until the user exits)
+        let hasQoderProcess = activeProcesses.contains { $0.tool == .qoder }
+        let isQoderAppRunning = !NSRunningApplication.runningApplications(
+            withBundleIdentifier: "com.qoder.ide"
+        ).isEmpty
+        if hasQoderProcess || isQoderAppRunning {
+            for session in sessions where session.tool == .qoder && !session.isDemoSession {
+                if session.isSessionEnded { continue }
+                aliveIDs.insert(session.id)
+            }
+        }
+
         // Cursor sessions: prefer concrete cursor-agent processes when they
         // are visible (Cursor CLI / integrated terminal), then fall back to
         // app-level liveness for IDE-only hook sessions where there is no

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -1003,6 +1003,10 @@ public final class BridgeServer: @unchecked Sendable {
             clearAllActiveSubagents(fromSession: payload.sessionID)
             dropPendingClaudeContexts(forSession: payload.sessionID)
 
+            // Qoder IDE sends SessionEnd after every model response, not just
+            // on actual exit. Treat it as Stop for Qoder so the session
+            // persists via the Qoder.app liveness check until the IDE is closed.
+            let isSessionEnd = payload.resolvedAgentTool != .qoder
             emit(
                 .sessionCompleted(
                     SessionCompleted(
@@ -1010,7 +1014,7 @@ public final class BridgeServer: @unchecked Sendable {
                         summary: "\(payload.resolvedAgentTool.displayName) session ended.",
                         timestamp: .now,
                         isInterrupt: true,
-                        isSessionEnd: true
+                        isSessionEnd: isSessionEnd
                     )
                 )
             )

--- a/Tests/OpenIslandAppTests/ActiveAgentProcessDiscoveryTests.swift
+++ b/Tests/OpenIslandAppTests/ActiveAgentProcessDiscoveryTests.swift
@@ -257,4 +257,44 @@ struct ActiveAgentProcessDiscoveryTests {
             ),
         ])
     }
+
+    @Test
+    func discoverDetectsQoderCLIProcess() {
+        let discovery = ActiveAgentProcessDiscovery { executablePath, arguments in
+            if executablePath == "/bin/ps" {
+                return """
+                  102 301 ttys002 qoder
+                  301 900 ttys002 -/opt/homebrew/bin/fish
+                  900 1 ?? /Applications/Ghostty.app/Contents/MacOS/ghostty
+                """
+            }
+
+            guard executablePath == "/usr/sbin/lsof",
+                  let pid = arguments.dropFirst(2).first else {
+                return nil
+            }
+
+            switch pid {
+            case "102":
+                return """
+                fcwd
+                n/tmp/open-island
+                """
+            default:
+                Issue.record("unexpected lsof lookup for pid \(pid)")
+                return nil
+            }
+        }
+
+        let snapshots = discovery.discover()
+
+        #expect(snapshots.count == 1)
+        #expect(snapshots.contains(.init(
+            tool: .qoder,
+            sessionID: nil,
+            workingDirectory: "/tmp/open-island",
+            terminalTTY: "/dev/ttys002",
+            terminalApp: "Ghostty"
+        )))
+    }
 }


### PR DESCRIPTION
## Summary

Qoder sessions disappeared from the island within seconds of the model finishing a response. This PR fixes three root causes that combined to create the bug.

## Root causes

1. **No process detection**: `ActiveAgentProcessDiscovery` had matchers for Claude Code, Codex, OpenCode, Gemini, Kimi, and Cursor - but not Qoder. The `qoder` binary (installed by `@qoder-ai/qodercli`) was never discovered as an active process.

2. **No liveness case**: `sessionIDsWithAliveProcesses` had no Qoder case. Because Qoder sessions are hook-managed (`isHookManaged = true`), the default `not in aliveSessionIDs` path incremented `processNotSeenCount` on every poll. After 2 polls (~2-4s), `isSessionEnded = true` and the session was removed.

3. **Qoder sends `SessionEnd` after every model response** (not just on actual session exit). This is different from Claude Code CLI, where `SessionEnd` is only sent on `/exit`. Qoder's `SessionEnd` set `isSessionEnded = true`, which caused `removeInvisibleSessions` to immediately remove the session - even though the user was still in the conversation.

This last cause was discovered via runtime debug logging: Qoder sends `UserPromptSubmit → Stop → SessionEnd` in rapid succession for each turn, with no `SessionStart`. Each turn's `SessionEnd` immediately doomed the session.

## Fix

Three changes, each addressing one root cause:

### 1. Add `isQoderProcess` detection (`ActiveAgentProcessDiscovery.swift`)

Follows the `isKimiProcess` pattern (commit `201f2b1`): strict match on binary name `qoder`. Adds a Qoder branch in `discover()` that creates `ProcessSnapshot(tool: .qoder, ...)`.

### 2. Add Qoder liveness case (`ProcessMonitoringCoordinator.swift`)

Two liveness signals (OR):
- A `qoder` CLI process is running (standalone CLI usage)
- **Qoder.app is running** (IDE usage - bundle ID `com.qoder.ide`). The IDE spawns a short-lived CLI process per task that exits when the task completes. The session should persist as long as the IDE is open, matching Claude Code behavior where sessions persist until the user exits.

### 3. Treat `SessionEnd` as `Stop` for Qoder (`BridgeServer.swift`)

```swift
let isSessionEnd = payload.resolvedAgentTool != .qoder
```

Qoder's `SessionEnd` means "turn complete", not "session closed". Treating it as permanent would evict every turn's session within seconds. Instead, treat it as a regular `Stop` (don't set `isSessionEnd = true`) so the session persists via the app-level liveness check until the IDE is actually closed.

Other agents (Claude Code, Codex, etc.) are unaffected - they still treat `SessionEnd` as permanent.

## Verification

- ✅ `swift build` - 288/288 compiled, 0 errors, 0 warnings
- ✅ `swift test` - 315/315 tests passed (314 existing + 1 new), 0 failures
- ✅ New test: `discoverDetectsQoderCLIProcess` verifies Qoder process is discovered
- ✅ **End-to-end tested**: multiple concurrent Qoder IDE conversations across 5+ turns - sessions persist in the island while Qoder IDE is open and are cleaned up when the IDE is closed
- ✅ Diff is minimal (97 lines added, 1 line changed across 4 files)

## Related

- Commit `201f2b1` (Kimi fix - original process detection pattern)
- Commit `163aa8e` (added Qoder support without process detection)
- Issue #507 (OpenCode has a different symptom but related root cause)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting Qoder CLI sessions and tracking them as a distinct agent tool.
  * Qoder sessions can now be recognized as active through either the CLI process or the Qoder desktop app.
* **Bug Fixes**
  * Improved session end handling so Qoder activity stays active when it should, instead of ending too early.
* **Tests**
  * Added coverage for detecting Qoder CLI processes and associated working directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->