### PR TITLE
fix: prevent injected Codex context from becoming session titles

### DIFF
--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -168,7 +168,8 @@ extension AgentSession {
     }
 
     var spotlightHeadlineText: String {
-        var headline = spotlightWorkspaceName
+        let workspaceName = spotlightWorkspaceName
+        var headline = workspaceName
 
         if let branch = spotlightWorktreeBranch {
             headline += " (\(branch))"
@@ -176,6 +177,10 @@ extension AgentSession {
 
         guard let prompt = spotlightHeadlinePromptText else {
             return headline
+        }
+
+        guard workspaceName != "/" else {
+            return prompt
         }
 
         return "\(headline) · \(prompt)"

--- a/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
+++ b/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
@@ -320,7 +320,8 @@ final class SessionDiscoveryCoordinator {
         }
 
         let existingInitialPrompt = existing.initialUserPrompt
-        let shouldReplaceInitialPrompt = existingInitialPrompt.map(Self.isInjectedCodexPromptPreview) ?? false
+        let shouldReplaceInitialPrompt =
+            existingInitialPrompt.map(CodexRolloutReducer.isInjectedPromptBlock) ?? false
         let initialUserPrompt = shouldReplaceInitialPrompt
             ? discovered.initialUserPrompt ?? discovered.lastUserPrompt ?? existingInitialPrompt
             : existingInitialPrompt ?? discovered.initialUserPrompt ?? discovered.lastUserPrompt
@@ -334,16 +335,6 @@ final class SessionDiscoveryCoordinator {
             currentCommandPreview: discovered.currentCommandPreview ?? existing.currentCommandPreview
         )
         return merged.isEmpty ? nil : merged
-    }
-
-    private static func isInjectedCodexPromptPreview(_ prompt: String) -> Bool {
-        let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.hasPrefix("<recommended_plugins>")
-            || trimmed.hasPrefix("# AGENTS.md instructions")
-            || trimmed.hasPrefix("# Files mentioned by the user:")
-            || trimmed.hasPrefix("# Chrome tabs:")
-            || trimmed.hasPrefix("## Referenced chats with Codex:")
-            || trimmed.hasPrefix("<image name=")
     }
 
     private func mergeClaudeMetadata(

--- a/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
+++ b/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
@@ -319,15 +319,31 @@ final class SessionDiscoveryCoordinator {
             return existing.isEmpty ? nil : existing
         }
 
+        let existingInitialPrompt = existing.initialUserPrompt
+        let shouldReplaceInitialPrompt = existingInitialPrompt.map(Self.isInjectedCodexPromptPreview) ?? false
+        let initialUserPrompt = shouldReplaceInitialPrompt
+            ? discovered.initialUserPrompt ?? discovered.lastUserPrompt ?? existingInitialPrompt
+            : existingInitialPrompt ?? discovered.initialUserPrompt ?? discovered.lastUserPrompt
+
         let merged = CodexSessionMetadata(
             transcriptPath: discovered.transcriptPath ?? existing.transcriptPath,
-            initialUserPrompt: existing.initialUserPrompt ?? discovered.initialUserPrompt ?? discovered.lastUserPrompt,
+            initialUserPrompt: initialUserPrompt,
             lastUserPrompt: discovered.lastUserPrompt ?? existing.lastUserPrompt,
             lastAssistantMessage: discovered.lastAssistantMessage ?? existing.lastAssistantMessage,
             currentTool: discovered.currentTool ?? existing.currentTool,
             currentCommandPreview: discovered.currentCommandPreview ?? existing.currentCommandPreview
         )
         return merged.isEmpty ? nil : merged
+    }
+
+    private static func isInjectedCodexPromptPreview(_ prompt: String) -> Bool {
+        let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.hasPrefix("<recommended_plugins>")
+            || trimmed.hasPrefix("# AGENTS.md instructions")
+            || trimmed.hasPrefix("# Files mentioned by the user:")
+            || trimmed.hasPrefix("# Chrome tabs:")
+            || trimmed.hasPrefix("## Referenced chats with Codex:")
+            || trimmed.hasPrefix("<image name=")
     }
 
     private func mergeClaudeMetadata(

--- a/Sources/OpenIslandCore/CodexSessionTracking.swift
+++ b/Sources/OpenIslandCore/CodexSessionTracking.swift
@@ -727,7 +727,7 @@ public enum CodexRolloutReducer {
             snapshot.isInterrupted = false
             snapshot.summary = snapshot.summary ?? "Codex started a new turn."
         case "user_message":
-            guard let message = clipped(payload["message"] as? String), !message.isEmpty else {
+            guard let message = userPromptText(from: payload["message"] as? String), !message.isEmpty else {
                 break
             }
 
@@ -1340,16 +1340,11 @@ public enum CodexRolloutReducer {
                 return nil
             }
 
-            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else {
-                return nil
+            if skipsInjectedBlocks {
+                return userVisiblePromptSegment(from: text)
             }
 
-            if skipsInjectedBlocks, isInjectedPromptBlock(trimmed) {
-                return nil
-            }
-
-            return trimmed
+            return text.trimmingCharacters(in: .whitespacesAndNewlines)
         }
 
         guard !segments.isEmpty else {
@@ -1359,8 +1354,38 @@ public enum CodexRolloutReducer {
         return clipped(segments.joined(separator: " "))
     }
 
+    private static func userPromptText(from text: String?) -> String? {
+        guard let text,
+              let segment = userVisiblePromptSegment(from: text) else {
+            return nil
+        }
+
+        return clipped(segment)
+    }
+
+    private static func userVisiblePromptSegment(from text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return nil
+        }
+
+        if let markerRange = trimmed.range(of: "## My request for Codex:", options: .backwards) {
+            let request = trimmed[markerRange.upperBound...]
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return request.isEmpty ? nil : request
+        }
+
+        return isInjectedPromptBlock(trimmed) ? nil : trimmed
+    }
+
     private static func isInjectedPromptBlock(_ text: String) -> Bool {
-        text.hasPrefix("# AGENTS.md instructions for ")
+        text.hasPrefix("<recommended_plugins>")
+            || text.hasPrefix("# AGENTS.md instructions")
+            || text.hasPrefix("# Files mentioned by the user:")
+            || text.hasPrefix("# Chrome tabs:")
+            || text.hasPrefix("## Referenced chats with Codex:")
+            || text.hasPrefix("<image name=")
+            || text == "</image>"
             || text.hasPrefix("<environment_context>")
             || text.hasPrefix("<permissions instructions>")
             || text.hasPrefix("<collaboration_mode>")

--- a/Sources/OpenIslandCore/CodexSessionTracking.swift
+++ b/Sources/OpenIslandCore/CodexSessionTracking.swift
@@ -1378,18 +1378,19 @@ public enum CodexRolloutReducer {
         return isInjectedPromptBlock(trimmed) ? nil : trimmed
     }
 
-    private static func isInjectedPromptBlock(_ text: String) -> Bool {
-        text.hasPrefix("<recommended_plugins>")
-            || text.hasPrefix("# AGENTS.md instructions")
-            || text.hasPrefix("# Files mentioned by the user:")
-            || text.hasPrefix("# Chrome tabs:")
-            || text.hasPrefix("## Referenced chats with Codex:")
-            || text.hasPrefix("<image name=")
-            || text == "</image>"
-            || text.hasPrefix("<environment_context>")
-            || text.hasPrefix("<permissions instructions>")
-            || text.hasPrefix("<collaboration_mode>")
-            || text.hasPrefix("<skills_instructions>")
+    package static func isInjectedPromptBlock(_ text: String) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.hasPrefix("<recommended_plugins>")
+            || trimmed.hasPrefix("# AGENTS.md instructions")
+            || trimmed.hasPrefix("# Files mentioned by the user:")
+            || trimmed.hasPrefix("# Chrome tabs:")
+            || trimmed.hasPrefix("## Referenced chats with Codex:")
+            || trimmed.hasPrefix("<image name=")
+            || trimmed == "</image>"
+            || trimmed.hasPrefix("<environment_context>")
+            || trimmed.hasPrefix("<permissions instructions>")
+            || trimmed.hasPrefix("<collaboration_mode>")
+            || trimmed.hasPrefix("<skills_instructions>")
     }
 
     private static func clipped(_ value: String?, limit: Int = 110) -> String? {

--- a/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
+++ b/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
@@ -214,6 +214,31 @@ struct AgentSessionPresentationTests {
     }
 
     @Test
+    func headlineOmitsRootWorkspacePlaceholderWhenPromptExists() {
+        let session = AgentSession(
+            id: "codex-root-session",
+            title: "Codex · /",
+            tool: .codex,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Working",
+            updatedAt: Date(timeIntervalSince1970: 10_000),
+            jumpTarget: JumpTarget(
+                terminalApp: "Codex.app",
+                workspaceName: "/",
+                paneTitle: "Codex",
+                workingDirectory: "/"
+            ),
+            codexMetadata: CodexSessionMetadata(
+                initialUserPrompt: "Fix the session headline."
+            )
+        )
+
+        #expect(session.spotlightHeadlineText == "Fix the session headline.")
+    }
+
+    @Test
     func detachedSessionHeadlineShowsInitialPrompt() {
         let session = AgentSession(
             id: "session-1",

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -883,6 +883,79 @@ struct AppModelSessionListTests {
     }
 
     @Test
+    func mergeDiscoveredCodexSessionsReplacesInjectedCachedInitialPromptOnly() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let model = AppModel()
+        model.state = SessionState(
+            sessions: [
+                AgentSession(
+                    id: "wrapped-codex-session",
+                    title: "Codex · /",
+                    tool: .codex,
+                    origin: .live,
+                    attachmentState: .stale,
+                    phase: .completed,
+                    summary: "Recovered from cache",
+                    updatedAt: now.addingTimeInterval(-60),
+                    codexMetadata: CodexSessionMetadata(
+                        initialUserPrompt: "# Files mentioned by the user: ## screenshot.png: /tmp/screenshot.png",
+                        lastUserPrompt: "# Chrome tabs: - Current URL: https://example.com"
+                    )
+                ),
+                AgentSession(
+                    id: "valid-codex-session",
+                    title: "Codex · project",
+                    tool: .codex,
+                    origin: .live,
+                    attachmentState: .stale,
+                    phase: .completed,
+                    summary: "Recovered from cache",
+                    updatedAt: now.addingTimeInterval(-60),
+                    codexMetadata: CodexSessionMetadata(
+                        initialUserPrompt: "Keep this valid cached topic."
+                    )
+                ),
+            ]
+        )
+
+        let merged = model.discovery.mergeDiscoveredSessions([
+            AgentSession(
+                id: "wrapped-codex-session",
+                title: "Codex · /",
+                tool: .codex,
+                origin: .live,
+                attachmentState: .stale,
+                phase: .completed,
+                summary: "Recovered from rollout",
+                updatedAt: now,
+                codexMetadata: CodexSessionMetadata(
+                    initialUserPrompt: "Fix the session headline.",
+                    lastUserPrompt: "The headline still looks wrong."
+                )
+            ),
+            AgentSession(
+                id: "valid-codex-session",
+                title: "Codex · project",
+                tool: .codex,
+                origin: .live,
+                attachmentState: .stale,
+                phase: .completed,
+                summary: "Recovered from rollout",
+                updatedAt: now,
+                codexMetadata: CodexSessionMetadata(
+                    initialUserPrompt: "Do not replace the cached topic."
+                )
+            ),
+        ])
+
+        let wrapped = merged.first(where: { $0.id == "wrapped-codex-session" })
+        let valid = merged.first(where: { $0.id == "valid-codex-session" })
+        #expect(wrapped?.codexMetadata?.initialUserPrompt == "Fix the session headline.")
+        #expect(wrapped?.codexMetadata?.lastUserPrompt == "The headline still looks wrong.")
+        #expect(valid?.codexMetadata?.initialUserPrompt == "Keep this valid cached topic.")
+    }
+
+    @Test
     func mergedWithSyntheticClaudeSessionsAddsGhosttyClaudeProcessWhenNoTrackedSessionExists() {
         let now = Date(timeIntervalSince1970: 2_000)
         let model = AppModel()

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -915,6 +915,23 @@ struct AppModelSessionListTests {
                         initialUserPrompt: "Keep this valid cached topic."
                     )
                 ),
+                AgentSession(
+                    id: "environment-context-codex-session",
+                    title: "Codex · /",
+                    tool: .codex,
+                    origin: .live,
+                    attachmentState: .stale,
+                    phase: .completed,
+                    summary: "Recovered from cache",
+                    updatedAt: now.addingTimeInterval(-60),
+                    codexMetadata: CodexSessionMetadata(
+                        initialUserPrompt: """
+                            <environment_context>
+                              <cwd>/tmp/open-island</cwd>
+                            </environment_context>
+                            """
+                    )
+                ),
             ]
         )
 
@@ -946,13 +963,31 @@ struct AppModelSessionListTests {
                     initialUserPrompt: "Do not replace the cached topic."
                 )
             ),
+            AgentSession(
+                id: "environment-context-codex-session",
+                title: "Codex · /",
+                tool: .codex,
+                origin: .live,
+                attachmentState: .stale,
+                phase: .completed,
+                summary: "Recovered from rollout",
+                updatedAt: now,
+                codexMetadata: CodexSessionMetadata(
+                    initialUserPrompt: "Replace the injected environment context."
+                )
+            ),
         ])
 
         let wrapped = merged.first(where: { $0.id == "wrapped-codex-session" })
         let valid = merged.first(where: { $0.id == "valid-codex-session" })
+        let environmentContext = merged.first(where: { $0.id == "environment-context-codex-session" })
         #expect(wrapped?.codexMetadata?.initialUserPrompt == "Fix the session headline.")
         #expect(wrapped?.codexMetadata?.lastUserPrompt == "The headline still looks wrong.")
         #expect(valid?.codexMetadata?.initialUserPrompt == "Keep this valid cached topic.")
+        #expect(
+            environmentContext?.codexMetadata?.initialUserPrompt
+                == "Replace the injected environment context."
+        )
     }
 
     @Test

--- a/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
@@ -791,7 +791,11 @@ struct CodexSessionTrackingTests {
                     "content": [
                         [
                             "type": "input_text",
-                            "text": "# AGENTS.md instructions for /tmp/repo\n\n<INSTRUCTIONS>\nRepository guide\n</INSTRUCTIONS>",
+                            "text": "<recommended_plugins>\nHere is a list of plugins that are available but not installed.\n</recommended_plugins>",
+                        ],
+                        [
+                            "type": "input_text",
+                            "text": "# AGENTS.md instructions\n\n<INSTRUCTIONS>\nRepository guide\n</INSTRUCTIONS>",
                         ],
                         [
                             "type": "input_text",
@@ -809,9 +813,25 @@ struct CodexSessionTrackingTests {
                     "content": [
                         [
                             "type": "input_text",
-                            "text": "读一下这篇论文 https://arxiv.org/html/2603.28052v1，然后对比一下 autoresearch 的实现。",
+                            "text": "# Chrome tabs:\n- Current URL: https://arxiv.org/html/2603.28052v1\n\n## My request for Codex:\n读一下这篇论文 https://arxiv.org/html/2603.28052v1，然后对比一下 autoresearch 的实现。",
+                        ],
+                        [
+                            "type": "input_text",
+                            "text": "<image name=[Image #1] path=\"/tmp/paper.png\">",
+                        ],
+                        [
+                            "type": "input_text",
+                            "text": "</image>",
                         ],
                     ],
+                ]
+            ),
+            rolloutLine(
+                timestamp: "2026-04-02T14:37:28.500Z",
+                type: "event_msg",
+                payload: [
+                    "type": "user_message",
+                    "message": "# Files mentioned by the user:\n\n## paper.png: /tmp/paper.png\n\n## My request for Codex:\n读一下这篇论文 https://arxiv.org/html/2603.28052v1，然后对比一下 autoresearch 的实现。",
                 ]
             ),
             rolloutLine(


### PR DESCRIPTION
## Summary

- ignore Codex-injected plugin, repository, environment, attachment, and browser-context blocks when deriving user prompt previews
- extract the actual request that follows `## My request for Codex:` from wrapped desktop-app messages
- replace stale cached prompt previews only when the cached value is known injected context
- avoid showing the root workspace placeholder (`/`) when a usable prompt title exists

## Problem

Codex desktop rollouts can store system-provided context alongside the user's request. Open Island treated the first available block as the session topic, so the island could display headings such as `<recommended_plugins>`, `# Files mentioned by the user`, or other wrapper metadata instead of the user's request.

### Visual reproduction

Before this fix, injected plugin metadata could become the visible session headline:

<img width="936" height="594" alt="Open Island showing recommended_plugins as Codex session titles before the fix" src="https://github.com/user-attachments/assets/d130e8a3-81ff-47de-bb0c-4cdc8bbef0ef" />

Expected behavior: the headline should use the extracted user-authored request and omit injected wrapper metadata.

## Root cause

Prompt extraction skipped a small set of whole injected blocks, but it did not recognize newer Codex wrapper formats or extract the user-authored portion of a combined message. Persisted sessions could also retain an already-cached injected preview after rediscovery.

## Validation

The following targeted tests pass:

- `codexRolloutReducerTracksMessageResponsePromptsWithoutInjectedBlocks`
- `headlineOmitsRootWorkspacePlaceholderWhenPromptExists`
- `mergeDiscoveredCodexSessionsReplacesInjectedCachedInitialPromptOnly`

This PR is limited to prompt/title parsing and its regression coverage. It does not change Codex app-server startup, network configuration, or thread-name discovery.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session headline generation: root workspace placeholders no longer show when a prompt exists.
  * Refined Codex prompt extraction and injected-content filtering to surface the actual user request, including updated handling for multiple injected markers and message segments.
  * Enhanced discovery/merge behavior so injected cached initial prompts are correctly replaced (while valid cached prompts are preserved).
* **Tests**
  * Added headline coverage for root workspace behavior.
  * Added coverage for merging discovered Codex session prompts and updated injected-block prompt tracking fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
