### PR TITLE
fix: refresh display picker after screen changes

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -622,6 +622,7 @@ final class AppModel {
 
         overlay.appModel = self
         overlay.restoreDisplayPreference()
+        overlay.startObservingDisplayChanges()
         overlay.onStatusMessage = { [weak self] message in
             self?.lastActionMessage = message
         }

--- a/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
+++ b/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
@@ -177,9 +177,16 @@ enum OverlayDisplayResolver {
         return fallbackScreenID(for: screen)
     }
 
+    /// Disambiguates identical displays (e.g. two AirPlay receivers with the
+    /// same model name and resolution) by appending the arrangement origin.
+    /// The origin is not stable across display rearrangement, but a mismatched
+    /// preference will self-heal through the existing
+    /// `validSelectionIDs.contains` check in `refreshOverlayDisplayConfiguration()`.
     private static func fallbackScreenID(for screen: NSScreen) -> String {
-        let width = Int(screen.frame.width)
-        let height = Int(screen.frame.height)
-        return "fallback-\(screen.localizedName)-\(width)x\(height)"
+        let width = Int(screen.frame.width.rounded())
+        let height = Int(screen.frame.height.rounded())
+        let originX = Int(screen.frame.origin.x.rounded())
+        let originY = Int(screen.frame.origin.y.rounded())
+        return "fallback-\(screen.localizedName)-\(width)x\(height)@\(originX),\(originY)"
     }
 }

--- a/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
+++ b/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
@@ -153,12 +153,33 @@ enum OverlayDisplayResolver {
         placementMode(for: screen) == .notch ? "Built-in notch" : "Top-bar fallback"
     }
 
-    private static func screenID(for screen: NSScreen) -> String {
+    /// Returns a string that identifies the physical display backing `screen`
+    /// stably across reconnects.
+    ///
+    /// Uses `CGDisplayCreateUUIDFromDisplayID` so the value survives the
+    /// `CGDirectDisplayID` churn that happens on hotplug / sleep / arrangement
+    /// changes — without this, a reassigned `CGDirectDisplayID` could silently
+    /// route the overlay to a different physical monitor than the one the user
+    /// picked. Falls back to a `localizedName + frame` composite when macOS
+    /// can't issue a UUID (some AirPlay / virtual displays).
+    static func screenID(for screen: NSScreen) -> String {
         let key = NSDeviceDescriptionKey("NSScreenNumber")
-        if let number = screen.deviceDescription[key] as? NSNumber {
-            return "display-\(number.uint32Value)"
+        guard let number = screen.deviceDescription[key] as? NSNumber else {
+            return fallbackScreenID(for: screen)
         }
 
-        return screen.localizedName
+        let displayID = number.uint32Value
+        if let uuid = CGDisplayCreateUUIDFromDisplayID(displayID)?.takeRetainedValue(),
+           let cfString = CFUUIDCreateString(nil, uuid) {
+            return cfString as String
+        }
+
+        return fallbackScreenID(for: screen)
+    }
+
+    private static func fallbackScreenID(for screen: NSScreen) -> String {
+        let width = Int(screen.frame.width)
+        let height = Int(screen.frame.height)
+        return "fallback-\(screen.localizedName)-\(width)x\(height)"
     }
 }

--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -198,6 +198,13 @@ final class OverlayPanelController {
         notchRect = NSRect(x: notchX, y: notchY, width: notchSize.width, height: notchSize.height)
     }
 
+    /// Picks the screen to anchor the overlay to.
+    ///
+    /// Priority: persisted manual preference (matched via the stable
+    /// `OverlayDisplayResolver.screenID` so a hotplug-reassigned
+    /// `CGDirectDisplayID` can't silently re-target the wrong monitor) →
+    /// first notched screen → `NSScreen.main` → first available screen.
+    /// Returns `nil` only when no displays are connected.
     private func resolveTargetScreen(preferredScreenID: String? = nil) -> NSScreen? {
         let screens = NSScreen.screens
         guard !screens.isEmpty else { return nil }

--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -203,7 +203,7 @@ final class OverlayPanelController {
         guard !screens.isEmpty else { return nil }
 
         if let preferredScreenID,
-           let screen = screens.first(where: { screenID(for: $0) == preferredScreenID }) {
+           let screen = screens.first(where: { OverlayDisplayResolver.screenID(for: $0) == preferredScreenID }) {
             return screen
         }
 
@@ -212,14 +212,6 @@ final class OverlayPanelController {
         }
 
         return NSScreen.main ?? screens[0]
-    }
-
-    private func screenID(for screen: NSScreen) -> String {
-        let key = NSDeviceDescriptionKey("NSScreenNumber")
-        if let number = screen.deviceDescription[key] as? NSNumber {
-            return "display-\(number.uint32Value)"
-        }
-        return screen.localizedName
     }
 
     // MARK: - Mouse event monitoring

--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -49,6 +49,9 @@ final class OverlayUICoordinator {
     let overlayPanelController = OverlayPanelController()
 
     @ObservationIgnored
+    private var screenParametersObserver: NSObjectProtocol?
+
+    @ObservationIgnored
     private var overlayTransitionGeneration: UInt64 = 0
 
     @ObservationIgnored
@@ -92,6 +95,25 @@ final class OverlayUICoordinator {
         overlayDisplaySelectionID = UserDefaults.standard.string(
             forKey: "overlay.display.preference"
         ) ?? OverlayDisplayOption.automaticID
+    }
+
+    /// Re-syncs the cached display options and the target panel placement
+    /// whenever macOS reports a screen configuration change (hotplug,
+    /// arrangement change, sleep/wake). Without this, the picker list keeps
+    /// stale entries after disconnect, and a saved preference whose
+    /// `CGDirectDisplayID` gets reused for a different physical display can
+    /// silently route the island to the wrong screen.
+    func startObservingDisplayChanges() {
+        guard screenParametersObserver == nil else { return }
+        screenParametersObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.refreshOverlayDisplayConfiguration()
+            }
+        }
     }
 
     // MARK: - Overlay transitions

--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -116,6 +116,12 @@ final class OverlayUICoordinator {
         }
     }
 
+    isolated deinit {
+        if let observer = screenParametersObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
     // MARK: - Overlay transitions
 
     func toggleOverlay() {

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -136,7 +136,7 @@ struct IslandPanelView: View {
 
     private var targetOverlayScreen: NSScreen? {
         if let targetScreenID = model.overlayPlacementDiagnostics?.targetScreenID,
-           let screen = NSScreen.screens.first(where: { screenID(for: $0) == targetScreenID }) {
+           let screen = NSScreen.screens.first(where: { OverlayDisplayResolver.screenID(for: $0) == targetScreenID }) {
             return screen
         }
 
@@ -1028,15 +1028,6 @@ struct IslandPanelView: View {
         }
         .lineLimit(1)
         .fixedSize(horizontal: true, vertical: false)
-    }
-
-    private func screenID(for screen: NSScreen) -> String {
-        let key = NSDeviceDescriptionKey("NSScreenNumber")
-        if let number = screen.deviceDescription[key] as? NSNumber {
-            return "display-\(number.uint32Value)"
-        }
-
-        return screen.localizedName
     }
 
     private func compactUsageChip(_ provider: UsageProviderPresentation, usesShortTitle: Bool) -> some View {


### PR DESCRIPTION
## Summary

- refresh the overlay display picker when macOS screen parameters change
- identify physical displays with stable CoreGraphics UUIDs instead of reusable display IDs
- disambiguate virtual-display fallbacks and align island screen lookup with the shared resolver
- clean up the screen-parameter observer during coordinator teardown

## Why

After hotplug, sleep/wake, or display rearrangement, macOS may reuse `CGDirectDisplayID` values. A persisted selection could therefore point at the wrong physical display, and the picker did not refresh until unrelated app state changed.

This rebases the reviewed work from #494 onto the current `main` without changing its resulting source tree. The original commits and author attribution are preserved. Supersedes #494 and addresses #493.

## Compatibility note

Legacy `display-<CGDirectDisplayID>` preferences are invalidated once and fall back to **Automatic**. Users with a fixed display selection may need to select it again after updating. AirPlay or virtual displays without UUIDs use a name, frame, and origin fallback; rearranging one may likewise fall back to Automatic.

## Validation

- `git diff --check origin/main...HEAD`
- `swift build`
- Original PR hardware verification: disconnecting the selected display falls back to Automatic without jumping to another monitor; disconnecting an unselected display preserves placement
- `swift test --filter OverlayPanelControllerTests` was attempted locally, but this machine's Command Line Tools installation cannot load the repository-wide `Testing` module; GitHub Actions is the authoritative test gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Overlay placement now automatically refreshes when displays are connected, disconnected, rearranged, or wake from sleep.
  * Display identification is more stable, helping preserve the selected screen across configuration changes.

* **Bug Fixes**
  * Improved overlay targeting when multiple displays share similar names or resolutions.
  * Added safer fallback handling when display identification is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->