### PR TITLE
fix: fold Codex rollout appends incrementally in rediscover scans

### DIFF
--- a/Sources/OpenIslandCore/CodexSessionTracking.swift
+++ b/Sources/OpenIslandCore/CodexSessionTracking.swift
@@ -342,6 +342,20 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
     private struct Candidate {
         var fileURL: URL
         var modifiedAt: Date
+        var fileSize: Int
+    }
+
+    /// Per-file incremental parse state. `snapshot`/`sessionMeta` only
+    /// reflect bytes up to `consumedOffset` — always the end of the last
+    /// complete line — so a partial trailing line is never folded in twice
+    /// when a later append completes it.
+    private struct ParseState {
+        var consumedOffset: Int
+        var snapshot: CodexRolloutSnapshot
+        var sessionMeta: SessionMeta?
+        var fileSize: Int
+        var modifiedAt: Date
+        var record: CodexTrackedSessionRecord?
     }
 
     private struct SessionMeta {
@@ -373,6 +387,10 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
     private let maxAge: TimeInterval
     private let maxFiles: Int
 
+    private let stateLock = NSLock()
+    private var parseStates: [String: ParseState] = [:]
+    private var scanInProgress = false
+
     public init(
         rootURL: URL = CodexRolloutDiscovery.defaultRootURL,
         fileManager: FileManager = .default,
@@ -386,10 +404,26 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
     }
 
     public func discoverRecentSessions(now: Date = .now) -> [CodexTrackedSessionRecord] {
+        // Re-entrancy guard: with a large active rollout a scan can outlast
+        // the caller's 10s rediscover throttle, and overlapping scans parse
+        // the same files on multiple threads at once.
+        stateLock.lock()
+        if scanInProgress {
+            stateLock.unlock()
+            return []
+        }
+        scanInProgress = true
+        stateLock.unlock()
+        defer {
+            stateLock.lock()
+            scanInProgress = false
+            stateLock.unlock()
+        }
+
         guard fileManager.fileExists(atPath: rootURL.path),
               let enumerator = fileManager.enumerator(
                 at: rootURL,
-                includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey],
+                includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey, .fileSizeKey],
                 options: [.skipsHiddenFiles]
               ) else {
             return []
@@ -405,7 +439,7 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             }
 
             guard let resourceValues = try? fileURL.resourceValues(
-                forKeys: [.contentModificationDateKey, .isRegularFileKey]
+                forKeys: [.contentModificationDateKey, .isRegularFileKey, .fileSizeKey]
             ),
             resourceValues.isRegularFile == true else {
                 continue
@@ -416,7 +450,11 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
                 continue
             }
 
-            candidates.append(Candidate(fileURL: fileURL, modifiedAt: modifiedAt))
+            candidates.append(Candidate(
+                fileURL: fileURL,
+                modifiedAt: modifiedAt,
+                fileSize: resourceValues.fileSize ?? 0
+            ))
         }
 
         let recentCandidates = candidates
@@ -429,11 +467,19 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             }
             .prefix(maxFiles)
 
+        // Drop parse state for files that fell out of the scan window so
+        // the cache stays bounded by `maxFiles`.
+        let candidatePaths = Set(recentCandidates.map { $0.fileURL.path })
+        stateLock.lock()
+        parseStates = parseStates.filter { candidatePaths.contains($0.key) }
+        stateLock.unlock()
+
         var recordsByID: [String: CodexTrackedSessionRecord] = [:]
         for candidate in recentCandidates {
             guard let record = discoverRecord(
                 fileURL: candidate.fileURL,
-                modifiedAt: candidate.modifiedAt
+                modifiedAt: candidate.modifiedAt,
+                fileSize: candidate.fileSize
             ) else {
                 continue
             }
@@ -456,27 +502,57 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
 
     private func discoverRecord(
         fileURL: URL,
-        modifiedAt: Date
+        modifiedAt: Date,
+        fileSize: Int
     ) -> CodexTrackedSessionRecord? {
-        // Stream the rollout line by line instead of slurping the whole
-        // file. Long-lived Codex sessions accumulate JSONL files of tens
-        // of MB; combined with the 10s rediscover throttle that meant a
-        // full-file `String(contentsOf:)` + `split` + `map(String.init)`
-        // every 10 seconds — high autorelease churn that pushed the app
-        // toward swap. Peak working set is now one chunk plus the
-        // accumulated `CodexRolloutSnapshot`.
+        // Rollouts are append-only folds, so parse them incrementally:
+        // cache the accumulated snapshot per file and only reduce bytes
+        // past `consumedOffset`. Re-reducing every recent rollout from
+        // byte 0 on each 10s rediscover pass pinned a core for hours once
+        // an active session's file grew past a few tens of MB (a single
+        // 80 MB rollout takes ~the whole 10s window to fold), and the
+        // resulting overlap stacked concurrent full parses on top.
+        let path = fileURL.path
+
+        stateLock.lock()
+        var state = parseStates[path]
+        stateLock.unlock()
+
+        if let cached = state, cached.fileSize == fileSize, cached.modifiedAt == modifiedAt {
+            return cached.record
+        }
+        if let cached = state, fileSize < cached.consumedOffset {
+            // Truncated or replaced in place — the cached fold no longer
+            // matches the bytes on disk.
+            state = nil
+        }
+
         guard let fileHandle = try? FileHandle(forReadingFrom: fileURL) else {
             return nil
         }
         defer { try? fileHandle.close() }
 
-        var snapshot = CodexRolloutSnapshot()
-        var sessionMeta: SessionMeta?
+        var snapshot = state?.snapshot ?? CodexRolloutSnapshot()
+        var sessionMeta = state?.sessionMeta
+        var startOffset = state?.consumedOffset ?? 0
+
+        if startOffset > 0 {
+            do {
+                try fileHandle.seek(toOffset: UInt64(startOffset))
+            } catch {
+                snapshot = CodexRolloutSnapshot()
+                sessionMeta = nil
+                startOffset = 0
+            }
+        }
+
         var buffer = Data()
+        var bytesRead = 0
 
         while let chunk = try? fileHandle.read(upToCount: Self.streamingChunkSize),
               !chunk.isEmpty {
             buffer.append(chunk)
+            bytesRead += chunk.count
             for line in extractCompleteLines(from: &buffer) {
                 CodexRolloutReducer.apply(line: line, to: &snapshot)
                 if sessionMeta == nil {
@@ -485,17 +561,52 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             }
         }
 
+        // Cache only the fold over complete lines; the leftover partial
+        // line is folded into a throwaway copy below so it can't be
+        // applied twice once a later append completes it.
+        let consumedOffset = startOffset + bytesRead - buffer.count
+
+        var recordSnapshot = snapshot
+        var recordMeta = sessionMeta
+
         // A trailing line without a final newline should still count.
         if !buffer.isEmpty {
             let trailing = String(decoding: buffer, as: UTF8.self)
             if !trailing.isEmpty {
-                CodexRolloutReducer.apply(line: trailing, to: &snapshot)
-                if sessionMeta == nil {
-                    sessionMeta = parseSessionMeta(fromLine: trailing)
+                CodexRolloutReducer.apply(line: trailing, to: &recordSnapshot)
+                if recordMeta == nil {
+                    recordMeta = parseSessionMeta(fromLine: trailing)
                 }
             }
         }
 
+        let record = makeRecord(
+            fileURL: fileURL,
+            modifiedAt: modifiedAt,
+            snapshot: recordSnapshot,
+            sessionMeta: recordMeta
+        )
+
+        stateLock.lock()
+        parseStates[path] = ParseState(
+            consumedOffset: consumedOffset,
+            snapshot: snapshot,
+            sessionMeta: sessionMeta,
+            fileSize: fileSize,
+            modifiedAt: modifiedAt,
+            record: record
+        )
+        stateLock.unlock()
+
+        return record
+    }
+
+    private func makeRecord(
+        fileURL: URL,
+        modifiedAt: Date,
+        snapshot: CodexRolloutSnapshot,
+        sessionMeta: SessionMeta?
+    ) -> CodexTrackedSessionRecord? {
         guard let sessionMeta else { return nil }
 
         let summary = snapshot.summary ?? sessionMeta.defaultSummary

--- a/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
@@ -1325,6 +1325,158 @@ struct CodexSessionTrackingTests {
         #expect(records.first?.sessionID == "codex-session-trailing")
         #expect(records.first?.codexMetadata?.lastAssistantMessage == "Final line without newline.")
     }
+
+    @Test
+    func codexRolloutDiscoveryFoldsAppendedLinesIncrementally() throws {
+        // Pins the incremental re-scan path: a second discovery pass over a
+        // grown rollout must only fold the appended bytes, and a trailing
+        // partial line from the first pass must fold exactly once when a
+        // later append completes it. If the cached offset drifted into the
+        // partial line, the completed line would be parsed from mid-line
+        // garbage and the final assistant message would be lost.
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-discovery-incr-\(UUID().uuidString)", isDirectory: true)
+        let rolloutDirectoryURL = rootURL.appendingPathComponent("2026/04/02", isDirectory: true)
+        let rolloutURL = rolloutDirectoryURL.appendingPathComponent("rollout-incremental.jsonl")
+        let now = Date(timeIntervalSince1970: 1_743_555_200)
+
+        try FileManager.default.createDirectory(at: rolloutDirectoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let completedLine = rolloutLine(
+            timestamp: "2026-04-02T04:03:46.000Z",
+            type: "event_msg",
+            payload: [
+                "type": "agent_message",
+                "message": "Message completed across two scans.",
+            ]
+        )
+        let splitIndex = completedLine.index(completedLine.startIndex, offsetBy: completedLine.count / 2)
+
+        let firstChunk = [
+            sessionMetaLine(
+                sessionID: "codex-session-incremental",
+                timestamp: "2026-04-02T04:03:44.000Z",
+                cwd: "/Users/wangruobing/Personal/open-island"
+            ),
+            rolloutLine(
+                timestamp: "2026-04-02T04:03:45.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "user_message",
+                    "message": "Start the incremental scan.",
+                ]
+            ),
+        ].joined(separator: "\n").appending("\n").appending(String(completedLine[..<splitIndex]))
+
+        try firstChunk.write(to: rolloutURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.modificationDate: now], ofItemAtPath: rolloutURL.path)
+
+        let discovery = CodexRolloutDiscovery(
+            rootURL: rootURL,
+            fileManager: .default,
+            maxAge: 86_400,
+            maxFiles: 10
+        )
+
+        let firstPass = discovery.discoverRecentSessions(now: now)
+        #expect(firstPass.count == 1)
+        #expect(firstPass.first?.codexMetadata?.lastUserPrompt == "Start the incremental scan.")
+
+        let secondChunk = String(completedLine[splitIndex...]).appending("\n").appending(
+            rolloutLine(
+                timestamp: "2026-04-02T04:03:47.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "user_message",
+                    "message": "Appended after the first scan.",
+                ]
+            )
+        ).appending("\n")
+
+        let appendHandle = try FileHandle(forWritingTo: rolloutURL)
+        try appendHandle.seekToEnd()
+        try appendHandle.write(contentsOf: Data(secondChunk.utf8))
+        try appendHandle.close()
+        let later = now.addingTimeInterval(30)
+        try FileManager.default.setAttributes([.modificationDate: later], ofItemAtPath: rolloutURL.path)
+
+        let secondPass = discovery.discoverRecentSessions(now: later)
+        let freshPass = CodexRolloutDiscovery(
+            rootURL: rootURL,
+            fileManager: .default,
+            maxAge: 86_400,
+            maxFiles: 10
+        ).discoverRecentSessions(now: later)
+
+        #expect(secondPass.count == 1)
+        #expect(secondPass.first?.sessionID == "codex-session-incremental")
+        #expect(secondPass.first?.codexMetadata?.lastAssistantMessage == "Message completed across two scans.")
+        #expect(secondPass.first?.codexMetadata?.lastUserPrompt == "Appended after the first scan.")
+        #expect(secondPass.first == freshPass.first)
+    }
+
+    @Test
+    func codexRolloutDiscoveryReparsesTruncatedRollouts() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-discovery-trunc-\(UUID().uuidString)", isDirectory: true)
+        let rolloutDirectoryURL = rootURL.appendingPathComponent("2026/04/02", isDirectory: true)
+        let rolloutURL = rolloutDirectoryURL.appendingPathComponent("rollout-truncated.jsonl")
+        let now = Date(timeIntervalSince1970: 1_743_555_200)
+
+        try FileManager.default.createDirectory(at: rolloutDirectoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let longLines = [
+            sessionMetaLine(
+                sessionID: "codex-session-truncated",
+                timestamp: "2026-04-02T04:03:44.000Z",
+                cwd: "/Users/wangruobing/Personal/open-island"
+            ),
+            rolloutLine(
+                timestamp: "2026-04-02T04:03:45.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "agent_message",
+                    "message": "Original content before truncation, padded to outsize the rewrite. \(String(repeating: "x", count: 512))",
+                ]
+            ),
+        ]
+        try longLines.joined(separator: "\n").appending("\n").write(to: rolloutURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.modificationDate: now], ofItemAtPath: rolloutURL.path)
+
+        let discovery = CodexRolloutDiscovery(
+            rootURL: rootURL,
+            fileManager: .default,
+            maxAge: 86_400,
+            maxFiles: 10
+        )
+        _ = discovery.discoverRecentSessions(now: now)
+
+        let rewrittenLines = [
+            sessionMetaLine(
+                sessionID: "codex-session-truncated",
+                timestamp: "2026-04-02T04:03:44.000Z",
+                cwd: "/Users/wangruobing/Personal/open-island"
+            ),
+            rolloutLine(
+                timestamp: "2026-04-02T04:03:48.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "agent_message",
+                    "message": "Rewritten after truncation.",
+                ]
+            ),
+        ]
+        try rewrittenLines.joined(separator: "\n").appending("\n").write(to: rolloutURL, atomically: true, encoding: .utf8)
+        let later = now.addingTimeInterval(30)
+        try FileManager.default.setAttributes([.modificationDate: later], ofItemAtPath: rolloutURL.path)
+
+        let records = discovery.discoverRecentSessions(now: later)
+
+        #expect(records.count == 1)
+        #expect(records.first?.codexMetadata?.lastAssistantMessage == "Rewritten after truncation.")
+    }
 }
 
 private final class MissingTranscriptFileManager: FileManager, @unchecked Sendable {


### PR DESCRIPTION
## Problem

The 10s Codex rediscover pass (`CodexRolloutDiscovery.discoverRecentSessions`) re-reduces **every rollout modified in the last 24h from byte 0** on every tick. The streaming reader (introduced to fix memory churn) keeps the working set small, but the CPU cost is still proportional to total file size × scan frequency.

Once an active session's rollout grows to tens of MB, a single fold outlasts the 10s throttle window, the next `Task.detached` tick starts before the previous one finishes, and concurrent full parses stack up.

Observed on a real machine today: an 80 MB active rollout (plus ~25 MB of other recent files) drove the app to a sustained full core — **354 min CPU over 12.5 h** — with WindowServer dragged to ~32% average by the resulting UI churn, making the whole system visibly laggy.

## Fix

- **Incremental fold per file**: cache parse state keyed by path — the byte offset past the last complete line, the accumulated `CodexRolloutSnapshot`, and the parsed `session_meta`. On re-scan, seek to the cached offset and reduce only appended bytes. Files whose (size, mtime) are unchanged return the cached record without opening the file.
- **No double-fold of partial lines**: the cached snapshot only ever includes complete lines; a trailing line without a final newline is folded into a throwaway copy for the returned record, so it can't be applied twice once a later append completes it (pinned by a test that splits a JSONL line across two scans).
- **Truncation safety**: if a file shrinks below the cached offset, its state is reset and it's re-parsed from scratch.
- **Re-entrancy guard**: `discoverRecentSessions` returns early if a scan is already in flight, so a slow scan can no longer overlap the next tick.
- Cache is pruned to the current candidate set, so it stays bounded by `maxFiles`.

## Testing

- New: `codexRolloutDiscoveryFoldsAppendedLinesIncrementally` (append + partial-line completion across two passes; result must equal a from-scratch parse) and `codexRolloutDiscoveryReparsesTruncatedRollouts`.
- Existing discovery tests unchanged and expected to pass.
- Note: my machine only has Swift 6.0 CLT (package requires 6.2), so I could not run `swift build`/`swift test` locally — syntax-checked with `swiftc -parse` and relying on CI here for the full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)