### PR TITLE
fix: cmux jump-back selects the target tab and workspace

### DIFF
--- a/Sources/OpenIslandApp/TerminalJumpService.swift
+++ b/Sources/OpenIslandApp/TerminalJumpService.swift
@@ -530,8 +530,10 @@ struct TerminalJumpService {
         }
         guard connectResult == 0 else { return false }
 
-        // Send JSON-RPC surface.focus request.
-        let request = #"{"jsonrpc":"2.0","method":"surface.focus","params":{"surface_id":"\#(surfaceID)"},"id":1}"# + "\n"
+        // Send JSON-RPC surface.focus request. `select:true` makes the surface
+        // the visible tab in its pane and brings its workspace forward — without
+        // it, cmux only moves focus and leaves whatever tab/workspace was showing.
+        let request = #"{"jsonrpc":"2.0","method":"surface.focus","params":{"surface_id":"\#(surfaceID)","select":true},"id":1}"# + "\n"
         let sent = request.withCString { ptr in
             Darwin.send(fd, ptr, strlen(ptr), 0)
         }


### PR DESCRIPTION
`jumpToCmuxTerminal` sends `surface.focus` without `select:true`, so cmux moves focus to the surface but leaves whatever tab was already visible in the pane showing, and doesn't bring the surface's workspace forward. Jumping back lands you in the right window but the wrong tab/workspace.

Adding `"select":true` to the params fixes both. Tested against a live cmux socket: with plain `surface.focus` the pane's `selected_surface_id` doesn't change; with `select:true` it flips to the target surface *and* the active workspace switches to match - so for the single-window case the separate `workspace.select`/`window.focus` calls aren't needed. I didn't test a multi-window setup, so `window.focus` on the returned `window_id` might still be worth adding there - happy to follow up if a maintainer wants it.

**Test plan** (needs a real cmux, so CI can't cover it):
- Put two tabs in one cmux workspace plus a second workspace. Focus the *other* tab and switch to the *other* workspace.
- Trigger jump-back to a session in the first workspace → it now lands on the correct tab in the correct workspace, not just the right window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal navigation so the selected terminal is now brought forward and displayed as the active tab in its pane.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->