### PR TITLE
fix: improve Codex session titles

### DIFF
--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -131,6 +131,16 @@ extension AgentSession {
         return trimmedTitle
     }
 
+    var spotlightSessionName: String {
+        if tool == .codex,
+           let threadName = codexMetadata?.threadName?.trimmedForSurface,
+           !threadName.isEmpty {
+            return threadName
+        }
+
+        return spotlightWorkspaceName
+    }
+
     var spotlightWorktreeBranch: String? {
         // This is a SwiftUI computed property read on every layout
         // pass. It MUST stay free of filesystem IO. Calling
@@ -168,7 +178,7 @@ extension AgentSession {
     }
 
     var spotlightHeadlineText: String {
-        var headline = spotlightWorkspaceName
+        var headline = spotlightSessionName
 
         if let branch = spotlightWorktreeBranch {
             headline += " (\(branch))"

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -671,6 +671,9 @@ final class AppModel {
         codexAppServer.onEvent = { [weak self] event in
             self?.applyTrackedEvent(event, ingress: .bridge)
         }
+        codexAppServer.onThreadNameUpdated = { [weak self] sessionID, threadName in
+            self?.discovery.applyCodexThreadNames([sessionID: threadName])
+        }
         codexAppServer.onStatusMessage = { [weak self] message in
             self?.lastActionMessage = message
         }
@@ -1074,6 +1077,11 @@ final class AppModel {
 
         if loadRuntimeState {
             isResolvingInitialLiveSessions = true
+
+            // Thread names and live app-server events should not wait for the
+            // potentially expensive transcript discovery pass to finish.
+            discovery.startCodexThreadNameMonitoringIfNeeded()
+            codexAppServer.ensureConnected()
 
             Task.detached(priority: .userInitiated) { [weak self] in
                 guard let self else { return }

--- a/Sources/OpenIslandApp/CodexAppServerCoordinator.swift
+++ b/Sources/OpenIslandApp/CodexAppServerCoordinator.swift
@@ -21,6 +21,11 @@ final class CodexAppServerCoordinator {
     @ObservationIgnored
     var onEvent: ((AgentEvent) -> Void)?
 
+    /// Delivers Codex's generated thread name without rebuilding the session
+    /// and clobbering its live phase, prompt, or attachment state.
+    @ObservationIgnored
+    var onThreadNameUpdated: ((String, String) -> Void)?
+
     /// Callback to log status messages.
     @ObservationIgnored
     var onStatusMessage: ((String) -> Void)?
@@ -40,6 +45,9 @@ final class CodexAppServerCoordinator {
     /// already connected or a connection attempt is in progress.
     func ensureConnected() {
         guard !isConnected, connectTask == nil else { return }
+        guard !NSRunningApplication.runningApplications(
+            withBundleIdentifier: "com.openai.codex"
+        ).isEmpty else { return }
 
         // Resolve the Codex.app bundle location dynamically — users may
         // have installed Codex outside `/Applications` (e.g. ~/Applications).
@@ -101,7 +109,10 @@ final class CodexAppServerCoordinator {
                 // Skip threads already tracked — re-emitting sessionStarted
                 // rebuilds the AgentSession and would wipe richer state
                 // already accumulated from hooks or rediscovery.
-                if isSessionTracked?(thread.id) == true { continue }
+                if isSessionTracked?(thread.id) == true {
+                    emitThreadNameIfPresent(from: thread)
+                    continue
+                }
                 emitSessionStarted(from: thread)
                 created += 1
             }
@@ -115,11 +126,14 @@ final class CodexAppServerCoordinator {
 
     // MARK: - Notification handling
 
-    private func handleNotification(_ notification: CodexAppServerNotification) {
+    func handleNotification(_ notification: CodexAppServerNotification) {
         switch notification {
         case .threadStarted(let thread):
             guard !thread.ephemeral else { return }
-            guard isSessionTracked?(thread.id) != true else { return }
+            guard isSessionTracked?(thread.id) != true else {
+                emitThreadNameIfPresent(from: thread)
+                return
+            }
             emitSessionStarted(from: thread)
 
         case .threadStatusChanged(let threadId, let status):
@@ -195,12 +209,8 @@ final class CodexAppServerCoordinator {
                 )
             ))
 
-        case .threadNameUpdated:
-            // Title updates don't have a dedicated AgentEvent and we can't
-            // safely overwrite phase/summary here (would clobber running or
-            // waiting-for-approval state).  Skip for now — the title is
-            // populated at sessionStarted time which is usually enough.
-            break
+        case .threadNameUpdated(let threadId, let name):
+            emitThreadName(threadId: threadId, name: name)
 
         case .turnStarted(let threadId, _):
             onEvent?(.activityUpdated(
@@ -240,9 +250,23 @@ final class CodexAppServerCoordinator {
 
     // MARK: - Helpers
 
+    private func emitThreadNameIfPresent(from thread: CodexThread) {
+        emitThreadName(threadId: thread.id, name: thread.name)
+    }
+
+    private func emitThreadName(threadId: String, name: String?) {
+        guard let name else { return }
+        let threadName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !threadName.isEmpty else { return }
+        onThreadNameUpdated?(threadId, threadName)
+    }
+
     private func emitSessionStarted(from thread: CodexThread) {
         let workspaceName = URL(fileURLWithPath: thread.cwd).lastPathComponent
-        let title = thread.name ?? workspaceName
+        let trimmedThreadName = thread.name?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let threadName = trimmedThreadName.flatMap { $0.isEmpty ? nil : $0 }
+        let title = "Codex · \(threadName ?? workspaceName)"
         let summary = thread.preview.isEmpty ? "Codex session." : String(thread.preview.prefix(120))
 
         let phase: SessionPhase
@@ -270,6 +294,7 @@ final class CodexAppServerCoordinator {
                 ),
                 codexMetadata: CodexSessionMetadata(
                     transcriptPath: thread.path,
+                    threadName: threadName,
                     initialUserPrompt: thread.preview.isEmpty ? nil : thread.preview
                 )
             )

--- a/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
+++ b/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
@@ -321,7 +321,7 @@ final class SessionDiscoveryCoordinator {
 
         let merged = CodexSessionMetadata(
             transcriptPath: discovered.transcriptPath ?? existing.transcriptPath,
-            initialUserPrompt: existing.initialUserPrompt ?? discovered.initialUserPrompt ?? discovered.lastUserPrompt,
+            initialUserPrompt: discovered.initialUserPrompt ?? existing.initialUserPrompt ?? discovered.lastUserPrompt,
             lastUserPrompt: discovered.lastUserPrompt ?? existing.lastUserPrompt,
             lastAssistantMessage: discovered.lastAssistantMessage ?? existing.lastAssistantMessage,
             currentTool: discovered.currentTool ?? existing.currentTool,

--- a/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
+++ b/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
@@ -55,13 +55,19 @@ final class SessionDiscoveryCoordinator {
     let codexRolloutWatcher = CodexRolloutWatcher()
 
     @ObservationIgnored
-    private let codexRolloutDiscovery = CodexRolloutDiscovery()
+    private let codexRolloutDiscovery: CodexRolloutDiscovery
 
     @ObservationIgnored
     private let claudeTranscriptDiscovery = ClaudeTranscriptDiscovery()
 
     @ObservationIgnored
     private var codexSessionPersistenceTask: Task<Void, Never>?
+
+    @ObservationIgnored
+    private var codexAppRediscoveryTask: Task<Void, Never>?
+
+    @ObservationIgnored
+    private var codexThreadNameMonitoringTask: Task<Void, Never>?
 
     @ObservationIgnored
     private var claudeSessionPersistenceTask: Task<Void, Never>?
@@ -217,14 +223,27 @@ final class SessionDiscoveryCoordinator {
     private func merge(discovered: AgentSession, into existing: AgentSession) -> AgentSession {
         var merged = existing
         let discoveredIsNewer = discovered.updatedAt >= existing.updatedAt
+        let discoveredThreadName = discovered.codexMetadata?.threadName?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
 
         if discoveredIsNewer {
-            merged.title = discovered.title
+            // Keep a persisted Codex thread name when the index is temporarily
+            // unavailable and discovery falls back to the workspace title.
+            if existing.codexMetadata?.threadName == nil {
+                merged.title = discovered.title
+            }
             merged.phase = discovered.phase
             merged.summary = discovered.summary
             merged.updatedAt = discovered.updatedAt
             merged.permissionRequest = discovered.permissionRequest
             merged.questionPrompt = discovered.questionPrompt
+        }
+
+        // Codex generates and renames thread titles asynchronously, so a
+        // newly discovered title must win even when the session has newer
+        // live activity that should otherwise remain untouched.
+        if let discoveredThreadName, !discoveredThreadName.isEmpty {
+            merged.title = discovered.title
         }
 
         merged.origin = existing.origin ?? discovered.origin
@@ -321,6 +340,7 @@ final class SessionDiscoveryCoordinator {
 
         let merged = CodexSessionMetadata(
             transcriptPath: discovered.transcriptPath ?? existing.transcriptPath,
+            threadName: discovered.threadName ?? existing.threadName,
             initialUserPrompt: discovered.initialUserPrompt ?? existing.initialUserPrompt ?? discovered.lastUserPrompt,
             lastUserPrompt: discovered.lastUserPrompt ?? existing.lastUserPrompt,
             lastAssistantMessage: discovered.lastAssistantMessage ?? existing.lastAssistantMessage,
@@ -365,6 +385,10 @@ final class SessionDiscoveryCoordinator {
 
     @ObservationIgnored
     private var lastCodexAppReconcileDate: Date = .distantPast
+
+    init(codexRolloutDiscovery: CodexRolloutDiscovery = CodexRolloutDiscovery()) {
+        self.codexRolloutDiscovery = codexRolloutDiscovery
+    }
 
     // MARK: - Rollout tracking
 
@@ -412,26 +436,114 @@ final class SessionDiscoveryCoordinator {
 
     // MARK: - Codex.app periodic re-discovery
 
+    /// Keeps the small Codex title index in sync independently from rollout
+    /// discovery. A rollout can be hundreds of megabytes, while the index is
+    /// tiny and is the authoritative source for generated and renamed titles.
+    func startCodexThreadNameMonitoringIfNeeded() {
+        guard codexThreadNameMonitoringTask == nil else { return }
+
+        let discovery = codexRolloutDiscovery
+        codexThreadNameMonitoringTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                let sessionIDs = Set(self.state.sessions.lazy.filter { $0.tool == .codex }.map(\.id))
+
+                if !sessionIDs.isEmpty {
+                    let threadNames = await Task.detached(priority: .utility) {
+                        discovery.indexedThreadNames(for: sessionIDs)
+                    }.value
+                    guard !Task.isCancelled else { return }
+                    self.applyCodexThreadNames(threadNames)
+                }
+
+                try? await Task.sleep(for: .seconds(2))
+            }
+        }
+    }
+
+    func stopCodexThreadNameMonitoring() {
+        codexThreadNameMonitoringTask?.cancel()
+        codexThreadNameMonitoringTask = nil
+    }
+
     /// Re-scan `~/.codex/sessions/` for rollout files not yet tracked.
     /// Called periodically when Codex.app is running as a fallback when
     /// the app-server connection is unavailable.  Throttled to at most
     /// once per 10 seconds.
     func rediscoverCodexAppSessionsIfNeeded() {
         let now = Date.now
-        guard now.timeIntervalSince(lastCodexAppRescanDate) >= 10 else { return }
+        guard now.timeIntervalSince(lastCodexAppRescanDate) >= 10,
+              codexAppRediscoveryTask == nil else { return }
         lastCodexAppRescanDate = now
 
         let discovery = codexRolloutDiscovery
-        Task.detached(priority: .utility) { [weak self] in
+        let trackedSessionIDs = Set(state.sessions.lazy.filter { $0.tool == .codex }.map(\.id))
+        codexAppRediscoveryTask = Task.detached(priority: .utility) { [weak self] in
+            let indexedThreadNames = discovery.indexedThreadNames(for: trackedSessionIDs)
+            if !indexedThreadNames.isEmpty {
+                _ = await MainActor.run { [weak self] in
+                    self?.applyCodexThreadNames(indexedThreadNames)
+                }
+            }
+
             let discovered = discovery.discoverRecentSessions()
-            guard !discovered.isEmpty else { return }
             await MainActor.run { [weak self] in
-                self?.applyCodexAppRediscovery(discovered)
+                guard let self else { return }
+                if !discovered.isEmpty {
+                    self.applyCodexAppRediscovery(discovered)
+                }
+                self.codexAppRediscoveryTask = nil
             }
         }
     }
 
-    private func applyCodexAppRediscovery(_ records: [CodexTrackedSessionRecord]) {
+    func mergingCodexThreadNames(
+        _ threadNamesBySessionID: [String: String],
+        into sessions: [AgentSession]
+    ) -> [AgentSession] {
+        var merged = sessions
+
+        for index in merged.indices where merged[index].tool == .codex {
+            guard let rawThreadName = threadNamesBySessionID[merged[index].id] else {
+                continue
+            }
+
+            let threadName = rawThreadName.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !threadName.isEmpty else { continue }
+
+            merged[index].title = "Codex · \(threadName)"
+            var metadata = merged[index].codexMetadata ?? CodexSessionMetadata()
+            metadata.threadName = threadName
+            merged[index].codexMetadata = metadata
+        }
+
+        return merged
+    }
+
+    @discardableResult
+    func applyCodexThreadNames(_ threadNamesBySessionID: [String: String]) -> Int {
+        let sessionsWithUpdatedTitles = mergingCodexThreadNames(
+            threadNamesBySessionID,
+            into: state.sessions
+        )
+        let updatedTitleCount = zip(state.sessions, sessionsWithUpdatedTitles).count { existing, updated in
+            existing.title != updated.title
+                || existing.codexMetadata?.threadName != updated.codexMetadata?.threadName
+        }
+        guard updatedTitleCount > 0 else { return 0 }
+
+        state = SessionState(sessions: sessionsWithUpdatedTitles)
+        scheduleCodexSessionPersistence()
+        onStatusMessage?("Updated \(updatedTitleCount) Codex session title(s).")
+        return updatedTitleCount
+    }
+
+    func applyCodexAppRediscovery(_ records: [CodexTrackedSessionRecord]) {
+        let indexedThreadNames = Dictionary(uniqueKeysWithValues: records.compactMap { record in
+            record.codexMetadata?.threadName.map { (record.sessionID, $0) }
+        })
+        let updatedTitleCount = applyCodexThreadNames(indexedThreadNames)
+
         let existingIDs = Set(state.sessions.filter { $0.tool == .codex }.map(\.id))
         let existingPaths = Set(state.sessions.compactMap(\.codexMetadata?.transcriptPath))
 
@@ -439,7 +551,7 @@ final class SessionDiscoveryCoordinator {
             !existingIDs.contains(record.sessionID)
                 && (record.codexMetadata?.transcriptPath).map { !existingPaths.contains($0) } ?? true
         }
-        guard !newRecords.isEmpty else { return }
+        guard !newRecords.isEmpty || updatedTitleCount > 0 else { return }
 
         let newSessions = newRecords.map { record -> AgentSession in
             var session = record.session
@@ -463,11 +575,15 @@ final class SessionDiscoveryCoordinator {
             return session
         }
 
-        let merged = mergeDiscoveredSessions(newSessions)
-        state = SessionState(sessions: merged)
+        if !newSessions.isEmpty {
+            let merged = mergeDiscoveredSessions(newSessions)
+            state = SessionState(sessions: merged)
+        }
         refreshCodexRolloutTracking()
         scheduleCodexSessionPersistence()
-        onStatusMessage?("Discovered \(newRecords.count) new Codex.app session(s) via rollout re-scan.")
+        if !newRecords.isEmpty {
+            onStatusMessage?("Discovered \(newRecords.count) new Codex.app session(s) via rollout re-scan.")
+        }
     }
 
     // MARK: - Persistence scheduling

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -2021,6 +2021,7 @@ public final class BridgeServer: @unchecked Sendable {
     ) -> CodexSessionMetadata {
         CodexSessionMetadata(
             transcriptPath: update.transcriptPath ?? existing?.transcriptPath,
+            threadName: update.threadName ?? existing?.threadName,
             initialUserPrompt: existing?.initialUserPrompt ?? update.initialUserPrompt ?? update.lastUserPrompt,
             lastUserPrompt: update.lastUserPrompt ?? existing?.lastUserPrompt,
             lastAssistantMessage: update.lastAssistantMessage ?? existing?.lastAssistantMessage,

--- a/Sources/OpenIslandCore/CodexSessionTracking.swift
+++ b/Sources/OpenIslandCore/CodexSessionTracking.swift
@@ -3,6 +3,7 @@ import Foundation
 
 public struct CodexSessionMetadata: Equatable, Codable, Sendable {
     public var transcriptPath: String?
+    public var threadName: String?
     public var initialUserPrompt: String?
     public var lastUserPrompt: String?
     public var lastAssistantMessage: String?
@@ -11,6 +12,7 @@ public struct CodexSessionMetadata: Equatable, Codable, Sendable {
 
     public init(
         transcriptPath: String? = nil,
+        threadName: String? = nil,
         initialUserPrompt: String? = nil,
         lastUserPrompt: String? = nil,
         lastAssistantMessage: String? = nil,
@@ -18,6 +20,7 @@ public struct CodexSessionMetadata: Equatable, Codable, Sendable {
         currentCommandPreview: String? = nil
     ) {
         self.transcriptPath = transcriptPath
+        self.threadName = threadName
         self.initialUserPrompt = initialUserPrompt
         self.lastUserPrompt = lastUserPrompt
         self.lastAssistantMessage = lastAssistantMessage
@@ -27,6 +30,7 @@ public struct CodexSessionMetadata: Equatable, Codable, Sendable {
 
     public var isEmpty: Bool {
         transcriptPath == nil
+            && threadName == nil
             && initialUserPrompt == nil
             && lastUserPrompt == nil
             && lastAssistantMessage == nil
@@ -368,18 +372,26 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             .appendingPathComponent(".codex/sessions", isDirectory: true)
     }
 
+    public static var defaultSessionIndexURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex/session_index.jsonl")
+    }
+
     private let rootURL: URL
+    private let sessionIndexURL: URL
     private let fileManager: FileManager
     private let maxAge: TimeInterval
     private let maxFiles: Int
 
     public init(
         rootURL: URL = CodexRolloutDiscovery.defaultRootURL,
+        sessionIndexURL: URL = CodexRolloutDiscovery.defaultSessionIndexURL,
         fileManager: FileManager = .default,
         maxAge: TimeInterval = 86_400,
         maxFiles: Int = 40
     ) {
         self.rootURL = rootURL
+        self.sessionIndexURL = sessionIndexURL
         self.fileManager = fileManager
         self.maxAge = maxAge
         self.maxFiles = maxFiles
@@ -444,6 +456,8 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
 
             recordsByID[record.sessionID] = record
         }
+
+        applyIndexedThreadNames(to: &recordsByID)
 
         return recordsByID.values.sorted { lhs, rhs in
             if lhs.updatedAt == rhs.updatedAt {
@@ -522,6 +536,65 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
     }
 
     private static let streamingChunkSize = 64 * 1_024
+
+    private func applyIndexedThreadNames(
+        to recordsByID: inout [String: CodexTrackedSessionRecord]
+    ) {
+        for (sessionID, threadName) in indexedThreadNames(for: Set(recordsByID.keys)) {
+            guard var record = recordsByID[sessionID] else { continue }
+            record.title = "Codex · \(threadName)"
+
+            var metadata = record.codexMetadata ?? CodexSessionMetadata()
+            metadata.threadName = threadName
+            record.codexMetadata = metadata
+            recordsByID[sessionID] = record
+        }
+    }
+
+    /// Reads only Codex's append-only title index. This deliberately avoids
+    /// parsing rollout transcripts so live title updates stay fast even when
+    /// a recent session has a very large JSONL file.
+    public func indexedThreadNames(for sessionIDs: Set<String>) -> [String: String] {
+        guard !sessionIDs.isEmpty,
+              let fileHandle = try? FileHandle(forReadingFrom: sessionIndexURL) else {
+            return [:]
+        }
+        defer { try? fileHandle.close() }
+
+        var namesByID: [String: String] = [:]
+        var buffer = Data()
+
+        let processLine: (String) -> Void = { line in
+            guard let object = codexRolloutJSONObject(for: line),
+                  let sessionID = object["id"] as? String,
+                  sessionIDs.contains(sessionID),
+                  let rawThreadName = object["thread_name"] as? String else {
+                return
+            }
+
+            let threadName = rawThreadName.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !threadName.isEmpty else { return }
+
+            // Codex's session index is append-only. Scanning forward and
+            // replacing the value mirrors its batch lookup: the last valid,
+            // non-empty name for each thread wins.
+            namesByID[sessionID] = threadName
+        }
+
+        while let chunk = try? fileHandle.read(upToCount: Self.streamingChunkSize),
+              !chunk.isEmpty {
+            buffer.append(chunk)
+            for line in extractCompleteLines(from: &buffer) {
+                processLine(line)
+            }
+        }
+
+        if !buffer.isEmpty {
+            processLine(String(decoding: buffer, as: UTF8.self))
+        }
+
+        return namesByID
+    }
 
     private func parseSessionMeta(fromLine line: String) -> SessionMeta? {
         guard let object = codexRolloutJSONObject(for: line),

--- a/Sources/OpenIslandCore/CodexSessionTracking.swift
+++ b/Sources/OpenIslandCore/CodexSessionTracking.swift
@@ -1360,11 +1360,12 @@ public enum CodexRolloutReducer {
     }
 
     private static func isInjectedPromptBlock(_ text: String) -> Bool {
-        text.hasPrefix("# AGENTS.md instructions for ")
+        text.hasPrefix("# AGENTS.md instructions")
             || text.hasPrefix("<environment_context>")
             || text.hasPrefix("<permissions instructions>")
             || text.hasPrefix("<collaboration_mode>")
             || text.hasPrefix("<skills_instructions>")
+            || text.hasPrefix("<recommended_plugins>")
     }
 
     private static func clipped(_ value: String?, limit: Int = 110) -> String? {

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -60,10 +60,15 @@ public struct SessionState: Equatable, Sendable {
             let preservedFirstSeenAt = existingSession?.firstSeenAt
             var codexMetadata = payload.codexMetadata
             if payload.tool == .codex,
-               codexMetadata?.threadName == nil,
-               let existingThreadName = existingSession?.codexMetadata?.threadName {
+               let existingCodexMetadata = existingSession?.codexMetadata {
                 var preservedMetadata = codexMetadata ?? CodexSessionMetadata()
-                preservedMetadata.threadName = existingThreadName
+                preservedMetadata.transcriptPath = preservedMetadata.transcriptPath ?? existingCodexMetadata.transcriptPath
+                preservedMetadata.threadName = preservedMetadata.threadName ?? existingCodexMetadata.threadName
+                preservedMetadata.initialUserPrompt = preservedMetadata.initialUserPrompt ?? existingCodexMetadata.initialUserPrompt
+                preservedMetadata.lastUserPrompt = preservedMetadata.lastUserPrompt ?? existingCodexMetadata.lastUserPrompt
+                preservedMetadata.lastAssistantMessage = preservedMetadata.lastAssistantMessage ?? existingCodexMetadata.lastAssistantMessage
+                preservedMetadata.currentTool = preservedMetadata.currentTool ?? existingCodexMetadata.currentTool
+                preservedMetadata.currentCommandPreview = preservedMetadata.currentCommandPreview ?? existingCodexMetadata.currentCommandPreview
                 codexMetadata = preservedMetadata
             }
             let title = payload.tool == .codex

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -56,10 +56,24 @@ public struct SessionState: Equatable, Sendable {
     public mutating func apply(_ event: AgentEvent) {
         switch event {
         case let .sessionStarted(payload):
-            let preservedFirstSeenAt = sessionsByID[payload.sessionID]?.firstSeenAt
+            let existingSession = sessionsByID[payload.sessionID]
+            let preservedFirstSeenAt = existingSession?.firstSeenAt
+            var codexMetadata = payload.codexMetadata
+            if payload.tool == .codex,
+               codexMetadata?.threadName == nil,
+               let existingThreadName = existingSession?.codexMetadata?.threadName {
+                var preservedMetadata = codexMetadata ?? CodexSessionMetadata()
+                preservedMetadata.threadName = existingThreadName
+                codexMetadata = preservedMetadata
+            }
+            let title = payload.tool == .codex
+                && payload.codexMetadata?.threadName == nil
+                && existingSession?.codexMetadata?.threadName != nil
+                ? existingSession?.title ?? payload.title
+                : payload.title
             var session = AgentSession(
                 id: payload.sessionID,
-                title: payload.title,
+                title: title,
                 tool: payload.tool,
                 origin: payload.origin,
                 attachmentState: .attached,
@@ -68,7 +82,7 @@ public struct SessionState: Equatable, Sendable {
                 updatedAt: payload.timestamp,
                 firstSeenAt: preservedFirstSeenAt,
                 jumpTarget: payload.jumpTarget,
-                codexMetadata: payload.codexMetadata?.isEmpty == true ? nil : payload.codexMetadata,
+                codexMetadata: codexMetadata?.isEmpty == true ? nil : codexMetadata,
                 claudeMetadata: payload.claudeMetadata?.isEmpty == true ? nil : payload.claudeMetadata,
                 geminiMetadata: payload.geminiMetadata?.isEmpty == true ? nil : payload.geminiMetadata,
                 openCodeMetadata: payload.openCodeMetadata?.isEmpty == true ? nil : payload.openCodeMetadata,
@@ -166,7 +180,9 @@ public struct SessionState: Equatable, Sendable {
                 return
             }
 
-            session.codexMetadata = payload.codexMetadata.isEmpty ? nil : payload.codexMetadata
+            var metadata = payload.codexMetadata
+            metadata.threadName = metadata.threadName ?? session.codexMetadata?.threadName
+            session.codexMetadata = metadata.isEmpty ? nil : metadata
             session.updatedAt = payload.timestamp
             upsert(session)
 

--- a/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
+++ b/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
@@ -202,6 +202,7 @@ struct AgentSessionPresentationTests {
                 terminalSessionID: "ghostty-1"
             ),
             codexMetadata: CodexSessionMetadata(
+                threadName: "Open-Vibe-Island Fork",
                 initialUserPrompt: "Start by fixing the island hover behavior.",
                 lastUserPrompt: "Now make the overlay height fit the content.",
                 lastAssistantMessage: "Updating the layout logic."
@@ -209,8 +210,34 @@ struct AgentSessionPresentationTests {
         )
 
         // Headline uses initial prompt (session topic), prompt line uses latest
-        #expect(session.spotlightHeadlineText == "worktree · Start by fixing the island hover behavior.")
+        #expect(session.spotlightHeadlineText == "Open-Vibe-Island Fork · Start by fixing the island hover behavior.")
         #expect(session.spotlightPromptLineText == "You: Now make the overlay height fit the content.")
+    }
+
+    @Test
+    func claudeHeadlineStillUsesWorkspaceName() {
+        let session = AgentSession(
+            id: "claude-session",
+            title: "Claude · worktree",
+            tool: .claudeCode,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Working",
+            updatedAt: Date(timeIntervalSince1970: 10_000),
+            jumpTarget: JumpTarget(
+                terminalApp: "Ghostty",
+                workspaceName: "worktree",
+                paneTitle: "claude ~/tmp/worktree",
+                workingDirectory: "/tmp/worktree",
+                terminalSessionID: "ghostty-claude"
+            ),
+            claudeMetadata: ClaudeSessionMetadata(
+                initialUserPrompt: "Keep the Claude title unchanged."
+            )
+        )
+
+        #expect(session.spotlightHeadlineText == "worktree · Keep the Claude title unchanged.")
     }
 
     @Test

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -868,6 +868,120 @@ struct AppModelSessionListTests {
     }
 
     @Test
+    func rediscoveredCodexThreadNamePreservesNewerLiveState() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        var existing = AgentSession(
+            id: "codex-session",
+            title: "Codex · had",
+            tool: .codex,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Current live summary",
+            updatedAt: now,
+            jumpTarget: JumpTarget(
+                terminalApp: "Codex.app",
+                workspaceName: "had",
+                paneTitle: "Codex · had",
+                workingDirectory: "/tmp/had",
+                codexThreadID: "codex-session"
+            ),
+            codexMetadata: CodexSessionMetadata(
+                transcriptPath: "/tmp/codex.jsonl",
+                initialUserPrompt: "Current initial prompt",
+                lastUserPrompt: "Current latest prompt",
+                lastAssistantMessage: "Current assistant response"
+            )
+        )
+        existing.isCodexAppSession = true
+        existing.isProcessAlive = true
+
+        let model = AppModel()
+        let merged = model.discovery.mergingCodexThreadNames(
+            ["codex-session": "Open-Vibe-Island Fork"],
+            into: [existing]
+        )
+
+        #expect(merged.count == 1)
+        #expect(merged.first?.title == "Codex · Open-Vibe-Island Fork")
+        #expect(merged.first?.codexMetadata?.threadName == "Open-Vibe-Island Fork")
+        #expect(merged.first?.phase == .running)
+        #expect(merged.first?.summary == "Current live summary")
+        #expect(merged.first?.updatedAt == now)
+        #expect(merged.first?.attachmentState == .attached)
+        #expect(merged.first?.jumpTarget?.workspaceName == "had")
+        #expect(merged.first?.codexMetadata?.initialUserPrompt == "Current initial prompt")
+        #expect(merged.first?.codexMetadata?.lastUserPrompt == "Current latest prompt")
+        #expect(merged.first?.codexMetadata?.lastAssistantMessage == "Current assistant response")
+        #expect(merged.first?.isCodexAppSession == true)
+        #expect(merged.first?.isProcessAlive == true)
+    }
+
+    @Test
+    func codexAppServerPublishesGeneratedThreadNameImmediately() {
+        let coordinator = CodexAppServerCoordinator()
+        var receivedSessionID: String?
+        var receivedThreadName: String?
+        coordinator.onThreadNameUpdated = { sessionID, threadName in
+            receivedSessionID = sessionID
+            receivedThreadName = threadName
+        }
+
+        coordinator.handleNotification(
+            .threadNameUpdated(
+                threadId: "codex-session",
+                name: "  Handle test prompt  "
+            )
+        )
+
+        #expect(receivedSessionID == "codex-session")
+        #expect(receivedThreadName == "Handle test prompt")
+    }
+
+    @Test
+    func codexThreadNameMonitoringDoesNotWaitForRolloutDiscovery() async throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-title-monitor-\(UUID().uuidString)", isDirectory: true)
+        let indexURL = rootURL.appendingPathComponent("session_index.jsonl")
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+        try #"{"id":"codex-session","thread_name":"Handle test prompt"}"#
+            .write(to: indexURL, atomically: true, encoding: .utf8)
+
+        let discovery = SessionDiscoveryCoordinator(
+            codexRolloutDiscovery: CodexRolloutDiscovery(
+                rootURL: rootURL.appendingPathComponent("missing-rollouts"),
+                sessionIndexURL: indexURL
+            )
+        )
+        defer { discovery.stopCodexThreadNameMonitoring() }
+
+        var state = SessionState(sessions: [
+            AgentSession(
+                id: "codex-session",
+                title: "Codex · hi",
+                tool: .codex,
+                origin: .live,
+                attachmentState: .attached,
+                phase: .completed,
+                summary: "Done",
+                updatedAt: .now,
+                codexMetadata: CodexSessionMetadata(initialUserPrompt: "hi this is a test")
+            ),
+        ])
+        discovery.stateAccessor = { state }
+        discovery.stateUpdater = { state = $0 }
+
+        discovery.startCodexThreadNameMonitoringIfNeeded()
+        for _ in 0..<20 where state.session(id: "codex-session")?.codexMetadata?.threadName == nil {
+            try await Task.sleep(for: .milliseconds(50))
+        }
+
+        #expect(state.session(id: "codex-session")?.title == "Codex · Handle test prompt")
+        #expect(state.session(id: "codex-session")?.codexMetadata?.threadName == "Handle test prompt")
+    }
+
+    @Test
     func mergeDiscoveredClaudeSessionsPreservesRegistryJumpTargetAndAddsTranscriptMetadata() {
         let now = Date(timeIntervalSince1970: 2_000)
         let model = AppModel()

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -824,6 +824,50 @@ struct AppModelSessionListTests {
     }
 
     @Test
+    func mergeDiscoveredCodexSessionsRepairsCachedContextualPrompt() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let model = AppModel()
+        model.state = SessionState(
+            sessions: [
+                AgentSession(
+                    id: "codex-session",
+                    title: "Codex · open-island",
+                    tool: .codex,
+                    origin: .live,
+                    attachmentState: .stale,
+                    phase: .completed,
+                    summary: "Recovered from registry",
+                    updatedAt: now.addingTimeInterval(-60),
+                    codexMetadata: CodexSessionMetadata(
+                        transcriptPath: "/tmp/codex.jsonl",
+                        initialUserPrompt: "<recommended_plugins>stale contextual metadata</recommended_plugins>"
+                    )
+                ),
+            ]
+        )
+
+        let merged = model.discovery.mergeDiscoveredSessions([
+            AgentSession(
+                id: "codex-session",
+                title: "Codex · open-island",
+                tool: .codex,
+                origin: .live,
+                attachmentState: .stale,
+                phase: .running,
+                summary: "Recovered from transcript",
+                updatedAt: now,
+                codexMetadata: CodexSessionMetadata(
+                    transcriptPath: "/tmp/codex.jsonl",
+                    initialUserPrompt: "Fix the Codex session title."
+                )
+            ),
+        ])
+
+        #expect(merged.count == 1)
+        #expect(merged.first?.codexMetadata?.initialUserPrompt == "Fix the Codex session title.")
+    }
+
+    @Test
     func mergeDiscoveredClaudeSessionsPreservesRegistryJumpTargetAndAddsTranscriptMetadata() {
         let now = Date(timeIntervalSince1970: 2_000)
         let model = AppModel()

--- a/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
@@ -1176,6 +1176,7 @@ struct CodexSessionTrackingTests {
 
         let discovery = CodexRolloutDiscovery(
             rootURL: rootURL,
+            sessionIndexURL: rootURL.appendingPathComponent("missing-session-index.jsonl"),
             fileManager: .default,
             maxAge: 86_400,
             maxFiles: 10
@@ -1199,6 +1200,86 @@ struct CodexSessionTrackingTests {
         #expect(records.first?.codexMetadata?.currentCommandPreview == nil)
         #expect(records.first?.origin == .live)
         #expect(records.first?.attachmentState == .stale)
+    }
+
+    @Test
+    func codexRolloutDiscoveryUsesLatestIndexedThreadName() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-discovery-title-\(UUID().uuidString)", isDirectory: true)
+        let rolloutDirectoryURL = rootURL.appendingPathComponent("2026/04/02", isDirectory: true)
+        let rolloutURL = rolloutDirectoryURL.appendingPathComponent("rollout-named.jsonl")
+        let sessionIndexURL = rootURL.appendingPathComponent("session_index.jsonl")
+        let now = Date(timeIntervalSince1970: 1_743_555_200)
+
+        try FileManager.default.createDirectory(at: rolloutDirectoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let rollout = [
+            sessionMetaLine(
+                sessionID: "codex-session-named",
+                timestamp: "2026-04-02T04:03:44.000Z",
+                cwd: "/Users/wangruobing/Personal/had"
+            ),
+            rolloutLine(
+                timestamp: "2026-04-02T04:03:45.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "user_message",
+                    "message": "Fix the session title.",
+                ]
+            ),
+        ]
+        try rollout.joined(separator: "\n").appending("\n")
+            .write(to: rolloutURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.modificationDate: now], ofItemAtPath: rolloutURL.path)
+
+        let indexLines = [
+            #"{"id":"other-session","thread_name":"Ignore me","updated_at":"2026-04-02T04:03:40Z"}"#,
+            #"{"id":"codex-session-named","thread_name":"Old title","updated_at":"2026-04-02T04:03:41Z"}"#,
+            #"{"id":"codex-session-named","thread_name":"   ","updated_at":"2026-04-02T04:03:42Z"}"#,
+            "not valid JSON",
+            #"{"id":"codex-session-named","thread_name":"Open-Vibe-Island Fork","updated_at":"2026-04-02T04:03:43Z"}"#,
+        ]
+        // Deliberately omit the trailing newline to cover an index mid-flush.
+        try indexLines.joined(separator: "\n")
+            .write(to: sessionIndexURL, atomically: true, encoding: .utf8)
+
+        let discovery = CodexRolloutDiscovery(
+            rootURL: rootURL,
+            sessionIndexURL: sessionIndexURL,
+            fileManager: .default,
+            maxAge: 86_400,
+            maxFiles: 10
+        )
+
+        let records = discovery.discoverRecentSessions(now: now)
+
+        #expect(records.count == 1)
+        #expect(records.first?.title == "Codex · Open-Vibe-Island Fork")
+        #expect(records.first?.codexMetadata?.threadName == "Open-Vibe-Island Fork")
+        #expect(records.first?.codexMetadata?.initialUserPrompt == "Fix the session title.")
+    }
+
+    @Test
+    func codexRolloutDiscoveryReadsThreadNamesWithoutParsingRollouts() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-index-only-\(UUID().uuidString)", isDirectory: true)
+        let sessionIndexURL = rootURL.appendingPathComponent("session_index.jsonl")
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        try #"{"id":"codex-session","thread_name":"Handle test prompt"}"#
+            .write(to: sessionIndexURL, atomically: true, encoding: .utf8)
+
+        let discovery = CodexRolloutDiscovery(
+            rootURL: rootURL.appendingPathComponent("missing-rollouts"),
+            sessionIndexURL: sessionIndexURL
+        )
+
+        #expect(
+            discovery.indexedThreadNames(for: ["codex-session"])
+                == ["codex-session": "Handle test prompt"]
+        )
     }
 
     @Test
@@ -1267,6 +1348,7 @@ struct CodexSessionTrackingTests {
 
         let discovery = CodexRolloutDiscovery(
             rootURL: rootURL,
+            sessionIndexURL: rootURL.appendingPathComponent("missing-session-index.jsonl"),
             fileManager: .default,
             maxAge: 86_400,
             maxFiles: 10
@@ -1318,6 +1400,7 @@ struct CodexSessionTrackingTests {
 
         let discovery = CodexRolloutDiscovery(
             rootURL: rootURL,
+            sessionIndexURL: rootURL.appendingPathComponent("missing-session-index.jsonl"),
             fileManager: .default,
             maxAge: 86_400,
             maxFiles: 10

--- a/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
@@ -791,7 +791,11 @@ struct CodexSessionTrackingTests {
                     "content": [
                         [
                             "type": "input_text",
-                            "text": "# AGENTS.md instructions for /tmp/repo\n\n<INSTRUCTIONS>\nRepository guide\n</INSTRUCTIONS>",
+                            "text": "<recommended_plugins>\nHere is a list of plugins that are available but not installed.\n\n- Example (example@openai-curated-remote)\n</recommended_plugins>",
+                        ],
+                        [
+                            "type": "input_text",
+                            "text": "# AGENTS.md instructions\n\n<INSTRUCTIONS>\nRepository guide\n</INSTRUCTIONS>",
                         ],
                         [
                             "type": "input_text",

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -66,6 +66,58 @@ struct SessionStateTests {
         #expect(state.session(id: "codex-named")?.codexMetadata?.threadName == "Open-Vibe-Island Fork")
     }
 
+    @Test
+    func codexSessionRestartPreservesMetadataMissingFromHookPayload() {
+        let startedAt = Date(timeIntervalSince1970: 1_000)
+        var state = SessionState()
+
+        state.apply(
+            .sessionStarted(
+                SessionStarted(
+                    sessionID: "codex-restart",
+                    title: "Codex · Open-Vibe-Island Fork",
+                    tool: .codex,
+                    origin: .live,
+                    summary: "Working",
+                    timestamp: startedAt,
+                    codexMetadata: CodexSessionMetadata(
+                        transcriptPath: "/tmp/codex-restart.jsonl",
+                        threadName: "Open-Vibe-Island Fork",
+                        initialUserPrompt: "Fix the title.",
+                        lastUserPrompt: "Inspect the session index.",
+                        lastAssistantMessage: "I found the index entry.",
+                        currentTool: "functions.exec",
+                        currentCommandPreview: "swift test"
+                    )
+                )
+            )
+        )
+
+        state.apply(
+            .sessionStarted(
+                SessionStarted(
+                    sessionID: "codex-restart",
+                    title: "Codex · had",
+                    tool: .codex,
+                    origin: .live,
+                    summary: "Resumed from a hook",
+                    timestamp: startedAt.addingTimeInterval(10),
+                    codexMetadata: CodexSessionMetadata(lastUserPrompt: "Continue the fix.")
+                )
+            )
+        )
+
+        let metadata = state.session(id: "codex-restart")?.codexMetadata
+        #expect(state.session(id: "codex-restart")?.title == "Codex · Open-Vibe-Island Fork")
+        #expect(metadata?.transcriptPath == "/tmp/codex-restart.jsonl")
+        #expect(metadata?.threadName == "Open-Vibe-Island Fork")
+        #expect(metadata?.initialUserPrompt == "Fix the title.")
+        #expect(metadata?.lastUserPrompt == "Continue the fix.")
+        #expect(metadata?.lastAssistantMessage == "I found the index entry.")
+        #expect(metadata?.currentTool == "functions.exec")
+        #expect(metadata?.currentCommandPreview == "swift test")
+    }
+
     /// Completed Codex CLI sessions outside Codex.app should age out even while Codex.app is running.
     @Test
     func completedCodexCLISessionEndsEvenWhenCodexAppIsRunning() {

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -5,6 +5,67 @@ import Testing
 
 /// Regression coverage for core session lifecycle and visibility behavior.
 struct SessionStateTests {
+    @Test
+    func codexMetadataUpdatesPreserveIndexedThreadName() {
+        let startedAt = Date(timeIntervalSince1970: 1_000)
+        var state = SessionState()
+
+        state.apply(
+            .sessionStarted(
+                SessionStarted(
+                    sessionID: "codex-named",
+                    title: "Codex · Open-Vibe-Island Fork",
+                    tool: .codex,
+                    origin: .live,
+                    summary: "Working",
+                    timestamp: startedAt,
+                    codexMetadata: CodexSessionMetadata(
+                        transcriptPath: "/tmp/codex.jsonl",
+                        threadName: "Open-Vibe-Island Fork",
+                        initialUserPrompt: "Fix the title."
+                    )
+                )
+            )
+        )
+
+        state.apply(
+            .sessionMetadataUpdated(
+                SessionMetadataUpdated(
+                    sessionID: "codex-named",
+                    codexMetadata: CodexSessionMetadata(
+                        transcriptPath: "/tmp/codex.jsonl",
+                        initialUserPrompt: "Fix the title.",
+                        lastUserPrompt: "Keep the generated name."
+                    ),
+                    timestamp: startedAt.addingTimeInterval(5)
+                )
+            )
+        )
+
+        #expect(state.session(id: "codex-named")?.codexMetadata?.threadName == "Open-Vibe-Island Fork")
+        #expect(state.session(id: "codex-named")?.codexMetadata?.lastUserPrompt == "Keep the generated name.")
+
+        state.apply(
+            .sessionStarted(
+                SessionStarted(
+                    sessionID: "codex-named",
+                    title: "Codex · had",
+                    tool: .codex,
+                    origin: .live,
+                    summary: "Resumed from a hook",
+                    timestamp: startedAt.addingTimeInterval(10),
+                    codexMetadata: CodexSessionMetadata(
+                        transcriptPath: "/tmp/codex.jsonl",
+                        initialUserPrompt: "Fix the title."
+                    )
+                )
+            )
+        )
+
+        #expect(state.session(id: "codex-named")?.title == "Codex · Open-Vibe-Island Fork")
+        #expect(state.session(id: "codex-named")?.codexMetadata?.threadName == "Open-Vibe-Island Fork")
+    }
+
     /// Completed Codex CLI sessions outside Codex.app should age out even while Codex.app is running.
     @Test
     func completedCodexCLISessionEndsEvenWhenCodexAppIsRunning() {


### PR DESCRIPTION
## Summary

- ignore Codex-injected `<recommended_plugins>` and pathless AGENTS context when selecting the initial user prompt
- use Codex's generated thread name for session headlines while keeping the workspace identity for grouping and jump-back
- reconcile generated and renamed titles from `session_index.jsonl` independently of large rollout transcripts, and consume live app-server rename notifications
- preserve live session state and cached titles while preventing overlapping rollout rediscovery passes

## Test Plan

- `swift test --filter CodexSessionTrackingTests`
- focused `SessionStateTests`, `AppModelSessionListTests`, and `AgentSessionPresentationTests` title regressions
- `swift build`
- manual verification with Codex.app thread generation and rename behavior
- `swift test` *(title regressions pass; the full run still reports pre-existing shared-preference failures in three appearance tests and one flaky AgentsGrid observation test)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Codex session titles now preferentially reflect the latest thread name when available.
  - Thread-title updates can appear live during an active session, without requiring a full refresh.
  - Session discovery can populate Codex thread names from the session index data.

- **Bug Fixes**
  - Preserved Codex thread names and session context across metadata updates and rediscovery.
  - Spotlight headlines now use thread names for Codex while keeping workspace names for other tools.
  - Improved recognition of additional injected prompt content during session tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->