### PR TITLE
fix: tag transcript-discovered Claude Desktop sessions as Claude.app

### DIFF
--- a/Sources/OpenIslandCore/ClaudeTranscriptDiscovery.swift
+++ b/Sources/OpenIslandCore/ClaudeTranscriptDiscovery.swift
@@ -80,6 +80,7 @@ public final class ClaudeTranscriptDiscovery: @unchecked Sendable {
 
         var sessionID = fileURL.deletingPathExtension().lastPathComponent
         var cwd: String?
+        var entrypoint: String?
         var updatedAt = fallbackUpdatedAt
         var initialUserPrompt: String?
         var lastUserPrompt: String?
@@ -101,6 +102,15 @@ public final class ClaudeTranscriptDiscovery: @unchecked Sendable {
 
             if let value = object["cwd"] as? String, !value.isEmpty {
                 cwd = value
+            }
+
+            // Claude Code records how it was launched ("claude-desktop" vs
+            // "cli") as a top-level field. The desktop app runs a TTY-less
+            // subprocess that process discovery can't see, so latch the
+            // entrypoint here to stamp a "Claude.app" jump target below —
+            // mirroring the hook path's inferTerminalApp detection.
+            if let value = object["entrypoint"] as? String, !value.isEmpty {
+                entrypoint = value
             }
 
             if let timestampText = object["timestamp"] as? String,
@@ -204,7 +214,7 @@ public final class ClaudeTranscriptDiscovery: @unchecked Sendable {
             summary: summary,
             updatedAt: updatedAt,
             jumpTarget: JumpTarget(
-                terminalApp: "Unknown",
+                terminalApp: entrypoint == "claude-desktop" ? "Claude.app" : "Unknown",
                 workspaceName: workspaceName,
                 paneTitle: "Claude \(sessionID.prefix(8))",
                 workingDirectory: cwd

--- a/Sources/OpenIslandCore/ClaudeTranscriptDiscovery.swift
+++ b/Sources/OpenIslandCore/ClaudeTranscriptDiscovery.swift
@@ -108,8 +108,10 @@ public final class ClaudeTranscriptDiscovery: @unchecked Sendable {
             // "cli") as a top-level field. The desktop app runs a TTY-less
             // subprocess that process discovery can't see, so latch the
             // entrypoint here to stamp a "Claude.app" jump target below —
-            // mirroring the hook path's inferTerminalApp detection.
-            if let value = object["entrypoint"] as? String, !value.isEmpty {
+            // mirroring the hook path's inferTerminalApp detection. Latch the
+            // first non-empty value so later records can't overwrite it.
+            if entrypoint == nil,
+               let value = object["entrypoint"] as? String, !value.isEmpty {
                 entrypoint = value
             }
 

--- a/Tests/OpenIslandCoreTests/ClaudeTranscriptDiscoveryTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeTranscriptDiscoveryTests.swift
@@ -34,7 +34,7 @@ struct ClaudeTranscriptDiscoveryTests {
     }
 
     @Test
-    func missingDesktopEntrypointStaysUnknown() throws {
+    func cliEntrypointStaysUnknown() throws {
         // A terminal (`cli`) session has no claude-desktop entrypoint and must
         // keep the "Unknown" sentinel — the terminal resolver handles it later.
         let line = #"{"type":"attachment","sessionId":"def67890","cwd":"/Users/test/project","entrypoint":"cli","timestamp":"2026-07-22T18:00:00Z"}"#
@@ -45,5 +45,44 @@ struct ClaudeTranscriptDiscoveryTests {
 
         #expect(sessions.count == 1)
         #expect(sessions.first?.jumpTarget?.terminalApp == "Unknown")
+    }
+
+    @Test
+    func absentEntrypointFieldStaysUnknown() throws {
+        // Older transcripts predate the entrypoint field entirely; they must
+        // still resolve to "Unknown" rather than crashing or misclassifying.
+        let line = #"{"type":"attachment","sessionId":"aaa11111","cwd":"/Users/test/project","timestamp":"2026-07-22T18:00:00Z"}"#
+        let (discovery, root) = try makeDiscovery(line: line)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let sessions = discovery.discoverRecentSessions()
+
+        #expect(sessions.count == 1)
+        #expect(sessions.first?.jumpTarget?.terminalApp == "Unknown")
+    }
+
+    @Test
+    func firstNonEmptyEntrypointIsLatched() throws {
+        // The entrypoint is latched from the first record that carries it; a
+        // later record must not overwrite the captured value.
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-transcript-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let lines = [
+            #"{"type":"attachment","sessionId":"bbb22222","cwd":"/Users/test/project","entrypoint":"claude-desktop","timestamp":"2026-07-22T18:00:00Z"}"#,
+            #"{"type":"attachment","sessionId":"bbb22222","entrypoint":"cli","timestamp":"2026-07-22T18:05:00Z"}"#,
+        ].joined(separator: "\n") + "\n"
+        try lines.write(
+            to: root.appendingPathComponent("bbb22222.jsonl"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let sessions = ClaudeTranscriptDiscovery(rootURL: root).discoverRecentSessions()
+
+        #expect(sessions.count == 1)
+        #expect(sessions.first?.jumpTarget?.terminalApp == "Claude.app")
     }
 }

--- a/Tests/OpenIslandCoreTests/ClaudeTranscriptDiscoveryTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeTranscriptDiscoveryTests.swift
@@ -63,15 +63,17 @@ struct ClaudeTranscriptDiscoveryTests {
 
     @Test
     func firstNonEmptyEntrypointIsLatched() throws {
-        // The entrypoint is latched from the first record that carries it; a
-        // later record must not overwrite the captured value.
+        // An empty earlier entrypoint is skipped, the first non-empty value is
+        // latched ("claude-desktop"), and a later record ("cli") must not
+        // overwrite it.
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("open-island-transcript-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
 
         let lines = [
-            #"{"type":"attachment","sessionId":"bbb22222","cwd":"/Users/test/project","entrypoint":"claude-desktop","timestamp":"2026-07-22T18:00:00Z"}"#,
+            #"{"type":"attachment","sessionId":"bbb22222","cwd":"/Users/test/project","entrypoint":"","timestamp":"2026-07-22T17:55:00Z"}"#,
+            #"{"type":"attachment","sessionId":"bbb22222","entrypoint":"claude-desktop","timestamp":"2026-07-22T18:00:00Z"}"#,
             #"{"type":"attachment","sessionId":"bbb22222","entrypoint":"cli","timestamp":"2026-07-22T18:05:00Z"}"#,
         ].joined(separator: "\n") + "\n"
         try lines.write(

--- a/Tests/OpenIslandCoreTests/ClaudeTranscriptDiscoveryTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeTranscriptDiscoveryTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+struct ClaudeTranscriptDiscoveryTests {
+    /// Writes a single-line jsonl transcript into a throwaway root and returns
+    /// the discovery instance pointed at it. Caller is responsible for cleanup
+    /// via the returned root URL.
+    private func makeDiscovery(
+        line: String,
+        fileName: String = "\(UUID().uuidString).jsonl"
+    ) throws -> (discovery: ClaudeTranscriptDiscovery, root: URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-transcript-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try line.write(
+            to: root.appendingPathComponent(fileName),
+            atomically: true,
+            encoding: .utf8
+        )
+        return (ClaudeTranscriptDiscovery(rootURL: root), root)
+    }
+
+    @Test
+    func desktopEntrypointTagsSessionAsClaudeApp() throws {
+        let line = #"{"type":"attachment","sessionId":"abc12345","cwd":"/Users/test/project","entrypoint":"claude-desktop","timestamp":"2026-07-22T18:00:00Z"}"#
+        let (discovery, root) = try makeDiscovery(line: line)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let sessions = discovery.discoverRecentSessions()
+
+        #expect(sessions.count == 1)
+        #expect(sessions.first?.jumpTarget?.terminalApp == "Claude.app")
+    }
+
+    @Test
+    func missingDesktopEntrypointStaysUnknown() throws {
+        // A terminal (`cli`) session has no claude-desktop entrypoint and must
+        // keep the "Unknown" sentinel — the terminal resolver handles it later.
+        let line = #"{"type":"attachment","sessionId":"def67890","cwd":"/Users/test/project","entrypoint":"cli","timestamp":"2026-07-22T18:00:00Z"}"#
+        let (discovery, root) = try makeDiscovery(line: line)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let sessions = discovery.discoverRecentSessions()
+
+        #expect(sessions.count == 1)
+        #expect(sessions.first?.jumpTarget?.terminalApp == "Unknown")
+    }
+}


### PR DESCRIPTION
## Problem

Claude Code sessions launched by the **Claude desktop app** ("local agent mode") show up with an **`Unknown`** host and can't be jumped to. The desktop app runs Claude Code as a TTY-less subprocess that `ps`/`lsof` discovery can't attribute to any terminal, so any session recovered from a transcript file (`~/.claude/projects/**.jsonl`) gets stamped `terminalApp: "Unknown"` in `ClaudeTranscriptDiscovery`.

The **hook path** already handles this — `ClaudeHooks.inferTerminalApp` maps `CLAUDE_CODE_ENTRYPOINT == "claude-desktop"` → `"Claude.app"`. But the **transcript-discovery path** never looked at the entrypoint, so desktop sessions restored on launch (or seen before a hook fires) stayed `Unknown`, and `ProcessMonitoringCoordinator`'s desktop-liveness branch (keyed on `terminalApp == "Claude.app"`) never engaged — reproducing the ~6s eviction described in #510 for transcript-first sessions.

## Root cause

Claude records the launch entrypoint as a top-level `entrypoint` field in the transcript (`"claude-desktop"` vs `"cli"`). `ClaudeTranscriptDiscovery.parseSession` captured `cwd`, prompts, model, etc. but not `entrypoint`, then hardcoded `terminalApp: "Unknown"`.

## Fix

Latch `entrypoint` during the line scan (same pattern as `cwd`) and, when it's `"claude-desktop"`, stamp `"Claude.app"` instead of `"Unknown"` — the exact string the hook path emits, so all downstream behavior lights up with no other changes:

- **Liveness** — `ProcessMonitoringCoordinator` keeps `Claude.app`-tagged sessions alive while Claude.app is running (fixes the #510-style eviction for transcript-first sessions).
- **Jump-back** — `TerminalJumpService` maps `Claude.app` → activate the app.
- **Classification** — mirrors the existing `isCodexAppSession` "upgrade, never downgrade" pattern.

Non-desktop (`cli`) and older transcripts without the field keep `"Unknown"`, so the change is additive and fail-safe (+11/−1 in source).

## Testing

- New `ClaudeTranscriptDiscoveryTests` (2 cases): `claude-desktop` entrypoint → `Claude.app`; missing/`cli` → `Unknown`. Both pass.
- Verified live: after the change, the persisted `claude-session-registry.json` flips real Claude Desktop sessions from `Unknown` → `Claude.app` while Ghostty/terminal sessions are untouched.
- `swift build` clean; no new test regressions.

> Note: `AppModelSessionListTests` has 4 failures on a clean checkout of `main` (section grouping collapses to `["all"]`, list sort reversed) that are unrelated to this change — confirmed pre-existing by stashing this diff and re-running. Happy to open a separate issue.

---

### 中文摘要

修复：通过 Claude 桌面应用（"local agent mode"）启动的 Claude Code 会话是无 TTY 的子进程，进程发现无法识别，因此从 transcript 文件恢复的会话被标记为 `Unknown`，无法跳转、且会触发 #510 的约 6 秒驱逐问题。

Claude 会在 transcript 顶层记录 `entrypoint` 字段（`claude-desktop` / `cli`）。本 PR 在解析时读取该字段，当值为 `claude-desktop` 时将 `terminalApp` 标记为 `Claude.app`（与 hook 路径 `inferTerminalApp` 输出一致），从而复用现有的存活检测、跳转与分类逻辑。非桌面会话与缺少该字段的旧 transcript 仍保持 `Unknown`，改动为增量且安全（源码 +11/−1）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session details now detect Claude Desktop JSONL transcript `entrypoint` values and label the originating terminal app as **Claude.app**.

* **Bug Fixes**
  * Improved terminal app resolution to handle missing or empty `entrypoint` fields and to latch the first non-empty value so later records can’t overwrite it.

* **Tests**
  * Added coverage for `claude-desktop` → **Claude.app**, non-desktop values (e.g., `cli`) → **Unknown**, missing `entrypoint` → **Unknown**, and first-non-empty latching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->