### PR TITLE
fix: harden Kimi hook placeholder cleanup

### DIFF
--- a/Sources/OpenIslandCore/KimiHookInstaller.swift
+++ b/Sources/OpenIslandCore/KimiHookInstaller.swift
@@ -57,7 +57,9 @@ public enum KimiHookInstaller {
         hookCommand: String
     ) -> KimiHookFileMutation {
         let original = existingContents ?? ""
-        let cleaned = stripManagedBlocks(from: original, managedCommand: hookCommand)
+        let cleaned = stripEmptyTopLevelHooksArray(
+            from: stripManagedBlocks(from: original, managedCommand: hookCommand)
+        )
 
         var output = cleaned
         if !output.isEmpty, !output.hasSuffix("\n") {
@@ -144,6 +146,44 @@ public enum KimiHookInstaller {
         }
 
         return result.joined(separator: "\n")
+    }
+
+    /// Kimi may seed config.toml with a top-level `hooks = []` placeholder.
+    /// Managed hooks use TOML array-of-tables syntax (`[[hooks]]`), so the
+    /// empty placeholder must be removed before appending managed blocks.
+    private static func stripEmptyTopLevelHooksArray(from contents: String) -> String {
+        let lines = contents.components(separatedBy: "\n")
+        var result: [String] = []
+        var hasEnteredTable = false
+
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            if !hasEnteredTable, isEmptyHooksArrayAssignment(trimmed) {
+                continue
+            }
+
+            if trimmed.hasPrefix("[") && trimmed.hasSuffix("]") {
+                hasEnteredTable = true
+            }
+
+            result.append(line)
+        }
+
+        return result.joined(separator: "\n")
+    }
+
+    private static func isEmptyHooksArrayAssignment(_ trimmedLine: String) -> Bool {
+        guard trimmedLine.hasPrefix("hooks") else { return false }
+        guard let equalsIndex = trimmedLine.firstIndex(of: "=") else { return false }
+
+        let key = trimmedLine[..<equalsIndex].trimmingCharacters(in: .whitespaces)
+        guard key == "hooks" else { return false }
+
+        let rhs = trimmedLine[trimmedLine.index(after: equalsIndex)...]
+        let value = rhs.split(separator: "#", maxSplits: 1, omittingEmptySubsequences: false)[0]
+            .trimmingCharacters(in: .whitespaces)
+        return value == "[]"
     }
 
     private static func isHooksHeader(_ line: String) -> Bool {

--- a/Sources/OpenIslandCore/KimiHookInstaller.swift
+++ b/Sources/OpenIslandCore/KimiHookInstaller.swift
@@ -155,15 +155,17 @@ public enum KimiHookInstaller {
         let lines = contents.components(separatedBy: "\n")
         var result: [String] = []
         var hasEnteredTable = false
+        var multilineString: TOMLMultilineString?
 
         for line in lines {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            let syntax = tomlSyntax(in: line, multilineString: &multilineString)
+            let trimmedSyntax = syntax.trimmingCharacters(in: .whitespaces)
 
-            if !hasEnteredTable, isEmptyHooksArrayAssignment(trimmed) {
+            if !hasEnteredTable, isEmptyHooksArrayAssignment(trimmedSyntax) {
                 continue
             }
 
-            if trimmed.hasPrefix("[") && trimmed.hasSuffix("]") {
+            if isTableHeader(trimmedSyntax) {
                 hasEnteredTable = true
             }
 
@@ -173,17 +175,117 @@ public enum KimiHookInstaller {
         return result.joined(separator: "\n")
     }
 
-    private static func isEmptyHooksArrayAssignment(_ trimmedLine: String) -> Bool {
-        guard trimmedLine.hasPrefix("hooks") else { return false }
-        guard let equalsIndex = trimmedLine.firstIndex(of: "=") else { return false }
+    private enum TOMLMultilineString {
+        case basic
+        case literal
 
-        let key = trimmedLine[..<equalsIndex].trimmingCharacters(in: .whitespaces)
+        var quote: UInt8 {
+            switch self {
+            case .basic: Character("\"").asciiValue!
+            case .literal: Character("'").asciiValue!
+            }
+        }
+
+        var honorsEscapes: Bool {
+            switch self {
+            case .basic: true
+            case .literal: false
+            }
+        }
+    }
+
+    /// Returns only syntax outside TOML strings and comments. Tracking
+    /// multiline delimiters prevents string contents from looking like keys or
+    /// table headers without requiring a full TOML parser.
+    private static func tomlSyntax(
+        in line: String,
+        multilineString: inout TOMLMultilineString?
+    ) -> String {
+        let bytes = Array(line.utf8)
+        var result: [UInt8] = []
+        var index = 0
+
+        while index < bytes.count {
+            if let activeString = multilineString {
+                while index < bytes.count {
+                    if hasTripleQuote(activeString.quote, in: bytes, at: index),
+                       !activeString.honorsEscapes || !isEscaped(index, in: bytes) {
+                        multilineString = nil
+                        index += 3
+                        break
+                    }
+                    index += 1
+                }
+
+                if multilineString != nil {
+                    break
+                }
+                continue
+            }
+
+            switch bytes[index] {
+            case Character("#").asciiValue:
+                return String(decoding: result, as: UTF8.self)
+            case Character("\"").asciiValue, Character("'").asciiValue:
+                let quote = bytes[index]
+                let honorsEscapes = quote == Character("\"").asciiValue
+                if hasTripleQuote(quote, in: bytes, at: index) {
+                    multilineString = honorsEscapes ? .basic : .literal
+                    index += 3
+                } else {
+                    index += 1
+                    while index < bytes.count {
+                        if bytes[index] == quote, !honorsEscapes || !isEscaped(index, in: bytes) {
+                            index += 1
+                            break
+                        }
+                        index += 1
+                    }
+                }
+            default:
+                result.append(bytes[index])
+                index += 1
+            }
+        }
+
+        return String(decoding: result, as: UTF8.self)
+    }
+
+    private static func hasTripleQuote(_ quote: UInt8, in bytes: [UInt8], at index: Int) -> Bool {
+        index + 2 < bytes.count
+            && bytes[index] == quote
+            && bytes[index + 1] == quote
+            && bytes[index + 2] == quote
+    }
+
+    private static func isEscaped(_ index: Int, in bytes: [UInt8]) -> Bool {
+        guard index > 0 else { return false }
+        var backslashCount = 0
+        var cursor = index - 1
+
+        while bytes[cursor] == Character("\\").asciiValue {
+            backslashCount += 1
+            guard cursor > 0 else { break }
+            cursor -= 1
+        }
+
+        return backslashCount.isMultiple(of: 2) == false
+    }
+
+    private static func isTableHeader(_ syntax: String) -> Bool {
+        syntax.hasPrefix("[") && syntax.hasSuffix("]")
+    }
+
+    private static func isEmptyHooksArrayAssignment(_ syntax: String) -> Bool {
+        guard let equalsIndex = syntax.firstIndex(of: "=") else { return false }
+
+        let key = syntax[..<equalsIndex].trimmingCharacters(in: .whitespaces)
         guard key == "hooks" else { return false }
 
-        let rhs = trimmedLine[trimmedLine.index(after: equalsIndex)...]
-        let value = rhs.split(separator: "#", maxSplits: 1, omittingEmptySubsequences: false)[0]
-            .trimmingCharacters(in: .whitespaces)
-        return value == "[]"
+        let value = syntax[syntax.index(after: equalsIndex)...].trimmingCharacters(in: .whitespaces)
+        guard value.hasPrefix("["), value.hasSuffix("]") else { return false }
+
+        return value.dropFirst().dropLast().trimmingCharacters(in: .whitespaces).isEmpty
     }
 
     private static func isHooksHeader(_ line: String) -> Bool {

--- a/Sources/OpenIslandCore/KimiHookInstaller.swift
+++ b/Sources/OpenIslandCore/KimiHookInstaller.swift
@@ -159,7 +159,7 @@ public enum KimiHookInstaller {
 
         for line in lines {
             let syntax = tomlSyntax(in: line, multilineString: &multilineString)
-            let trimmedSyntax = syntax.trimmingCharacters(in: .whitespaces)
+            let trimmedSyntax = syntax.trimmingCharacters(in: .whitespacesAndNewlines)
 
             if !hasEnteredTable, isEmptyHooksArrayAssignment(trimmedSyntax) {
                 continue
@@ -232,6 +232,7 @@ public enum KimiHookInstaller {
                 if hasTripleQuote(quote, in: bytes, at: index) {
                     multilineString = honorsEscapes ? .basic : .literal
                     index += 3
+                    result.append(0x01)
                 } else {
                     index += 1
                     while index < bytes.count {
@@ -241,6 +242,7 @@ public enum KimiHookInstaller {
                         }
                         index += 1
                     }
+                    result.append(0x01)
                 }
             default:
                 result.append(bytes[index])
@@ -279,13 +281,16 @@ public enum KimiHookInstaller {
     private static func isEmptyHooksArrayAssignment(_ syntax: String) -> Bool {
         guard let equalsIndex = syntax.firstIndex(of: "=") else { return false }
 
-        let key = syntax[..<equalsIndex].trimmingCharacters(in: .whitespaces)
+        let key = syntax[..<equalsIndex].trimmingCharacters(in: .whitespacesAndNewlines)
         guard key == "hooks" else { return false }
 
-        let value = syntax[syntax.index(after: equalsIndex)...].trimmingCharacters(in: .whitespaces)
+        let value = syntax[syntax.index(after: equalsIndex)...]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         guard value.hasPrefix("["), value.hasSuffix("]") else { return false }
 
-        return value.dropFirst().dropLast().trimmingCharacters(in: .whitespaces).isEmpty
+        return value.dropFirst().dropLast()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty
     }
 
     private static func isHooksHeader(_ line: String) -> Bool {

--- a/Tests/OpenIslandCoreTests/KimiHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/KimiHooksTests.swift
@@ -48,6 +48,53 @@ struct KimiHooksTests {
     }
 
     @Test
+    func installRemovesEmptyTopLevelHooksArrayPlaceholder() {
+        let userToml = """
+        default_model = "kimi-code/kimi-for-coding"
+        default_thinking = true
+        hooks = [] # Kimi may seed this placeholder
+
+        [models."kimi-code/kimi-for-coding"]
+        provider = "managed:kimi-code"
+
+        [[hooks]]
+        event = "PostToolUse"
+        command = "user-hook"
+
+        """
+        let command = KimiHookInstaller.hookCommand(for: "/opt/open-island/OpenIslandHooks")
+        let mutation = KimiHookInstaller.installConfigTOML(
+            existingContents: userToml,
+            hookCommand: command
+        )
+
+        let contents = try! #require(mutation.contents)
+        #expect(contents.contains("hooks = []") == false)
+        #expect(contents.contains("[models.\"kimi-code/kimi-for-coding\"]"))
+        #expect(contents.contains("command = \"user-hook\""))
+        #expect(contents.contains("event = \"SessionStart\""))
+    }
+
+    @Test
+    func installKeepsNonTopLevelHooksArrayAssignments() {
+        let userToml = """
+        [harness]
+        hooks = []
+        embedded = true
+
+        """
+        let command = KimiHookInstaller.hookCommand(for: "/opt/open-island/OpenIslandHooks")
+        let mutation = KimiHookInstaller.installConfigTOML(
+            existingContents: userToml,
+            hookCommand: command
+        )
+
+        let contents = try! #require(mutation.contents)
+        #expect(contents.contains("[harness]\nhooks = []\nembedded = true"))
+        #expect(contents.contains("event = \"SessionStart\""))
+    }
+
+    @Test
     func reinstallIsIdempotent() {
         let command = KimiHookInstaller.hookCommand(for: "/opt/open-island/OpenIslandHooks")
         let firstInstall = KimiHookInstaller.installConfigTOML(

--- a/Tests/OpenIslandCoreTests/KimiHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/KimiHooksTests.swift
@@ -95,6 +95,71 @@ struct KimiHooksTests {
     }
 
     @Test
+    func installRemovesSpacedEmptyTopLevelHooksArrayPlaceholder() {
+        let userToml = """
+        default_model = "kimi-code/kimi-for-coding"
+        hooks = [ ] # Kimi may seed this placeholder
+
+        """
+        let command = KimiHookInstaller.hookCommand(for: "/opt/open-island/OpenIslandHooks")
+        let mutation = KimiHookInstaller.installConfigTOML(
+            existingContents: userToml,
+            hookCommand: command
+        )
+
+        let contents = try! #require(mutation.contents)
+        #expect(contents.contains("hooks = [ ] # Kimi may seed this placeholder") == false)
+        #expect(contents.contains("event = \"SessionStart\""))
+    }
+
+    @Test
+    func installKeepsHooksArrayAfterCommentedTableHeader() {
+        let userToml = """
+        [harness] # user-owned table
+        hooks = [ ]
+        embedded = true
+
+        """
+        let command = KimiHookInstaller.hookCommand(for: "/opt/open-island/OpenIslandHooks")
+        let mutation = KimiHookInstaller.installConfigTOML(
+            existingContents: userToml,
+            hookCommand: command
+        )
+
+        let contents = try! #require(mutation.contents)
+        #expect(contents.contains("[harness] # user-owned table\nhooks = [ ]\nembedded = true"))
+        #expect(contents.contains("event = \"SessionStart\""))
+    }
+
+    @Test
+    func installKeepsHooksTextInsideMultilineStrings() {
+        let userToml = #"""
+        basic_message = """
+        hooks = []
+        """
+        literal_message = '''
+        hooks = [ ]
+        '''
+        hooks = [ ] # actual placeholder
+
+        """#
+        let command = KimiHookInstaller.hookCommand(for: "/opt/open-island/OpenIslandHooks")
+        let mutation = KimiHookInstaller.installConfigTOML(
+            existingContents: userToml,
+            hookCommand: command
+        )
+
+        let contents = try! #require(mutation.contents)
+        #expect(contents.contains("hooks = [ ] # actual placeholder") == false)
+        #expect(contents.contains(#"""
+        basic_message = """
+        hooks = []
+        """
+        """#))
+        #expect(contents.contains("literal_message = '''\nhooks = [ ]\n'''"))
+    }
+
+    @Test
     func reinstallIsIdempotent() {
         let command = KimiHookInstaller.hookCommand(for: "/opt/open-island/OpenIslandHooks")
         let firstInstall = KimiHookInstaller.installConfigTOML(

--- a/Tests/OpenIslandCoreTests/KimiHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/KimiHooksTests.swift
@@ -160,6 +160,38 @@ struct KimiHooksTests {
     }
 
     @Test
+    func installKeepsNonEmptyTopLevelHooksArrayWithStrings() {
+        let userToml = #"""
+        default_model = "kimi-code/kimi-for-coding"
+        hooks = ["user-hook"]
+
+        """#
+        let command = KimiHookInstaller.hookCommand(for: "/opt/open-island/OpenIslandHooks")
+        let mutation = KimiHookInstaller.installConfigTOML(
+            existingContents: userToml,
+            hookCommand: command
+        )
+
+        let contents = try! #require(mutation.contents)
+        #expect(contents.contains(#"hooks = ["user-hook"]"#))
+        #expect(contents.contains("event = \"SessionStart\""))
+    }
+
+    @Test
+    func installRemovesEmptyTopLevelHooksArrayFromCRLFConfig() {
+        let userToml = "default_model = \"kimi-code/kimi-for-coding\"\r\nhooks = []\r\n"
+        let command = KimiHookInstaller.hookCommand(for: "/opt/open-island/OpenIslandHooks")
+        let mutation = KimiHookInstaller.installConfigTOML(
+            existingContents: userToml,
+            hookCommand: command
+        )
+
+        let contents = try! #require(mutation.contents)
+        #expect(contents.contains("hooks = []") == false)
+        #expect(contents.contains("event = \"SessionStart\""))
+    }
+
+    @Test
     func reinstallIsIdempotent() {
         let command = KimiHookInstaller.hookCommand(for: "/opt/open-island/OpenIslandHooks")
         let firstInstall = KimiHookInstaller.installConfigTOML(


### PR DESCRIPTION
## Summary

- remove Kimi's empty top-level `hooks = []` / `hooks = [ ]` placeholder before appending managed `[[hooks]]` entries
- preserve nested user-owned `hooks` arrays after TOML table headers, including headers with trailing comments
- ignore comments, single-line strings, and basic/literal multiline strings while identifying the placeholder
- add regression coverage for the standard collision, spaced arrays, commented table headers, and multiline-string content

## Root cause

Kimi can seed `config.toml` with a top-level `hooks = []`. Open Island appends `[[hooks]]` array-of-table entries, and TOML rejects the same key being defined with both shapes. The original #499 fixed the common case, but its line-based table detection could delete user data after a commented table header or inside a multiline string.

This branch preserves the original #499 commit and author attribution, then adds a separate hardening commit on the current `main`. Supersedes #499 and closes #498.

## Validation

- `git diff --check origin/main...HEAD`
- `swift build`
- production-module smoke against the built `OpenIslandCore`: standard placeholder removal, commented nested table preservation, and basic/literal multiline-string preservation — passed
- `swift test --filter KimiHooksTests` was attempted locally, but this machine's Command Line Tools installation cannot load the repository-wide `Testing` module; GitHub Actions is the authoritative test gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented an empty top-level `hooks = []` placeholder from lingering when managed hooks are appended.
  * Improved correctness by preserving `hooks`-like text inside comments/strings (including multiline strings) and in non-top-level sections.
  * Handled additional variations, including spaced forms (`hooks = [ ]`), CRLF line endings, and ensuring non-empty top-level hook arrays are kept.

* **Tests**
  * Expanded `KimiHookInstaller` coverage for placeholder removal/preservation and multiline/comment/formatting edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->