### PR TITLE
fix: make hook stderr logging fail open

### DIFF
--- a/Sources/OpenIslandCore/SafeFileDescriptorWriter.swift
+++ b/Sources/OpenIslandCore/SafeFileDescriptorWriter.swift
@@ -1,0 +1,34 @@
+import Darwin
+import Foundation
+
+package enum SafeFileDescriptorWriter {
+    /// Writes without allowing an unavailable pipe or descriptor to terminate the hook process.
+    package static func write(_ data: Data, to fileDescriptor: Int32 = STDERR_FILENO) {
+        guard fcntl(fileDescriptor, F_SETNOSIGPIPE, 1) != -1 else {
+            return
+        }
+
+        data.withUnsafeBytes { buffer in
+            guard let baseAddress = buffer.baseAddress else {
+                return
+            }
+
+            var offset = 0
+            while offset < buffer.count {
+                let bytesWritten = Darwin.write(
+                    fileDescriptor,
+                    baseAddress.advanced(by: offset),
+                    buffer.count - offset
+                )
+
+                if bytesWritten > 0 {
+                    offset += bytesWritten
+                } else if bytesWritten == -1, errno == EINTR {
+                    continue
+                } else {
+                    return
+                }
+            }
+        }
+    }
+}

--- a/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
+++ b/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
@@ -116,7 +116,7 @@ struct OpenIslandHooksCLI {
 
     private static func logStderr(_ message: String) {
         guard let data = "[OpenIslandHooks] \(message)\n".data(using: .utf8) else { return }
-        FileHandle.standardError.write(data)
+        SafeFileDescriptorWriter.write(data)
     }
 
     private static func hookSource(arguments: [String]) -> HookSource {

--- a/Tests/OpenIslandCoreTests/SafeFileDescriptorWriterTests.swift
+++ b/Tests/OpenIslandCoreTests/SafeFileDescriptorWriterTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+struct SafeFileDescriptorWriterTests {
+    @Test
+    func writesToAvailablePipe() throws {
+        let pipe = Pipe()
+        let data = Data("hook diagnostic\n".utf8)
+
+        SafeFileDescriptorWriter.write(data, to: pipe.fileHandleForWriting.fileDescriptor)
+        try pipe.fileHandleForWriting.close()
+
+        #expect(try pipe.fileHandleForReading.readToEnd() == data)
+    }
+
+    @Test
+    func ignoresClosedFileDescriptor() throws {
+        let pipe = Pipe()
+        let fileDescriptor = pipe.fileHandleForWriting.fileDescriptor
+        try pipe.fileHandleForWriting.close()
+
+        SafeFileDescriptorWriter.write(Data("discarded".utf8), to: fileDescriptor)
+    }
+
+    @Test
+    func ignoresPipeWithoutReader() throws {
+        let pipe = Pipe()
+        try pipe.fileHandleForReading.close()
+
+        SafeFileDescriptorWriter.write(
+            Data("discarded".utf8),
+            to: pipe.fileHandleForWriting.fileDescriptor
+        )
+        try pipe.fileHandleForWriting.close()
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #561.

- Replace hook stderr logging through `FileHandle` with a fail-open file-descriptor writer.
- Disable `SIGPIPE` for stderr writes and handle partial writes plus `EINTR`.
- Silently drop diagnostics when stderr is closed or its pipe reader has disappeared.
- Add regression coverage for a normal pipe, a closed descriptor, and a broken pipe.

## Root cause

After sleep/wake or terminal teardown, the hook process can inherit an invalid or severed stderr pipe. `FileHandle.standardError.write` may raise an Objective-C exception for a closed descriptor, while a raw write to a pipe without a reader can terminate the process with `SIGPIPE`. Either failure aborts the hook instead of preserving its intended fail-open behavior.

## Validation

- `swift build`
- `SafeFileDescriptorWriterTests`: 3/3 passed
- Closed stderr reproduction: exit 134 before, exit 0 after
- Broken pipe reproduction: exit 141 before, exit 0 after
- Normal stderr diagnostics still write successfully
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic logging reliability when the output stream is unavailable or interrupted.
  * Prevented logging writes from terminating the process unexpectedly.

* **Tests**
  * Added coverage for successful output, closed file descriptors, and unavailable pipe readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->