### PR TITLE
ci: require notarization before release

### DIFF
--- a/.github/workflows/notary-preflight.yml
+++ b/.github/workflows/notary-preflight.yml
@@ -1,0 +1,43 @@
+name: Notary Preflight
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-credentials:
+    runs-on: macos-26
+    steps:
+      - name: Validate Apple notarization credentials
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          : "${APPLE_ID:?APPLE_ID secret is required}"
+          : "${APPLE_TEAM_ID:?APPLE_TEAM_ID secret is required}"
+          : "${APPLE_APP_SPECIFIC_PASSWORD:?APPLE_APP_SPECIFIC_PASSWORD secret is required}"
+
+          keychain_path="$RUNNER_TEMP/notary-preflight.keychain-db"
+          keychain_password="$(uuidgen)"
+
+          cleanup() {
+            security delete-keychain "$keychain_path" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          security create-keychain -p "$keychain_password" "$keychain_path"
+          security set-keychain-settings -lut 3600 "$keychain_path"
+          security unlock-keychain -p "$keychain_password" "$keychain_path"
+
+          xcrun notarytool store-credentials "open-island-notary-preflight" \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+            --keychain "$keychain_path"
+
+          echo "Apple notarization credentials are valid."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,22 +58,19 @@ jobs:
           # Add the keychain to the search list
           security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
 
-          # Store notarytool credentials in the keychain when possible. Apple
-          # can reject credential validation while legal agreements are pending
-          # or expired; keep the release moving as a signed, non-notarized build
-          # in that case and let the later notarization step skip itself.
+          # A release is notarized unless SKIP_NOTARIZE is explicitly enabled.
+          # Credential validation failures must stop the workflow before any
+          # release assets or update metadata are published.
           if [[ "${SKIP_NOTARIZE:-}" == "true" ]]; then
             echo "Skipping notarytool credential setup because SKIP_NOTARIZE is true."
             echo "notary_ready=false" >> "$GITHUB_OUTPUT"
-          elif xcrun notarytool store-credentials "open-island-notary" \
+          else
+            xcrun notarytool store-credentials "open-island-notary" \
               --apple-id "${{ secrets.APPLE_ID }}" \
               --team-id "${{ secrets.APPLE_TEAM_ID }}" \
               --password "${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}" \
-              --keychain "$KEYCHAIN_PATH"; then
+              --keychain "$KEYCHAIN_PATH"
             echo "notary_ready=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::warning::Notary credential validation failed; continuing with a signed, non-notarized release."
-            echo "notary_ready=false" >> "$GITHUB_OUTPUT"
           fi
 
           # Clean up
@@ -126,10 +123,9 @@ jobs:
 
           echo "Bundle structure OK"
 
-      - name: Notarize (best-effort)
+      - name: Notarize
         if: vars.SKIP_NOTARIZE != 'true' && steps.signing.outputs.notary_ready == 'true'
         id: notarize
-        continue-on-error: true
         env:
           OPEN_ISLAND_APP_NAME: "Open Island"
         run: |
@@ -140,7 +136,7 @@ jobs:
           echo "Submitting for notarization..."
           xcrun notarytool submit "$zip_path" \
             --keychain-profile "open-island-notary" \
-            --wait --timeout 10m || { echo "::warning::Notarization failed or timed out"; exit 1; }
+            --wait --timeout 10m
 
           echo "Stapling app bundle..."
           xcrun stapler staple -v "$bundle"
@@ -153,7 +149,7 @@ jobs:
           codesign --force --sign "${{ secrets.APPLE_SIGNING_IDENTITY }}" --timestamp "$dmg_path"
           xcrun notarytool submit "$dmg_path" \
             --keychain-profile "open-island-notary" \
-            --wait --timeout 10m || { echo "::warning::DMG notarization failed or timed out"; exit 1; }
+            --wait --timeout 10m
           xcrun stapler staple -v "$dmg_path"
 
           echo "notarized=true" >> "$GITHUB_OUTPUT"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -10,6 +10,24 @@ Follow [Semantic Versioning](https://semver.org/):
 - **Minor** (0.x.0): new features, non-breaking changes
 - **Major** (x.0.0): breaking changes
 
+## Notarization Preflight
+
+Before pushing a release tag, validate the repository's Apple notarization
+credentials against Apple's service:
+
+```bash
+gh workflow run "Notary Preflight" --ref main
+gh run list --workflow "Notary Preflight" --limit 1
+```
+
+Open the reported run and confirm that `Validate Apple notarization credentials`
+passes. Updated or expired Apple Developer agreements can make this check fail
+even while the existing Developer ID certificate can still sign an app.
+
+The release workflow treats signing and notarization as required by default. Set
+the `SKIP_NOTARIZE` repository variable to `true` only when intentionally shipping
+a signed but non-notarized build.
+
 ## Checklist
 
 1. **Confirm target**: ensure all intended changes are merged to `main`.


### PR DESCRIPTION
## Summary

- add a manual Notary Preflight workflow that validates the existing Apple notarization secrets
- stop releases when credential validation or notarization fails unless `SKIP_NOTARIZE=true` is explicitly set
- document the preflight step for future releases

## Why

v1.1.5 continued as a signed, non-notarized build after Apple rejected credential validation for a pending agreement. The workflow still appeared green and updated Sparkle/Homebrew metadata. This makes notarization fail closed by default and provides a no-release preflight before tagging.

## Validation

- `git diff --check`
- parsed both workflow YAML files with Ruby/Psych
- checked the preflight shell script with `bash -n`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered notarization preflight workflow to validate Apple credentials before release.

* **Bug Fixes**
  * Release notarization now fails immediately when credential setup or notarization encounters an error.

* **Documentation**
  * Added release guidance for running the notarization preflight and handling signed, non-notarized builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->