### PR TITLE
fix: keep display preference across monitor reconnect

### DIFF
--- a/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
+++ b/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
@@ -6,6 +6,10 @@ struct OverlayDisplayOption: Identifiable, Equatable {
     let id: String
     let title: String
     let subtitle: String
+    /// `false` when this entry represents a remembered display that is not
+    /// currently connected. Such entries are kept in the picker so the saved
+    /// preference survives a disconnect and the island routes back on reconnect.
+    var isConnected: Bool = true
 }
 
 enum OverlayPlacementMode: String, Equatable {
@@ -67,6 +71,50 @@ enum OverlayDisplayResolver {
                 subtitle: "\(screenKindDescription(for: screen)) · \(Int(screen.frame.width))×\(Int(screen.frame.height))"
             )
         }
+    }
+
+    struct DisplaySelectionState: Equatable {
+        /// The picker option list, including a remembered (not-connected) entry
+        /// when the preferred display is temporarily unplugged.
+        let options: [OverlayDisplayOption]
+        /// `true` when the current preference is "automatic" or points at a
+        /// display that is connected right now.
+        let isPreferredDisplayConnected: Bool
+    }
+
+    /// Reconciles the picker option list with the persisted selection **without
+    /// mutating the selection or its persistence.**
+    ///
+    /// When the preferred display is temporarily disconnected (cable pulled,
+    /// sleep, KVM switch) its remembered entry is kept in the list — marked
+    /// `isConnected == false` — instead of the selection being reset to
+    /// automatic. Keeping the preference is what lets the island route straight
+    /// back to that monitor when it reconnects, rather than getting stuck on the
+    /// built-in screen. Placement itself falls back gracefully through
+    /// `resolveScreen(preferredScreenID:)` while the display is absent.
+    static func reconcileDisplaySelection(
+        selectionID: String,
+        rememberedName: String?,
+        connectedOptions: [OverlayDisplayOption]
+    ) -> DisplaySelectionState {
+        if selectionID == OverlayDisplayOption.automaticID
+            || connectedOptions.contains(where: { $0.id == selectionID }) {
+            return DisplaySelectionState(
+                options: connectedOptions,
+                isPreferredDisplayConnected: true
+            )
+        }
+
+        let remembered = OverlayDisplayOption(
+            id: selectionID,
+            title: rememberedName ?? selectionID,
+            subtitle: "",
+            isConnected: false
+        )
+        return DisplaySelectionState(
+            options: connectedOptions + [remembered],
+            isPreferredDisplayConnected: false
+        )
     }
 
     static func diagnostics(preferredScreenID: String?, panelSize: NSSize) -> OverlayPlacementDiagnostics? {
@@ -180,8 +228,9 @@ enum OverlayDisplayResolver {
     /// Disambiguates identical displays (e.g. two AirPlay receivers with the
     /// same model name and resolution) by appending the arrangement origin.
     /// The origin is not stable across display rearrangement, but a mismatched
-    /// preference will self-heal through the existing
-    /// `validSelectionIDs.contains` check in `refreshOverlayDisplayConfiguration()`.
+    /// preference simply falls back to the built-in notch via
+    /// `resolveScreen(preferredScreenID:)`; the stored preference is left intact
+    /// so the island routes back once the intended display returns.
     private static func fallbackScreenID(for screen: NSScreen) -> String {
         let width = Int(screen.frame.width.rounded())
         let height = Int(screen.frame.height.rounded())

--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -93,7 +93,7 @@ final class OverlayUICoordinator {
 
     func restoreDisplayPreference() {
         overlayDisplaySelectionID = UserDefaults.standard.string(
-            forKey: "overlay.display.preference"
+            forKey: Self.displayPreferenceKey
         ) ?? OverlayDisplayOption.automaticID
     }
 
@@ -258,12 +258,23 @@ final class OverlayUICoordinator {
     // MARK: - Display configuration
 
     func refreshOverlayDisplayConfiguration() {
-        overlayDisplayOptions = overlayPanelController.availableDisplayOptions()
+        let connectedOptions = overlayPanelController.availableDisplayOptions()
+        let resolution = OverlayDisplayResolver.reconcileDisplaySelection(
+            selectionID: overlayDisplaySelectionID,
+            rememberedName: rememberedOverlayDisplayName,
+            connectedOptions: connectedOptions
+        )
 
-        let validSelectionIDs = Set(overlayDisplayOptions.map(\.id))
-        if !validSelectionIDs.contains(overlayDisplaySelectionID) {
-            overlayDisplaySelectionID = OverlayDisplayOption.automaticID
-            return
+        overlayDisplayOptions = resolution.options
+
+        // Keep the friendly name of the chosen display fresh while it is
+        // connected, so the picker can still label it after a later disconnect.
+        // The preference itself is never reset here — a temporarily unplugged
+        // display must survive so the island returns to it on reconnect.
+        if resolution.isPreferredDisplayConnected,
+           overlayDisplaySelectionID != OverlayDisplayOption.automaticID,
+           let name = connectedOptions.first(where: { $0.id == overlayDisplaySelectionID })?.title {
+            rememberOverlayDisplayName(name)
         }
 
         refreshOverlayPlacement()
@@ -509,12 +520,29 @@ final class OverlayUICoordinator {
 
     // MARK: - Persistence
 
+    private static let displayPreferenceKey = "overlay.display.preference"
+    private static let displayPreferenceNameKey = "overlay.display.preference.name"
+
+    private var rememberedOverlayDisplayName: String? {
+        UserDefaults.standard.string(forKey: Self.displayPreferenceNameKey)
+    }
+
+    private func rememberOverlayDisplayName(_ name: String) {
+        UserDefaults.standard.set(name, forKey: Self.displayPreferenceNameKey)
+    }
+
     private func persistOverlayDisplayPreference() {
         let defaults = UserDefaults.standard
         if overlayDisplaySelectionID == OverlayDisplayOption.automaticID {
-            defaults.removeObject(forKey: "overlay.display.preference")
+            defaults.removeObject(forKey: Self.displayPreferenceKey)
+            defaults.removeObject(forKey: Self.displayPreferenceNameKey)
         } else {
-            defaults.set(overlayDisplaySelectionID, forKey: "overlay.display.preference")
+            defaults.set(overlayDisplaySelectionID, forKey: Self.displayPreferenceKey)
+            // Capture the friendly name at pick time; the chosen display is
+            // connected now, so it is present in the current option list.
+            if let name = overlayDisplayOptions.first(where: { $0.id == overlayDisplaySelectionID })?.title {
+                defaults.set(name, forKey: Self.displayPreferenceNameKey)
+            }
         }
     }
 }

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -117,6 +117,7 @@
 /* Settings - Display */
 "settings.display.monitor" = "Monitor";
 "settings.display.position" = "Display Position";
+"settings.display.disconnected" = "disconnected";
 "settings.display.diagnostics" = "Diagnostics";
 "settings.display.currentScreen" = "Current Screen";
 "settings.display.layoutMode" = "Layout Mode";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -117,6 +117,7 @@
 /* Settings - Display */
 "settings.display.monitor" = "显示器";
 "settings.display.position" = "显示位置";
+"settings.display.disconnected" = "未连接";
 "settings.display.diagnostics" = "诊断";
 "settings.display.currentScreen" = "当前屏幕";
 "settings.display.layoutMode" = "布局模式";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -117,6 +117,7 @@
 /* Settings - Display */
 "settings.display.monitor" = "顯示器";
 "settings.display.position" = "顯示位置";
+"settings.display.disconnected" = "未連接";
 "settings.display.diagnostics" = "診斷";
 "settings.display.currentScreen" = "目前螢幕";
 "settings.display.layoutMode" = "版面模式";

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -4,6 +4,15 @@ import OpenIslandCore
 
 // MARK: - Settings tabs
 
+/// Picker label for a display option. A remembered display that is not
+/// currently connected is suffixed so the user can see their choice is retained
+/// while the island temporarily falls back to the built-in screen.
+func overlayDisplayOptionLabel(_ option: OverlayDisplayOption, lang: LanguageManager) -> String {
+    option.isConnected
+        ? option.title
+        : "\(option.title) (\(lang.t("settings.display.disconnected")))"
+}
+
 enum SettingsTab: String, CaseIterable, Identifiable {
     case general
     case setup
@@ -188,7 +197,7 @@ struct GeneralSettingsPane: View {
                 )) {
                     Text(lang.t("settings.general.automatic")).tag(OverlayDisplayOption.automaticID)
                     ForEach(model.overlayDisplayOptions) { option in
-                        Text(option.title).tag(option.id)
+                        Text(overlayDisplayOptionLabel(option, lang: lang)).tag(option.id)
                     }
                 }
             }
@@ -247,7 +256,7 @@ struct DisplaySettingsPane: View {
                 )) {
                     Text(lang.t("settings.general.automatic")).tag(OverlayDisplayOption.automaticID)
                     ForEach(model.overlayDisplayOptions) { option in
-                        Text(option.title).tag(option.id)
+                        Text(overlayDisplayOptionLabel(option, lang: lang)).tag(option.id)
                     }
                 }
             }

--- a/Tests/OpenIslandAppTests/OverlayPanelControllerTests.swift
+++ b/Tests/OpenIslandAppTests/OverlayPanelControllerTests.swift
@@ -116,4 +116,68 @@ struct OverlayPanelControllerTests {
         let height = NSScreen.computeIslandClosedHeight(safeAreaInsetsTop: 0, topStatusBarHeight: 24)
         #expect(height == 24)
     }
+
+    // MARK: - Display selection reconciliation (reconnect survival)
+
+    private static func makeOption(_ id: String, _ title: String) -> OverlayDisplayOption {
+        OverlayDisplayOption(id: id, title: title, subtitle: "")
+    }
+
+    @Test
+    func automaticSelectionLeavesConnectedOptionsUntouched() {
+        let connected = [Self.makeOption("built-in", "Built-in Display")]
+        let state = OverlayDisplayResolver.reconcileDisplaySelection(
+            selectionID: OverlayDisplayOption.automaticID,
+            rememberedName: nil,
+            connectedOptions: connected
+        )
+        #expect(state.isPreferredDisplayConnected)
+        #expect(state.options == connected)
+    }
+
+    @Test
+    func connectedPreferredSelectionLeavesOptionsUntouched() {
+        let connected = [
+            Self.makeOption("built-in", "Built-in Display"),
+            Self.makeOption("EXT-UUID", "L34A650U")
+        ]
+        let state = OverlayDisplayResolver.reconcileDisplaySelection(
+            selectionID: "EXT-UUID",
+            rememberedName: "L34A650U",
+            connectedOptions: connected
+        )
+        #expect(state.isPreferredDisplayConnected)
+        #expect(state.options == connected)
+    }
+
+    @Test
+    func disconnectedPreferredSelectionIsKeptAsRememberedOption() {
+        // The external monitor is unplugged: it must NOT be dropped/reset, so the
+        // preference survives and the island can route back on reconnect.
+        let connected = [Self.makeOption("built-in", "Built-in Display")]
+        let state = OverlayDisplayResolver.reconcileDisplaySelection(
+            selectionID: "EXT-UUID",
+            rememberedName: "L34A650U",
+            connectedOptions: connected
+        )
+        #expect(!state.isPreferredDisplayConnected)
+        #expect(state.options.count == 2)
+
+        let remembered = state.options.last
+        #expect(remembered?.id == "EXT-UUID")
+        #expect(remembered?.title == "L34A650U")
+        #expect(remembered?.isConnected == false)
+    }
+
+    @Test
+    func disconnectedPreferredSelectionFallsBackToIDWhenNameUnknown() {
+        let state = OverlayDisplayResolver.reconcileDisplaySelection(
+            selectionID: "EXT-UUID",
+            rememberedName: nil,
+            connectedOptions: []
+        )
+        #expect(!state.isPreferredDisplayConnected)
+        #expect(state.options.last?.title == "EXT-UUID")
+        #expect(state.options.last?.isConnected == false)
+    }
 }


### PR DESCRIPTION
## Problem
When you pick a specific external monitor for the island (Settings → Display / Monitor) and then unplug and replug that monitor, the island reverts to the built-in notch and the saved preference is gone — you have to re-pick the monitor every single time the cable is disconnected.

## Root cause
`OverlayUICoordinator.refreshOverlayDisplayConfiguration()` reset `overlayDisplaySelectionID` to `automatic` whenever the saved display was not in the currently-connected set. That assignment's `didSet` calls `persistOverlayDisplayPreference()`, which **removes** the key from `UserDefaults` when the value is `automatic`. So a transient disconnect permanently erased the stored preference; on reconnect there was nothing left to restore.

## Fix
- Stop resetting the selection just because a display is temporarily absent. A new pure function `OverlayDisplayResolver.reconcileDisplaySelection(...)` keeps a disconnected preferred display as a remembered, `isConnected == false` picker entry instead. Placement already falls back to the built-in notch via `resolveScreen(preferredScreenID:)` while the display is gone, and routes back automatically on reconnect.
- Persist the display's friendly name (`overlay.display.preference.name`) so the picker can show `<name> (disconnected)` rather than a bare UUID.
- New localization key `settings.display.disconnected` (en / zh-Hans / zh-Hant).
- Unit tests covering the automatic / connected / disconnected-with-name / disconnected-without-name states.

## Verification
- `swift build` — clean (Swift 6.2.4).
- `swift test` needs XCTest (only bundled with a full Xcode, unavailable in my environment). The new logic uses `swift-testing`; I additionally verified it by compiling the real `OverlayDisplayConfiguration.swift` against a small assertion harness — all cases pass, including the reconnect-survival case.

## 中文
修复：拔插外接显示器后灵动岛显示器偏好被清除的问题。此前当首选显示器断开时，`refreshOverlayDisplayConfiguration()` 会把选择重置为“自动”，其 `didSet` 又从 `UserDefaults` 删除该键，导致重新连接后无法恢复，只能每次重新选择。现在断开时保留偏好（在选择器中标记为“未连接”），重新连接后自动切回。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Remembered display selections are preserved when a preferred display is temporarily disconnected.
  - Disconnected displays remain visible in display settings and are labeled accordingly.
  - Overlay placement continues to use an available display while retaining the saved preference for reconnection.

- **Localization**
  - Added “disconnected” labels in English, Simplified Chinese, and Traditional Chinese.

- **Tests**
  - Added coverage for automatic, connected, disconnected, and unknown display selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->