### PR TITLE
Add OpenAI-compatible graph executor runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ Package.resolved
 
 # Local tooling artifacts
 .claude/
+.agents/
+.jarvis-memory
+.opencode/
+JARVIS_MEMORY.md
 .playwright-mcp/
 output/
 

--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,10 @@ let package = Package(
             name: "openisland",
             targets: ["OpenIslandCLI"]
         ),
+        .executable(
+            name: "OpenIslandProcessFixtureAgent",
+            targets: ["OpenIslandProcessFixtureAgent"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.4.1"),
@@ -61,9 +65,12 @@ let package = Package(
             name: "OpenIslandCLI",
             dependencies: ["OpenIslandCore"]
         ),
+        .executableTarget(
+            name: "OpenIslandProcessFixtureAgent"
+        ),
         .testTarget(
             name: "OpenIslandCoreTests",
-            dependencies: ["OpenIslandCore"],
+            dependencies: ["OpenIslandCore", "OpenIslandProcessFixtureAgent"],
             resources: [
                 .copy("Fixtures"),
             ]

--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,10 @@ let package = Package(
             name: "OpenIslandApp",
             targets: ["OpenIslandApp"]
         ),
+        .executable(
+            name: "openisland",
+            targets: ["OpenIslandCLI"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.4.1"),
@@ -52,6 +56,10 @@ let package = Package(
             resources: [
                 .process("Resources"),
             ]
+        ),
+        .executableTarget(
+            name: "OpenIslandCLI",
+            dependencies: ["OpenIslandCore"]
         ),
         .testTarget(
             name: "OpenIslandCoreTests",

--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,10 @@ let package = Package(
         ),
         .testTarget(
             name: "OpenIslandCoreTests",
-            dependencies: ["OpenIslandCore"]
+            dependencies: ["OpenIslandCore"],
+            resources: [
+                .copy("Fixtures"),
+            ]
         ),
         .testTarget(
             name: "OpenIslandAppTests",

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -381,6 +381,15 @@ final class AppModel {
     var openSettingsWindow: (() -> Void)?
 
     @ObservationIgnored
+    var openGraphWorkspaceWindow: (() -> Void)?
+
+    @ObservationIgnored
+    var newGraphDefinitionAction: (() -> Void)?
+
+    @ObservationIgnored
+    var openGraphDefinitionAction: (() -> Void)?
+
+    @ObservationIgnored
     private var hasFinishedInit = false
 
     func appearancePreferences(for profile: IslandAppearanceDisplayProfile) -> IslandAppearancePreferences {
@@ -1272,6 +1281,19 @@ final class AppModel {
             window.makeKey()
         }
         NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func showGraphWorkspace() {
+        openGraphWorkspaceWindow?()
+        let application = NSApplication.shared
+        if let window = application.windows.first(where: {
+            $0.identifier?.rawValue == "graph-workspace"
+                || $0.title == "Graph Workspace"
+        }) {
+            window.orderFrontRegardless()
+            window.makeKey()
+        }
+        application.activate(ignoringOtherApps: true)
     }
 
     /// Opens Settings on the Setup tab so the user can install hooks.

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1238,6 +1238,10 @@ final class AppModel {
     var showsNotificationCard: Bool { overlay.showsNotificationCard }
     var shouldDeferTimedNotificationAutoCollapse: Bool { overlay.shouldDeferTimedNotificationAutoCollapse }
     var hasPendingNotificationAutoCollapse: Bool { overlay.hasPendingNotificationAutoCollapse }
+    var pointerLocationAccessor: (() -> NSPoint)? {
+        get { overlay.pointerLocationAccessor }
+        set { overlay.pointerLocationAccessor = newValue }
+    }
 
     func loadDebugSnapshot(
         _ snapshot: IslandDebugSnapshot,

--- a/Sources/OpenIslandApp/CodexAppServerCoordinator.swift
+++ b/Sources/OpenIslandApp/CodexAppServerCoordinator.swift
@@ -97,7 +97,10 @@ final class CodexAppServerCoordinator {
         do {
             let threads = try await client.listLoadedThreads()
             var created = 0
-            for thread in threads where !thread.ephemeral {
+            for thread in threads where Self.shouldSurface(
+                status: thread.status.type,
+                ephemeral: thread.ephemeral
+            ) {
                 // Skip threads already tracked — re-emitting sessionStarted
                 // rebuilds the AgentSession and would wipe richer state
                 // already accumulated from hooks or rediscovery.
@@ -118,72 +121,23 @@ final class CodexAppServerCoordinator {
     private func handleNotification(_ notification: CodexAppServerNotification) {
         switch notification {
         case .threadStarted(let thread):
-            guard !thread.ephemeral else { return }
+            guard Self.shouldSurface(
+                status: thread.status.type,
+                ephemeral: thread.ephemeral
+            ) else { return }
             guard isSessionTracked?(thread.id) != true else { return }
             emitSessionStarted(from: thread)
 
         case .threadStatusChanged(let threadId, let status):
-            switch status.type {
-            case .active:
-                if status.isWaitingOnApproval {
-                    onEvent?(.permissionRequested(
-                        PermissionRequested(
-                            sessionID: threadId,
-                            request: PermissionRequest(
-                                title: "Approval Required",
-                                summary: "Codex is waiting for approval.",
-                                affectedPath: ""
-                            ),
-                            timestamp: .now
-                        )
-                    ))
-                } else if status.isWaitingOnUserInput {
-                    onEvent?(.questionAsked(
-                        QuestionAsked(
-                            sessionID: threadId,
-                            prompt: QuestionPrompt(
-                                title: "Codex is waiting for input.",
-                                options: []
-                            ),
-                            timestamp: .now
-                        )
-                    ))
-                } else {
-                    onEvent?(.activityUpdated(
-                        SessionActivityUpdated(
-                            sessionID: threadId,
-                            summary: "Codex is working…",
-                            phase: .running,
-                            timestamp: .now
-                        )
-                    ))
+            if status.type == .active, isSessionTracked?(threadId) != true {
+                Task { [weak self] in
+                    guard let self else { return }
+                    await self.syncLoadedThreads()
+                    self.emitThreadStatusChanged(threadId: threadId, status: status)
                 }
-            case .idle:
-                // Idle means "between turns" in the same thread — the thread
-                // is still open.  Only `thread/closed` truly ends a session.
-                onEvent?(.activityUpdated(
-                    SessionActivityUpdated(
-                        sessionID: threadId,
-                        summary: "Idle.",
-                        phase: .completed,
-                        timestamp: .now
-                    )
-                ))
-            case .systemError:
-                // Quota limits and other hard failures can leave the thread in
-                // systemError without a turn/completed notification. Mark the
-                // turn as finished so the island does not stay stuck running.
-                onEvent?(.activityUpdated(
-                    SessionActivityUpdated(
-                        sessionID: threadId,
-                        summary: "Turn failed.",
-                        phase: .completed,
-                        timestamp: .now
-                    )
-                ))
-            case .notLoaded:
-                break
+                return
             }
+            emitThreadStatusChanged(threadId: threadId, status: status)
 
         case .threadClosed(let threadId):
             onEvent?(.sessionCompleted(
@@ -213,10 +167,6 @@ final class CodexAppServerCoordinator {
             ))
 
         case .turnCompleted(let threadId, let turn):
-            // A turn completing doesn't end the thread — the user can send
-            // another message.  Use activityUpdated(phase: .completed) so the
-            // session stays visible as "Completed" rather than being torn
-            // down.  `thread/closed` is the authoritative end signal.
             let summary: String
             switch turn.status {
             case .completed: summary = "Turn completed."
@@ -234,6 +184,72 @@ final class CodexAppServerCoordinator {
             ))
 
         case .unknown:
+            break
+        }
+    }
+
+    static func shouldSurface(
+        status: CodexThreadStatusType,
+        ephemeral: Bool
+    ) -> Bool {
+        !ephemeral && status == .active
+    }
+
+    private func emitThreadStatusChanged(threadId: String, status: CodexThreadStatus) {
+        switch status.type {
+        case .active:
+            if status.isWaitingOnApproval {
+                onEvent?(.permissionRequested(
+                    PermissionRequested(
+                        sessionID: threadId,
+                        request: PermissionRequest(
+                            title: "Approval Required",
+                            summary: "Codex is waiting for approval.",
+                            affectedPath: ""
+                        ),
+                        timestamp: .now
+                    )
+                ))
+            } else if status.isWaitingOnUserInput {
+                onEvent?(.questionAsked(
+                    QuestionAsked(
+                        sessionID: threadId,
+                        prompt: QuestionPrompt(
+                            title: "Codex is waiting for input.",
+                            options: []
+                        ),
+                        timestamp: .now
+                    )
+                ))
+            } else {
+                onEvent?(.activityUpdated(
+                    SessionActivityUpdated(
+                        sessionID: threadId,
+                        summary: "Codex is working…",
+                        phase: .running,
+                        timestamp: .now
+                    )
+                ))
+            }
+        case .idle:
+            onEvent?(.activityUpdated(
+                SessionActivityUpdated(
+                    sessionID: threadId,
+                    summary: "Idle.",
+                    phase: .completed,
+                    timestamp: .now
+                )
+            ))
+        case .systemError:
+            onEvent?(.activityUpdated(
+                SessionActivityUpdated(
+                    sessionID: threadId,
+                    summary: "Turn failed.",
+                    phase: .completed,
+                    timestamp: .now
+                )
+            ))
+        case .notLoaded:
             break
         }
     }

--- a/Sources/OpenIslandApp/GraphRuntimeCatalog.swift
+++ b/Sources/OpenIslandApp/GraphRuntimeCatalog.swift
@@ -1,0 +1,505 @@
+import Foundation
+import OpenIslandCore
+
+enum GraphRuntimeProviderKind:
+    String,
+    Codable,
+    CaseIterable,
+    Identifiable,
+    Sendable
+{
+    case localProcess = "local_process"
+    case ollama
+    case qwenCode = "qwen_code"
+    case geminiCLI = "gemini_cli"
+    case openCode = "open_code"
+    case openAICompatible = "openai_compatible"
+    case custom
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .localProcess: "Local Process"
+        case .ollama: "Ollama"
+        case .qwenCode: "Qwen Code"
+        case .geminiCLI: "Gemini CLI"
+        case .openCode: "OpenCode"
+        case .openAICompatible: "OpenAI-Compatible Endpoint"
+        case .custom: "Custom Runtime"
+        }
+    }
+}
+
+enum GraphRuntimeTransport:
+    String,
+    Codable,
+    CaseIterable,
+    Sendable
+{
+    case localProcess = "local_process"
+    case openAICompatible = "openai_compatible"
+}
+
+struct GraphRuntimeModel:
+    Identifiable,
+    Equatable,
+    Codable,
+    Sendable
+{
+    let id: String
+    let name: String
+    let providerID: GraphRuntimeProviderKind
+    let details: String?
+}
+
+struct GraphRuntimeAgentProfile:
+    Identifiable,
+    Equatable,
+    Codable,
+    Sendable
+{
+    let id: String
+    let name: String
+    let providerID: GraphRuntimeProviderKind
+    let executable: String?
+    let details: String?
+}
+
+struct GraphRuntimeProvider:
+    Identifiable,
+    Equatable,
+    Codable,
+    Sendable
+{
+    let id: GraphRuntimeProviderKind
+    let transport: GraphRuntimeTransport
+    let endpoint: String?
+    let adapterKind: String
+    let operation: String
+    let requiredCapabilities: [String]
+    let executableNames: [String]
+    let supportsModelDiscovery: Bool
+    let supportsAgentProfiles: Bool
+
+    var displayName: String { id.displayName }
+}
+
+struct GraphRuntimeCatalogSnapshot:
+    Equatable,
+    Sendable
+{
+    var providers: [GraphRuntimeProvider]
+    var models: [GraphRuntimeModel]
+    var agents: [GraphRuntimeAgentProfile]
+    var diagnostics: [String]
+
+    static let empty = GraphRuntimeCatalogSnapshot(
+        providers: [],
+        models: [],
+        agents: [],
+        diagnostics: []
+    )
+
+    func provider(
+        _ id: GraphRuntimeProviderKind
+    ) -> GraphRuntimeProvider? {
+        providers.first { $0.id == id }
+    }
+
+    func models(
+        for providerID: GraphRuntimeProviderKind
+    ) -> [GraphRuntimeModel] {
+        models
+            .filter { $0.providerID == providerID }
+            .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+    }
+
+    func agents(
+        for providerID: GraphRuntimeProviderKind
+    ) -> [GraphRuntimeAgentProfile] {
+        agents
+            .filter { $0.providerID == providerID }
+            .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+    }
+}
+
+struct GraphRuntimeNodeBinding: Equatable, Sendable {
+    let specification: GraphImmutableExecutionSpecification
+    let executorKind: GraphDefinitionExecutorKind
+    let requiredCapabilities: [String]
+    let environmentAllowlist: [String]
+}
+
+enum GraphRuntimeNodeBindingFactory {
+    static func make(
+        provider: GraphRuntimeProvider,
+        model: String,
+        agentProfileID: String,
+        catalog: GraphRuntimeCatalogSnapshot
+    ) throws -> GraphRuntimeNodeBinding {
+        switch provider.transport {
+        case .localProcess:
+            if provider.id == .localProcess {
+                return GraphRuntimeNodeBinding(
+                    specification: try GraphLocalProcessSpecification(
+                        executable: "/usr/bin/true"
+                    ).immutableSpecification(),
+                    executorKind: .supervisedLocalProcess,
+                    requiredCapabilities: provider.requiredCapabilities,
+                    environmentAllowlist: []
+                )
+            }
+
+            guard let agent = catalog.agents.first(where: {
+                $0.id == agentProfileID && $0.providerID == provider.id
+            }),
+            let executable = agent.executable else {
+                return GraphRuntimeNodeBinding(
+                    specification: GraphImmutableExecutionSpecification(
+                        adapterKind: "generic_agent",
+                        operation: "unbound",
+                        parameters: [
+                            "provider": .string(provider.id.rawValue),
+                            "model": .string(model),
+                            "agentProfile": .string(agentProfileID),
+                        ]
+                    ),
+                    executorKind: .unboundAgent,
+                    requiredCapabilities: provider.requiredCapabilities,
+                    environmentAllowlist: []
+                )
+            }
+
+            let process = GraphLocalProcessSpecification(
+                executable: executable,
+                arguments: [],
+                workingDirectory: ".",
+                inheritedEnvironment: .allowlisted,
+                stdin: .nullDevice
+            )
+
+            return GraphRuntimeNodeBinding(
+                specification: try process.immutableSpecification(),
+                executorKind: .supervisedLocalProcess,
+                requiredCapabilities: provider.requiredCapabilities,
+                environmentAllowlist: defaultEnvironmentAllowlist(
+                    for: provider.id
+                )
+            )
+
+        case .openAICompatible:
+            var parameters: [String: GraphJSONValue] = [
+                "provider": .string(provider.id.rawValue),
+                "model": .string(model),
+            ]
+
+            if let endpoint = provider.endpoint {
+                parameters["endpoint"] = .string(endpoint)
+            }
+
+            return GraphRuntimeNodeBinding(
+                specification: GraphImmutableExecutionSpecification(
+                    adapterKind: provider.adapterKind,
+                    operation: provider.operation,
+                    parameters: parameters
+                ),
+                executorKind: .openAICompatible,
+                requiredCapabilities: provider.requiredCapabilities,
+                environmentAllowlist: []
+            )
+        }
+    }
+
+    private static func defaultEnvironmentAllowlist(
+        for provider: GraphRuntimeProviderKind
+    ) -> [String] {
+        switch provider {
+        case .qwenCode:
+            [
+                "HOME",
+                "PATH",
+                "LANG",
+                "LC_ALL",
+                "TERM",
+                "OLLAMA_HOST",
+                "OPENAI_API_KEY",
+                "OPENAI_BASE_URL",
+                "GOOGLE_GENERATIVE_AI_API_KEY",
+            ]
+        case .geminiCLI:
+            [
+                "HOME",
+                "PATH",
+                "LANG",
+                "LC_ALL",
+                "TERM",
+                "GEMINI_API_KEY",
+                "GOOGLE_API_KEY",
+                "GOOGLE_GENERATIVE_AI_API_KEY",
+            ]
+        case .openCode:
+            [
+                "HOME",
+                "PATH",
+                "LANG",
+                "LC_ALL",
+                "TERM",
+                "OPENAI_API_KEY",
+                "OPENAI_BASE_URL",
+                "GOOGLE_GENERATIVE_AI_API_KEY",
+                "ANTHROPIC_API_KEY",
+            ]
+        case .localProcess, .ollama, .openAICompatible, .custom:
+            []
+        }
+    }
+}
+
+
+protocol GraphRuntimeCatalogDiscovering: Sendable {
+    func discover() async -> GraphRuntimeCatalogSnapshot
+}
+
+struct GraphRuntimeCatalogDiscovery:
+    GraphRuntimeCatalogDiscovering,
+    Sendable
+{
+    var environment: [String: String]
+    var isExecutableFile: @Sendable (String) -> Bool
+    var session: URLSession
+
+    init(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        isExecutableFile: @escaping @Sendable (String) -> Bool = {
+            FileManager.default.isExecutableFile(atPath: $0)
+        },
+        session: URLSession = .shared
+    ) {
+        self.environment = environment
+        self.isExecutableFile = isExecutableFile
+        self.session = session
+    }
+
+    func discover() async -> GraphRuntimeCatalogSnapshot {
+        let providers = Self.builtInProviders
+        var models: [GraphRuntimeModel] = []
+        var agents: [GraphRuntimeAgentProfile] = []
+        var diagnostics: [String] = []
+
+        for provider in providers {
+            for executableName in provider.executableNames {
+                if let path = resolveExecutable(executableName) {
+                    agents.append(
+                        GraphRuntimeAgentProfile(
+                            id: "\(provider.id.rawValue):\(path)",
+                            name: provider.displayName,
+                            providerID: provider.id,
+                            executable: path,
+                            details: "Installed at \(path)"
+                        )
+                    )
+                    break
+                }
+            }
+        }
+
+        do {
+            models.append(contentsOf: try await discoverOllamaModels())
+        } catch {
+            diagnostics.append(
+                "Ollama model discovery failed: \(error.localizedDescription)"
+            )
+        }
+
+        return GraphRuntimeCatalogSnapshot(
+            providers: providers,
+            models: models,
+            agents: agents,
+            diagnostics: diagnostics.sorted()
+        )
+    }
+
+    private func resolveExecutable(_ name: String) -> String? {
+        let path = environment["PATH"] ?? ""
+        for directory in path.split(separator: ":") {
+            let candidate = URL(fileURLWithPath: String(directory))
+                .appendingPathComponent(name)
+                .path
+            if isExecutableFile(candidate) {
+                return candidate
+            }
+        }
+
+        let commonDirectories = [
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/usr/bin",
+            "\(NSHomeDirectory())/.local/bin",
+        ]
+
+        for directory in commonDirectories {
+            let candidate = URL(fileURLWithPath: directory)
+                .appendingPathComponent(name)
+                .path
+            if isExecutableFile(candidate) {
+                return candidate
+            }
+        }
+
+        return nil
+    }
+
+    private func discoverOllamaModels() async throws
+        -> [GraphRuntimeModel]
+    {
+        let url = URL(string: "http://127.0.0.1:11434/api/tags")!
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 3
+
+        let (data, response) = try await session.data(for: request)
+
+        guard let http = response as? HTTPURLResponse,
+              (200 ... 299).contains(http.statusCode)
+        else {
+            throw GraphRuntimeCatalogError.invalidOllamaResponse
+        }
+
+        let payload = try JSONDecoder().decode(
+            OllamaTagsResponse.self,
+            from: data
+        )
+
+        return payload.models.map {
+            GraphRuntimeModel(
+                id: "ollama:\($0.name)",
+                name: $0.name,
+                providerID: .ollama,
+                details: $0.details?.parameterSize
+            )
+        }
+    }
+
+    static let builtInProviders: [GraphRuntimeProvider] = [
+        GraphRuntimeProvider(
+            id: .localProcess,
+            transport: .localProcess,
+            endpoint: nil,
+            adapterKind: "local_process",
+            operation: "execute",
+            requiredCapabilities: ["local-process"],
+            executableNames: [],
+            supportsModelDiscovery: false,
+            supportsAgentProfiles: false
+        ),
+        GraphRuntimeProvider(
+            id: .ollama,
+            transport: .openAICompatible,
+            endpoint: "http://127.0.0.1:11434/v1",
+            adapterKind: "openai_compatible",
+            operation: "chat_completion",
+            requiredCapabilities: ["agent", "model-inference"],
+            executableNames: ["ollama"],
+            supportsModelDiscovery: true,
+            supportsAgentProfiles: false
+        ),
+        GraphRuntimeProvider(
+            id: .qwenCode,
+            transport: .localProcess,
+            endpoint: nil,
+            adapterKind: "local_process",
+            operation: "execute",
+            requiredCapabilities: [
+                "agent",
+                "local-process",
+                "workspace-read",
+                "workspace-write",
+            ],
+            executableNames: ["qwen"],
+            supportsModelDiscovery: false,
+            supportsAgentProfiles: true
+        ),
+        GraphRuntimeProvider(
+            id: .geminiCLI,
+            transport: .localProcess,
+            endpoint: nil,
+            adapterKind: "local_process",
+            operation: "execute",
+            requiredCapabilities: [
+                "agent",
+                "local-process",
+                "workspace-read",
+                "workspace-write",
+            ],
+            executableNames: ["gemini"],
+            supportsModelDiscovery: false,
+            supportsAgentProfiles: true
+        ),
+        GraphRuntimeProvider(
+            id: .openCode,
+            transport: .localProcess,
+            endpoint: nil,
+            adapterKind: "local_process",
+            operation: "execute",
+            requiredCapabilities: [
+                "agent",
+                "local-process",
+                "workspace-read",
+                "workspace-write",
+            ],
+            executableNames: ["opencode"],
+            supportsModelDiscovery: false,
+            supportsAgentProfiles: true
+        ),
+        GraphRuntimeProvider(
+            id: .openAICompatible,
+            transport: .openAICompatible,
+            endpoint: nil,
+            adapterKind: "openai_compatible",
+            operation: "chat_completion",
+            requiredCapabilities: ["agent", "model-inference"],
+            executableNames: [],
+            supportsModelDiscovery: true,
+            supportsAgentProfiles: false
+        ),
+        GraphRuntimeProvider(
+            id: .custom,
+            transport: .localProcess,
+            endpoint: nil,
+            adapterKind: "generic_agent",
+            operation: "unbound",
+            requiredCapabilities: ["agent"],
+            executableNames: [],
+            supportsModelDiscovery: false,
+            supportsAgentProfiles: true
+        ),
+    ]
+}
+
+private struct OllamaTagsResponse: Decodable {
+    let models: [OllamaModel]
+}
+
+private struct OllamaModel: Decodable {
+    let name: String
+    let details: OllamaModelDetails?
+}
+
+private struct OllamaModelDetails: Decodable {
+    let parameterSize: String?
+
+    enum CodingKeys: String, CodingKey {
+        case parameterSize = "parameter_size"
+    }
+}
+
+enum GraphRuntimeCatalogError: Error, LocalizedError {
+    case invalidOllamaResponse
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidOllamaResponse:
+            "Ollama returned an invalid model-list response."
+        }
+    }
+}

--- a/Sources/OpenIslandApp/GraphWorkspaceAuthoringState.swift
+++ b/Sources/OpenIslandApp/GraphWorkspaceAuthoringState.swift
@@ -1,0 +1,107 @@
+import CryptoKit
+import Foundation
+import OpenIslandCore
+
+struct GraphDocumentFileState: Equatable, Sendable {
+    let contentDigest: String
+    let modificationDate: Date?
+    let byteCount: Int
+
+    init(data: Data, modificationDate: Date?) {
+        contentDigest = SHA256.hash(data: data)
+            .map { String(format: "%02x", $0) }
+            .joined()
+        self.modificationDate = modificationDate
+        byteCount = data.count
+    }
+}
+
+enum GraphDocumentStoreError: Error, Equatable {
+    case externallyModified(URL)
+}
+
+extension GraphDocumentStoreError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case let .externallyModified(url):
+            "The graph changed on disk after it was opened: \(url.path). Use Revert or Save As."
+        }
+    }
+}
+
+struct GraphNewDocumentRequest: Equatable, Sendable {
+    var name: String
+    var graphID: String
+    var definitionVersion: String
+    var description: String
+    var defaultRetryMaximumAttempts: Int
+    var defaultExecutionTimeoutSeconds: UInt64
+    var defaultExecutorKind: String
+    var workspaceDirectory: String?
+
+    init(
+        name: String,
+        graphID: String,
+        definitionVersion: String,
+        description: String = "",
+        defaultRetryMaximumAttempts: Int = 2,
+        defaultExecutionTimeoutSeconds: UInt64 = 300,
+        defaultExecutorKind: String = "local_process",
+        workspaceDirectory: String? = nil
+    ) {
+        self.name = name
+        self.graphID = graphID
+        self.definitionVersion = definitionVersion
+        self.description = description
+        self.defaultRetryMaximumAttempts = max(1, defaultRetryMaximumAttempts)
+        self.defaultExecutionTimeoutSeconds = max(1, defaultExecutionTimeoutSeconds)
+        self.defaultExecutorKind = defaultExecutorKind
+        self.workspaceDirectory = workspaceDirectory
+    }
+
+    static func defaults(
+        id: String = UUID().uuidString.lowercased()
+    ) -> GraphNewDocumentRequest {
+        GraphNewDocumentRequest(
+            name: "Untitled Graph",
+            graphID: id,
+            definitionVersion: "1",
+            description: "",
+            defaultRetryMaximumAttempts: 2,
+            defaultExecutionTimeoutSeconds: 300,
+            defaultExecutorKind: "local_process",
+            workspaceDirectory: FileManager.default.currentDirectoryPath
+        )
+    }
+}
+
+enum GraphUnsavedCloseChoice: Equatable, Sendable {
+    case save
+    case discard
+    case cancel
+}
+
+enum GraphDocumentCloseState: Equatable, Sendable {
+    case idle
+    case confirmationRequired
+}
+
+struct GraphAuthoringUndoSnapshot: Equatable, Sendable {
+    let document: GraphDefinitionDocument
+    let selectedNodeIDs: Set<String>
+    let selectedEdgeID: String?
+}
+
+enum GraphAuthoringMutationKind: Equatable, Sendable {
+    case semantic
+    case layout
+}
+
+enum GraphDefinitionVersioning {
+    static func nextVersion(after current: String) -> String {
+        if let number = Int(current) {
+            return String(number + 1)
+        }
+        return "\(current).1"
+    }
+}

--- a/Sources/OpenIslandApp/GraphWorkspaceAuthoringState.swift
+++ b/Sources/OpenIslandApp/GraphWorkspaceAuthoringState.swift
@@ -105,3 +105,42 @@ enum GraphDefinitionVersioning {
         return "\(current).1"
     }
 }
+
+enum GraphWorkspaceExecutionBackend: String, CaseIterable, Identifiable, Sendable {
+    case supervisedLocalProcess = "Supervised Local Process"
+    case deterministicTest = "Deterministic Test Executor"
+    case codex = "Codex - not configured"
+    case qwen = "Qwen - not configured"
+    case ollama = "Ollama - not configured"
+    case openClaw = "OpenClaw - not configured"
+
+    var id: String { rawValue }
+
+    var isConfigured: Bool {
+        self == .supervisedLocalProcess || self == .deterministicTest
+    }
+}
+
+struct GraphRunCreationDraft: Equatable, Sendable {
+    var backend: GraphWorkspaceExecutionBackend
+    var inputValues: [String: String]
+    var secretReferences: [String: String]
+    var workspaceDirectory: String?
+
+    init(
+        backend: GraphWorkspaceExecutionBackend = .supervisedLocalProcess,
+        inputValues: [String: String] = [:],
+        secretReferences: [String: String] = [:],
+        workspaceDirectory: String? = nil
+    ) {
+        self.backend = backend
+        self.inputValues = inputValues
+        self.secretReferences = secretReferences
+        self.workspaceDirectory = workspaceDirectory
+    }
+
+    var resolvedInputIDs: Set<String> {
+        Set(inputValues.filter { !$0.value.isEmpty }.map(\.key))
+            .union(secretReferences.filter { !$0.value.isEmpty }.map(\.key))
+    }
+}

--- a/Sources/OpenIslandApp/GraphWorkspaceAuthoringState.swift
+++ b/Sources/OpenIslandApp/GraphWorkspaceAuthoringState.swift
@@ -2,6 +2,39 @@ import CryptoKit
 import Foundation
 import OpenIslandCore
 
+enum GraphWorkspaceTemplate: String, CaseIterable, Identifiable, Sendable {
+    case blank = "blank"
+    case linearPipeline = "linear_pipeline"
+    case fanOutFanIn = "fan_out_fan_in"
+    case reviewLoop = "review_loop"
+    case compendiumFill = "compendium_fill"
+    case localProcessExample = "local_process_example"
+
+    var id: String { rawValue }
+
+    var name: String {
+        switch self {
+        case .blank: "Blank Graph"
+        case .linearPipeline: "Linear Pipeline"
+        case .fanOutFanIn: "Fan-Out/Fan-In"
+        case .reviewLoop: "Review Loop"
+        case .compendiumFill: "Compendium Fill"
+        case .localProcessExample: "Local Process Example"
+        }
+    }
+
+    var summary: String {
+        switch self {
+        case .blank: "Start with an empty editable canvas."
+        case .linearPipeline: "Three deterministic stages in sequence."
+        case .fanOutFanIn: "Parallel branches joined by a final stage."
+        case .reviewLoop: "Draft, parallel review, revision, and final review as a DAG."
+        case .compendiumFill: "Architect, researcher, graph, and reviewer local processes."
+        case .localProcessExample: "Generate, transform, and verify using supervised processes."
+        }
+    }
+}
+
 struct GraphDocumentFileState: Equatable, Sendable {
     let contentDigest: String
     let modificationDate: Date?
@@ -30,6 +63,7 @@ extension GraphDocumentStoreError: LocalizedError {
 }
 
 struct GraphNewDocumentRequest: Equatable, Sendable {
+    var template: GraphWorkspaceTemplate
     var name: String
     var graphID: String
     var definitionVersion: String
@@ -40,6 +74,7 @@ struct GraphNewDocumentRequest: Equatable, Sendable {
     var workspaceDirectory: String?
 
     init(
+        template: GraphWorkspaceTemplate = .blank,
         name: String,
         graphID: String,
         definitionVersion: String,
@@ -49,6 +84,7 @@ struct GraphNewDocumentRequest: Equatable, Sendable {
         defaultExecutorKind: String = "local_process",
         workspaceDirectory: String? = nil
     ) {
+        self.template = template
         self.name = name
         self.graphID = graphID
         self.definitionVersion = definitionVersion
@@ -63,6 +99,7 @@ struct GraphNewDocumentRequest: Equatable, Sendable {
         id: String = UUID().uuidString.lowercased()
     ) -> GraphNewDocumentRequest {
         GraphNewDocumentRequest(
+            template: .blank,
             name: "Untitled Graph",
             graphID: id,
             definitionVersion: "1",
@@ -70,7 +107,7 @@ struct GraphNewDocumentRequest: Equatable, Sendable {
             defaultRetryMaximumAttempts: 2,
             defaultExecutionTimeoutSeconds: 300,
             defaultExecutorKind: "local_process",
-            workspaceDirectory: FileManager.default.currentDirectoryPath
+            workspaceDirectory: nil
         )
     }
 }

--- a/Sources/OpenIslandApp/GraphWorkspaceBundledFixtures.swift
+++ b/Sources/OpenIslandApp/GraphWorkspaceBundledFixtures.swift
@@ -1,0 +1,122 @@
+import Foundation
+import OpenIslandCore
+
+enum GraphWorkspaceBundledFixtures {
+    static let compendiumResourceName =
+        "dose-regulations-compendium.openisland-graph"
+    static let fixtureExecutablePlaceholder =
+        "${OPENISLAND_PROCESS_FIXTURE}"
+    static let workspacePlaceholder =
+        "${OPENISLAND_COMPENDIUM_WORKSPACE}"
+
+    static func loadCompendium() throws -> GraphDefinitionDocument {
+        try loadCompendium(
+            executableURL: fixtureExecutableURL(),
+            workspaceURL: compendiumWorkspaceURL()
+        )
+    }
+
+    static func loadCompendium(
+        executableURL: URL,
+        workspaceURL: URL
+    ) throws -> GraphDefinitionDocument {
+        guard let url = Bundle.module.url(
+            forResource: compendiumResourceName,
+            withExtension: "json"
+        ) else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        let document = try GraphDefinitionDocumentCodec.load(url: url)
+        return try materialize(
+            document,
+            executableURL: executableURL,
+            workspaceURL: workspaceURL
+        )
+    }
+
+    static func materialize(
+        _ document: GraphDefinitionDocument,
+        executableURL: URL,
+        workspaceURL: URL
+    ) throws -> GraphDefinitionDocument {
+        try FileManager.default.createDirectory(
+            at: workspaceURL,
+            withIntermediateDirectories: true
+        )
+        var result = document
+        for index in result.nodes.indices {
+            var node = result.nodes[index]
+            if node.specification.adapterKind
+                == GraphLocalProcessSpecification.adapterKind {
+                let source = try GraphLocalProcessSpecification(
+                    immutableSpecification: node.specification
+                )
+                let executable = source.executable
+                    == fixtureExecutablePlaceholder
+                    ? executableURL.path : source.executable
+                node.specification = try GraphLocalProcessSpecification(
+                    executable: executable,
+                    arguments: source.arguments,
+                    workingDirectory: source.workingDirectory,
+                    environment: source.environment,
+                    inheritedEnvironment: source.inheritedEnvironment,
+                    stdin: source.stdin,
+                    outputArtifacts: source.outputArtifacts,
+                    retryableExitCodes: source.retryableExitCodes,
+                    logPolicy: source.logPolicy
+                ).immutableSpecification()
+            }
+            if node.workspace.root == workspacePlaceholder {
+                node.workspace = GraphExecutionWorkspaceContext(
+                    root: workspaceURL.path,
+                    writableRelativePaths: node.workspace.writableRelativePaths
+                )
+            }
+            result.nodes[index] = node
+        }
+        try result.validate()
+        return result
+    }
+
+    static func fixtureExecutableURL() throws -> URL {
+        let bundled = Bundle.main.bundleURL
+            .appendingPathComponent("Contents/Helpers", isDirectory: true)
+            .appendingPathComponent("OpenIslandProcessFixtureAgent")
+        if FileManager.default.isExecutableFile(atPath: bundled.path) {
+            return bundled
+        }
+        let sibling = URL(fileURLWithPath: CommandLine.arguments[0])
+            .deletingLastPathComponent()
+            .appendingPathComponent("OpenIslandProcessFixtureAgent")
+        if FileManager.default.isExecutableFile(atPath: sibling.path) {
+            return sibling
+        }
+        let development = URL(
+            fileURLWithPath: FileManager.default.currentDirectoryPath
+        ).appendingPathComponent(
+            ".build/debug/OpenIslandProcessFixtureAgent"
+        )
+        guard FileManager.default.isExecutableFile(
+            atPath: development.path
+        ) else {
+            throw GraphLocalProcessSpecificationError
+                .executableUnavailable(development.path)
+        }
+        return development
+    }
+
+    static func compendiumWorkspaceURL() throws -> URL {
+        let support = try FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        return support
+            .appendingPathComponent("OpenIsland", isDirectory: true)
+            .appendingPathComponent(
+                "compendium-process-workspace",
+                isDirectory: true
+            )
+    }
+}

--- a/Sources/OpenIslandApp/GraphWorkspaceBundledFixtures.swift
+++ b/Sources/OpenIslandApp/GraphWorkspaceBundledFixtures.swift
@@ -119,4 +119,17 @@ enum GraphWorkspaceBundledFixtures {
                 isDirectory: true
             )
     }
+
+    static func templateWorkspaceURL(graphID: String) throws -> URL {
+        let support = try FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        return support
+            .appendingPathComponent("OpenIsland", isDirectory: true)
+            .appendingPathComponent("graph-template-workspaces", isDirectory: true)
+            .appendingPathComponent(graphID, isDirectory: true)
+    }
 }

--- a/Sources/OpenIslandApp/GraphWorkspaceService.swift
+++ b/Sources/OpenIslandApp/GraphWorkspaceService.swift
@@ -90,7 +90,9 @@ actor GraphWorkspaceService: GraphWorkspaceServicing {
         readStore: any GraphExecutionReadStore,
         snapshotStore: any GraphExecutionSnapshotReadStore,
         processExecutor: SupervisedLocalProcessExecutor,
-        launchStore: GraphLocalProcessLaunchStore
+        launchStore: GraphLocalProcessLaunchStore,
+        openAICompatibleExecutor: OpenAICompatibleGraphExecutor =
+            OpenAICompatibleGraphExecutor()
     ) {
         let deterministic = DeterministicGraphExecutor(
             capabilities: ["deterministic", "compendium"],
@@ -99,6 +101,8 @@ actor GraphWorkspaceService: GraphWorkspaceServicing {
         let router = RoutingGraphExecutor(adapters: [
             GraphLocalProcessSpecification.adapterKind: processExecutor,
             "deterministic": deterministic,
+            OpenAICompatibleGraphExecutor.adapterKind:
+                openAICompatibleExecutor,
         ])
         mutator = DefaultGraphMutationService(
             eventStore: eventStore,
@@ -117,6 +121,7 @@ actor GraphWorkspaceService: GraphWorkspaceServicing {
                 supportedAdapterKinds: [
                     GraphLocalProcessSpecification.adapterKind,
                     "deterministic",
+                    OpenAICompatibleGraphExecutor.adapterKind,
                 ]
             )
         )
@@ -247,7 +252,11 @@ actor GraphWorkspaceService: GraphWorkspaceServicing {
             }
         }
         return GraphDefinitionValidationContext(
-            supportedExecutors: [.supervisedLocalProcess, .deterministicTest],
+            supportedExecutors: [
+                .supervisedLocalProcess,
+                .deterministicTest,
+                .openAICompatible,
+            ],
             availableCapabilities: workspaceExecutorCapabilities,
             availableExecutablePaths: executablePaths,
             availableDirectoryPaths: directoryPaths

--- a/Sources/OpenIslandApp/GraphWorkspaceService.swift
+++ b/Sources/OpenIslandApp/GraphWorkspaceService.swift
@@ -59,6 +59,8 @@ protocol GraphWorkspaceServicing: Sendable {
         -> GraphCausalExplanation
     func logs(runID: String, nodeID: String) async throws
         -> GraphProcessLogPage
+    func waitForProcessChange(runID: String, nodeID: String) async
+    func waitForRetryEligibility(runID: String) async
     func exportRun(runID: String, url: URL) async throws
 }
 
@@ -70,6 +72,7 @@ actor GraphWorkspaceService: GraphWorkspaceServicing {
     private let launchStore: GraphLocalProcessLaunchStore
     private var revision: UInt64 = 0
     private var revisionObservers: [UUID: AsyncStream<UInt64>.Continuation] = [:]
+    private var logicalTimes: [String: Date] = [:]
 
     init(
         eventStore: any GraphExecutionEventStore,
@@ -167,13 +170,17 @@ actor GraphWorkspaceService: GraphWorkspaceServicing {
         occurredAt: Date
     ) async -> GraphWorkspaceCommandResult {
         do {
+            let logicalTime = monotonicLogicalTime(
+                runID: runID,
+                proposed: occurredAt
+            )
             try document.validate()
             let report = try await mutator.create(
                 GraphCreateRequest(
                     runID: runID,
                     definition: try document.executableDefinition(),
                     idempotencyKey: "workspace-create-\(runID)",
-                    occurredAt: occurredAt,
+                    occurredAt: logicalTime,
                     producer: workspaceProducer
                 )
             )
@@ -193,12 +200,16 @@ actor GraphWorkspaceService: GraphWorkspaceServicing {
         occurredAt: Date
     ) async -> GraphWorkspaceCommandResult {
         do {
+            let logicalTime = monotonicLogicalTime(
+                runID: runID,
+                proposed: occurredAt
+            )
             let report = try await mutator.start(
                 GraphStartRequest(
                     runID: runID,
                     idempotencyKey: "workspace-start-\(runID)",
                     requestedBy: NSUserName(),
-                    occurredAt: occurredAt,
+                    occurredAt: logicalTime,
                     producer: workspaceProducer
                 )
             )
@@ -218,10 +229,14 @@ actor GraphWorkspaceService: GraphWorkspaceServicing {
         occurredAt: Date
     ) async -> GraphWorkspaceCommandResult {
         do {
+            let logicalTime = monotonicLogicalTime(
+                runID: runID,
+                proposed: occurredAt
+            )
             let report = try await orchestrator.step(
                 GraphOrchestrationStepRequest(
                     runID: runID,
-                    logicalTime: occurredAt
+                    logicalTime: logicalTime
                 )
             )
             emitRevision()
@@ -253,13 +268,17 @@ actor GraphWorkspaceService: GraphWorkspaceServicing {
         occurredAt: Date
     ) async -> GraphWorkspaceCommandResult {
         do {
+            let logicalTime = monotonicLogicalTime(
+                runID: runID,
+                proposed: occurredAt
+            )
             let report = try await mutator.retry(
                 GraphRetryMutationRequest(
                     runID: runID,
                     nodeID: nodeID,
                     idempotencyKey: "workspace-retry-\(UUID().uuidString)",
                     requestedBy: NSUserName(),
-                    occurredAt: occurredAt,
+                    occurredAt: logicalTime,
                     producer: workspaceProducer
                 )
             )
@@ -281,6 +300,10 @@ actor GraphWorkspaceService: GraphWorkspaceServicing {
         occurredAt: Date
     ) async -> GraphWorkspaceCommandResult {
         do {
+            let logicalTime = monotonicLogicalTime(
+                runID: runID,
+                proposed: occurredAt
+            )
             let report = try await mutator.cancel(
                 GraphCancelMutationRequest(
                     runID: runID,
@@ -288,7 +311,7 @@ actor GraphWorkspaceService: GraphWorkspaceServicing {
                     idempotencyKey: "workspace-cancel-\(UUID().uuidString)",
                     requestedBy: NSUserName(),
                     reason: "graph_workspace",
-                    occurredAt: occurredAt,
+                    occurredAt: logicalTime,
                     producer: workspaceProducer
                 )
             )
@@ -353,6 +376,38 @@ actor GraphWorkspaceService: GraphWorkspaceServicing {
         )
     }
 
+    func waitForProcessChange(runID: String, nodeID: String) async {
+        guard let record = try? await launchStore.records().filter({
+            $0.identity.runID == runID && $0.identity.nodeID == nodeID
+        }).max(by: {
+            $0.identity.attemptOrdinal < $1.identity.attemptOrdinal
+        }), record.exit == nil else { return }
+        let events = await processExecutor.exitEvents()
+        if let refreshed = try? await launchStore.record(id: record.id),
+           refreshed.exit != nil {
+            return
+        }
+        for await launchID in events {
+            if Task.isCancelled || launchID == record.id { return }
+        }
+    }
+
+    func waitForRetryEligibility(runID: String) async {
+        guard let inspection = try? await inspect(runID: runID),
+              let scheduling = inspection.scheduling,
+              let eligibleAt = scheduling.retries
+                .map(\.eligibleAt)
+                .filter({ $0 > Date() })
+                .min() else {
+            return
+        }
+        let milliseconds = max(
+            1,
+            Int(ceil(eligibleAt.timeIntervalSinceNow * 1_000))
+        )
+        try? await Task.sleep(for: .milliseconds(milliseconds))
+    }
+
     func exportRun(runID: String, url: URL) async throws {
         let inspection = try await inspect(runID: runID)
         let encoder = JSONEncoder()
@@ -370,6 +425,15 @@ actor GraphWorkspaceService: GraphWorkspaceServicing {
             id: "openisland.graph-workspace",
             kind: .application
         )
+    }
+
+    private func monotonicLogicalTime(
+        runID: String,
+        proposed: Date
+    ) -> Date {
+        let logicalTime = max(logicalTimes[runID] ?? proposed, proposed)
+        logicalTimes[runID] = logicalTime
+        return logicalTime
     }
 
     private func result(
@@ -418,6 +482,8 @@ actor UnavailableGraphWorkspaceService: GraphWorkspaceServicing {
     func history(runID: String) throws -> GraphInspectionEventPage { throw error }
     func explain(runID: String, nodeID: String?) throws -> GraphCausalExplanation { throw error }
     func logs(runID: String, nodeID: String) throws -> GraphProcessLogPage { throw error }
+    func waitForProcessChange(runID: String, nodeID: String) {}
+    func waitForRetryEligibility(runID: String) {}
     func exportRun(runID: String, url: URL) throws { throw error }
 
     private var error: NSError {

--- a/Sources/OpenIslandApp/GraphWorkspaceService.swift
+++ b/Sources/OpenIslandApp/GraphWorkspaceService.swift
@@ -38,7 +38,14 @@ struct GraphWorkspaceCommandResult: Equatable, Codable, Sendable {
 protocol GraphWorkspaceServicing: Sendable {
     func revisions() async -> AsyncStream<UInt64>
     func loadDocument(url: URL) async throws -> GraphDefinitionDocument
-    func saveDocument(_ document: GraphDefinitionDocument, url: URL) async throws
+    func documentFileState(url: URL) async throws -> GraphDocumentFileState
+    func saveDocument(
+        _ document: GraphDefinitionDocument,
+        url: URL,
+        expectedContentDigest: String?
+    ) async throws -> GraphDocumentFileState
+    func associatedRunCount(graphID: String, definitionVersion: String) async
+        throws -> Int
     func createRun(
         document: GraphDefinitionDocument,
         runID: String,
@@ -157,11 +164,47 @@ actor GraphWorkspaceService: GraphWorkspaceServicing {
         try GraphDefinitionDocumentCodec.load(url: url)
     }
 
+    func documentFileState(url: URL) throws -> GraphDocumentFileState {
+        let data = try Data(contentsOf: url)
+        let values = try url.resourceValues(forKeys: [.contentModificationDateKey])
+        return GraphDocumentFileState(
+            data: data,
+            modificationDate: values.contentModificationDate
+        )
+    }
+
     func saveDocument(
         _ document: GraphDefinitionDocument,
-        url: URL
-    ) throws {
+        url: URL,
+        expectedContentDigest: String?
+    ) throws -> GraphDocumentFileState {
+        if let expectedContentDigest,
+           FileManager.default.fileExists(atPath: url.path),
+           try documentFileState(url: url).contentDigest != expectedContentDigest {
+            throw GraphDocumentStoreError.externallyModified(url)
+        }
         try GraphDefinitionDocumentCodec.save(document, to: url)
+        return try documentFileState(url: url)
+    }
+
+    func associatedRunCount(
+        graphID: String,
+        definitionVersion: String
+    ) async throws -> Int {
+        let summaries = try await inspector.listRuns(state: nil, limit: 250)
+            .filter { $0.graphID == graphID }
+        var count = 0
+        for summary in summaries {
+            let run = try await inspector.inspect(
+                runID: summary.runID,
+                includeArtifacts: false,
+                includeDiagnostics: false
+            )
+            if run.graphDefinitionVersion == definitionVersion {
+                count += 1
+            }
+        }
+        return count
     }
 
     func createRun(
@@ -471,7 +514,9 @@ actor UnavailableGraphWorkspaceService: GraphWorkspaceServicing {
     }
 
     func loadDocument(url: URL) throws -> GraphDefinitionDocument { throw error }
-    func saveDocument(_ document: GraphDefinitionDocument, url: URL) throws { throw error }
+    func documentFileState(url: URL) throws -> GraphDocumentFileState { throw error }
+    func saveDocument(_ document: GraphDefinitionDocument, url: URL, expectedContentDigest: String?) throws -> GraphDocumentFileState { throw error }
+    func associatedRunCount(graphID: String, definitionVersion: String) throws -> Int { throw error }
     func createRun(document: GraphDefinitionDocument, runID: String, occurredAt: Date) -> GraphWorkspaceCommandResult { rejected(runID) }
     func startRun(runID: String, occurredAt: Date) -> GraphWorkspaceCommandResult { rejected(runID) }
     func step(runID: String, occurredAt: Date) -> GraphWorkspaceCommandResult { rejected(runID) }

--- a/Sources/OpenIslandApp/GraphWorkspaceService.swift
+++ b/Sources/OpenIslandApp/GraphWorkspaceService.swift
@@ -1,0 +1,442 @@
+import Foundation
+import OpenIslandCore
+
+enum GraphWorkspaceRefreshBehavior: String, Codable, Sendable {
+    case none
+    case refreshRun = "refresh_run"
+    case refreshHistory = "refresh_history"
+    case refreshAll = "refresh_all"
+}
+
+struct GraphWorkspaceCommandResult: Equatable, Codable, Sendable {
+    let accepted: Bool
+    let reasonCode: String
+    let streamVersion: UInt64?
+    let runID: String?
+    let nodeIDs: [String]
+    let diagnostics: [String]
+    let suggestedRefresh: GraphWorkspaceRefreshBehavior
+
+    static func rejected(
+        _ reasonCode: String,
+        runID: String? = nil,
+        nodeIDs: [String] = [],
+        diagnostic: String
+    ) -> GraphWorkspaceCommandResult {
+        GraphWorkspaceCommandResult(
+            accepted: false,
+            reasonCode: reasonCode,
+            streamVersion: nil,
+            runID: runID,
+            nodeIDs: nodeIDs.sorted(),
+            diagnostics: [diagnostic],
+            suggestedRefresh: .none
+        )
+    }
+}
+
+protocol GraphWorkspaceServicing: Sendable {
+    func revisions() async -> AsyncStream<UInt64>
+    func loadDocument(url: URL) async throws -> GraphDefinitionDocument
+    func saveDocument(_ document: GraphDefinitionDocument, url: URL) async throws
+    func createRun(
+        document: GraphDefinitionDocument,
+        runID: String,
+        occurredAt: Date
+    ) async -> GraphWorkspaceCommandResult
+    func startRun(runID: String, occurredAt: Date) async
+        -> GraphWorkspaceCommandResult
+    func step(runID: String, occurredAt: Date) async
+        -> GraphWorkspaceCommandResult
+    func retry(runID: String, nodeID: String, occurredAt: Date) async
+        -> GraphWorkspaceCommandResult
+    func cancel(runID: String, nodeID: String?, occurredAt: Date) async
+        -> GraphWorkspaceCommandResult
+    func inspect(runID: String) async throws -> GraphRunInspection
+    func listRuns() async throws -> [GraphRunInspectionSummary]
+    func history(runID: String) async throws -> GraphInspectionEventPage
+    func explain(runID: String, nodeID: String?) async throws
+        -> GraphCausalExplanation
+    func logs(runID: String, nodeID: String) async throws
+        -> GraphProcessLogPage
+    func exportRun(runID: String, url: URL) async throws
+}
+
+actor GraphWorkspaceService: GraphWorkspaceServicing {
+    private let mutator: any GraphMutating
+    private let orchestrator: any GraphOrchestrating
+    private let inspector: any GraphTemporalInspecting
+    private let processExecutor: SupervisedLocalProcessExecutor
+    private let launchStore: GraphLocalProcessLaunchStore
+    private var revision: UInt64 = 0
+    private var revisionObservers: [UUID: AsyncStream<UInt64>.Continuation] = [:]
+
+    init(
+        eventStore: any GraphExecutionEventStore,
+        readStore: any GraphExecutionReadStore,
+        snapshotStore: any GraphExecutionSnapshotReadStore,
+        processExecutor: SupervisedLocalProcessExecutor,
+        launchStore: GraphLocalProcessLaunchStore
+    ) {
+        mutator = DefaultGraphMutationService(
+            eventStore: eventStore,
+            readStore: readStore
+        )
+        orchestrator = DefaultGraphOrchestrationService(
+            eventStore: eventStore,
+            schedulingRepository: DefaultGraphSchedulingRepository(
+                eventStore: eventStore
+            ),
+            executorRepository: DefaultGraphExecutorRepository(
+                eventStore: eventStore
+            ),
+            executor: processExecutor,
+            confirmationPolicy: LocalProcessExecutionConfirmationPolicy()
+        )
+        inspector = DefaultGraphTemporalInspector(
+            readStore: readStore,
+            snapshotStore: snapshotStore,
+            evidenceSource: GraphLocalProcessEvidenceSource(
+                launchStore: launchStore
+            )
+        )
+        self.processExecutor = processExecutor
+        self.launchStore = launchStore
+    }
+
+    static func live() throws -> GraphWorkspaceService {
+        let databasePath = try SQLiteGraphExecutionStore.defaultDatabasePath()
+        let store = try SQLiteGraphExecutionStore(databasePath: databasePath)
+        let launchStore = try GraphLocalProcessLaunchStore(
+            rootURL: GraphLocalProcessLaunchStore.defaultRootURL()
+        )
+        let executor = SupervisedLocalProcessExecutor(
+            launchStore: launchStore
+        )
+        return GraphWorkspaceService(
+            eventStore: store,
+            readStore: store,
+            snapshotStore: store,
+            processExecutor: executor,
+            launchStore: launchStore
+        )
+    }
+
+    static func inMemory(
+        rootURL: URL
+    ) throws -> GraphWorkspaceService {
+        let store = InMemoryGraphExecutionEventStore()
+        let launchStore = try GraphLocalProcessLaunchStore(rootURL: rootURL)
+        let executor = SupervisedLocalProcessExecutor(
+            launchStore: launchStore
+        )
+        return GraphWorkspaceService(
+            eventStore: store,
+            readStore: store,
+            snapshotStore: InMemoryGraphExecutionSnapshotStore(),
+            processExecutor: executor,
+            launchStore: launchStore
+        )
+    }
+
+    func revisions() -> AsyncStream<UInt64> {
+        let id = UUID()
+        return AsyncStream { continuation in
+            revisionObservers[id] = continuation
+            continuation.yield(revision)
+            continuation.onTermination = { [weak self] _ in
+                Task { await self?.removeRevisionObserver(id) }
+            }
+        }
+    }
+
+    func loadDocument(url: URL) throws -> GraphDefinitionDocument {
+        try GraphDefinitionDocumentCodec.load(url: url)
+    }
+
+    func saveDocument(
+        _ document: GraphDefinitionDocument,
+        url: URL
+    ) throws {
+        try GraphDefinitionDocumentCodec.save(document, to: url)
+    }
+
+    func createRun(
+        document: GraphDefinitionDocument,
+        runID: String,
+        occurredAt: Date
+    ) async -> GraphWorkspaceCommandResult {
+        do {
+            try document.validate()
+            let report = try await mutator.create(
+                GraphCreateRequest(
+                    runID: runID,
+                    definition: try document.executableDefinition(),
+                    idempotencyKey: "workspace-create-\(runID)",
+                    occurredAt: occurredAt,
+                    producer: workspaceProducer
+                )
+            )
+            emitRevision()
+            return result(report, reasonCode: "run_created")
+        } catch {
+            return .rejected(
+                "run_create_rejected",
+                runID: runID,
+                diagnostic: error.localizedDescription
+            )
+        }
+    }
+
+    func startRun(
+        runID: String,
+        occurredAt: Date
+    ) async -> GraphWorkspaceCommandResult {
+        do {
+            let report = try await mutator.start(
+                GraphStartRequest(
+                    runID: runID,
+                    idempotencyKey: "workspace-start-\(runID)",
+                    requestedBy: NSUserName(),
+                    occurredAt: occurredAt,
+                    producer: workspaceProducer
+                )
+            )
+            emitRevision()
+            return result(report, reasonCode: "run_start_requested")
+        } catch {
+            return .rejected(
+                "run_start_rejected",
+                runID: runID,
+                diagnostic: error.localizedDescription
+            )
+        }
+    }
+
+    func step(
+        runID: String,
+        occurredAt: Date
+    ) async -> GraphWorkspaceCommandResult {
+        do {
+            let report = try await orchestrator.step(
+                GraphOrchestrationStepRequest(
+                    runID: runID,
+                    logicalTime: occurredAt
+                )
+            )
+            emitRevision()
+            return GraphWorkspaceCommandResult(
+                accepted: report.status != .adapterUnavailable,
+                reasonCode: report.policyDenials.first?.rawValue
+                    ?? report.status.rawValue,
+                streamVersion: report.streamVersion,
+                runID: report.runID,
+                nodeIDs: [report.claimedNodeID].compactMap { $0 },
+                diagnostics: [
+                    report.executorStatus?.rawValue,
+                    report.executorOperation?.rawValue,
+                ].compactMap { $0 },
+                suggestedRefresh: .refreshAll
+            )
+        } catch {
+            return .rejected(
+                "orchestration_step_rejected",
+                runID: runID,
+                diagnostic: error.localizedDescription
+            )
+        }
+    }
+
+    func retry(
+        runID: String,
+        nodeID: String,
+        occurredAt: Date
+    ) async -> GraphWorkspaceCommandResult {
+        do {
+            let report = try await mutator.retry(
+                GraphRetryMutationRequest(
+                    runID: runID,
+                    nodeID: nodeID,
+                    idempotencyKey: "workspace-retry-\(UUID().uuidString)",
+                    requestedBy: NSUserName(),
+                    occurredAt: occurredAt,
+                    producer: workspaceProducer
+                )
+            )
+            emitRevision()
+            return result(report, reasonCode: "retry_requested")
+        } catch {
+            return .rejected(
+                "retry_rejected",
+                runID: runID,
+                nodeIDs: [nodeID],
+                diagnostic: error.localizedDescription
+            )
+        }
+    }
+
+    func cancel(
+        runID: String,
+        nodeID: String?,
+        occurredAt: Date
+    ) async -> GraphWorkspaceCommandResult {
+        do {
+            let report = try await mutator.cancel(
+                GraphCancelMutationRequest(
+                    runID: runID,
+                    nodeID: nodeID,
+                    idempotencyKey: "workspace-cancel-\(UUID().uuidString)",
+                    requestedBy: NSUserName(),
+                    reason: "graph_workspace",
+                    occurredAt: occurredAt,
+                    producer: workspaceProducer
+                )
+            )
+            emitRevision()
+            return result(report, reasonCode: "cancellation_requested")
+        } catch {
+            return .rejected(
+                "cancellation_rejected",
+                runID: runID,
+                nodeIDs: [nodeID].compactMap { $0 },
+                diagnostic: error.localizedDescription
+            )
+        }
+    }
+
+    func inspect(runID: String) async throws -> GraphRunInspection {
+        try await inspector.inspect(
+            runID: runID,
+            includeArtifacts: true,
+            includeDiagnostics: true
+        )
+    }
+
+    func listRuns() async throws -> [GraphRunInspectionSummary] {
+        try await inspector.listRuns(state: nil, limit: 250)
+    }
+
+    func history(runID: String) async throws -> GraphInspectionEventPage {
+        try await inspector.eventPage(
+            runID: runID,
+            filter: GraphInspectionEventFilter(limit: 2_000)
+        )
+    }
+
+    func explain(
+        runID: String,
+        nodeID: String?
+    ) async throws -> GraphCausalExplanation {
+        try await inspector.explain(runID: runID, nodeID: nodeID)
+    }
+
+    func logs(
+        runID: String,
+        nodeID: String
+    ) async throws -> GraphProcessLogPage {
+        let records = try await launchStore.records().filter {
+            $0.identity.runID == runID && $0.identity.nodeID == nodeID
+        }
+        guard let record = records.max(by: {
+            if $0.identity.attemptOrdinal != $1.identity.attemptOrdinal {
+                return $0.identity.attemptOrdinal < $1.identity.attemptOrdinal
+            }
+            return $0.preparedAt < $1.preparedAt
+        }) else {
+            throw GraphLocalProcessRuntimeError.launchRecordMissing(
+                "\(runID)/\(nodeID)"
+            )
+        }
+        return try await processExecutor.logs(
+            launchRecordID: record.id,
+            limit: 5_000
+        )
+    }
+
+    func exportRun(runID: String, url: URL) async throws {
+        let inspection = try await inspect(runID: runID)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [
+            .prettyPrinted,
+            .sortedKeys,
+            .withoutEscapingSlashes,
+        ]
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(inspection).write(to: url, options: .atomic)
+    }
+
+    private var workspaceProducer: GraphExecutionProducer {
+        GraphExecutionProducer(
+            id: "openisland.graph-workspace",
+            kind: .application
+        )
+    }
+
+    private func result(
+        _ report: GraphMutationReport,
+        reasonCode: String
+    ) -> GraphWorkspaceCommandResult {
+        GraphWorkspaceCommandResult(
+            accepted: report.status != .proposed,
+            reasonCode: reasonCode,
+            streamVersion: report.streamVersion,
+            runID: report.runID,
+            nodeIDs: report.nodeIDs,
+            diagnostics: report.eventTypes,
+            suggestedRefresh: .refreshAll
+        )
+    }
+
+    private func emitRevision() {
+        revision &+= 1
+        revisionObservers.values.forEach { $0.yield(revision) }
+    }
+
+    private func removeRevisionObserver(_ id: UUID) {
+        revisionObservers.removeValue(forKey: id)
+    }
+}
+
+actor UnavailableGraphWorkspaceService: GraphWorkspaceServicing {
+    private let message: String
+
+    init(message: String) { self.message = message }
+
+    func revisions() -> AsyncStream<UInt64> {
+        AsyncStream { $0.yield(0); $0.finish() }
+    }
+
+    func loadDocument(url: URL) throws -> GraphDefinitionDocument { throw error }
+    func saveDocument(_ document: GraphDefinitionDocument, url: URL) throws { throw error }
+    func createRun(document: GraphDefinitionDocument, runID: String, occurredAt: Date) -> GraphWorkspaceCommandResult { rejected(runID) }
+    func startRun(runID: String, occurredAt: Date) -> GraphWorkspaceCommandResult { rejected(runID) }
+    func step(runID: String, occurredAt: Date) -> GraphWorkspaceCommandResult { rejected(runID) }
+    func retry(runID: String, nodeID: String, occurredAt: Date) -> GraphWorkspaceCommandResult { rejected(runID, nodeID) }
+    func cancel(runID: String, nodeID: String?, occurredAt: Date) -> GraphWorkspaceCommandResult { rejected(runID, nodeID) }
+    func inspect(runID: String) throws -> GraphRunInspection { throw error }
+    func listRuns() throws -> [GraphRunInspectionSummary] { throw error }
+    func history(runID: String) throws -> GraphInspectionEventPage { throw error }
+    func explain(runID: String, nodeID: String?) throws -> GraphCausalExplanation { throw error }
+    func logs(runID: String, nodeID: String) throws -> GraphProcessLogPage { throw error }
+    func exportRun(runID: String, url: URL) throws { throw error }
+
+    private var error: NSError {
+        NSError(
+            domain: "OpenIsland.GraphWorkspace",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: message]
+        )
+    }
+
+    private func rejected(
+        _ runID: String,
+        _ nodeID: String? = nil
+    ) -> GraphWorkspaceCommandResult {
+        .rejected(
+            "workspace_unavailable",
+            runID: runID,
+            nodeIDs: [nodeID].compactMap { $0 },
+            diagnostic: message
+        )
+    }
+}

--- a/Sources/OpenIslandApp/GraphWorkspaceService.swift
+++ b/Sources/OpenIslandApp/GraphWorkspaceService.swift
@@ -46,9 +46,12 @@ protocol GraphWorkspaceServicing: Sendable {
     ) async throws -> GraphDocumentFileState
     func associatedRunCount(graphID: String, definitionVersion: String) async
         throws -> Int
+    func validationContext(for document: GraphDefinitionDocument) async
+        -> GraphDefinitionValidationContext
     func createRun(
         document: GraphDefinitionDocument,
         runID: String,
+        resolvedGraphInputIDs: Set<String>,
         occurredAt: Date
     ) async -> GraphWorkspaceCommandResult
     func startRun(runID: String, occurredAt: Date) async
@@ -77,6 +80,7 @@ actor GraphWorkspaceService: GraphWorkspaceServicing {
     private let inspector: any GraphTemporalInspecting
     private let processExecutor: SupervisedLocalProcessExecutor
     private let launchStore: GraphLocalProcessLaunchStore
+    private let workspaceExecutorCapabilities: Set<String>
     private var revision: UInt64 = 0
     private var revisionObservers: [UUID: AsyncStream<UInt64>.Continuation] = [:]
     private var logicalTimes: [String: Date] = [:]
@@ -88,6 +92,14 @@ actor GraphWorkspaceService: GraphWorkspaceServicing {
         processExecutor: SupervisedLocalProcessExecutor,
         launchStore: GraphLocalProcessLaunchStore
     ) {
+        let deterministic = DeterministicGraphExecutor(
+            capabilities: ["deterministic", "compendium"],
+            script: GraphDeterministicExecutionScript(attempts: [])
+        )
+        let router = RoutingGraphExecutor(adapters: [
+            GraphLocalProcessSpecification.adapterKind: processExecutor,
+            "deterministic": deterministic,
+        ])
         mutator = DefaultGraphMutationService(
             eventStore: eventStore,
             readStore: readStore
@@ -100,8 +112,13 @@ actor GraphWorkspaceService: GraphWorkspaceServicing {
             executorRepository: DefaultGraphExecutorRepository(
                 eventStore: eventStore
             ),
-            executor: processExecutor,
-            confirmationPolicy: LocalProcessExecutionConfirmationPolicy()
+            executor: router,
+            confirmationPolicy: RoutingGraphExecutionConfirmationPolicy(
+                supportedAdapterKinds: [
+                    GraphLocalProcessSpecification.adapterKind,
+                    "deterministic",
+                ]
+            )
         )
         inspector = DefaultGraphTemporalInspector(
             readStore: readStore,
@@ -112,6 +129,7 @@ actor GraphWorkspaceService: GraphWorkspaceServicing {
         )
         self.processExecutor = processExecutor
         self.launchStore = launchStore
+        workspaceExecutorCapabilities = Set(router.capabilities.capabilities)
     }
 
     static func live() throws -> GraphWorkspaceService {
@@ -207,9 +225,39 @@ actor GraphWorkspaceService: GraphWorkspaceServicing {
         return count
     }
 
+    func validationContext(
+        for document: GraphDefinitionDocument
+    ) -> GraphDefinitionValidationContext {
+        var executablePaths: Set<String> = []
+        var directoryPaths: Set<String> = []
+        for node in document.nodes where node.nodeType == .localProcess {
+            if let process = try? GraphLocalProcessSpecification(
+                immutableSpecification: node.specification
+            ), FileManager.default.isExecutableFile(atPath: process.executable) {
+                executablePaths.insert(process.executable)
+            }
+            if let root = node.workspace.root {
+                var isDirectory: ObjCBool = false
+                if FileManager.default.fileExists(
+                    atPath: root,
+                    isDirectory: &isDirectory
+                ), isDirectory.boolValue {
+                    directoryPaths.insert(root)
+                }
+            }
+        }
+        return GraphDefinitionValidationContext(
+            supportedExecutors: [.supervisedLocalProcess, .deterministicTest],
+            availableCapabilities: workspaceExecutorCapabilities,
+            availableExecutablePaths: executablePaths,
+            availableDirectoryPaths: directoryPaths
+        )
+    }
+
     func createRun(
         document: GraphDefinitionDocument,
         runID: String,
+        resolvedGraphInputIDs: Set<String>,
         occurredAt: Date
     ) async -> GraphWorkspaceCommandResult {
         do {
@@ -218,6 +266,19 @@ actor GraphWorkspaceService: GraphWorkspaceServicing {
                 proposed: occurredAt
             )
             try document.validate()
+            var context = validationContext(for: document)
+            context.resolvedGraphInputIDs = resolvedGraphInputIDs
+            let validationErrors = GraphDefinitionValidator.validate(
+                document,
+                context: context
+            ).filter { $0.severity == .error }
+            guard validationErrors.isEmpty else {
+                return .rejected(
+                    "run_validation_failed",
+                    runID: runID,
+                    diagnostic: validationErrors.map(\.message).joined(separator: "\n")
+                )
+            }
             let report = try await mutator.create(
                 GraphCreateRequest(
                     runID: runID,
@@ -517,7 +578,8 @@ actor UnavailableGraphWorkspaceService: GraphWorkspaceServicing {
     func documentFileState(url: URL) throws -> GraphDocumentFileState { throw error }
     func saveDocument(_ document: GraphDefinitionDocument, url: URL, expectedContentDigest: String?) throws -> GraphDocumentFileState { throw error }
     func associatedRunCount(graphID: String, definitionVersion: String) throws -> Int { throw error }
-    func createRun(document: GraphDefinitionDocument, runID: String, occurredAt: Date) -> GraphWorkspaceCommandResult { rejected(runID) }
+    func validationContext(for document: GraphDefinitionDocument) -> GraphDefinitionValidationContext { .init() }
+    func createRun(document: GraphDefinitionDocument, runID: String, resolvedGraphInputIDs: Set<String>, occurredAt: Date) -> GraphWorkspaceCommandResult { rejected(runID) }
     func startRun(runID: String, occurredAt: Date) -> GraphWorkspaceCommandResult { rejected(runID) }
     func step(runID: String, occurredAt: Date) -> GraphWorkspaceCommandResult { rejected(runID) }
     func retry(runID: String, nodeID: String, occurredAt: Date) -> GraphWorkspaceCommandResult { rejected(runID, nodeID) }

--- a/Sources/OpenIslandApp/GraphWorkspaceTemplateFactory.swift
+++ b/Sources/OpenIslandApp/GraphWorkspaceTemplateFactory.swift
@@ -1,0 +1,318 @@
+import Foundation
+import OpenIslandCore
+
+enum GraphWorkspaceTemplateFactory {
+    static func make(
+        request: GraphNewDocumentRequest,
+        executableURL: URL? = nil,
+        workspaceURL: URL? = nil,
+        now: Date = Date(),
+        author: String = NSUserName()
+    ) throws -> GraphDefinitionDocument {
+        let workspace = try resolveWorkspace(
+            request: request,
+            workspaceURL: workspaceURL
+        )
+        let executable = try executableURL
+            ?? (request.template == .compendiumFill
+                || request.template == .localProcessExample
+                ? GraphWorkspaceBundledFixtures.fixtureExecutableURL() : nil)
+        let nodesAndEdges = try content(
+            template: request.template,
+            executableURL: executable,
+            workspaceURL: workspace
+        )
+        var document = GraphDefinitionDocument(
+            graphID: request.graphID,
+            definitionVersion: request.definitionVersion,
+            name: request.name,
+            description: request.description.isEmpty
+                ? request.template.summary : request.description,
+            graphOutputs: nodesAndEdges.nodes.last.flatMap { node in
+                node.outputs.first.map {
+                    [GraphDefinitionOutput(
+                        id: "graph-output",
+                        name: "Result",
+                        sourceNodeID: node.id,
+                        sourceOutputID: $0.id
+                    )]
+                }
+            } ?? [],
+            nodes: nodesAndEdges.nodes,
+            edges: nodesAndEdges.edges,
+            schedulerPolicy: GraphSchedulerPolicy(
+                policyID: "\(request.graphID)-policy",
+                version: request.definitionVersion,
+                retryPolicy: GraphRetryPolicy(
+                    maximumAttempts: request.defaultRetryMaximumAttempts,
+                    retryableFailureCategories: [
+                        "execution_failure",
+                        "process_exit_unobserved",
+                        "timeout",
+                    ],
+                    nonRetryableFailureCategories: [
+                        "artifact_collection_failure",
+                        "invalid_process_specification",
+                    ]
+                ),
+                attemptExecutionTimeoutSeconds:
+                    request.defaultExecutionTimeoutSeconds,
+                cancellationAcknowledgementTimeoutSeconds: 10
+            ),
+            layout: GraphLayoutMetadata(nodes: nodesAndEdges.layout),
+            metadata: GraphDefinitionDocumentMetadata(
+                createdAt: now,
+                modifiedAt: now,
+                createdBy: author,
+                modifiedBy: author
+            )
+        )
+        if request.template == .blank {
+            document.graphOutputs = []
+        } else {
+            try document.validate()
+        }
+        return document
+    }
+
+    private static func resolveWorkspace(
+        request: GraphNewDocumentRequest,
+        workspaceURL: URL?
+    ) throws -> URL? {
+        guard request.template == .compendiumFill
+                || request.template == .localProcessExample else {
+            return workspaceURL
+                ?? request.workspaceDirectory.map(URL.init(fileURLWithPath:))
+        }
+        let resolved: URL
+        if let workspaceURL {
+            resolved = workspaceURL
+        } else if let path = request.workspaceDirectory {
+            resolved = URL(fileURLWithPath: path)
+        } else {
+            resolved = try GraphWorkspaceBundledFixtures.templateWorkspaceURL(
+                graphID: request.graphID
+            )
+        }
+        try FileManager.default.createDirectory(
+            at: resolved.appendingPathComponent("artifacts", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        return resolved
+    }
+
+    private static func content(
+        template: GraphWorkspaceTemplate,
+        executableURL: URL?,
+        workspaceURL: URL?
+    ) throws -> (
+        nodes: [GraphDefinitionDocumentNode],
+        edges: [GraphDefinitionEdge],
+        layout: [GraphNodeLayoutMetadata]
+    ) {
+        switch template {
+        case .blank:
+            return ([], [], [])
+        case .linearPipeline:
+            return deterministicDAG(
+                nodes: ["prepare", "process", "verify"],
+                edges: [("prepare", "process"), ("process", "verify")]
+            )
+        case .fanOutFanIn:
+            return deterministicDAG(
+                nodes: ["source", "branch-a", "branch-b", "merge"],
+                edges: [
+                    ("source", "branch-a"),
+                    ("source", "branch-b"),
+                    ("branch-a", "merge"),
+                    ("branch-b", "merge"),
+                ],
+                positions: [
+                    "source": .init(x: 0, y: 150),
+                    "branch-a": .init(x: 300, y: 0),
+                    "branch-b": .init(x: 300, y: 300),
+                    "merge": .init(x: 600, y: 150),
+                ]
+            )
+        case .reviewLoop:
+            return deterministicDAG(
+                nodes: ["draft", "review-a", "review-b", "revision", "final-review"],
+                edges: [
+                    ("draft", "review-a"),
+                    ("draft", "review-b"),
+                    ("review-a", "revision"),
+                    ("review-b", "revision"),
+                    ("revision", "final-review"),
+                ],
+                positions: [
+                    "draft": .init(x: 0, y: 150),
+                    "review-a": .init(x: 300, y: 0),
+                    "review-b": .init(x: 300, y: 300),
+                    "revision": .init(x: 600, y: 150),
+                    "final-review": .init(x: 900, y: 150),
+                ]
+            )
+        case .compendiumFill:
+            guard let executableURL, let workspaceURL else {
+                throw CocoaError(.fileNoSuchFile)
+            }
+            return try localProcessDAG(
+                executableURL: executableURL,
+                workspaceURL: workspaceURL,
+                stages: [
+                    ("architect", .nodeOutput, []),
+                    ("researcher", .structuredResult, [.nodeOutput]),
+                    ("graph", .diagnostic, [.structuredResult]),
+                    ("reviewer", .structuredResult, [
+                        .nodeOutput, .structuredResult, .diagnostic,
+                    ]),
+                ]
+            )
+        case .localProcessExample:
+            guard let executableURL, let workspaceURL else {
+                throw CocoaError(.fileNoSuchFile)
+            }
+            return try localProcessDAG(
+                executableURL: executableURL,
+                workspaceURL: workspaceURL,
+                stages: [
+                    ("generate", .nodeOutput, []),
+                    ("transform", .structuredResult, [.nodeOutput]),
+                    ("verify", .diagnostic, [.structuredResult]),
+                ]
+            )
+        }
+    }
+
+    private static func deterministicDAG(
+        nodes ids: [String],
+        edges: [(String, String)],
+        positions: [String: GraphCanvasPoint] = [:]
+    ) -> (
+        nodes: [GraphDefinitionDocumentNode],
+        edges: [GraphDefinitionEdge],
+        layout: [GraphNodeLayoutMetadata]
+    ) {
+        let nodes = ids.enumerated().map { index, id in
+            GraphDefinitionDocumentNode(
+                id: id,
+                name: displayName(id),
+                nodeType: .deterministicTest,
+                requiredCapabilities: ["deterministic"],
+                executorKind: .deterministicTest,
+                specification: GraphImmutableExecutionSpecification(
+                    adapterKind: "deterministic",
+                    operation: "test",
+                    parameters: [
+                        "artifactRole": .string(GraphArtifactRole.nodeOutput.rawValue),
+                    ]
+                ),
+                inputArtifactRoles: [],
+                outputs: [GraphNodeOutputDefinition(
+                    id: "output",
+                    name: "Result",
+                    role: .nodeOutput,
+                    relativePath: "artifacts/\(id).json",
+                    mediaType: "application/json"
+                )],
+                timeoutPolicy: .init(
+                    executionSeconds: 60,
+                    cancellationAcknowledgementSeconds: 5
+                )
+            )
+        }
+        return (
+            nodes,
+            edges.map {
+                GraphDefinitionEdge(
+                    sourceNodeID: $0.0,
+                    targetNodeID: $0.1
+                )
+            },
+            ids.enumerated().map { index, id in
+                GraphNodeLayoutMetadata(
+                    nodeID: id,
+                    position: positions[id]
+                        ?? GraphCanvasPoint(x: Double(index) * 300, y: 0)
+                )
+            }
+        )
+    }
+
+    private static func localProcessDAG(
+        executableURL: URL,
+        workspaceURL: URL,
+        stages: [(String, GraphArtifactRole, [GraphArtifactRole])]
+    ) throws -> (
+        nodes: [GraphDefinitionDocumentNode],
+        edges: [GraphDefinitionEdge],
+        layout: [GraphNodeLayoutMetadata]
+    ) {
+        var nodes: [GraphDefinitionDocumentNode] = []
+        for (id, outputRole, inputRoles) in stages {
+            let output = GraphNodeOutputDefinition(
+                id: "output-\(outputRole.rawValue)",
+                name: "Result",
+                role: outputRole,
+                relativePath: "artifacts/\(id).json",
+                mediaType: "application/json",
+                maximumBytes: 1_024 * 1_024
+            )
+            var arguments = ["--role", id]
+            for role in inputRoles {
+                arguments += ["--input", "${input:\(role.rawValue)}"]
+            }
+            arguments += ["--output", "${artifact:\(outputRole.rawValue)}"]
+            if id == "architect" || id == "generate" {
+                arguments.append("--stderr")
+            }
+            let process = GraphLocalProcessSpecification(
+                executable: executableURL.path,
+                arguments: arguments,
+                outputArtifacts: [GraphLocalProcessArtifactDeclaration(
+                    identifier: output.id,
+                    relativePath: output.relativePath,
+                    mediaType: output.mediaType,
+                    role: output.role,
+                    maximumBytes: output.maximumBytes
+                )],
+                retryableExitCodes: [23]
+            )
+            nodes.append(GraphDefinitionDocumentNode(
+                id: id,
+                name: displayName(id),
+                nodeType: .localProcess,
+                requiredCapabilities: ["local-process"],
+                executorKind: .supervisedLocalProcess,
+                specification: try process.immutableSpecification(),
+                workspace: GraphExecutionWorkspaceContext(
+                    root: workspaceURL.path,
+                    writableRelativePaths: ["artifacts"]
+                ),
+                inputArtifactRoles: inputRoles,
+                outputs: [output],
+                timeoutPolicy: .init(
+                    executionSeconds: 60,
+                    cancellationAcknowledgementSeconds: 5
+                )
+            ))
+        }
+        let edges = zip(stages, stages.dropFirst()).map { source, target in
+            GraphDefinitionEdge(
+                sourceNodeID: source.0,
+                targetNodeID: target.0
+            )
+        }
+        let layout = stages.enumerated().map { index, stage in
+            GraphNodeLayoutMetadata(
+                nodeID: stage.0,
+                position: GraphCanvasPoint(x: Double(index) * 300, y: 0)
+            )
+        }
+        return (nodes, edges, layout)
+    }
+
+    private static func displayName(_ id: String) -> String {
+        id.split(separator: "-").map { $0.capitalized }.joined(separator: " ")
+    }
+}

--- a/Sources/OpenIslandApp/GraphWorkspaceViewModel.swift
+++ b/Sources/OpenIslandApp/GraphWorkspaceViewModel.swift
@@ -299,28 +299,14 @@ final class GraphWorkspaceViewModel {
         request: GraphNewDocumentRequest = .defaults()
     ) {
         pauseOrchestration()
-        var newDocument = GraphDefinitionDocument.empty(graphID: request.graphID)
-        newDocument.name = request.name
-        newDocument.definitionVersion = request.definitionVersion
-        newDocument.description = request.description
-        newDocument.schedulerPolicy = GraphSchedulerPolicy(
-            policyID: "\(request.graphID)-policy",
-            version: request.definitionVersion,
-            retryPolicy: GraphRetryPolicy(
-                maximumAttempts: request.defaultRetryMaximumAttempts,
-                retryableFailureCategories: [
-                    "execution_failure",
-                    "process_exit_unobserved",
-                    "timeout",
-                ],
-                nonRetryableFailureCategories: [
-                    "artifact_collection_failure",
-                    "invalid_process_specification",
-                ]
-            ),
-            attemptExecutionTimeoutSeconds: request.defaultExecutionTimeoutSeconds,
-            cancellationAcknowledgementTimeoutSeconds: 10
-        )
+        guard let newDocument = try? GraphWorkspaceTemplateFactory.make(
+            request: request
+        ) else {
+            return rejectLocalAction(
+                "template_create_failed",
+                CocoaError(.fileNoSuchFile)
+            )
+        }
         defaultNodeWorkspaceDirectory = request.workspaceDirectory
         defaultNodeTimeoutSeconds = request.defaultExecutionTimeoutSeconds
         defaultNodeExecutorKind = request.defaultExecutorKind
@@ -334,7 +320,7 @@ final class GraphWorkspaceViewModel {
         inspection = nil
         history = nil
         explanation = nil
-        selectedNodeIDs = []
+        selectedNodeIDs = Set(newDocument.nodes.first.map { [$0.id] } ?? [])
         selectedEdgeID = nil
         validationDiagnostics = GraphDefinitionValidator.validate(newDocument)
         lastSuccessfulValidation = nil
@@ -349,7 +335,10 @@ final class GraphWorkspaceViewModel {
         mode = .definition
         defaults.removeObject(forKey: Self.lastDocumentPathKey)
         defaults.removeObject(forKey: Self.lastRunIDKey)
-        acceptedLocalAction("new_definition")
+        acceptedLocalAction(
+            request.template == .blank
+                ? "new_definition" : "template_definition_created"
+        )
     }
 
     func openDocument(url: URL) async {
@@ -383,23 +372,11 @@ final class GraphWorkspaceViewModel {
     }
 
     func openBundledCompendium() {
-        do {
-            let loaded = try GraphWorkspaceBundledFixtures.loadCompendium()
-            document = loaded
-            documentURL = nil
-            documentFileState = nil
-            lastSavedDocument = nil
-            associatedRunCount = 0
-            isDraft = false
-            selectedNodeIDs = Set(loaded.nodes.first.map { [$0.id] } ?? [])
-            selectedEdgeID = nil
-            validationDiagnostics = GraphDefinitionValidator.validate(loaded)
-            resetUndoHistory()
-            mode = .definition
-            acceptedLocalAction("compendium_definition_opened")
-        } catch {
-            rejectLocalAction("compendium_definition_open_failed", error)
-        }
+        var request = GraphNewDocumentRequest.defaults(id: "compendium-fill")
+        request.template = .compendiumFill
+        request.name = "Compendium Fill"
+        request.description = GraphWorkspaceTemplate.compendiumFill.summary
+        newDocument(request: request)
     }
 
     func saveDocument(url: URL? = nil) async {
@@ -867,8 +844,8 @@ final class GraphWorkspaceViewModel {
             node.workspace = GraphExecutionWorkspaceContext(
                 root: workspaceRoot,
                 writableRelativePaths: node.outputs.compactMap {
-                    let path = URL(fileURLWithPath: $0.relativePath)
-                        .deletingLastPathComponent().path
+                    let path = ($0.relativePath as NSString)
+                        .deletingLastPathComponent
                     return path == "." ? "" : path
                 }.filter { !$0.isEmpty }
             )
@@ -1221,6 +1198,10 @@ final class GraphWorkspaceViewModel {
         } catch {
             rejectLocalAction("layout_update_rejected", error)
         }
+    }
+
+    func endUndoCoalescing() {
+        undoCoalescingKey = nil
     }
 
     func automaticLayout() {
@@ -1689,6 +1670,7 @@ final class GraphWorkspaceViewModel {
                 root: defaultNodeWorkspaceDirectory
                     ?? FileManager.default.currentDirectoryPath
             ),
+            inputArtifactRoles: [],
             outputs: outputs,
             timeoutPolicy: GraphExecutionTimeoutPolicy(
                 executionSeconds: defaultNodeTimeoutSeconds,
@@ -1781,8 +1763,7 @@ final class GraphWorkspaceViewModel {
             logPolicy: process.logPolicy
         ).immutableSpecification()) ?? node.specification
         let writable = node.outputs.map {
-            URL(fileURLWithPath: $0.relativePath)
-                .deletingLastPathComponent().path
+            ($0.relativePath as NSString).deletingLastPathComponent
         }.filter { !$0.isEmpty && $0 != "." }
         node.workspace = GraphExecutionWorkspaceContext(
             root: node.workspace.root,

--- a/Sources/OpenIslandApp/GraphWorkspaceViewModel.swift
+++ b/Sources/OpenIslandApp/GraphWorkspaceViewModel.swift
@@ -110,8 +110,9 @@ enum GraphWorkspaceCommandPolicy {
                     denial: "retry_requires_attempt"
                 )
             }
-            let retryPolicy = inspection?.scheduling?.currentPolicy?.retryPolicy
-                ?? document?.schedulerPolicy.retryPolicy
+            let retryPolicy = inspection?.scheduling?.currentPolicy?
+                .retryPolicy(for: selectedNodeID)
+                ?? document?.schedulerPolicy.retryPolicy(for: selectedNodeID)
             let category = attempt.statusReason ?? "execution_failure"
             let categoryAllowed = retryPolicy.map {
                 !$0.nonRetryableFailureCategories.contains(category)
@@ -290,7 +291,9 @@ final class GraphWorkspaceViewModel {
                     "artifact_collection_failure",
                     "invalid_process_specification",
                 ]
-            )
+            ),
+            attemptExecutionTimeoutSeconds: request.defaultExecutionTimeoutSeconds,
+            cancellationAcknowledgementTimeoutSeconds: 10
         )
         defaultNodeWorkspaceDirectory = request.workspaceDirectory
         defaultNodeTimeoutSeconds = request.defaultExecutionTimeoutSeconds
@@ -482,7 +485,18 @@ final class GraphWorkspaceViewModel {
         }
     }
 
-    func addNode() {
+    func updateGraphIdentity(name: String, description: String) {
+        guard var document else { return }
+        registerUndo(coalescingKey: "graph-identity")
+        document.name = name
+        document.description = description
+        document.metadata.modifiedAt = Date()
+        document.metadata.modifiedBy = NSUserName()
+        self.document = document
+        markSemanticMutation()
+    }
+
+    func addNode(type: GraphDefinitionNodeType = .localProcess) {
         guard var document else { return }
         registerUndo(coalescingKey: nil)
         let existing = Set(document.nodes.map(\.id))
@@ -493,24 +507,13 @@ final class GraphWorkspaceViewModel {
             nodeID = "node-\(ordinal)"
         }
         do {
-            let specification = GraphLocalProcessSpecification(
-                executable: "/usr/bin/true"
+            let definition = try defaultNodeDefinition(
+                id: nodeID,
+                ordinal: ordinal,
+                type: type
             )
             try GraphDefinitionDocumentEditor.addNode(
-                GraphDefinitionDocumentNode(
-                    id: nodeID,
-                    name: "Node \(ordinal)",
-                    requiredCapabilities: ["local-process"],
-                    specification: try specification.immutableSpecification(),
-                    workspace: GraphExecutionWorkspaceContext(
-                        root: defaultNodeWorkspaceDirectory
-                            ?? FileManager.default.currentDirectoryPath
-                    ),
-                    timeoutPolicy: GraphExecutionTimeoutPolicy(
-                        executionSeconds: defaultNodeTimeoutSeconds,
-                        cancellationAcknowledgementSeconds: 10
-                    )
-                ),
+                definition,
                 to: &document,
                 position: GraphCanvasPoint(
                     x: Double(ordinal - 1) * 260,
@@ -573,6 +576,232 @@ final class GraphWorkspaceViewModel {
         } catch {
             rejectLocalAction("node_execution_edit_rejected", error)
         }
+    }
+
+    func updateSelectedNodeIdentity(
+        name: String,
+        description: String,
+        tags: [String]
+    ) {
+        mutateSelectedNode(coalescingKey: "identity") { node, _ in
+            node.name = name
+            node.description = description
+            node.tags = tags.sorted()
+        }
+    }
+
+    func updateSelectedNodeType(_ type: GraphDefinitionNodeType) {
+        guard let nodeID = selectedNodeID,
+              let ordinal = document?.nodes.firstIndex(where: { $0.id == nodeID })
+        else { return }
+        do {
+            let replacement = try defaultNodeDefinition(
+                id: nodeID,
+                ordinal: ordinal + 1,
+                type: type
+            )
+            mutateSelectedNode(coalescingKey: nil) { node, _ in
+                let identity = (node.name, node.description, node.tags)
+                node = replacement
+                node.name = identity.0
+                node.description = identity.1
+                node.tags = identity.2
+            }
+        } catch {
+            rejectLocalAction("node_type_edit_rejected", error)
+        }
+    }
+
+    func updateSelectedNodeCapabilities(
+        required: [String],
+        preferred: [String],
+        executorKind: GraphDefinitionExecutorKind,
+        platformConstraints: [String]
+    ) {
+        mutateSelectedNode(coalescingKey: "capabilities") { node, _ in
+            node.requiredCapabilities = required.sorted()
+            node.preferredCapabilities = preferred.sorted()
+            node.executorKind = executorKind
+            node.platformConstraints = platformConstraints.sorted()
+        }
+    }
+
+    func updateSelectedLocalProcess(
+        executable: String,
+        arguments: [String],
+        workingDirectory: String,
+        inheritedEnvironment: GraphLocalProcessEnvironmentInheritance,
+        stdin: GraphLocalProcessStdinPolicy,
+        environmentAllowlist: [String],
+        workspaceRoot: String?
+    ) {
+        mutateSelectedNode(coalescingKey: "local-process") { node, _ in
+            guard node.nodeType == .localProcess else { return }
+            let existing = (try? GraphLocalProcessSpecification(
+                immutableSpecification: node.specification
+            )) ?? GraphLocalProcessSpecification(executable: "/usr/bin/true")
+            let process = GraphLocalProcessSpecification(
+                executable: executable,
+                arguments: arguments,
+                workingDirectory: workingDirectory,
+                environment: existing.environment,
+                inheritedEnvironment: inheritedEnvironment,
+                stdin: stdin,
+                outputArtifacts: node.outputs.map(Self.processDeclaration),
+                retryableExitCodes: existing.retryableExitCodes,
+                logPolicy: existing.logPolicy
+            )
+            if let specification = try? process.immutableSpecification() {
+                node.specification = specification
+            }
+            node.environmentAllowlist = environmentAllowlist.sorted()
+            node.workspace = GraphExecutionWorkspaceContext(
+                root: workspaceRoot,
+                writableRelativePaths: node.outputs.compactMap {
+                    let path = URL(fileURLWithPath: $0.relativePath)
+                        .deletingLastPathComponent().path
+                    return path == "." ? "" : path
+                }.filter { !$0.isEmpty }
+            )
+        }
+    }
+
+    func addSelectedNodeArgument() {
+        guard let process = selectedLocalProcessSpecification else { return }
+        updateSelectedLocalProcess(
+            executable: process.executable,
+            arguments: process.arguments + [""],
+            workingDirectory: process.workingDirectory,
+            inheritedEnvironment: process.inheritedEnvironment,
+            stdin: process.stdin,
+            environmentAllowlist: selectedNode?.environmentAllowlist ?? [],
+            workspaceRoot: selectedNode?.workspace.root
+        )
+    }
+
+    func updateSelectedNodeArgument(at index: Int, value: String) {
+        guard let process = selectedLocalProcessSpecification,
+              process.arguments.indices.contains(index) else { return }
+        var arguments = process.arguments
+        arguments[index] = value
+        replaceSelectedProcessArguments(arguments, process: process)
+    }
+
+    func removeSelectedNodeArgument(at index: Int) {
+        guard let process = selectedLocalProcessSpecification,
+              process.arguments.indices.contains(index) else { return }
+        var arguments = process.arguments
+        arguments.remove(at: index)
+        replaceSelectedProcessArguments(arguments, process: process)
+    }
+
+    func moveSelectedNodeArgument(from index: Int, offset: Int) {
+        guard let process = selectedLocalProcessSpecification else { return }
+        let destination = index + offset
+        guard process.arguments.indices.contains(index),
+              process.arguments.indices.contains(destination) else { return }
+        var arguments = process.arguments
+        arguments.swapAt(index, destination)
+        replaceSelectedProcessArguments(arguments, process: process)
+    }
+
+    func addSelectedNodeInput() {
+        mutateSelectedNode(coalescingKey: nil) { node, _ in
+            let id = Self.nextStableID(prefix: "input", existing: node.inputs.map(\.id))
+            node.inputs.append(
+                GraphNodeInputDefinition(id: id, name: "Input \(node.inputs.count + 1)")
+            )
+            node.inputs.sort { $0.id < $1.id }
+        }
+    }
+
+    func updateSelectedNodeInput(_ input: GraphNodeInputDefinition) {
+        mutateSelectedNode(coalescingKey: "input:\(input.id)") { node, _ in
+            guard let index = node.inputs.firstIndex(where: { $0.id == input.id }) else {
+                return
+            }
+            node.inputs[index] = input
+        }
+    }
+
+    func removeSelectedNodeInput(_ inputID: String) {
+        mutateSelectedNode(coalescingKey: nil) { node, _ in
+            node.inputs.removeAll { $0.id == inputID }
+        }
+    }
+
+    func addSelectedNodeOutput() {
+        mutateSelectedNode(coalescingKey: nil) { node, _ in
+            let used = Set(node.outputs.map(\.role))
+            let role = GraphArtifactRole.allCases.first { !used.contains($0) }
+                ?? .nodeOutput
+            let id = Self.nextStableID(prefix: "output", existing: node.outputs.map(\.id))
+            node.outputs.append(
+                GraphNodeOutputDefinition(
+                    id: id,
+                    name: "Output \(node.outputs.count + 1)",
+                    role: role,
+                    relativePath: "artifacts/\(node.id)-\(id).json",
+                    mediaType: "application/json"
+                )
+            )
+            node.outputs.sort { $0.id < $1.id }
+            Self.synchronizeProcessOutputs(&node)
+        }
+    }
+
+    func updateSelectedNodeOutput(_ output: GraphNodeOutputDefinition) {
+        mutateSelectedNode(coalescingKey: "output:\(output.id)") { node, _ in
+            guard let index = node.outputs.firstIndex(where: { $0.id == output.id }) else {
+                return
+            }
+            node.outputs[index] = output
+            Self.synchronizeProcessOutputs(&node)
+        }
+    }
+
+    func removeSelectedNodeOutput(_ outputID: String) {
+        mutateSelectedNode(coalescingKey: nil) { node, _ in
+            node.outputs.removeAll { $0.id == outputID }
+            Self.synchronizeProcessOutputs(&node)
+        }
+    }
+
+    func updateSelectedNodeRetry(_ configuration: GraphNodeRetryConfiguration) {
+        mutateSelectedNode(coalescingKey: "retry") { node, _ in
+            node.retryConfiguration = configuration
+        }
+    }
+
+    func updateSelectedNodeTimeout(
+        _ configuration: GraphNodeTimeoutConfiguration
+    ) {
+        mutateSelectedNode(coalescingKey: "timeout") { node, document in
+            node.timeoutConfiguration = configuration
+            let execution = configuration.inheritsGraphDefault
+                ? document.schedulerPolicy.attemptExecutionTimeoutSeconds
+                : max(1, configuration.executionSeconds)
+            let cancellation = configuration.inheritsGraphDefault
+                ? document.schedulerPolicy.cancellationAcknowledgementTimeoutSeconds
+                : max(1, configuration.cancellationAcknowledgementSeconds)
+            node.timeoutPolicy = GraphExecutionTimeoutPolicy(
+                executionSeconds: execution,
+                cancellationAcknowledgementSeconds: cancellation
+            )
+        }
+    }
+
+    var selectedNode: GraphDefinitionDocumentNode? {
+        guard let selectedNodeID else { return nil }
+        return document?.nodes.first { $0.id == selectedNodeID }
+    }
+
+    var selectedLocalProcessSpecification: GraphLocalProcessSpecification? {
+        guard let node = selectedNode,
+              node.nodeType == .localProcess else { return nil }
+        return try? GraphLocalProcessSpecification(
+            immutableSpecification: node.specification
+        )
     }
 
     func deleteSelection() {
@@ -685,6 +914,12 @@ final class GraphWorkspaceViewModel {
             selectedNodeIDs = [nodeID]
         }
         if mode == .history { Task { await refreshExplanation() } }
+    }
+
+    func selectCanvas() {
+        selectedNodeIDs = []
+        selectedEdgeID = nil
+        undoCoalescingKey = nil
     }
 
     func createRun() async {
@@ -956,6 +1191,179 @@ final class GraphWorkspaceViewModel {
                 diagnostic: "Command rejected: \(decision.reasonCode)"
             )
         )
+    }
+
+    private func defaultNodeDefinition(
+        id: String,
+        ordinal: Int,
+        type: GraphDefinitionNodeType
+    ) throws -> GraphDefinitionDocumentNode {
+        let specification: GraphImmutableExecutionSpecification
+        let executorKind: GraphDefinitionExecutorKind
+        let capabilities: [String]
+        let outputs: [GraphNodeOutputDefinition]
+        switch type {
+        case .localProcess:
+            specification = try GraphLocalProcessSpecification(
+                executable: "/usr/bin/true"
+            ).immutableSpecification()
+            executorKind = .supervisedLocalProcess
+            capabilities = ["local-process"]
+            outputs = []
+        case .deterministicTest:
+            specification = GraphImmutableExecutionSpecification(
+                adapterKind: "deterministic",
+                operation: "test",
+                parameters: ["artifactRole": .string(GraphArtifactRole.nodeOutput.rawValue)]
+            )
+            executorKind = .deterministicTest
+            capabilities = ["deterministic"]
+            outputs = [
+                GraphNodeOutputDefinition(
+                    id: "output-node",
+                    name: "Node Output",
+                    role: .nodeOutput,
+                    relativePath: "artifacts/\(id).json",
+                    mediaType: "application/json"
+                ),
+            ]
+        case .genericAgent:
+            specification = GraphImmutableExecutionSpecification(
+                adapterKind: "generic_agent",
+                operation: "unbound"
+            )
+            executorKind = .unboundAgent
+            capabilities = ["agent"]
+            outputs = []
+        case .input, .output, .annotation:
+            specification = GraphImmutableExecutionSpecification(
+                adapterKind: "reference",
+                operation: type.rawValue
+            )
+            executorKind = .none
+            capabilities = []
+            outputs = []
+        }
+        return GraphDefinitionDocumentNode(
+            id: id,
+            name: "\(typeDisplayName(type)) \(ordinal)",
+            nodeType: type,
+            requiredCapabilities: capabilities,
+            executorKind: executorKind,
+            specification: specification,
+            workspace: GraphExecutionWorkspaceContext(
+                root: defaultNodeWorkspaceDirectory
+                    ?? FileManager.default.currentDirectoryPath
+            ),
+            outputs: outputs,
+            timeoutPolicy: GraphExecutionTimeoutPolicy(
+                executionSeconds: defaultNodeTimeoutSeconds,
+                cancellationAcknowledgementSeconds: 10
+            ),
+            timeoutConfiguration: GraphNodeTimeoutConfiguration(
+                executionSeconds: defaultNodeTimeoutSeconds,
+                cancellationAcknowledgementSeconds: 10
+            )
+        )
+    }
+
+    private func typeDisplayName(_ type: GraphDefinitionNodeType) -> String {
+        switch type {
+        case .localProcess: "Local Process"
+        case .deterministicTest: "Deterministic Test"
+        case .genericAgent: "Generic Agent"
+        case .input: "Input"
+        case .output: "Output"
+        case .annotation: "Annotation"
+        }
+    }
+
+    private func mutateSelectedNode(
+        coalescingKey: String?,
+        _ mutation: (inout GraphDefinitionDocumentNode, GraphDefinitionDocument) -> Void
+    ) {
+        guard var document,
+              let nodeID = selectedNodeID,
+              let index = document.nodes.firstIndex(where: { $0.id == nodeID })
+        else { return }
+        registerUndo(
+            coalescingKey: coalescingKey.map { "\($0):\(nodeID)" }
+        )
+        var node = document.nodes[index]
+        mutation(&node, document)
+        document.nodes[index] = node
+        document.metadata.modifiedAt = Date()
+        document.metadata.modifiedBy = NSUserName()
+        self.document = document
+        markSemanticMutation()
+    }
+
+    private func replaceSelectedProcessArguments(
+        _ arguments: [String],
+        process: GraphLocalProcessSpecification
+    ) {
+        updateSelectedLocalProcess(
+            executable: process.executable,
+            arguments: arguments,
+            workingDirectory: process.workingDirectory,
+            inheritedEnvironment: process.inheritedEnvironment,
+            stdin: process.stdin,
+            environmentAllowlist: selectedNode?.environmentAllowlist ?? [],
+            workspaceRoot: selectedNode?.workspace.root
+        )
+    }
+
+    private static func processDeclaration(
+        _ output: GraphNodeOutputDefinition
+    ) -> GraphLocalProcessArtifactDeclaration {
+        GraphLocalProcessArtifactDeclaration(
+            identifier: output.id,
+            relativePath: output.relativePath,
+            mediaType: output.mediaType,
+            role: output.role,
+            sensitivity: output.sensitivity,
+            maximumBytes: output.maximumBytes,
+            isRequired: output.isRequired,
+            downstreamVisibility: output.downstreamVisibility
+        )
+    }
+
+    private static func synchronizeProcessOutputs(
+        _ node: inout GraphDefinitionDocumentNode
+    ) {
+        guard node.nodeType == .localProcess,
+              let process = try? GraphLocalProcessSpecification(
+                immutableSpecification: node.specification
+              ) else { return }
+        node.specification = (try? GraphLocalProcessSpecification(
+            executable: process.executable,
+            arguments: process.arguments,
+            workingDirectory: process.workingDirectory,
+            environment: process.environment,
+            inheritedEnvironment: process.inheritedEnvironment,
+            stdin: process.stdin,
+            outputArtifacts: node.outputs.map(processDeclaration),
+            retryableExitCodes: process.retryableExitCodes,
+            logPolicy: process.logPolicy
+        ).immutableSpecification()) ?? node.specification
+        let writable = node.outputs.map {
+            URL(fileURLWithPath: $0.relativePath)
+                .deletingLastPathComponent().path
+        }.filter { !$0.isEmpty && $0 != "." }
+        node.workspace = GraphExecutionWorkspaceContext(
+            root: node.workspace.root,
+            writableRelativePaths: writable
+        )
+    }
+
+    private static func nextStableID(
+        prefix: String,
+        existing: [String]
+    ) -> String {
+        let values = Set(existing)
+        var ordinal = values.count + 1
+        while values.contains("\(prefix)-\(ordinal)") { ordinal += 1 }
+        return "\(prefix)-\(ordinal)"
     }
 
     private var authoringSnapshot: GraphAuthoringUndoSnapshot? {

--- a/Sources/OpenIslandApp/GraphWorkspaceViewModel.swift
+++ b/Sources/OpenIslandApp/GraphWorkspaceViewModel.swift
@@ -183,6 +183,8 @@ final class GraphWorkspaceViewModel {
     var explanation: GraphCausalExplanation?
     var selectedNodeIDs: Set<String> = []
     var selectedEdgeID: String?
+    var dependencySourceNodeID: String?
+    var connectionGuidance: String?
     var logPage: GraphProcessLogPage?
     var selectedLogChannel: GraphProcessLogChannel = .stdout
     var isFollowingLogs = true
@@ -223,6 +225,10 @@ final class GraphWorkspaceViewModel {
     }
 
     var selectedNodeID: String? { selectedNodeIDs.sorted().first }
+    var selectedEdge: GraphDefinitionEdge? {
+        guard let selectedEdgeID else { return nil }
+        return document?.edges.first { $0.id == selectedEdgeID }
+    }
     var isDirty: Bool {
         guard let document else { return false }
         return document != lastSavedDocument
@@ -805,6 +811,10 @@ final class GraphWorkspaceViewModel {
     }
 
     func deleteSelection() {
+        if let selectedEdgeID {
+            removeEdge(selectedEdgeID)
+            return
+        }
         guard var document, !selectedNodeIDs.isEmpty else { return }
         registerUndo(coalescingKey: nil)
         do {
@@ -828,24 +838,77 @@ final class GraphWorkspaceViewModel {
     }
 
     func connectSelectedNodes() {
-        guard var document, selectedNodeIDs.count == 2 else { return }
-        registerUndo(coalescingKey: nil)
+        guard selectedNodeIDs.count == 2 else { return }
         let ordered = selectedNodeIDs.sorted()
+        _ = connectNodes(sourceNodeID: ordered[0], targetNodeID: ordered[1])
+    }
+
+    @discardableResult
+    func connectNodes(
+        sourceNodeID: String,
+        targetNodeID: String,
+        portType: GraphDefinitionPortType = .dependency,
+        sourceOutputID: String? = nil,
+        targetInputID: String? = nil,
+        isRequired: Bool = true
+    ) -> GraphConnectionDecision {
+        guard var document else {
+            return .rejected(.sourceMissing, "No graph document is open.")
+        }
+        let resolvedSourceOutputID = sourceOutputID ?? (portType == .dependency
+            ? nil : document.nodes.first { $0.id == sourceNodeID }?
+                .outputs.first { $0.portType == portType }?.id)
+        let resolvedTargetInputID = targetInputID ?? (portType == .dependency
+            ? nil : document.nodes.first { $0.id == targetNodeID }?
+                .inputs.first { $0.portType == portType }?.id)
+        let decision = GraphConnectionEvaluator.evaluate(
+            document: document,
+            sourceNodeID: sourceNodeID,
+            targetNodeID: targetNodeID,
+            portType: portType,
+            sourceOutputID: resolvedSourceOutputID,
+            targetInputID: resolvedTargetInputID
+        )
+        guard decision.isAllowed else {
+            connectionGuidance = decision.message
+            apply(.rejected(
+                decision.rejection?.rawValue ?? "connection_rejected",
+                nodeIDs: [sourceNodeID, targetNodeID],
+                diagnostic: decision.message
+            ))
+            return decision
+        }
+        registerUndo(coalescingKey: nil)
         do {
+            let edge = GraphDefinitionEdge(
+                sourceNodeID: sourceNodeID,
+                targetNodeID: targetNodeID,
+                portType: portType,
+                sourceOutputID: resolvedSourceOutputID,
+                targetInputID: resolvedTargetInputID,
+                isRequired: isRequired
+            )
             try GraphDefinitionDocumentEditor.addEdge(
-                GraphDefinitionEdge(
-                    sourceNodeID: ordered[0],
-                    targetNodeID: ordered[1]
-                ),
+                edge,
                 to: &document,
                 modifiedAt: Date(),
                 modifiedBy: NSUserName()
             )
+            synchronizeArtifactBindings(in: &document)
             self.document = document
+            selectedNodeIDs = []
+            selectedEdgeID = edge.id
+            dependencySourceNodeID = nil
+            connectionGuidance = "Connected \(sourceNodeID) to \(targetNodeID)."
             markSemanticMutation()
-            acceptedLocalAction("dependency_added", nodeIDs: ordered)
+            acceptedLocalAction(
+                portType == .dependency ? "dependency_added" : "typed_connection_added",
+                nodeIDs: [sourceNodeID, targetNodeID]
+            )
+            return .allowed
         } catch {
             rejectLocalAction("dependency_add_rejected", error)
+            return .rejected(.cycle, error.localizedDescription)
         }
     }
 
@@ -859,6 +922,7 @@ final class GraphWorkspaceViewModel {
                 modifiedAt: Date(),
                 modifiedBy: NSUserName()
             )
+            synchronizeArtifactBindings(in: &document)
             self.document = document
             selectedEdgeID = nil
             markSemanticMutation()
@@ -866,6 +930,77 @@ final class GraphWorkspaceViewModel {
         } catch {
             rejectLocalAction("dependency_remove_rejected", error)
         }
+    }
+
+    func updateSelectedEdge(_ updated: GraphDefinitionEdge) {
+        guard var document,
+              let selectedEdgeID,
+              let index = document.edges.firstIndex(where: { $0.id == selectedEdgeID })
+        else { return }
+        var candidate = document
+        candidate.edges.remove(at: index)
+        let decision = GraphConnectionEvaluator.evaluate(
+            document: candidate,
+            sourceNodeID: updated.sourceNodeID,
+            targetNodeID: updated.targetNodeID,
+            portType: updated.portType,
+            sourceOutputID: updated.sourceOutputID,
+            targetInputID: updated.targetInputID
+        )
+        guard decision.isAllowed else {
+            connectionGuidance = decision.message
+            return
+        }
+        registerUndo(coalescingKey: "edge:\(selectedEdgeID)")
+        document.edges[index] = updated
+        document.edges.sort { $0.id < $1.id }
+        synchronizeArtifactBindings(in: &document)
+        document.metadata.modifiedAt = Date()
+        document.metadata.modifiedBy = NSUserName()
+        self.document = document
+        markSemanticMutation()
+    }
+
+    func beginDependencyCreation(from nodeID: String) {
+        dependencySourceNodeID = nodeID
+        connectionGuidance = "Choose a downstream target for \(nodeID)."
+    }
+
+    func completeDependencyCreation(to nodeID: String) {
+        guard let source = dependencySourceNodeID else {
+            beginDependencyCreation(from: nodeID)
+            return
+        }
+        _ = connectNodes(sourceNodeID: source, targetNodeID: nodeID)
+    }
+
+    func cancelDependencyCreation() {
+        dependencySourceNodeID = nil
+        connectionGuidance = nil
+    }
+
+    func canConnect(
+        sourceNodeID: String,
+        targetNodeID: String,
+        portType: GraphDefinitionPortType = .dependency
+    ) -> GraphConnectionDecision {
+        guard let document else {
+            return .rejected(.sourceMissing, "No graph document is open.")
+        }
+        let sourceOutputID = portType == .dependency ? nil : document.nodes
+            .first { $0.id == sourceNodeID }?.outputs
+            .first { $0.portType == portType }?.id
+        let targetInputID = portType == .dependency ? nil : document.nodes
+            .first { $0.id == targetNodeID }?.inputs
+            .first { $0.portType == portType }?.id
+        return GraphConnectionEvaluator.evaluate(
+            document: document,
+            sourceNodeID: sourceNodeID,
+            targetNodeID: targetNodeID,
+            portType: portType,
+            sourceOutputID: sourceOutputID,
+            targetInputID: targetInputID
+        )
     }
 
     func moveNode(_ nodeID: String, to position: GraphCanvasPoint) {
@@ -914,6 +1049,12 @@ final class GraphWorkspaceViewModel {
             selectedNodeIDs = [nodeID]
         }
         if mode == .history { Task { await refreshExplanation() } }
+    }
+
+    func selectEdge(_ edgeID: String) {
+        selectedNodeIDs = []
+        selectedEdgeID = edgeID
+        undoCoalescingKey = nil
     }
 
     func selectCanvas() {
@@ -1364,6 +1505,54 @@ final class GraphWorkspaceViewModel {
         var ordinal = values.count + 1
         while values.contains("\(prefix)-\(ordinal)") { ordinal += 1 }
         return "\(prefix)-\(ordinal)"
+    }
+
+    private func synchronizeArtifactBindings(
+        in document: inout GraphDefinitionDocument
+    ) {
+        for nodeIndex in document.nodes.indices {
+            for inputIndex in document.nodes[nodeIndex].inputs.indices {
+                let binding = document.nodes[nodeIndex].inputs[inputIndex].binding
+                if binding?.kind == .upstreamArtifact
+                    || binding?.kind == .upstreamArtifactCollection {
+                    document.nodes[nodeIndex].inputs[inputIndex].binding = nil
+                }
+            }
+        }
+        for edge in document.edges where edge.portType == .artifact {
+            guard let sourceOutputID = edge.sourceOutputID,
+                  let targetInputID = edge.targetInputID,
+                  let targetIndex = document.nodes.firstIndex(where: {
+                      $0.id == edge.targetNodeID
+                  }),
+                  let inputIndex = document.nodes[targetIndex].inputs.firstIndex(where: {
+                      $0.id == targetInputID
+                  }) else { continue }
+            let allowsMultiple = document.nodes[targetIndex]
+                .inputs[inputIndex].allowsMultiple
+            document.nodes[targetIndex].inputs[inputIndex].binding =
+                GraphNodeInputBinding(
+                    kind: allowsMultiple
+                        ? .upstreamArtifactCollection : .upstreamArtifact,
+                    sourceNodeID: edge.sourceNodeID,
+                    sourceOutputID: sourceOutputID
+                )
+        }
+        for nodeIndex in document.nodes.indices {
+            let nodeID = document.nodes[nodeIndex].id
+            let incoming = document.edges.filter {
+                $0.targetNodeID == nodeID && $0.portType == .artifact
+            }
+            guard !incoming.isEmpty else { continue }
+            let roles = incoming.compactMap { edge -> GraphArtifactRole? in
+                guard let source = document.nodes.first(where: {
+                    $0.id == edge.sourceNodeID
+                }), let outputID = edge.sourceOutputID else { return nil }
+                return source.outputs.first { $0.id == outputID }?.role
+            }
+            document.nodes[nodeIndex].inputArtifactRoles = Array(Set(roles))
+                .sorted { $0.rawValue < $1.rawValue }
+        }
     }
 
     private var authoringSnapshot: GraphAuthoringUndoSnapshot? {

--- a/Sources/OpenIslandApp/GraphWorkspaceViewModel.swift
+++ b/Sources/OpenIslandApp/GraphWorkspaceViewModel.swift
@@ -44,14 +44,26 @@ enum GraphWorkspaceCommandPolicy {
         document: GraphDefinitionDocument?,
         inspection: GraphRunInspection?,
         selectedNodeID: String?,
-        isOrchestrating: Bool
+        isOrchestrating: Bool,
+        validationDiagnostics: [GraphValidationDiagnostic] = [],
+        isDraft: Bool = false
     ) -> GraphWorkspaceCommandDecision {
         switch command {
         case .createRun:
+            let validationError = validationDiagnostics.contains {
+                $0.severity == .error
+                    && !($0.code == .missingRequiredInput
+                        && $0.target.kind == .graphInput)
+            }
             return decision(
                 command,
-                enabled: document?.nodes.isEmpty == false,
-                denial: "definition_has_no_nodes"
+                enabled: document?.nodes.isEmpty == false
+                    && !validationError && !isDraft,
+                denial: isDraft
+                    ? "definition_version_required"
+                    : validationError
+                        ? "definition_validation_failed"
+                        : "definition_has_no_nodes"
             )
         case .start:
             return decision(
@@ -193,6 +205,11 @@ final class GraphWorkspaceViewModel {
     var isOrchestrating = false
     var lastCommandResult: GraphWorkspaceCommandResult?
     var errorMessage: String?
+    var validationDiagnostics: [GraphValidationDiagnostic] = []
+    var lastSuccessfulValidation: Date?
+    var isShowingValidationPanel = false
+    var isShowingCreateRunSheet = false
+    var runCreationDraft = GraphRunCreationDraft()
 
     @ObservationIgnored private let service: any GraphWorkspaceServicing
     @ObservationIgnored private let defaults: UserDefaults
@@ -200,6 +217,7 @@ final class GraphWorkspaceViewModel {
     @ObservationIgnored private var orchestrationTask: Task<Void, Never>?
     @ObservationIgnored private var refreshGeneration: UInt64 = 0
     @ObservationIgnored private var hasStarted = false
+    @ObservationIgnored private var validationGeneration: UInt64 = 0
     @ObservationIgnored private var undoSnapshots: [GraphAuthoringUndoSnapshot] = []
     @ObservationIgnored private var redoSnapshots: [GraphAuthoringUndoSnapshot] = []
     @ObservationIgnored private var undoCoalescingKey: String?
@@ -271,7 +289,9 @@ final class GraphWorkspaceViewModel {
             document: document,
             inspection: inspection,
             selectedNodeID: selectedNodeID,
-            isOrchestrating: isOrchestrating
+            isOrchestrating: isOrchestrating,
+            validationDiagnostics: validationDiagnostics,
+            isDraft: isDraft
         )
     }
 
@@ -316,6 +336,15 @@ final class GraphWorkspaceViewModel {
         explanation = nil
         selectedNodeIDs = []
         selectedEdgeID = nil
+        validationDiagnostics = GraphDefinitionValidator.validate(newDocument)
+        lastSuccessfulValidation = nil
+        isShowingValidationPanel = false
+        isShowingCreateRunSheet = false
+        runCreationDraft = GraphRunCreationDraft(
+            backend: request.defaultExecutorKind == "deterministic"
+                ? .deterministicTest : .supervisedLocalProcess,
+            workspaceDirectory: request.workspaceDirectory
+        )
         resetUndoHistory()
         mode = .definition
         defaults.removeObject(forKey: Self.lastDocumentPathKey)
@@ -339,6 +368,10 @@ final class GraphWorkspaceViewModel {
             isDraft = false
             selectedNodeIDs = Set(loaded.nodes.first.map { [$0.id] } ?? [])
             selectedEdgeID = nil
+            validationDiagnostics = GraphDefinitionValidator.validate(loaded)
+            lastSuccessfulValidation = validationDiagnostics.contains {
+                $0.severity == .error
+            } ? nil : Date()
             resetUndoHistory()
             mode = .definition
             defaults.set(url.path, forKey: Self.lastDocumentPathKey)
@@ -360,6 +393,7 @@ final class GraphWorkspaceViewModel {
             isDraft = false
             selectedNodeIDs = Set(loaded.nodes.first.map { [$0.id] } ?? [])
             selectedEdgeID = nil
+            validationDiagnostics = GraphDefinitionValidator.validate(loaded)
             resetUndoHistory()
             mode = .definition
             acceptedLocalAction("compendium_definition_opened")
@@ -483,11 +517,101 @@ final class GraphWorkspaceViewModel {
     }
 
     func validateDocument() {
-        do {
-            try document?.validate()
+        guard let document else { return }
+        validationDiagnostics = GraphDefinitionValidator.validate(document)
+        isShowingValidationPanel = true
+        if validationDiagnostics.contains(where: { $0.severity == .error }) {
+            apply(.rejected(
+                "definition_invalid",
+                diagnostic: validationDiagnostics.filter {
+                    $0.severity == .error
+                }.map(\.message).joined(separator: "\n")
+            ))
+        } else {
+            lastSuccessfulValidation = Date()
             acceptedLocalAction("definition_valid")
-        } catch {
-            rejectLocalAction("definition_invalid", error)
+        }
+        Task { await refreshValidation(announce: true) }
+    }
+
+    func refreshValidation(
+        resolvedGraphInputIDs: Set<String> = [],
+        announce: Bool = false
+    ) async {
+        validationGeneration &+= 1
+        let generation = validationGeneration
+        guard let document else {
+            validationDiagnostics = []
+            return
+        }
+        var context = await service.validationContext(for: document)
+        guard generation == validationGeneration else { return }
+        context.resolvedGraphInputIDs = resolvedGraphInputIDs
+        if isDraft, let lastSavedDocument,
+           let digest = try? lastSavedDocument.semanticDigest() {
+            context.immutableDefinitionDigest = digest
+        }
+        validationDiagnostics = GraphDefinitionValidator.validate(
+            document,
+            context: context
+        )
+        let errors = validationDiagnostics.filter { $0.severity == .error }
+        if errors.isEmpty {
+            lastSuccessfulValidation = Date()
+            if announce { acceptedLocalAction("definition_valid") }
+        } else if announce {
+            apply(.rejected(
+                "definition_invalid",
+                diagnostic: errors.map(\.message).joined(separator: "\n")
+            ))
+        }
+    }
+
+    func selectValidationDiagnostic(_ diagnostic: GraphValidationDiagnostic) {
+        switch diagnostic.target.kind {
+        case .node:
+            if let id = diagnostic.target.id { selectNode(id) }
+        case .edge:
+            if let id = diagnostic.target.id { selectEdge(id) }
+        case .graph, .graphInput, .graphOutput:
+            selectCanvas()
+        }
+    }
+
+    func prepareCreateRun() async {
+        await refreshValidation(
+            resolvedGraphInputIDs: runCreationDraft.resolvedInputIDs
+        )
+        isShowingValidationPanel = !validationDiagnostics.isEmpty
+        let blocking = validationDiagnostics.filter {
+            $0.severity == .error
+                && !($0.code == .missingRequiredInput
+                    && $0.target.kind == .graphInput)
+        }
+        guard !isDraft, blocking.isEmpty,
+              document?.nodes.isEmpty == false else {
+            let policy = decision(.createRun)
+            return rejectedPolicy(policy)
+        }
+        if let document {
+            let types = Set(document.nodes.filter(\.nodeType.isExecutable).map(\.nodeType))
+            if types == [.deterministicTest] {
+                runCreationDraft.backend = .deterministicTest
+            } else {
+                runCreationDraft.backend = .supervisedLocalProcess
+            }
+            runCreationDraft.workspaceDirectory = document.nodes
+                .first(where: { $0.nodeType == .localProcess })?.workspace.root
+        }
+        isShowingCreateRunSheet = true
+    }
+
+    func runCreationInputDidChange() {
+        Task { [weak self] in
+            guard let self else { return }
+            await refreshValidation(
+                resolvedGraphInputIDs: runCreationDraft.resolvedInputIDs
+            )
         }
     }
 
@@ -498,6 +622,85 @@ final class GraphWorkspaceViewModel {
         document.description = description
         document.metadata.modifiedAt = Date()
         document.metadata.modifiedBy = NSUserName()
+        self.document = document
+        markSemanticMutation()
+    }
+
+    func addGraphInput() {
+        guard var document else { return }
+        registerUndo(coalescingKey: nil)
+        let id = Self.nextStableID(
+            prefix: "graph-input",
+            existing: document.graphInputs.map(\.id)
+        )
+        document.graphInputs.append(
+            GraphDefinitionInput(
+                id: id,
+                name: "Graph Input \(document.graphInputs.count + 1)",
+                dataType: .text
+            )
+        )
+        document.graphInputs.sort { $0.id < $1.id }
+        self.document = document
+        markSemanticMutation()
+    }
+
+    func updateGraphInput(_ input: GraphDefinitionInput) {
+        guard var document,
+              let index = document.graphInputs.firstIndex(where: {
+                  $0.id == input.id
+              }) else { return }
+        registerUndo(coalescingKey: "graph-input:\(input.id)")
+        document.graphInputs[index] = input
+        self.document = document
+        markSemanticMutation()
+    }
+
+    func removeGraphInput(_ inputID: String) {
+        guard var document else { return }
+        registerUndo(coalescingKey: nil)
+        document.graphInputs.removeAll { $0.id == inputID }
+        self.document = document
+        markSemanticMutation()
+    }
+
+    func addGraphOutput() {
+        guard var document,
+              let node = document.nodes.first(where: { !$0.outputs.isEmpty }),
+              let output = node.outputs.first else { return }
+        registerUndo(coalescingKey: nil)
+        let id = Self.nextStableID(
+            prefix: "graph-output",
+            existing: document.graphOutputs.map(\.id)
+        )
+        document.graphOutputs.append(
+            GraphDefinitionOutput(
+                id: id,
+                name: "Graph Output \(document.graphOutputs.count + 1)",
+                sourceNodeID: node.id,
+                sourceOutputID: output.id
+            )
+        )
+        document.graphOutputs.sort { $0.id < $1.id }
+        self.document = document
+        markSemanticMutation()
+    }
+
+    func updateGraphOutput(_ output: GraphDefinitionOutput) {
+        guard var document,
+              let index = document.graphOutputs.firstIndex(where: {
+                  $0.id == output.id
+              }) else { return }
+        registerUndo(coalescingKey: "graph-output:\(output.id)")
+        document.graphOutputs[index] = output
+        self.document = document
+        markSemanticMutation()
+    }
+
+    func removeGraphOutput(_ outputID: String) {
+        guard var document else { return }
+        registerUndo(coalescingKey: nil)
+        document.graphOutputs.removeAll { $0.id == outputID }
         self.document = document
         markSemanticMutation()
     }
@@ -1064,18 +1267,46 @@ final class GraphWorkspaceViewModel {
     }
 
     func createRun() async {
+        await confirmCreateRun()
+    }
+
+    func confirmCreateRun() async {
+        await refreshValidation(
+            resolvedGraphInputIDs: runCreationDraft.resolvedInputIDs
+        )
+        let unresolvedErrors = validationDiagnostics.filter {
+            $0.severity == .error
+        }
+        guard unresolvedErrors.isEmpty else {
+            return apply(.rejected(
+                "definition_validation_failed",
+                diagnostic: unresolvedErrors.map(\.message).joined(separator: "\n")
+            ))
+        }
         let policy = decision(.createRun)
         guard policy.isEnabled, let document else {
             return rejectedPolicy(policy)
         }
+        guard backendIsCompatible(runCreationDraft.backend, document: document) else {
+            return apply(.rejected(
+                "executor_backend_incompatible",
+                diagnostic: "The selected backend is incompatible with one or more executable nodes."
+            ))
+        }
+        let runtimeDocument = materializeRuntimeInputs(
+            document,
+            draft: runCreationDraft
+        )
         let runID = "\(document.graphID)-\(UUID().uuidString.lowercased())"
         let result = await service.createRun(
-            document: document,
+            document: runtimeDocument,
             runID: runID,
+            resolvedGraphInputIDs: runCreationDraft.resolvedInputIDs,
             occurredAt: Date()
         )
         apply(result)
         if result.accepted {
+            isShowingCreateRunSheet = false
             associatedRunCount += 1
             isDraft = false
             defaults.set(runID, forKey: Self.lastRunIDKey)
@@ -1332,6 +1563,68 @@ final class GraphWorkspaceViewModel {
                 diagnostic: "Command rejected: \(decision.reasonCode)"
             )
         )
+    }
+
+    private func backendIsCompatible(
+        _ backend: GraphWorkspaceExecutionBackend,
+        document: GraphDefinitionDocument
+    ) -> Bool {
+        let types = Set(document.nodes.filter(\.nodeType.isExecutable).map(\.nodeType))
+        switch backend {
+        case .supervisedLocalProcess:
+            return types == [.localProcess]
+        case .deterministicTest:
+            return types == [.deterministicTest]
+        case .codex, .qwen, .ollama, .openClaw:
+            return false
+        }
+    }
+
+    private func materializeRuntimeInputs(
+        _ source: GraphDefinitionDocument,
+        draft: GraphRunCreationDraft
+    ) -> GraphDefinitionDocument {
+        var document = source
+        var values = draft.inputValues
+        for input in source.graphInputs where values[input.id] == nil {
+            switch input.defaultValue {
+            case let .string(value): values[input.id] = value
+            case let .number(value): values[input.id] = String(value)
+            case let .bool(value): values[input.id] = String(value)
+            case .array, .object, .null, .none: break
+            }
+        }
+        for index in document.nodes.indices
+            where document.nodes[index].nodeType == .localProcess {
+            guard let process = try? GraphLocalProcessSpecification(
+                immutableSpecification: document.nodes[index].specification
+            ) else { continue }
+            let arguments = process.arguments.map { argument in
+                guard argument.hasPrefix("${graph-input:"),
+                      argument.hasSuffix("}") else { return argument }
+                let inputID = String(argument.dropFirst(14).dropLast())
+                return values[inputID] ?? argument
+            }
+            document.nodes[index].specification = (try? GraphLocalProcessSpecification(
+                executable: process.executable,
+                arguments: arguments,
+                workingDirectory: process.workingDirectory,
+                environment: process.environment,
+                inheritedEnvironment: process.inheritedEnvironment,
+                stdin: process.stdin,
+                outputArtifacts: process.outputArtifacts,
+                retryableExitCodes: process.retryableExitCodes,
+                logPolicy: process.logPolicy
+            ).immutableSpecification()) ?? document.nodes[index].specification
+            if let workspace = draft.workspaceDirectory, !workspace.isEmpty {
+                document.nodes[index].workspace = GraphExecutionWorkspaceContext(
+                    root: workspace,
+                    writableRelativePaths: document.nodes[index]
+                        .workspace.writableRelativePaths
+                )
+            }
+        }
+        return document
     }
 
     private func defaultNodeDefinition(
@@ -1592,6 +1885,10 @@ final class GraphWorkspaceViewModel {
 
     private func markSemanticMutation() {
         if associatedRunCount > 0 { isDraft = true }
+        if let document {
+            validationDiagnostics = GraphDefinitionValidator.validate(document)
+            Task { [weak self] in await self?.refreshValidation() }
+        }
     }
 
     private func closeDocumentDiscardingChanges() {

--- a/Sources/OpenIslandApp/GraphWorkspaceViewModel.swift
+++ b/Sources/OpenIslandApp/GraphWorkspaceViewModel.swift
@@ -208,6 +208,7 @@ final class GraphWorkspaceViewModel {
     var validationDiagnostics: [GraphValidationDiagnostic] = []
     var lastSuccessfulValidation: Date?
     var isShowingValidationPanel = false
+    var isShowingNewGraphSheet = false
     var isShowingCreateRunSheet = false
     var runCreationDraft = GraphRunCreationDraft()
 
@@ -293,6 +294,10 @@ final class GraphWorkspaceViewModel {
             validationDiagnostics: validationDiagnostics,
             isDraft: isDraft
         )
+    }
+
+    func presentNewGraphSheet() {
+        isShowingNewGraphSheet = true
     }
 
     func newDocument(

--- a/Sources/OpenIslandApp/GraphWorkspaceViewModel.swift
+++ b/Sources/OpenIslandApp/GraphWorkspaceViewModel.swift
@@ -159,17 +159,29 @@ final class GraphWorkspaceViewModel {
     static let lastDocumentPathKey = "graph.workspace.lastDocumentPath"
     static let lastRunIDKey = "graph.workspace.lastRunID"
     static let lastModeKey = "graph.workspace.lastMode"
+    static let recentDocumentPathsKey = "graph.workspace.recentDocumentPaths"
 
     var mode: GraphWorkspaceMode = .definition {
         didSet { defaults.set(mode.rawValue, forKey: Self.lastModeKey) }
     }
     var document: GraphDefinitionDocument?
     var documentURL: URL?
+    var documentFileState: GraphDocumentFileState?
+    var lastSavedDocument: GraphDefinitionDocument?
+    var recentDocumentURLs: [URL] = []
+    var closeState: GraphDocumentCloseState = .idle
+    var hasExternalModification = false
+    var associatedRunCount = 0
+    var isDraft = false
+    var defaultNodeWorkspaceDirectory: String?
+    var defaultNodeTimeoutSeconds: UInt64 = 300
+    var defaultNodeExecutorKind = GraphLocalProcessSpecification.adapterKind
     var inspection: GraphRunInspection?
     var runs: [GraphRunInspectionSummary] = []
     var history: GraphInspectionEventPage?
     var explanation: GraphCausalExplanation?
     var selectedNodeIDs: Set<String> = []
+    var selectedEdgeID: String?
     var logPage: GraphProcessLogPage?
     var selectedLogChannel: GraphProcessLogChannel = .stdout
     var isFollowingLogs = true
@@ -185,6 +197,9 @@ final class GraphWorkspaceViewModel {
     @ObservationIgnored private var orchestrationTask: Task<Void, Never>?
     @ObservationIgnored private var refreshGeneration: UInt64 = 0
     @ObservationIgnored private var hasStarted = false
+    @ObservationIgnored private var undoSnapshots: [GraphAuthoringUndoSnapshot] = []
+    @ObservationIgnored private var redoSnapshots: [GraphAuthoringUndoSnapshot] = []
+    @ObservationIgnored private var undoCoalescingKey: String?
 
     init(
         service: any GraphWorkspaceServicing,
@@ -196,6 +211,9 @@ final class GraphWorkspaceViewModel {
            let restored = GraphWorkspaceMode(rawValue: raw) {
             mode = restored
         }
+        recentDocumentURLs = defaults.stringArray(
+            forKey: Self.recentDocumentPathsKey
+        )?.map(URL.init(fileURLWithPath:)) ?? []
     }
 
     deinit {
@@ -204,6 +222,12 @@ final class GraphWorkspaceViewModel {
     }
 
     var selectedNodeID: String? { selectedNodeIDs.sorted().first }
+    var isDirty: Bool {
+        guard let document else { return false }
+        return document != lastSavedDocument
+    }
+    var canUndo: Bool { !undoSnapshots.isEmpty }
+    var canRedo: Bool { !redoSnapshots.isEmpty }
 
     func start() {
         guard !hasStarted else { return }
@@ -244,15 +268,46 @@ final class GraphWorkspaceViewModel {
         )
     }
 
-    func newDocument() {
+    func newDocument(
+        request: GraphNewDocumentRequest = .defaults()
+    ) {
         pauseOrchestration()
-        let newDocument = GraphDefinitionDocument.empty()
+        var newDocument = GraphDefinitionDocument.empty(graphID: request.graphID)
+        newDocument.name = request.name
+        newDocument.definitionVersion = request.definitionVersion
+        newDocument.description = request.description
+        newDocument.schedulerPolicy = GraphSchedulerPolicy(
+            policyID: "\(request.graphID)-policy",
+            version: request.definitionVersion,
+            retryPolicy: GraphRetryPolicy(
+                maximumAttempts: request.defaultRetryMaximumAttempts,
+                retryableFailureCategories: [
+                    "execution_failure",
+                    "process_exit_unobserved",
+                    "timeout",
+                ],
+                nonRetryableFailureCategories: [
+                    "artifact_collection_failure",
+                    "invalid_process_specification",
+                ]
+            )
+        )
+        defaultNodeWorkspaceDirectory = request.workspaceDirectory
+        defaultNodeTimeoutSeconds = request.defaultExecutionTimeoutSeconds
+        defaultNodeExecutorKind = request.defaultExecutorKind
         document = newDocument
         documentURL = nil
+        documentFileState = nil
+        lastSavedDocument = nil
+        hasExternalModification = false
+        associatedRunCount = 0
+        isDraft = false
         inspection = nil
         history = nil
         explanation = nil
         selectedNodeIDs = []
+        selectedEdgeID = nil
+        resetUndoHistory()
         mode = .definition
         defaults.removeObject(forKey: Self.lastDocumentPathKey)
         defaults.removeObject(forKey: Self.lastRunIDKey)
@@ -262,11 +317,23 @@ final class GraphWorkspaceViewModel {
     func openDocument(url: URL) async {
         do {
             let loaded = try await service.loadDocument(url: url)
+            let fileState = try await service.documentFileState(url: url)
             document = loaded
             documentURL = url
+            documentFileState = fileState
+            lastSavedDocument = loaded
+            hasExternalModification = false
+            associatedRunCount = try await service.associatedRunCount(
+                graphID: loaded.graphID,
+                definitionVersion: loaded.definitionVersion
+            )
+            isDraft = false
             selectedNodeIDs = Set(loaded.nodes.first.map { [$0.id] } ?? [])
+            selectedEdgeID = nil
+            resetUndoHistory()
             mode = .definition
             defaults.set(url.path, forKey: Self.lastDocumentPathKey)
+            recordRecentDocument(url)
             acceptedLocalAction("definition_opened")
         } catch {
             rejectLocalAction("definition_open_failed", error)
@@ -278,7 +345,13 @@ final class GraphWorkspaceViewModel {
             let loaded = try GraphWorkspaceBundledFixtures.loadCompendium()
             document = loaded
             documentURL = nil
+            documentFileState = nil
+            lastSavedDocument = nil
+            associatedRunCount = 0
+            isDraft = false
             selectedNodeIDs = Set(loaded.nodes.first.map { [$0.id] } ?? [])
+            selectedEdgeID = nil
+            resetUndoHistory()
             mode = .definition
             acceptedLocalAction("compendium_definition_opened")
         } catch {
@@ -300,13 +373,104 @@ final class GraphWorkspaceViewModel {
             )
         }
         do {
-            try await service.saveDocument(document, url: destination)
+            let expectedDigest = destination == documentURL
+                ? documentFileState?.contentDigest : nil
+            let savedState = try await service.saveDocument(
+                document,
+                url: destination,
+                expectedContentDigest: expectedDigest
+            )
             documentURL = destination
+            documentFileState = savedState
+            lastSavedDocument = document
+            hasExternalModification = false
             defaults.set(destination.path, forKey: Self.lastDocumentPathKey)
+            recordRecentDocument(destination)
             acceptedLocalAction("definition_saved")
         } catch {
             rejectLocalAction("definition_save_failed", error)
         }
+    }
+
+    func saveAsDocument(url: URL) async {
+        await saveDocument(url: url)
+    }
+
+    func refreshExternalModificationState() async {
+        guard let documentURL, let documentFileState else {
+            hasExternalModification = false
+            return
+        }
+        do {
+            hasExternalModification = try await service.documentFileState(
+                url: documentURL
+            ).contentDigest != documentFileState.contentDigest
+        } catch {
+            hasExternalModification = true
+        }
+    }
+
+    func revertDocument() async {
+        guard let documentURL else { return }
+        await openDocument(url: documentURL)
+        if errorMessage == nil {
+            acceptedLocalAction("definition_reverted")
+        }
+    }
+
+    func requestCloseDocument() {
+        if isDirty {
+            closeState = .confirmationRequired
+        } else {
+            closeDocumentDiscardingChanges()
+        }
+    }
+
+    func resolveCloseDocument(
+        _ choice: GraphUnsavedCloseChoice,
+        saveURL: URL? = nil
+    ) async {
+        switch choice {
+        case .save:
+            await saveDocument(url: saveURL)
+            if !isDirty { closeDocumentDiscardingChanges() }
+        case .discard:
+            closeDocumentDiscardingChanges()
+        case .cancel:
+            closeState = .idle
+        }
+    }
+
+    func createNewDefinitionVersion() {
+        guard var document else { return }
+        registerUndo(coalescingKey: nil)
+        document.definitionVersion = GraphDefinitionVersioning.nextVersion(
+            after: document.definitionVersion
+        )
+        document.metadata.modifiedAt = Date()
+        document.metadata.modifiedBy = NSUserName()
+        self.document = document
+        associatedRunCount = 0
+        isDraft = false
+        acceptedLocalAction("definition_version_created")
+    }
+
+    func undo() {
+        guard let snapshot = undoSnapshots.popLast(),
+              let current = authoringSnapshot else { return }
+        redoSnapshots.append(current)
+        restore(snapshot)
+        undoCoalescingKey = nil
+        acceptedLocalAction("authoring_undo")
+    }
+
+    func redo() {
+        guard let snapshot = redoSnapshots.popLast(),
+              let current = authoringSnapshot else { return }
+        undoSnapshots.append(current)
+        restore(snapshot)
+        undoCoalescingKey = nil
+        acceptedLocalAction("authoring_redo")
     }
 
     func validateDocument() {
@@ -320,6 +484,7 @@ final class GraphWorkspaceViewModel {
 
     func addNode() {
         guard var document else { return }
+        registerUndo(coalescingKey: nil)
         let existing = Set(document.nodes.map(\.id))
         var ordinal = document.nodes.count + 1
         var nodeID = "node-\(ordinal)"
@@ -338,10 +503,11 @@ final class GraphWorkspaceViewModel {
                     requiredCapabilities: ["local-process"],
                     specification: try specification.immutableSpecification(),
                     workspace: GraphExecutionWorkspaceContext(
-                        root: FileManager.default.currentDirectoryPath
+                        root: defaultNodeWorkspaceDirectory
+                            ?? FileManager.default.currentDirectoryPath
                     ),
                     timeoutPolicy: GraphExecutionTimeoutPolicy(
-                        executionSeconds: 300,
+                        executionSeconds: defaultNodeTimeoutSeconds,
                         cancellationAcknowledgementSeconds: 10
                     )
                 ),
@@ -354,7 +520,9 @@ final class GraphWorkspaceViewModel {
                 modifiedBy: NSUserName()
             )
             self.document = document
+            markSemanticMutation()
             selectedNodeIDs = [nodeID]
+            selectedEdgeID = nil
             acceptedLocalAction("node_added", nodeIDs: [nodeID])
         } catch {
             rejectLocalAction("node_add_rejected", error)
@@ -363,6 +531,7 @@ final class GraphWorkspaceViewModel {
 
     func updateSelectedNode(name: String, description: String) {
         guard var document, let nodeID = selectedNodeID else { return }
+        registerUndo(coalescingKey: "identity:\(nodeID)")
         do {
             try GraphDefinitionDocumentEditor.renameNode(
                 id: nodeID,
@@ -373,6 +542,7 @@ final class GraphWorkspaceViewModel {
                 modifiedBy: NSUserName()
             )
             self.document = document
+            markSemanticMutation()
         } catch {
             rejectLocalAction("node_edit_rejected", error)
         }
@@ -387,6 +557,7 @@ final class GraphWorkspaceViewModel {
               let index = document.nodes.firstIndex(where: {
                   $0.id == nodeID
               }) else { return }
+        registerUndo(coalescingKey: "execution:\(nodeID)")
         document.nodes[index].requiredCapabilities = capabilities.sorted()
         document.nodes[index].timeoutPolicy = GraphExecutionTimeoutPolicy(
             executionSeconds: executionSeconds,
@@ -398,6 +569,7 @@ final class GraphWorkspaceViewModel {
         do {
             try document.validate()
             self.document = document
+            markSemanticMutation()
         } catch {
             rejectLocalAction("node_execution_edit_rejected", error)
         }
@@ -405,6 +577,7 @@ final class GraphWorkspaceViewModel {
 
     func deleteSelection() {
         guard var document, !selectedNodeIDs.isEmpty else { return }
+        registerUndo(coalescingKey: nil)
         do {
             for nodeID in selectedNodeIDs.sorted() {
                 try GraphDefinitionDocumentEditor.removeNode(
@@ -416,7 +589,9 @@ final class GraphWorkspaceViewModel {
             }
             let removed = selectedNodeIDs.sorted()
             selectedNodeIDs = []
+            selectedEdgeID = nil
             self.document = document
+            markSemanticMutation()
             acceptedLocalAction("selection_deleted", nodeIDs: removed)
         } catch {
             rejectLocalAction("selection_delete_rejected", error)
@@ -425,6 +600,7 @@ final class GraphWorkspaceViewModel {
 
     func connectSelectedNodes() {
         guard var document, selectedNodeIDs.count == 2 else { return }
+        registerUndo(coalescingKey: nil)
         let ordered = selectedNodeIDs.sorted()
         do {
             try GraphDefinitionDocumentEditor.addEdge(
@@ -437,6 +613,7 @@ final class GraphWorkspaceViewModel {
                 modifiedBy: NSUserName()
             )
             self.document = document
+            markSemanticMutation()
             acceptedLocalAction("dependency_added", nodeIDs: ordered)
         } catch {
             rejectLocalAction("dependency_add_rejected", error)
@@ -445,6 +622,7 @@ final class GraphWorkspaceViewModel {
 
     func removeEdge(_ edgeID: String) {
         guard var document else { return }
+        registerUndo(coalescingKey: nil)
         do {
             try GraphDefinitionDocumentEditor.removeEdge(
                 id: edgeID,
@@ -453,6 +631,8 @@ final class GraphWorkspaceViewModel {
                 modifiedBy: NSUserName()
             )
             self.document = document
+            selectedEdgeID = nil
+            markSemanticMutation()
             acceptedLocalAction("dependency_removed")
         } catch {
             rejectLocalAction("dependency_remove_rejected", error)
@@ -461,6 +641,7 @@ final class GraphWorkspaceViewModel {
 
     func moveNode(_ nodeID: String, to position: GraphCanvasPoint) {
         guard var document else { return }
+        registerUndo(coalescingKey: "move:\(nodeID)")
         do {
             try GraphDefinitionDocumentEditor.setPosition(
                 nodeID: nodeID,
@@ -477,6 +658,7 @@ final class GraphWorkspaceViewModel {
 
     func automaticLayout() {
         guard var document else { return }
+        registerUndo(coalescingKey: nil)
         do {
             try GraphDefinitionDocumentEditor.applyAutomaticLayout(
                 to: &document,
@@ -491,6 +673,8 @@ final class GraphWorkspaceViewModel {
     }
 
     func selectNode(_ nodeID: String, extending: Bool = false) {
+        undoCoalescingKey = nil
+        selectedEdgeID = nil
         if extending {
             if selectedNodeIDs.contains(nodeID) {
                 selectedNodeIDs.remove(nodeID)
@@ -516,6 +700,8 @@ final class GraphWorkspaceViewModel {
         )
         apply(result)
         if result.accepted {
+            associatedRunCount += 1
+            isDraft = false
             defaults.set(runID, forKey: Self.lastRunIDKey)
             mode = .run
             await refreshRunAndHistory()
@@ -724,7 +910,9 @@ final class GraphWorkspaceViewModel {
            FileManager.default.fileExists(atPath: path) {
             await openDocument(url: URL(fileURLWithPath: path))
         } else {
-            document = GraphDefinitionDocument.empty()
+            document = nil
+            lastSavedDocument = nil
+            documentFileState = nil
         }
         await refreshRunAndHistory()
         if inspection != nil {
@@ -767,6 +955,73 @@ final class GraphWorkspaceViewModel {
                 nodeIDs: [selectedNodeID].compactMap { $0 },
                 diagnostic: "Command rejected: \(decision.reasonCode)"
             )
+        )
+    }
+
+    private var authoringSnapshot: GraphAuthoringUndoSnapshot? {
+        guard let document else { return nil }
+        return GraphAuthoringUndoSnapshot(
+            document: document,
+            selectedNodeIDs: selectedNodeIDs,
+            selectedEdgeID: selectedEdgeID
+        )
+    }
+
+    private func registerUndo(coalescingKey: String?) {
+        guard let snapshot = authoringSnapshot else { return }
+        if let coalescingKey, undoCoalescingKey == coalescingKey {
+            return
+        }
+        undoSnapshots.append(snapshot)
+        if undoSnapshots.count > 200 {
+            undoSnapshots.removeFirst(undoSnapshots.count - 200)
+        }
+        redoSnapshots.removeAll()
+        undoCoalescingKey = coalescingKey
+    }
+
+    private func restore(_ snapshot: GraphAuthoringUndoSnapshot) {
+        document = snapshot.document
+        selectedNodeIDs = snapshot.selectedNodeIDs
+        selectedEdgeID = snapshot.selectedEdgeID
+        isDraft = associatedRunCount > 0
+    }
+
+    private func resetUndoHistory() {
+        undoSnapshots.removeAll()
+        redoSnapshots.removeAll()
+        undoCoalescingKey = nil
+    }
+
+    private func markSemanticMutation() {
+        if associatedRunCount > 0 { isDraft = true }
+    }
+
+    private func closeDocumentDiscardingChanges() {
+        pauseOrchestration()
+        document = nil
+        documentURL = nil
+        documentFileState = nil
+        lastSavedDocument = nil
+        hasExternalModification = false
+        associatedRunCount = 0
+        isDraft = false
+        selectedNodeIDs = []
+        selectedEdgeID = nil
+        closeState = .idle
+        resetUndoHistory()
+        defaults.removeObject(forKey: Self.lastDocumentPathKey)
+        mode = .definition
+        acceptedLocalAction("definition_closed")
+    }
+
+    private func recordRecentDocument(_ url: URL) {
+        recentDocumentURLs.removeAll { $0.standardizedFileURL == url.standardizedFileURL }
+        recentDocumentURLs.insert(url.standardizedFileURL, at: 0)
+        recentDocumentURLs = Array(recentDocumentURLs.prefix(10))
+        defaults.set(
+            recentDocumentURLs.map(\.path),
+            forKey: Self.recentDocumentPathsKey
         )
     }
 }

--- a/Sources/OpenIslandApp/GraphWorkspaceViewModel.swift
+++ b/Sources/OpenIslandApp/GraphWorkspaceViewModel.swift
@@ -377,10 +377,15 @@ final class GraphWorkspaceViewModel {
     }
 
     func openBundledCompendium() {
-        var request = GraphNewDocumentRequest.defaults(id: "compendium-fill")
-        request.template = .compendiumFill
-        request.name = "Compendium Fill"
-        request.description = GraphWorkspaceTemplate.compendiumFill.summary
+        openTemplate(.compendiumFill)
+    }
+
+    func openTemplate(_ template: GraphWorkspaceTemplate) {
+        var request = GraphNewDocumentRequest.defaults()
+        request.template = template
+        request.name = template == .blank ? "Untitled Graph" : template.name
+        request.description = template.summary
+        request.workspaceDirectory = defaultNodeWorkspaceDirectory
         newDocument(request: request)
     }
 
@@ -814,6 +819,39 @@ final class GraphWorkspaceViewModel {
             node.preferredCapabilities = preferred.sorted()
             node.executorKind = executorKind
             node.platformConstraints = platformConstraints.sorted()
+        }
+    }
+
+
+    func updateSelectedNodeWorkspace(root: String?) {
+        mutateSelectedNode(coalescingKey: "workspace") { node, _ in
+            node.workspace = GraphExecutionWorkspaceContext(
+                root: root?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
+                writableRelativePaths: node.workspace.writableRelativePaths
+            )
+        }
+    }
+
+    func updateSelectedNodeRuntime(
+        provider: String,
+        model: String,
+        agentProfile: String
+    ) {
+        mutateSelectedNode(coalescingKey: "agent-runtime") { node, _ in
+            let reservedPrefixes = ["provider:", "model:", "agent:"]
+            var tags = node.tags.filter { tag in
+                !reservedPrefixes.contains { tag.hasPrefix($0) }
+            }
+            let values = [
+                ("provider:", provider),
+                ("model:", model),
+                ("agent:", agentProfile),
+            ]
+            for (prefix, value) in values {
+                let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty { tags.append(prefix + trimmed) }
+            }
+            node.tags = tags.sorted()
         }
     }
 
@@ -1904,4 +1942,8 @@ final class GraphWorkspaceViewModel {
             forKey: Self.recentDocumentPathsKey
         )
     }
+}
+
+private extension String {
+    var nilIfEmpty: String? { isEmpty ? nil : self }
 }

--- a/Sources/OpenIslandApp/GraphWorkspaceViewModel.swift
+++ b/Sources/OpenIslandApp/GraphWorkspaceViewModel.swift
@@ -1,0 +1,751 @@
+import AppKit
+import Foundation
+import Observation
+import OpenIslandCore
+import SwiftUI
+
+enum GraphWorkspaceEntryPoint {
+    static let windowID = "graph-workspace"
+    static let label = "Graph Workspace"
+    static let shortcutKey: KeyEquivalent = "g"
+}
+
+enum GraphWorkspaceMode: String, CaseIterable, Identifiable {
+    case definition = "Definition"
+    case run = "Run"
+    case history = "History"
+
+    var id: String { rawValue }
+}
+
+enum GraphWorkspaceCommand: String, CaseIterable, Sendable {
+    case createRun = "create_run"
+    case start
+    case step
+    case run
+    case pauseLocal = "pause_local"
+    case cancelRun = "cancel_run"
+    case cancelNode = "cancel_node"
+    case retryNode = "retry_node"
+    case openLogs = "open_logs"
+    case inspectHistory = "inspect_history"
+    case export
+}
+
+struct GraphWorkspaceCommandDecision: Equatable, Sendable {
+    let command: GraphWorkspaceCommand
+    let isEnabled: Bool
+    let reasonCode: String
+}
+
+enum GraphWorkspaceCommandPolicy {
+    static func decision(
+        _ command: GraphWorkspaceCommand,
+        document: GraphDefinitionDocument?,
+        inspection: GraphRunInspection?,
+        selectedNodeID: String?,
+        isOrchestrating: Bool
+    ) -> GraphWorkspaceCommandDecision {
+        switch command {
+        case .createRun:
+            return decision(
+                command,
+                enabled: document?.nodes.isEmpty == false,
+                denial: "definition_has_no_nodes"
+            )
+        case .start:
+            return decision(
+                command,
+                enabled: inspection != nil
+                    && inspection?.summary.persistedState.isTerminal == false,
+                denial: "run_unavailable_or_terminal"
+            )
+        case .step, .run:
+            return decision(
+                command,
+                enabled: inspection != nil
+                    && inspection?.summary.persistedState.isTerminal == false
+                    && !isOrchestrating,
+                denial: isOrchestrating
+                    ? "orchestration_already_running"
+                    : "run_unavailable_or_terminal"
+            )
+        case .pauseLocal:
+            return decision(
+                command,
+                enabled: isOrchestrating,
+                denial: "local_orchestration_not_running"
+            )
+        case .cancelRun:
+            return decision(
+                command,
+                enabled: inspection != nil
+                    && inspection?.summary.persistedState.isTerminal == false,
+                denial: "run_unavailable_or_terminal"
+            )
+        case .cancelNode:
+            guard let selectedNodeID,
+                  let node = inspection?.nodes.first(where: {
+                      $0.id == selectedNodeID
+                  }) else {
+                return decision(
+                    command,
+                    enabled: false,
+                    denial: "node_not_selected"
+                )
+            }
+            return decision(
+                command,
+                enabled: !node.reconciledState.isTerminal,
+                denial: "node_already_terminal"
+            )
+        case .retryNode:
+            guard let selectedNodeID,
+                  let attempt = inspection?.attempts
+                    .filter({ $0.nodeID == selectedNodeID })
+                    .max(by: { $0.ordinal < $1.ordinal }) else {
+                return decision(
+                    command,
+                    enabled: false,
+                    denial: "retry_requires_attempt"
+                )
+            }
+            let retryPolicy = inspection?.scheduling?.currentPolicy?.retryPolicy
+                ?? document?.schedulerPolicy.retryPolicy
+            let category = attempt.statusReason ?? "execution_failure"
+            let categoryAllowed = retryPolicy.map {
+                !$0.nonRetryableFailureCategories.contains(category)
+                    && ($0.retryableFailureCategories.isEmpty
+                        || $0.retryableFailureCategories.contains(category))
+                    && attempt.ordinal < $0.maximumAttempts
+            } ?? false
+            return decision(
+                command,
+                enabled: [.failed, .interrupted, .orphaned]
+                    .contains(attempt.reconciledState) && categoryAllowed,
+                denial: "retry_policy_denied"
+            )
+        case .openLogs:
+            return decision(
+                command,
+                enabled: inspection != nil && selectedNodeID != nil,
+                denial: "node_not_selected"
+            )
+        case .inspectHistory, .export:
+            return decision(
+                command,
+                enabled: inspection != nil,
+                denial: "run_not_selected"
+            )
+        }
+    }
+
+    private static func decision(
+        _ command: GraphWorkspaceCommand,
+        enabled: Bool,
+        denial: String
+    ) -> GraphWorkspaceCommandDecision {
+        GraphWorkspaceCommandDecision(
+            command: command,
+            isEnabled: enabled,
+            reasonCode: enabled ? "allowed" : denial
+        )
+    }
+}
+
+@MainActor
+@Observable
+final class GraphWorkspaceViewModel {
+    static let lastDocumentPathKey = "graph.workspace.lastDocumentPath"
+    static let lastRunIDKey = "graph.workspace.lastRunID"
+    static let lastModeKey = "graph.workspace.lastMode"
+
+    var mode: GraphWorkspaceMode = .definition {
+        didSet { defaults.set(mode.rawValue, forKey: Self.lastModeKey) }
+    }
+    var document: GraphDefinitionDocument?
+    var documentURL: URL?
+    var inspection: GraphRunInspection?
+    var runs: [GraphRunInspectionSummary] = []
+    var history: GraphInspectionEventPage?
+    var explanation: GraphCausalExplanation?
+    var selectedNodeIDs: Set<String> = []
+    var logPage: GraphProcessLogPage?
+    var selectedLogChannel: GraphProcessLogChannel = .stdout
+    var isFollowingLogs = true
+    var isShowingLogs = false
+    var isLoading = false
+    var isOrchestrating = false
+    var lastCommandResult: GraphWorkspaceCommandResult?
+    var errorMessage: String?
+
+    @ObservationIgnored private let service: any GraphWorkspaceServicing
+    @ObservationIgnored private let defaults: UserDefaults
+    @ObservationIgnored private var revisionTask: Task<Void, Never>?
+    @ObservationIgnored private var orchestrationTask: Task<Void, Never>?
+    @ObservationIgnored private var refreshGeneration: UInt64 = 0
+    @ObservationIgnored private var hasStarted = false
+
+    init(
+        service: any GraphWorkspaceServicing,
+        defaults: UserDefaults = .standard
+    ) {
+        self.service = service
+        self.defaults = defaults
+        if let raw = defaults.string(forKey: Self.lastModeKey),
+           let restored = GraphWorkspaceMode(rawValue: raw) {
+            mode = restored
+        }
+    }
+
+    deinit {
+        revisionTask?.cancel()
+        orchestrationTask?.cancel()
+    }
+
+    var selectedNodeID: String? { selectedNodeIDs.sorted().first }
+
+    func start() {
+        guard !hasStarted else { return }
+        hasStarted = true
+        isLoading = true
+        Task {
+            await restore()
+            let revisions = await service.revisions()
+            revisionTask = Task { [weak self] in
+                for await _ in revisions {
+                    guard !Task.isCancelled else { break }
+                    await self?.refreshRunAndHistory()
+                }
+            }
+            isLoading = false
+        }
+    }
+
+    func stop() {
+        revisionTask?.cancel()
+        revisionTask = nil
+        pauseOrchestration()
+    }
+
+    func restoreState() async {
+        await restore()
+    }
+
+    func decision(_ command: GraphWorkspaceCommand)
+        -> GraphWorkspaceCommandDecision
+    {
+        GraphWorkspaceCommandPolicy.decision(
+            command,
+            document: document,
+            inspection: inspection,
+            selectedNodeID: selectedNodeID,
+            isOrchestrating: isOrchestrating
+        )
+    }
+
+    func newDocument() {
+        pauseOrchestration()
+        let newDocument = GraphDefinitionDocument.empty()
+        document = newDocument
+        documentURL = nil
+        inspection = nil
+        history = nil
+        explanation = nil
+        selectedNodeIDs = []
+        mode = .definition
+        defaults.removeObject(forKey: Self.lastDocumentPathKey)
+        defaults.removeObject(forKey: Self.lastRunIDKey)
+        acceptedLocalAction("new_definition")
+    }
+
+    func openDocument(url: URL) async {
+        do {
+            let loaded = try await service.loadDocument(url: url)
+            document = loaded
+            documentURL = url
+            selectedNodeIDs = Set(loaded.nodes.first.map { [$0.id] } ?? [])
+            mode = .definition
+            defaults.set(url.path, forKey: Self.lastDocumentPathKey)
+            acceptedLocalAction("definition_opened")
+        } catch {
+            rejectLocalAction("definition_open_failed", error)
+        }
+    }
+
+    func saveDocument(url: URL? = nil) async {
+        guard let document else {
+            return rejectLocalAction(
+                "definition_missing",
+                GraphDefinitionDocumentError.missingGraphID
+            )
+        }
+        guard let destination = url ?? documentURL else {
+            return rejectLocalAction(
+                "definition_destination_missing",
+                CocoaError(.fileNoSuchFile)
+            )
+        }
+        do {
+            try await service.saveDocument(document, url: destination)
+            documentURL = destination
+            defaults.set(destination.path, forKey: Self.lastDocumentPathKey)
+            acceptedLocalAction("definition_saved")
+        } catch {
+            rejectLocalAction("definition_save_failed", error)
+        }
+    }
+
+    func validateDocument() {
+        do {
+            try document?.validate()
+            acceptedLocalAction("definition_valid")
+        } catch {
+            rejectLocalAction("definition_invalid", error)
+        }
+    }
+
+    func addNode() {
+        guard var document else { return }
+        let existing = Set(document.nodes.map(\.id))
+        var ordinal = document.nodes.count + 1
+        var nodeID = "node-\(ordinal)"
+        while existing.contains(nodeID) {
+            ordinal += 1
+            nodeID = "node-\(ordinal)"
+        }
+        do {
+            let specification = GraphLocalProcessSpecification(
+                executable: "/usr/bin/true"
+            )
+            try GraphDefinitionDocumentEditor.addNode(
+                GraphDefinitionDocumentNode(
+                    id: nodeID,
+                    name: "Node \(ordinal)",
+                    requiredCapabilities: ["local-process"],
+                    specification: try specification.immutableSpecification(),
+                    workspace: GraphExecutionWorkspaceContext(
+                        root: FileManager.default.currentDirectoryPath
+                    ),
+                    timeoutPolicy: GraphExecutionTimeoutPolicy(
+                        executionSeconds: 300,
+                        cancellationAcknowledgementSeconds: 10
+                    )
+                ),
+                to: &document,
+                position: GraphCanvasPoint(
+                    x: Double(ordinal - 1) * 260,
+                    y: 0
+                ),
+                modifiedAt: Date(),
+                modifiedBy: NSUserName()
+            )
+            self.document = document
+            selectedNodeIDs = [nodeID]
+            acceptedLocalAction("node_added", nodeIDs: [nodeID])
+        } catch {
+            rejectLocalAction("node_add_rejected", error)
+        }
+    }
+
+    func updateSelectedNode(name: String, description: String) {
+        guard var document, let nodeID = selectedNodeID else { return }
+        do {
+            try GraphDefinitionDocumentEditor.renameNode(
+                id: nodeID,
+                name: name,
+                description: description,
+                in: &document,
+                modifiedAt: Date(),
+                modifiedBy: NSUserName()
+            )
+            self.document = document
+        } catch {
+            rejectLocalAction("node_edit_rejected", error)
+        }
+    }
+
+    func updateSelectedNodeExecution(
+        capabilities: [String],
+        executionSeconds: UInt64
+    ) {
+        guard var document,
+              let nodeID = selectedNodeID,
+              let index = document.nodes.firstIndex(where: {
+                  $0.id == nodeID
+              }) else { return }
+        document.nodes[index].requiredCapabilities = capabilities.sorted()
+        document.nodes[index].timeoutPolicy = GraphExecutionTimeoutPolicy(
+            executionSeconds: executionSeconds,
+            cancellationAcknowledgementSeconds: document.nodes[index]
+                .timeoutPolicy.cancellationAcknowledgementSeconds
+        )
+        document.metadata.modifiedAt = Date()
+        document.metadata.modifiedBy = NSUserName()
+        do {
+            try document.validate()
+            self.document = document
+        } catch {
+            rejectLocalAction("node_execution_edit_rejected", error)
+        }
+    }
+
+    func deleteSelection() {
+        guard var document, !selectedNodeIDs.isEmpty else { return }
+        do {
+            for nodeID in selectedNodeIDs.sorted() {
+                try GraphDefinitionDocumentEditor.removeNode(
+                    id: nodeID,
+                    from: &document,
+                    modifiedAt: Date(),
+                    modifiedBy: NSUserName()
+                )
+            }
+            let removed = selectedNodeIDs.sorted()
+            selectedNodeIDs = []
+            self.document = document
+            acceptedLocalAction("selection_deleted", nodeIDs: removed)
+        } catch {
+            rejectLocalAction("selection_delete_rejected", error)
+        }
+    }
+
+    func connectSelectedNodes() {
+        guard var document, selectedNodeIDs.count == 2 else { return }
+        let ordered = selectedNodeIDs.sorted()
+        do {
+            try GraphDefinitionDocumentEditor.addEdge(
+                GraphDefinitionEdge(
+                    sourceNodeID: ordered[0],
+                    targetNodeID: ordered[1]
+                ),
+                to: &document,
+                modifiedAt: Date(),
+                modifiedBy: NSUserName()
+            )
+            self.document = document
+            acceptedLocalAction("dependency_added", nodeIDs: ordered)
+        } catch {
+            rejectLocalAction("dependency_add_rejected", error)
+        }
+    }
+
+    func removeEdge(_ edgeID: String) {
+        guard var document else { return }
+        do {
+            try GraphDefinitionDocumentEditor.removeEdge(
+                id: edgeID,
+                from: &document,
+                modifiedAt: Date(),
+                modifiedBy: NSUserName()
+            )
+            self.document = document
+            acceptedLocalAction("dependency_removed")
+        } catch {
+            rejectLocalAction("dependency_remove_rejected", error)
+        }
+    }
+
+    func moveNode(_ nodeID: String, to position: GraphCanvasPoint) {
+        guard var document else { return }
+        do {
+            try GraphDefinitionDocumentEditor.setPosition(
+                nodeID: nodeID,
+                position: position,
+                in: &document,
+                modifiedAt: Date(),
+                modifiedBy: NSUserName()
+            )
+            self.document = document
+        } catch {
+            rejectLocalAction("layout_update_rejected", error)
+        }
+    }
+
+    func automaticLayout() {
+        guard var document else { return }
+        do {
+            try GraphDefinitionDocumentEditor.applyAutomaticLayout(
+                to: &document,
+                modifiedAt: Date(),
+                modifiedBy: NSUserName()
+            )
+            self.document = document
+            acceptedLocalAction("automatic_layout_applied")
+        } catch {
+            rejectLocalAction("automatic_layout_rejected", error)
+        }
+    }
+
+    func selectNode(_ nodeID: String, extending: Bool = false) {
+        if extending {
+            if selectedNodeIDs.contains(nodeID) {
+                selectedNodeIDs.remove(nodeID)
+            } else {
+                selectedNodeIDs.insert(nodeID)
+            }
+        } else {
+            selectedNodeIDs = [nodeID]
+        }
+        if mode == .history { Task { await refreshExplanation() } }
+    }
+
+    func createRun() async {
+        let policy = decision(.createRun)
+        guard policy.isEnabled, let document else {
+            return rejectedPolicy(policy)
+        }
+        let runID = "\(document.graphID)-\(UUID().uuidString.lowercased())"
+        let result = await service.createRun(
+            document: document,
+            runID: runID,
+            occurredAt: Date()
+        )
+        apply(result)
+        if result.accepted {
+            defaults.set(runID, forKey: Self.lastRunIDKey)
+            mode = .run
+            await refreshRunAndHistory()
+        }
+    }
+
+    func startRun() async {
+        let policy = decision(.start)
+        guard policy.isEnabled, let runID = inspection?.summary.runID else {
+            return rejectedPolicy(policy)
+        }
+        apply(await service.startRun(runID: runID, occurredAt: Date()))
+        await refreshRunAndHistory()
+    }
+
+    func step() async {
+        let policy = decision(.step)
+        guard policy.isEnabled, let runID = inspection?.summary.runID else {
+            return rejectedPolicy(policy)
+        }
+        apply(await service.step(runID: runID, occurredAt: Date()))
+        await refreshRunAndHistory()
+    }
+
+    func run() {
+        let policy = decision(.run)
+        guard policy.isEnabled, let runID = inspection?.summary.runID else {
+            return rejectedPolicy(policy)
+        }
+        isOrchestrating = true
+        orchestrationTask = Task { [weak self] in
+            guard let self else { return }
+            for _ in 0..<1_000 {
+                guard !Task.isCancelled else { break }
+                let result = await service.step(
+                    runID: runID,
+                    occurredAt: Date()
+                )
+                apply(result)
+                await refreshRunAndHistory()
+                if isShowingLogs, isFollowingLogs {
+                    await refreshLogs()
+                }
+                if inspection?.summary.persistedState.isTerminal == true
+                    || !result.accepted {
+                    break
+                }
+                if inspection?.nodes.contains(where: {
+                    $0.reconciledState == .running
+                }) == true {
+                    try? await Task.sleep(for: .milliseconds(200))
+                }
+            }
+            isOrchestrating = false
+            orchestrationTask = nil
+        }
+    }
+
+    func pauseOrchestration() {
+        orchestrationTask?.cancel()
+        orchestrationTask = nil
+        isOrchestrating = false
+        acceptedLocalAction("local_orchestration_paused")
+    }
+
+    func waitForLocalOrchestration() async {
+        await orchestrationTask?.value
+    }
+
+    func cancelRun() async {
+        let policy = decision(.cancelRun)
+        guard policy.isEnabled, let runID = inspection?.summary.runID else {
+            return rejectedPolicy(policy)
+        }
+        apply(await service.cancel(
+            runID: runID,
+            nodeID: nil,
+            occurredAt: Date()
+        ))
+        await refreshRunAndHistory()
+    }
+
+    func cancelSelectedNode() async {
+        let policy = decision(.cancelNode)
+        guard policy.isEnabled,
+              let runID = inspection?.summary.runID,
+              let nodeID = selectedNodeID else {
+            return rejectedPolicy(policy)
+        }
+        apply(await service.cancel(
+            runID: runID,
+            nodeID: nodeID,
+            occurredAt: Date()
+        ))
+        await refreshRunAndHistory()
+    }
+
+    func retrySelectedNode() async {
+        let policy = decision(.retryNode)
+        guard policy.isEnabled,
+              let runID = inspection?.summary.runID,
+              let nodeID = selectedNodeID else {
+            return rejectedPolicy(policy)
+        }
+        apply(await service.retry(
+            runID: runID,
+            nodeID: nodeID,
+            occurredAt: Date()
+        ))
+        await refreshRunAndHistory()
+    }
+
+    func openLogs() async {
+        let policy = decision(.openLogs)
+        guard policy.isEnabled else { return rejectedPolicy(policy) }
+        isShowingLogs = true
+        await refreshLogs()
+    }
+
+    func refreshLogs() async {
+        guard let runID = inspection?.summary.runID,
+              let nodeID = selectedNodeID else { return }
+        do {
+            logPage = try await service.logs(runID: runID, nodeID: nodeID)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func inspectHistory() async {
+        let policy = decision(.inspectHistory)
+        guard policy.isEnabled else { return rejectedPolicy(policy) }
+        mode = .history
+        await refreshRunAndHistory()
+    }
+
+    func exportRun(url: URL) async {
+        let policy = decision(.export)
+        guard policy.isEnabled, let runID = inspection?.summary.runID else {
+            return rejectedPolicy(policy)
+        }
+        do {
+            try await service.exportRun(runID: runID, url: url)
+            acceptedLocalAction("run_exported")
+        } catch {
+            rejectLocalAction("run_export_failed", error)
+        }
+    }
+
+    func openRun(_ runID: String) async {
+        defaults.set(runID, forKey: Self.lastRunIDKey)
+        mode = .run
+        await refreshRunAndHistory()
+    }
+
+    func refreshRunAndHistory() async {
+        refreshGeneration &+= 1
+        let generation = refreshGeneration
+        do {
+            let listed = try await service.listRuns()
+            guard generation == refreshGeneration else { return }
+            runs = listed
+            guard let runID = defaults.string(forKey: Self.lastRunIDKey),
+                  listed.contains(where: { $0.runID == runID }) else {
+                inspection = nil
+                history = nil
+                explanation = nil
+                return
+            }
+            async let inspected = service.inspect(runID: runID)
+            async let events = service.history(runID: runID)
+            let (newInspection, newHistory) = try await (inspected, events)
+            guard generation == refreshGeneration else { return }
+            inspection = newInspection
+            history = newHistory
+            await refreshExplanation()
+        } catch {
+            guard generation == refreshGeneration else { return }
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func refreshExplanation() async {
+        guard let runID = inspection?.summary.runID else { return }
+        do {
+            explanation = try await service.explain(
+                runID: runID,
+                nodeID: selectedNodeID
+            )
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func restore() async {
+        let restoredMode = mode
+        if let path = defaults.string(forKey: Self.lastDocumentPathKey),
+           FileManager.default.fileExists(atPath: path) {
+            await openDocument(url: URL(fileURLWithPath: path))
+        } else {
+            document = GraphDefinitionDocument.empty()
+        }
+        await refreshRunAndHistory()
+        if inspection != nil {
+            mode = restoredMode
+        }
+    }
+
+    private func apply(_ result: GraphWorkspaceCommandResult) {
+        lastCommandResult = result
+        errorMessage = result.accepted
+            ? nil : result.diagnostics.joined(separator: "\n")
+    }
+
+    private func acceptedLocalAction(
+        _ reasonCode: String,
+        nodeIDs: [String] = []
+    ) {
+        apply(
+            GraphWorkspaceCommandResult(
+                accepted: true,
+                reasonCode: reasonCode,
+                streamVersion: inspection?.summary.streamVersion,
+                runID: inspection?.summary.runID,
+                nodeIDs: nodeIDs,
+                diagnostics: [],
+                suggestedRefresh: .none
+            )
+        )
+    }
+
+    private func rejectLocalAction(_ reasonCode: String, _ error: Error) {
+        apply(.rejected(reasonCode, diagnostic: error.localizedDescription))
+    }
+
+    private func rejectedPolicy(_ decision: GraphWorkspaceCommandDecision) {
+        apply(
+            .rejected(
+                decision.reasonCode,
+                runID: inspection?.summary.runID,
+                nodeIDs: [selectedNodeID].compactMap { $0 },
+                diagnostic: "Command rejected: \(decision.reasonCode)"
+            )
+        )
+    }
+}

--- a/Sources/OpenIslandApp/GraphWorkspaceViewModel.swift
+++ b/Sources/OpenIslandApp/GraphWorkspaceViewModel.swift
@@ -211,9 +211,14 @@ final class GraphWorkspaceViewModel {
     var isShowingNewGraphSheet = false
     var isShowingCreateRunSheet = false
     var runCreationDraft = GraphRunCreationDraft()
+    var runtimeCatalog = GraphRuntimeCatalogSnapshot.empty
+    var isRefreshingRuntimeCatalog = false
+    var runtimeCatalogStatus: String?
 
     @ObservationIgnored private let service: any GraphWorkspaceServicing
     @ObservationIgnored private let defaults: UserDefaults
+    @ObservationIgnored private let runtimeCatalogDiscovery:
+        any GraphRuntimeCatalogDiscovering
     @ObservationIgnored private var revisionTask: Task<Void, Never>?
     @ObservationIgnored private var orchestrationTask: Task<Void, Never>?
     @ObservationIgnored private var refreshGeneration: UInt64 = 0
@@ -225,10 +230,13 @@ final class GraphWorkspaceViewModel {
 
     init(
         service: any GraphWorkspaceServicing,
-        defaults: UserDefaults = .standard
+        defaults: UserDefaults = .standard,
+        runtimeCatalogDiscovery: any GraphRuntimeCatalogDiscovering =
+            GraphRuntimeCatalogDiscovery()
     ) {
         self.service = service
         self.defaults = defaults
+        self.runtimeCatalogDiscovery = runtimeCatalogDiscovery
         if let raw = defaults.string(forKey: Self.lastModeKey),
            let restored = GraphWorkspaceMode(rawValue: raw) {
             mode = restored
@@ -260,6 +268,7 @@ final class GraphWorkspaceViewModel {
         hasStarted = true
         isLoading = true
         Task {
+            await refreshRuntimeCatalog()
             await restore()
             let revisions = await service.revisions()
             revisionTask = Task { [weak self] in
@@ -832,6 +841,169 @@ final class GraphWorkspaceViewModel {
         }
     }
 
+    func refreshRuntimeCatalog() async {
+        guard !isRefreshingRuntimeCatalog else { return }
+        isRefreshingRuntimeCatalog = true
+        runtimeCatalogStatus = "Discovering providers, models, and agents…"
+
+        let snapshot = await runtimeCatalogDiscovery.discover()
+        runtimeCatalog = snapshot
+        isRefreshingRuntimeCatalog = false
+
+        let providerCount = snapshot.providers.count
+        let modelCount = snapshot.models.count
+        let agentCount = snapshot.agents.count
+
+        if snapshot.diagnostics.isEmpty {
+            runtimeCatalogStatus =
+                "Found \(providerCount) providers, \(modelCount) models, " +
+                "and \(agentCount) installed agents."
+        } else {
+            runtimeCatalogStatus =
+                "Found \(providerCount) providers, \(modelCount) models, " +
+                "and \(agentCount) installed agents. " +
+                snapshot.diagnostics.joined(separator: " ")
+        }
+    }
+
+    func runtimeProvider(
+        for node: GraphDefinitionDocumentNode
+    ) -> GraphRuntimeProviderKind {
+        guard let value = runtimeTagValue("provider:", in: node) else {
+            switch node.specification.adapterKind {
+            case GraphLocalProcessSpecification.adapterKind:
+                return .localProcess
+            case "openai_compatible":
+                return .openAICompatible
+            default:
+                return .custom
+            }
+        }
+
+        if let provider = GraphRuntimeProviderKind(rawValue: value) {
+            return provider
+        }
+
+        switch value.lowercased() {
+        case "local process":
+            return .localProcess
+        case "ollama":
+            return .ollama
+        case "qwen", "qwen code":
+            return .qwenCode
+        case "gemini", "gemini cli":
+            return .geminiCLI
+        case "opencode", "open code":
+            return .openCode
+        case "openai-compatible endpoint", "openai compatible":
+            return .openAICompatible
+        default:
+            return .custom
+        }
+    }
+
+    func runtimeModel(
+        for node: GraphDefinitionDocumentNode
+    ) -> String {
+        runtimeTagValue("model:", in: node) ?? ""
+    }
+
+    func runtimeAgentProfile(
+        for node: GraphDefinitionDocumentNode
+    ) -> String {
+        runtimeTagValue("agent:", in: node) ?? ""
+    }
+
+    func runtimeModels(
+        for provider: GraphRuntimeProviderKind
+    ) -> [GraphRuntimeModel] {
+        runtimeCatalog.models(for: provider)
+    }
+
+    func runtimeAgents(
+        for provider: GraphRuntimeProviderKind
+    ) -> [GraphRuntimeAgentProfile] {
+        runtimeCatalog.agents(for: provider)
+    }
+
+    func runtimeProviderDefinition(
+        _ provider: GraphRuntimeProviderKind
+    ) -> GraphRuntimeProvider? {
+        runtimeCatalog.provider(provider)
+            ?? GraphRuntimeCatalogDiscovery.builtInProviders.first {
+                $0.id == provider
+            }
+    }
+
+    func bindSelectedNodeRuntime(
+        provider: GraphRuntimeProviderKind,
+        model: String,
+        agentProfile: String
+    ) {
+        guard let providerDefinition = runtimeProviderDefinition(provider)
+        else {
+            updateSelectedNodeRuntime(
+                provider: provider.rawValue,
+                model: model,
+                agentProfile: agentProfile
+            )
+            return
+        }
+
+        do {
+            let binding = try GraphRuntimeNodeBindingFactory.make(
+                provider: providerDefinition,
+                model: model,
+                agentProfileID: agentProfile,
+                catalog: runtimeCatalog
+            )
+
+            mutateSelectedNode(
+                coalescingKey: "agent-runtime"
+            ) { node, _ in
+                let reservedPrefixes = [
+                    "provider:",
+                    "model:",
+                    "agent:",
+                ]
+
+                var tags = node.tags.filter { tag in
+                    !reservedPrefixes.contains {
+                        tag.hasPrefix($0)
+                    }
+                }
+
+                let values = [
+                    ("provider:", provider.rawValue),
+                    ("model:", model),
+                    ("agent:", agentProfile),
+                ]
+
+                for (prefix, value) in values {
+                    let trimmed = value.trimmingCharacters(
+                        in: .whitespacesAndNewlines
+                    )
+                    if !trimmed.isEmpty {
+                        tags.append(prefix + trimmed)
+                    }
+                }
+
+                node.tags = tags.sorted()
+                node.specification = binding.specification
+                node.executorKind = binding.executorKind
+                node.requiredCapabilities =
+                    binding.requiredCapabilities.sorted()
+                node.environmentAllowlist =
+                    binding.environmentAllowlist.sorted()
+            }
+        } catch {
+            rejectLocalAction(
+                "runtime_binding_rejected",
+                error
+            )
+        }
+    }
+
     func updateSelectedNodeRuntime(
         provider: String,
         model: String,
@@ -848,10 +1020,23 @@ final class GraphWorkspaceViewModel {
                 ("agent:", agentProfile),
             ]
             for (prefix, value) in values {
-                let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-                if !trimmed.isEmpty { tags.append(prefix + trimmed) }
+                let trimmed = value.trimmingCharacters(
+                    in: .whitespacesAndNewlines
+                )
+                if !trimmed.isEmpty {
+                    tags.append(prefix + trimmed)
+                }
             }
             node.tags = tags.sorted()
+        }
+    }
+
+    private func runtimeTagValue(
+        _ prefix: String,
+        in node: GraphDefinitionDocumentNode
+    ) -> String? {
+        node.tags.first { $0.hasPrefix(prefix) }.map {
+            String($0.dropFirst(prefix.count))
         }
     }
 

--- a/Sources/OpenIslandApp/GraphWorkspaceViewModel.swift
+++ b/Sources/OpenIslandApp/GraphWorkspaceViewModel.swift
@@ -273,6 +273,19 @@ final class GraphWorkspaceViewModel {
         }
     }
 
+    func openBundledCompendium() {
+        do {
+            let loaded = try GraphWorkspaceBundledFixtures.loadCompendium()
+            document = loaded
+            documentURL = nil
+            selectedNodeIDs = Set(loaded.nodes.first.map { [$0.id] } ?? [])
+            mode = .definition
+            acceptedLocalAction("compendium_definition_opened")
+        } catch {
+            rejectLocalAction("compendium_definition_open_failed", error)
+        }
+    }
+
     func saveDocument(url: URL? = nil) async {
         guard let document else {
             return rejectLocalAction(
@@ -551,9 +564,17 @@ final class GraphWorkspaceViewModel {
                     break
                 }
                 if inspection?.nodes.contains(where: {
-                    $0.reconciledState == .running
-                }) == true {
-                    try? await Task.sleep(for: .milliseconds(200))
+                    $0.persistedState == .running
+                }) == true,
+                   let nodeID = inspection?.nodes.first(where: {
+                       $0.persistedState == .running
+                   })?.id {
+                    await service.waitForProcessChange(
+                        runID: runID,
+                        nodeID: nodeID
+                    )
+                } else {
+                    await service.waitForRetryEligibility(runID: runID)
                 }
             }
             isOrchestrating = false

--- a/Sources/OpenIslandApp/IslandDebugScenario.swift
+++ b/Sources/OpenIslandApp/IslandDebugScenario.swift
@@ -243,8 +243,47 @@ private enum DebugSessionFactory {
                 lastAssistantMessage: "读取现有 notch 状态与事件路由，准备把提醒态从 session list 里拆出来。",
                 currentTool: "exec_command",
                 currentCommandPreview: "sed -n '1,260p' Sources/OpenIslandApp/Views/SettingsView.swift"
+            ),
+            observability: runningObservability(now: now)
+        )
+    }
+
+    static func runningObservability(now: Date) -> AgentSessionObservability {
+        var observability = AgentSessionObservability()
+        observability.record(
+            AgentTimelineEvent(
+                timestamp: now.addingTimeInterval(-12 * 60),
+                kind: .lifecycle,
+                title: "Session started",
+                detail: "Opened open-island orchestration work."
             )
         )
+        observability.record(
+            AgentTimelineEvent(
+                timestamp: now.addingTimeInterval(-8 * 60),
+                kind: .prompt,
+                title: "Prompt received",
+                detail: "Add active-session hygiene, logs, and metrics."
+            )
+        )
+        observability.record(
+            AgentTimelineEvent(
+                timestamp: now.addingTimeInterval(-3 * 60),
+                kind: .tool,
+                title: "Using exec_command",
+                detail: "swift test --filter AgentObservabilityTests",
+                toolName: "exec_command"
+            )
+        )
+        observability.record(
+            AgentTimelineEvent(
+                timestamp: now.addingTimeInterval(-45),
+                kind: .status,
+                title: "Running",
+                detail: "Reviewing the expanded session timeline."
+            )
+        )
+        return observability
     }
 
     static func recentCompletedSession(now: Date) -> AgentSession {

--- a/Sources/OpenIslandApp/OpenIslandApp.swift
+++ b/Sources/OpenIslandApp/OpenIslandApp.swift
@@ -4,6 +4,15 @@ import SwiftUI
 @MainActor
 final class OpenIslandAppDelegate: NSObject, NSApplicationDelegate {
     let model = AppModel()
+    let graphWorkspaceService: any GraphWorkspaceServicing = {
+        do {
+            return try GraphWorkspaceService.live()
+        } catch {
+            return UnavailableGraphWorkspaceService(
+                message: error.localizedDescription
+            )
+        }
+    }()
     private let harnessLaunchConfiguration = HarnessLaunchConfiguration()
     private let launchedAt = Date()
     private lazy var harnessRuntimeMonitor = HarnessRuntimeMonitor(launchedAt: launchedAt)
@@ -99,6 +108,18 @@ struct OpenIslandApp: App {
             SettingsWindowContent(model: appDelegate.model)
         }
         .windowResizability(.contentMinSize)
+
+        Window(
+            GraphWorkspaceEntryPoint.label,
+            id: GraphWorkspaceEntryPoint.windowID
+        ) {
+            GraphWorkspaceRegistrar(
+                model: appDelegate.model,
+                service: appDelegate.graphWorkspaceService
+            )
+        }
+        .defaultSize(width: 1_240, height: 780)
+        .windowResizability(.contentMinSize)
         .commands {
             CommandGroup(replacing: .appSettings) {
                 Button("Settings…") {
@@ -107,7 +128,51 @@ struct OpenIslandApp: App {
                 }
                 .keyboardShortcut(",", modifiers: .command)
             }
+            CommandGroup(after: .newItem) {
+                Button("New Graph") {
+                    openWindow(id: GraphWorkspaceEntryPoint.windowID)
+                    DispatchQueue.main.async {
+                        appDelegate.model.newGraphDefinitionAction?()
+                        appDelegate.model.showGraphWorkspace()
+                    }
+                }
+                .keyboardShortcut("n", modifiers: [.command, .shift])
+
+                Button("Open Graph Definition…") {
+                    openWindow(id: GraphWorkspaceEntryPoint.windowID)
+                    DispatchQueue.main.async {
+                        appDelegate.model.openGraphDefinitionAction?()
+                        appDelegate.model.showGraphWorkspace()
+                    }
+                }
+                .keyboardShortcut("o", modifiers: [.command, .shift])
+            }
+            CommandGroup(after: .windowArrangement) {
+                Button(GraphWorkspaceEntryPoint.label) {
+                    openWindow(id: GraphWorkspaceEntryPoint.windowID)
+                    appDelegate.model.showGraphWorkspace()
+                }
+                .keyboardShortcut(
+                    GraphWorkspaceEntryPoint.shortcutKey,
+                    modifiers: [.command, .shift]
+                )
+            }
         }
+    }
+}
+
+private struct GraphWorkspaceRegistrar: View {
+    var model: AppModel
+    let service: any GraphWorkspaceServicing
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        GraphWorkspaceWindowContent(model: model, service: service)
+            .onAppear {
+                model.openGraphWorkspaceWindow = { [openWindow] in
+                    openWindow(id: GraphWorkspaceEntryPoint.windowID)
+                }
+            }
     }
 }
 

--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -43,6 +43,9 @@ final class OverlayUICoordinator {
     var ignoresPointerExitAccessor: (() -> Bool)?
 
     @ObservationIgnored
+    var pointerLocationAccessor: (() -> NSPoint)?
+
+    @ObservationIgnored
     var harnessRuntimeMonitor: HarnessRuntimeMonitor?
 
     @ObservationIgnored
@@ -81,6 +84,10 @@ final class OverlayUICoordinator {
 
     private var ignoresPointerExitDuringHarness: Bool {
         ignoresPointerExitAccessor?() ?? false
+    }
+
+    private var pointerLocation: NSPoint {
+        pointerLocationAccessor?() ?? NSEvent.mouseLocation
     }
 
     private var preferredOverlayScreenID: String? {
@@ -417,7 +424,7 @@ final class OverlayUICoordinator {
             return
         }
 
-        if overlayPanelController.isPointInExpandedArea(NSEvent.mouseLocation) {
+        if overlayPanelController.isPointInExpandedArea(pointerLocation) {
             notePointerInsideIslandSurface()
             return
         }
@@ -448,7 +455,7 @@ final class OverlayUICoordinator {
 
     var shouldDeferTimedNotificationAutoCollapse: Bool {
         isPointerInsideIslandSurface
-            || overlayPanelController.isPointInExpandedArea(NSEvent.mouseLocation)
+            || overlayPanelController.isPointInExpandedArea(pointerLocation)
     }
 
     private var shouldTrackPointerInsideIslandSurface: Bool {
@@ -458,7 +465,7 @@ final class OverlayUICoordinator {
 
     private var isPointerInsideCurrentNotificationCard: Bool {
         isPointerInsideIslandSurface
-            || overlayPanelController.isPointInExpandedArea(NSEvent.mouseLocation)
+            || overlayPanelController.isPointInExpandedArea(pointerLocation)
     }
 
     // MARK: - Debug snapshots (overlay portion)

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -53,7 +53,6 @@ final class ProcessMonitoringCoordinator {
     private static let activePollInterval: TimeInterval = 60
     private static let idlePollInterval: TimeInterval = 300
     private static let cursorStalenessTimeout: TimeInterval = 600  // 10 minutes
-    private static let codexAppStalenessTimeout: TimeInterval = 600  // 10 minutes
     private static let claudeDesktopStalenessTimeout: TimeInterval = 600  // 10 minutes
 
     static func monitoringPollInterval(
@@ -389,15 +388,15 @@ final class ProcessMonitoringCoordinator {
                 .filter { $0.tool == .codex }
                 .compactMap(\.sessionID)
         )
-        // Codex.app sessions: keep alive while the desktop app is running.
+        // Codex.app is only host-process evidence. An individual thread is
+        // alive on the control surface only while app-server or rollout state
+        // says it is actively running or waiting for the user.
         for session in sessions where session.tool == .codex && !session.isDemoSession {
             if session.isCodexAppSession {
                 if session.isSessionEnded {
                     continue
                 }
-                let isStale = session.phase == .completed
-                    && session.updatedAt.addingTimeInterval(Self.codexAppStalenessTimeout) < Date.now
-                if isCodexAppRunning, !isStale {
+                if isCodexAppRunning, session.phase != .completed {
                     aliveIDs.insert(session.id)
                 }
             } else if codexProcessIDs.contains(session.id) {

--- a/Sources/OpenIslandApp/Resources/Graphs/dose-regulations-compendium.openisland-graph.json
+++ b/Sources/OpenIslandApp/Resources/Graphs/dose-regulations-compendium.openisland-graph.json
@@ -1,0 +1,231 @@
+{
+  "schemaVersion": 1,
+  "graphID": "dose-regulations-compendium-local-process",
+  "definitionVersion": "1",
+  "name": "Dose Regulations Compendium",
+  "description": "Deterministic four-stage process fixture for supervised graph execution.",
+  "nodes": [
+    {
+      "id": "architect",
+      "name": "Compendium Architect",
+      "description": "Defines the compendium section plan.",
+      "requiredCapabilities": ["compendium", "local-process"],
+      "specification": {
+        "schemaVersion": 1,
+        "adapterKind": "local_process",
+        "operation": "execute",
+        "parameters": {
+          "executable": "${OPENISLAND_PROCESS_FIXTURE}",
+          "arguments": ["--role", "architect", "--output", "${artifact:node_output}", "--stderr"],
+          "workingDirectory": ".",
+          "environment": {},
+          "inheritedEnvironment": "none",
+          "stdin": "null_device",
+          "outputArtifacts": [
+            {
+              "relativePath": "artifacts/architect.json",
+              "mediaType": "application/json",
+              "role": "node_output",
+              "sensitivity": "internalUse",
+              "maximumBytes": 1048576
+            }
+          ],
+          "retryableExitCodes": [23],
+          "logPolicy": {
+            "maximumBytesPerStream": 1048576,
+            "sensitiveEnvironmentKeys": []
+          }
+        }
+      },
+      "workspace": {
+        "root": "${OPENISLAND_COMPENDIUM_WORKSPACE}",
+        "writableRelativePaths": ["artifacts"]
+      },
+      "environmentAllowlist": [],
+      "inputArtifactRoles": [],
+      "timeoutPolicy": {
+        "executionSeconds": 60,
+        "cancellationAcknowledgementSeconds": 2
+      }
+    },
+    {
+      "id": "researcher",
+      "name": "Regulatory Researcher",
+      "description": "Produces deterministic researched findings from the architecture artifact.",
+      "requiredCapabilities": ["compendium", "local-process"],
+      "specification": {
+        "schemaVersion": 1,
+        "adapterKind": "local_process",
+        "operation": "execute",
+        "parameters": {
+          "executable": "${OPENISLAND_PROCESS_FIXTURE}",
+          "arguments": ["--role", "researcher", "--input", "${input:node_output}", "--output", "${artifact:structured_result}"],
+          "workingDirectory": ".",
+          "environment": {},
+          "inheritedEnvironment": "none",
+          "stdin": "null_device",
+          "outputArtifacts": [
+            {
+              "relativePath": "artifacts/researcher.json",
+              "mediaType": "application/json",
+              "role": "structured_result",
+              "sensitivity": "internalUse",
+              "maximumBytes": 1048576
+            }
+          ],
+          "retryableExitCodes": [23],
+          "logPolicy": {
+            "maximumBytesPerStream": 1048576,
+            "sensitiveEnvironmentKeys": []
+          }
+        }
+      },
+      "workspace": {
+        "root": "${OPENISLAND_COMPENDIUM_WORKSPACE}",
+        "writableRelativePaths": ["artifacts"]
+      },
+      "environmentAllowlist": [],
+      "inputArtifactRoles": ["node_output"],
+      "timeoutPolicy": {
+        "executionSeconds": 60,
+        "cancellationAcknowledgementSeconds": 2
+      }
+    },
+    {
+      "id": "graph",
+      "name": "Evidence Graph Builder",
+      "description": "Builds a deterministic evidence relationship graph.",
+      "requiredCapabilities": ["compendium", "local-process"],
+      "specification": {
+        "schemaVersion": 1,
+        "adapterKind": "local_process",
+        "operation": "execute",
+        "parameters": {
+          "executable": "${OPENISLAND_PROCESS_FIXTURE}",
+          "arguments": ["--role", "graph", "--input", "${input:structured_result}", "--output", "${artifact:diagnostic}"],
+          "workingDirectory": ".",
+          "environment": {},
+          "inheritedEnvironment": "none",
+          "stdin": "null_device",
+          "outputArtifacts": [
+            {
+              "relativePath": "artifacts/graph.json",
+              "mediaType": "application/json",
+              "role": "diagnostic",
+              "sensitivity": "internalUse",
+              "maximumBytes": 1048576
+            }
+          ],
+          "retryableExitCodes": [23],
+          "logPolicy": {
+            "maximumBytesPerStream": 1048576,
+            "sensitiveEnvironmentKeys": []
+          }
+        }
+      },
+      "workspace": {
+        "root": "${OPENISLAND_COMPENDIUM_WORKSPACE}",
+        "writableRelativePaths": ["artifacts"]
+      },
+      "environmentAllowlist": [],
+      "inputArtifactRoles": ["structured_result"],
+      "timeoutPolicy": {
+        "executionSeconds": 60,
+        "cancellationAcknowledgementSeconds": 2
+      }
+    },
+    {
+      "id": "reviewer",
+      "name": "Compendium Reviewer",
+      "description": "Consumes all intended upstream artifacts and emits the review verdict.",
+      "requiredCapabilities": ["compendium", "local-process"],
+      "specification": {
+        "schemaVersion": 1,
+        "adapterKind": "local_process",
+        "operation": "execute",
+        "parameters": {
+          "executable": "${OPENISLAND_PROCESS_FIXTURE}",
+          "arguments": ["--role", "reviewer", "--input", "${input:node_output}", "--input", "${input:structured_result}", "--input", "${input:diagnostic}", "--output", "${artifact:structured_result}"],
+          "workingDirectory": ".",
+          "environment": {},
+          "inheritedEnvironment": "none",
+          "stdin": "null_device",
+          "outputArtifacts": [
+            {
+              "relativePath": "artifacts/reviewer.json",
+              "mediaType": "application/json",
+              "role": "structured_result",
+              "sensitivity": "internalUse",
+              "maximumBytes": 1048576
+            }
+          ],
+          "retryableExitCodes": [23],
+          "logPolicy": {
+            "maximumBytesPerStream": 1048576,
+            "sensitiveEnvironmentKeys": []
+          }
+        }
+      },
+      "workspace": {
+        "root": "${OPENISLAND_COMPENDIUM_WORKSPACE}",
+        "writableRelativePaths": ["artifacts"]
+      },
+      "environmentAllowlist": [],
+      "inputArtifactRoles": ["diagnostic", "node_output", "structured_result"],
+      "timeoutPolicy": {
+        "executionSeconds": 60,
+        "cancellationAcknowledgementSeconds": 2
+      }
+    }
+  ],
+  "edges": [
+    {"sourceNodeID": "architect", "targetNodeID": "researcher", "portType": "dependency"},
+    {"sourceNodeID": "researcher", "targetNodeID": "graph", "portType": "dependency"},
+    {"sourceNodeID": "graph", "targetNodeID": "reviewer", "portType": "dependency"}
+  ],
+  "schedulerPolicy": {
+    "schemaVersion": 1,
+    "policyID": "local-process-compendium",
+    "version": "1",
+    "retryPolicy": {
+      "schemaVersion": 1,
+      "maximumAttempts": 2,
+      "retryableFailureCategories": ["process_exit_23", "process_exit_unobserved", "timeout"],
+      "nonRetryableFailureCategories": ["artifact_collection_failure", "invalid_process_specification", "process_exit_42"],
+      "initialBackoffSeconds": 0,
+      "backoffMultiplier": 2,
+      "maximumBackoffSeconds": 60,
+      "jitterBasisPoints": 0,
+      "jitterSeed": "local-process-compendium",
+      "timeoutBehavior": "retry",
+      "cancellationBehavior": "suppress",
+      "dependencyFailureBehavior": "fail_closed"
+    },
+    "defaultLeaseDurationSeconds": 60,
+    "claimAcquisitionTimeoutSeconds": 30,
+    "attemptExecutionTimeoutSeconds": 60,
+    "cancellationAcknowledgementTimeoutSeconds": 2,
+    "allowExpiredLeaseTakeover": true,
+    "schedulingEnabled": true
+  },
+  "policyReferences": ["openisland:local-process-compendium-v1"],
+  "layout": {
+    "schemaVersion": 1,
+    "nodes": [
+      {"nodeID": "architect", "position": {"x": 0, "y": 0}},
+      {"nodeID": "researcher", "position": {"x": 280, "y": 0}},
+      {"nodeID": "graph", "position": {"x": 560, "y": 0}},
+      {"nodeID": "reviewer", "position": {"x": 840, "y": 0}}
+    ],
+    "zoom": 0.85,
+    "pan": {"x": 0, "y": 0}
+  },
+  "metadata": {
+    "createdAt": "2026-07-22T00:00:00Z",
+    "modifiedAt": "2026-07-22T00:00:00Z",
+    "createdBy": "openisland",
+    "modifiedBy": "openisland"
+  },
+  "sourceRepository": null,
+  "fixtureKind": "supervised_local_process_compendium"
+}

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -212,6 +212,12 @@
 "subagents.completed" = "Completed";
 "tasks.summary" = "Tasks (%lld completed, %lld in progress, %lld pending)";
 
+/* Island Panel - Observability */
+"observability.events" = "events";
+"observability.tools" = "tools";
+"observability.elapsed" = "elapsed";
+"observability.timeline" = "Timeline";
+
 /* Island Panel - Question */
 "question.submit" = "Submit Answers";
 "question.answerNeeded" = "Answer needed";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -212,6 +212,12 @@
 "subagents.completed" = "完成";
 "tasks.summary" = "任务 (%lld 已完成, %lld 进行中, %lld 待处理)";
 
+/* Island Panel - Observability */
+"observability.events" = "事件";
+"observability.tools" = "工具";
+"observability.elapsed" = "耗时";
+"observability.timeline" = "时间线";
+
 /* Island Panel - Question */
 "question.submit" = "提交答案";
 "question.answerNeeded" = "需要回答";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -211,6 +211,12 @@
 "subagents.completed" = "完成";
 "tasks.summary" = "任務 (%lld 已完成, %lld 進行中, %lld 待處理)";
 
+/* Island Panel - Observability */
+"observability.events" = "事件";
+"observability.tools" = "工具";
+"observability.elapsed" = "耗時";
+"observability.timeline" = "時間線";
+
 /* Island Panel - Question */
 "question.submit" = "提交答案";
 "question.answerNeeded" = "需要回答";

--- a/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
+++ b/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
@@ -416,6 +416,8 @@ final class SessionDiscoveryCoordinator {
     /// Called periodically when Codex.app is running as a fallback when
     /// the app-server connection is unavailable.  Throttled to at most
     /// once per 10 seconds.
+    static let codexAppRediscoveryActiveWindow: TimeInterval = 120
+
     func rediscoverCodexAppSessionsIfNeeded() {
         let now = Date.now
         guard now.timeIntervalSince(lastCodexAppRescanDate) >= 10 else { return }
@@ -432,11 +434,13 @@ final class SessionDiscoveryCoordinator {
     }
 
     private func applyCodexAppRediscovery(_ records: [CodexTrackedSessionRecord]) {
+        let now = Date.now
         let existingIDs = Set(state.sessions.filter { $0.tool == .codex }.map(\.id))
         let existingPaths = Set(state.sessions.compactMap(\.codexMetadata?.transcriptPath))
 
         let newRecords = records.filter { record in
-            !existingIDs.contains(record.sessionID)
+            Self.shouldRediscoverCodexAppRecord(record, now: now)
+                && !existingIDs.contains(record.sessionID)
                 && (record.codexMetadata?.transcriptPath).map { !existingPaths.contains($0) } ?? true
         }
         guard !newRecords.isEmpty else { return }
@@ -468,6 +472,14 @@ final class SessionDiscoveryCoordinator {
         refreshCodexRolloutTracking()
         scheduleCodexSessionPersistence()
         onStatusMessage?("Discovered \(newRecords.count) new Codex.app session(s) via rollout re-scan.")
+    }
+
+    static func shouldRediscoverCodexAppRecord(
+        _ record: CodexTrackedSessionRecord,
+        now: Date
+    ) -> Bool {
+        record.phase == .running
+            && record.updatedAt >= now.addingTimeInterval(-codexAppRediscoveryActiveWindow)
     }
 
     // MARK: - Persistence scheduling

--- a/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
+++ b/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
@@ -98,7 +98,9 @@ final class SessionDiscoveryCoordinator {
         let allCursor = (try? cursorSessionRegistry.load()) ?? []
         let cursorRecords = allCursor.filter { $0.updatedAt >= cutoff && $0.shouldRestoreToLiveState }
 
-        let discoveredCodex = codexRolloutDiscovery.discoverRecentSessions()
+        let discoveredCodex = codexRolloutDiscovery
+            .discoverRecentSessions()
+            .filter(\.shouldRestoreToLiveState)
         let discoveredClaude = claudeTranscriptDiscovery.discoverRecentSessions()
 
         return StartupDiscoveryPayload(
@@ -503,14 +505,25 @@ final class SessionDiscoveryCoordinator {
     func scheduleCodexSessionPersistence() {
         codexSessionPersistenceTask?.cancel()
 
+        let now = Date.now
         let records = state.sessions
-            .filter { $0.isTrackedLiveCodexSession && $0.updatedAt >= Date.now.addingTimeInterval(-86_400) }
+            .filter { Self.shouldPersistCodexSession($0, now: now) }
             .map(CodexTrackedSessionRecord.init(session:))
         let store = codexSessionStore
 
         codexSessionPersistenceTask = Self.persistenceTask {
             try store.save(records)
         }
+    }
+
+    static func shouldPersistCodexSession(
+        _ session: AgentSession,
+        now: Date
+    ) -> Bool {
+        session.isTrackedLiveCodexSession
+            && session.phase != .completed
+            && !session.isSessionEnded
+            && session.updatedAt >= now.addingTimeInterval(-86_400)
     }
 
     func scheduleClaudeSessionPersistence() {

--- a/Sources/OpenIslandApp/Views/GraphWorkspaceView.swift
+++ b/Sources/OpenIslandApp/Views/GraphWorkspaceView.swift
@@ -1621,21 +1621,208 @@ private struct GraphDefinitionInspector: View {
 
     private var agentRuntimeSection: some View {
         Section("Agent Runtime") {
-            Picker("Provider", selection: runtimeBinding(prefix: "provider:", fallback: "Local Process")) {
-                Text("Local Process").tag("Local Process")
-                Text("Ollama").tag("Ollama")
-                Text("Qwen").tag("Qwen")
-                Text("OpenClaw").tag("OpenClaw")
-                Text("Codex (not configured)").tag("Codex")
-                Text("Custom Provider").tag("Custom Provider")
+            Picker(
+                "Provider",
+                selection: Binding(
+                    get: { selectedRuntimeProvider },
+                    set: { provider in
+                        viewModel.bindSelectedNodeRuntime(
+                            provider: provider,
+                            model: "",
+                            agentProfile: ""
+                        )
+                    }
+                )
+            ) {
+                ForEach(runtimeProviders) { provider in
+                    Text(provider.displayName).tag(provider.id)
+                }
             }
-            TextField("Model", text: runtimeBinding(prefix: "model:", fallback: ""))
-                .textContentType(.none)
-            TextField("Agent / Profile", text: runtimeBinding(prefix: "agent:", fallback: ""))
-            Text("Provider, model, and agent profile are saved with the node and remain provider-neutral until an adapter binds them at run time.")
+
+            runtimeModelEditor
+            runtimeAgentEditor
+
+            if let provider = selectedRuntimeProviderDefinition {
+                LabeledContent("Adapter", value: provider.adapterKind)
+                LabeledContent("Operation", value: provider.operation)
+
+                if let endpoint = provider.endpoint {
+                    LabeledContent("Default Endpoint", value: endpoint)
+                }
+
+                if !provider.requiredCapabilities.isEmpty {
+                    LabeledContent(
+                        "Runtime Capabilities",
+                        value: provider.requiredCapabilities.joined(
+                            separator: ", "
+                        )
+                    )
+                }
+            }
+
+            HStack {
+                Button {
+                    Task { await viewModel.refreshRuntimeCatalog() }
+                } label: {
+                    if viewModel.isRefreshingRuntimeCatalog {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Label("Refresh Catalog", systemImage: "arrow.clockwise")
+                    }
+                }
+                .disabled(viewModel.isRefreshingRuntimeCatalog)
+
+                Spacer()
+            }
+
+            if let status = viewModel.runtimeCatalogStatus {
+                Text(status)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+
+            Text(
+                "Choose a discovered provider, model, and agent profile. " +
+                "The next execution-binding step will convert this selection " +
+                "into the node adapter and runnable specification."
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var runtimeModelEditor: some View {
+        let models = viewModel.runtimeModels(
+            for: selectedRuntimeProvider
+        )
+        let provider = selectedRuntimeProviderDefinition
+
+        if !models.isEmpty {
+            Picker(
+                "Model",
+                selection: Binding(
+                    get: { selectedRuntimeModel },
+                    set: { model in
+                        viewModel.bindSelectedNodeRuntime(
+                            provider: selectedRuntimeProvider,
+                            model: model,
+                            agentProfile: selectedRuntimeAgent
+                        )
+                    }
+                )
+            ) {
+                Text("Select a model").tag("")
+                ForEach(models) { model in
+                    Text(model.name).tag(model.name)
+                }
+            }
+        } else if provider?.supportsModelDiscovery == true {
+            TextField(
+                "Model",
+                text: Binding(
+                    get: { selectedRuntimeModel },
+                    set: { model in
+                        viewModel.bindSelectedNodeRuntime(
+                            provider: selectedRuntimeProvider,
+                            model: model,
+                            agentProfile: selectedRuntimeAgent
+                        )
+                    }
+                )
+            )
+            .textContentType(.none)
+
+            Text("No models were discovered. Enter a model identifier or refresh the catalog.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
+    }
+
+    @ViewBuilder
+    private var runtimeAgentEditor: some View {
+        let agents = viewModel.runtimeAgents(
+            for: selectedRuntimeProvider
+        )
+        let provider = selectedRuntimeProviderDefinition
+
+        if !agents.isEmpty {
+            Picker(
+                "Agent / Profile",
+                selection: Binding(
+                    get: { selectedRuntimeAgent },
+                    set: { agent in
+                        viewModel.bindSelectedNodeRuntime(
+                            provider: selectedRuntimeProvider,
+                            model: selectedRuntimeModel,
+                            agentProfile: agent
+                        )
+                    }
+                )
+            ) {
+                Text("Select an installed agent").tag("")
+                ForEach(agents) { agent in
+                    Text(agent.name).tag(agent.id)
+                }
+            }
+
+            if let selected = agents.first(where: {
+                $0.id == selectedRuntimeAgent
+            }), let details = selected.details {
+                Text(details)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+        } else if provider?.supportsAgentProfiles == true {
+            TextField(
+                "Agent / Profile",
+                text: Binding(
+                    get: { selectedRuntimeAgent },
+                    set: { agent in
+                        viewModel.bindSelectedNodeRuntime(
+                            provider: selectedRuntimeProvider,
+                            model: selectedRuntimeModel,
+                            agentProfile: agent
+                        )
+                    }
+                )
+            )
+
+            Text("No installed executable or saved profile was discovered.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var runtimeProviders: [GraphRuntimeProvider] {
+        let discovered = viewModel.runtimeCatalog.providers
+        return discovered.isEmpty
+            ? GraphRuntimeCatalogDiscovery.builtInProviders
+            : discovered
+    }
+
+    private var selectedRuntimeProvider: GraphRuntimeProviderKind {
+        guard let selectedNode else { return .localProcess }
+        return viewModel.runtimeProvider(for: selectedNode)
+    }
+
+    private var selectedRuntimeProviderDefinition:
+        GraphRuntimeProvider?
+    {
+        viewModel.runtimeProviderDefinition(selectedRuntimeProvider)
+    }
+
+    private var selectedRuntimeModel: String {
+        guard let selectedNode else { return "" }
+        return viewModel.runtimeModel(for: selectedNode)
+    }
+
+    private var selectedRuntimeAgent: String {
+        guard let selectedNode else { return "" }
+        return viewModel.runtimeAgentProfile(for: selectedNode)
     }
 
     private var workspaceSection: some View {
@@ -1664,26 +1851,6 @@ private struct GraphDefinitionInspector: View {
                     .foregroundStyle(.orange)
             }
         }
-    }
-
-    private func runtimeBinding(prefix: String, fallback: String) -> Binding<String> {
-        Binding(
-            get: {
-                selectedNode?.tags.first(where: { $0.hasPrefix(prefix) })
-                    .map { String($0.dropFirst(prefix.count)) } ?? fallback
-            },
-            set: { newValue in
-                let provider = prefix == "provider:" ? newValue : runtimeValue("provider:", fallback: "Local Process")
-                let model = prefix == "model:" ? newValue : runtimeValue("model:", fallback: "")
-                let agent = prefix == "agent:" ? newValue : runtimeValue("agent:", fallback: "")
-                viewModel.updateSelectedNodeRuntime(provider: provider, model: model, agentProfile: agent)
-            }
-        )
-    }
-
-    private func runtimeValue(_ prefix: String, fallback: String) -> String {
-        selectedNode?.tags.first(where: { $0.hasPrefix(prefix) })
-            .map { String($0.dropFirst(prefix.count)) } ?? fallback
     }
 
     @ViewBuilder

--- a/Sources/OpenIslandApp/Views/GraphWorkspaceView.swift
+++ b/Sources/OpenIslandApp/Views/GraphWorkspaceView.swift
@@ -32,6 +32,7 @@ struct GraphWorkspaceWindowContent: View {
 struct GraphWorkspaceView: View {
     @Bindable var viewModel: GraphWorkspaceViewModel
     @State private var canvasZoom = 1.0
+    @State private var isShowingNewGraph = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -69,6 +70,31 @@ struct GraphWorkspaceView: View {
         .background(Color(nsColor: .windowBackgroundColor))
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Graph Workspace")
+        .sheet(isPresented: $isShowingNewGraph) {
+            GraphNewDocumentSheet { request in
+                viewModel.newDocument(request: request)
+                isShowingNewGraph = false
+            } onCancel: {
+                isShowingNewGraph = false
+            }
+        }
+        .confirmationDialog(
+            "Save changes before closing?",
+            isPresented: Binding(
+                get: { viewModel.closeState == .confirmationRequired },
+                set: { if !$0 { viewModel.closeState = .idle } }
+            )
+        ) {
+            Button("Save") {
+                GraphWorkspaceFilePanels.saveAndCloseDefinition(viewModel)
+            }
+            Button("Don't Save", role: .destructive) {
+                Task { await viewModel.resolveCloseDocument(.discard) }
+            }
+            Button("Cancel", role: .cancel) {
+                Task { await viewModel.resolveCloseDocument(.cancel) }
+            }
+        }
     }
 
     private var workspaceToolbar: some View {
@@ -86,6 +112,17 @@ struct GraphWorkspaceView: View {
             Text(viewModel.document?.name ?? "Graph Workspace")
                 .font(.headline)
                 .lineLimit(1)
+            if viewModel.isDirty {
+                Text("Edited")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel("Document has unsaved changes")
+            }
+            if viewModel.isDraft {
+                Text("Draft")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.orange)
+            }
 
             Spacer()
 
@@ -104,37 +141,82 @@ struct GraphWorkspaceView: View {
 
     private var definitionToolbar: some View {
         HStack(spacing: 6) {
-            iconButton("doc.badge.plus", help: "New Graph") {
-                viewModel.newDocument()
+            Button {
+                isShowingNewGraph = true
+            } label: {
+                Label("New Graph", systemImage: "doc.badge.plus")
             }
-            iconButton("folder", help: "Open Graph Definition") {
+            .keyboardShortcut("n", modifiers: [.command])
+            .help("Create a blank graph or start from a template")
+
+            Button {
                 GraphWorkspaceFilePanels.openDefinition(viewModel)
+            } label: {
+                Label("Open Graph", systemImage: "folder")
             }
-            iconButton("books.vertical", help: "Open Compendium Example") {
-                viewModel.openBundledCompendium()
-            }
-            iconButton("square.and.arrow.down", help: "Save Graph Definition") {
+            .keyboardShortcut("o", modifiers: [.command])
+
+            Button {
                 GraphWorkspaceFilePanels.saveDefinition(viewModel)
+            } label: {
+                Label("Save", systemImage: "square.and.arrow.down")
             }
-            iconButton("checkmark.seal", help: "Validate Graph") {
+            .disabled(viewModel.document == nil)
+            .keyboardShortcut("s", modifiers: [.command])
+
+            Menu {
+                Button("Save As") {
+                    GraphWorkspaceFilePanels.saveAsDefinition(viewModel)
+                }
+                .keyboardShortcut("s", modifiers: [.command, .shift])
+                Button("Revert to Saved") {
+                    Task { await viewModel.revertDocument() }
+                }
+                .disabled(viewModel.documentURL == nil)
+                Divider()
+                Button("Close Graph") { viewModel.requestCloseDocument() }
+                    .disabled(viewModel.document == nil)
+            } label: {
+                Label("Document", systemImage: "ellipsis.circle")
+            }
+
+            Button {
                 viewModel.validateDocument()
+            } label: {
+                Label("Validate", systemImage: "checkmark.seal")
             }
-            iconButton("plus", help: "Add Node") { viewModel.addNode() }
-            iconButton("arrow.triangle.branch", help: "Connect Selected Nodes") {
-                viewModel.connectSelectedNodes()
+            .disabled(viewModel.document == nil)
+            .keyboardShortcut("v", modifiers: [.command, .shift])
+
+            Menu {
+                Button("Add Node") { viewModel.addNode() }
+                    .keyboardShortcut("n", modifiers: [.command, .shift])
+                Button("Connect Selected Nodes") {
+                    viewModel.connectSelectedNodes()
+                }
+                .disabled(viewModel.selectedNodeIDs.count != 2)
+                Divider()
+                Button("Undo") { viewModel.undo() }
+                    .disabled(!viewModel.canUndo)
+                    .keyboardShortcut("z", modifiers: [.command])
+                Button("Redo") { viewModel.redo() }
+                    .disabled(!viewModel.canRedo)
+                    .keyboardShortcut("z", modifiers: [.command, .shift])
+                Divider()
+                Button("Auto Layout") { viewModel.automaticLayout() }
+                Button("Delete Selection", role: .destructive) {
+                    viewModel.deleteSelection()
+                }
+                .disabled(viewModel.selectedNodeIDs.isEmpty)
+            } label: {
+                Label("Edit", systemImage: "slider.horizontal.3")
             }
-            .disabled(viewModel.selectedNodeIDs.count != 2)
-            iconButton("wand.and.stars", help: "Automatic Layout") {
-                viewModel.automaticLayout()
-            }
-            iconButton("trash", help: "Delete Selection", role: .destructive) {
-                viewModel.deleteSelection()
-            }
-            .disabled(viewModel.selectedNodeIDs.isEmpty)
             Button("Create Run") { Task { await viewModel.createRun() } }
                 .buttonStyle(.borderedProminent)
                 .disabled(!viewModel.decision(.createRun).isEnabled)
+                .keyboardShortcut("r", modifiers: [.command, .shift])
         }
+        .controlSize(.small)
     }
 
     private var runToolbar: some View {
@@ -251,15 +333,27 @@ struct GraphWorkspaceView: View {
 
     @ViewBuilder
     private var workspaceContent: some View {
-        switch viewModel.mode {
-        case .definition, .run:
-            GraphCanvasView(
-                viewModel: viewModel,
-                zoom: $canvasZoom,
-                isEditable: viewModel.mode == .definition
+        if viewModel.document == nil && viewModel.mode == .definition {
+            GraphWorkspaceEmptyState(
+                recentURLs: viewModel.recentDocumentURLs,
+                onNew: { isShowingNewGraph = true },
+                onOpen: { GraphWorkspaceFilePanels.openDefinition(viewModel) },
+                onOpenRecent: { url in
+                    Task { await viewModel.openDocument(url: url) }
+                },
+                onOpenExample: { viewModel.openBundledCompendium() }
             )
-        case .history:
-            GraphHistoryView(viewModel: viewModel)
+        } else {
+            switch viewModel.mode {
+            case .definition, .run:
+                GraphCanvasView(
+                    viewModel: viewModel,
+                    zoom: $canvasZoom,
+                    isEditable: viewModel.mode == .definition
+                )
+            case .history:
+                GraphHistoryView(viewModel: viewModel)
+            }
         }
     }
 
@@ -338,6 +432,108 @@ struct GraphWorkspaceView: View {
         case .run: "play.rectangle"
         case .history: "clock.arrow.circlepath"
         }
+    }
+}
+
+private struct GraphWorkspaceEmptyState: View {
+    let recentURLs: [URL]
+    let onNew: () -> Void
+    let onOpen: () -> Void
+    let onOpenRecent: (URL) -> Void
+    let onOpenExample: () -> Void
+
+    var body: some View {
+        ContentUnavailableView {
+            Label(
+                "Build an Executable Graph",
+                systemImage: "point.3.connected.trianglepath.dotted"
+            )
+        } description: {
+            Text("Create a graph, add executable nodes, connect dependencies, validate, and run it here.")
+        } actions: {
+            HStack {
+                Button("Create New Graph", action: onNew)
+                    .buttonStyle(.borderedProminent)
+                Button("Open Existing Graph", action: onOpen)
+                Menu("Open Recent Graph") {
+                    if recentURLs.isEmpty {
+                        Text("No Recent Graphs")
+                    } else {
+                        ForEach(recentURLs, id: \.path) { url in
+                            Button(url.lastPathComponent) { onOpenRecent(url) }
+                        }
+                    }
+                }
+                Button("Open Example Graph", action: onOpenExample)
+            }
+        }
+        .accessibilityLabel("Empty Graph Workspace")
+    }
+}
+
+private struct GraphNewDocumentSheet: View {
+    @State private var request = GraphNewDocumentRequest.defaults()
+    let onCreate: (GraphNewDocumentRequest) -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("New Graph").font(.title2.weight(.semibold))
+            Form {
+                Section("Identity") {
+                    TextField("Graph Name", text: $request.name)
+                        .accessibilityHint("The name shown in the workspace and run summary")
+                    TextField("Stable Graph ID", text: $request.graphID)
+                    TextField("Definition Version", text: $request.definitionVersion)
+                    TextField("Description", text: $request.description, axis: .vertical)
+                        .lineLimit(2...4)
+                }
+                Section("Execution Defaults") {
+                    Picker("Default Executor", selection: $request.defaultExecutorKind) {
+                        Text("Supervised Local Process")
+                            .tag(GraphLocalProcessSpecification.adapterKind)
+                        Text("Deterministic Test").tag("deterministic")
+                    }
+                    Stepper(
+                        "Maximum Attempts: \(request.defaultRetryMaximumAttempts)",
+                        value: $request.defaultRetryMaximumAttempts,
+                        in: 1...20
+                    )
+                    Stepper(
+                        "Execution Timeout: \(request.defaultExecutionTimeoutSeconds)s",
+                        value: $request.defaultExecutionTimeoutSeconds,
+                        in: 1...86_400
+                    )
+                    HStack {
+                        LabeledContent(
+                            "Workspace",
+                            value: request.workspaceDirectory ?? "Not selected"
+                        )
+                        Button("Choose") {
+                            request.workspaceDirectory = GraphWorkspaceFilePanels
+                                .chooseDirectory()?.path
+                        }
+                    }
+                }
+            }
+            .formStyle(.grouped)
+            HStack {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                Button("Create Graph") { onCreate(request) }
+                    .buttonStyle(.borderedProminent)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(
+                        request.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            || request.graphID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            || request.definitionVersion.isEmpty
+                    )
+            }
+        }
+        .padding(20)
+        .frame(width: 560, height: 600)
+        .accessibilityLabel("New Graph Configuration")
     }
 }
 
@@ -982,6 +1178,37 @@ enum GraphWorkspaceFilePanels {
         panel.nameFieldStringValue = "\(viewModel.document?.graphID ?? "graph").openisland-graph.json"
         guard panel.runModal() == .OK, let url = panel.url else { return }
         Task { await viewModel.saveDocument(url: url) }
+    }
+
+    static func saveAsDefinition(_ viewModel: GraphWorkspaceViewModel) {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.json]
+        panel.nameFieldStringValue = "\(viewModel.document?.graphID ?? "graph").openisland-graph.json"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        Task { await viewModel.saveAsDocument(url: url) }
+    }
+
+    static func saveAndCloseDefinition(_ viewModel: GraphWorkspaceViewModel) {
+        if viewModel.documentURL != nil {
+            Task { await viewModel.resolveCloseDocument(.save) }
+            return
+        }
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.json]
+        panel.nameFieldStringValue = "\(viewModel.document?.graphID ?? "graph").openisland-graph.json"
+        guard panel.runModal() == .OK, let url = panel.url else {
+            Task { await viewModel.resolveCloseDocument(.cancel) }
+            return
+        }
+        Task { await viewModel.resolveCloseDocument(.save, saveURL: url) }
+    }
+
+    static func chooseDirectory() -> URL? {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        return panel.runModal() == .OK ? panel.url : nil
     }
 
     static func exportRun(_ viewModel: GraphWorkspaceViewModel) {

--- a/Sources/OpenIslandApp/Views/GraphWorkspaceView.swift
+++ b/Sources/OpenIslandApp/Views/GraphWorkspaceView.swift
@@ -59,6 +59,11 @@ struct GraphWorkspaceView: View {
                         max: 380
                     )
             }
+            if viewModel.isShowingValidationPanel {
+                Divider()
+                GraphValidationPanel(viewModel: viewModel)
+                    .frame(minHeight: 120, idealHeight: 180, maxHeight: 240)
+            }
             if viewModel.isShowingLogs {
                 Divider()
                 GraphLogViewer(viewModel: viewModel)
@@ -77,6 +82,9 @@ struct GraphWorkspaceView: View {
             } onCancel: {
                 isShowingNewGraph = false
             }
+        }
+        .sheet(isPresented: $viewModel.isShowingCreateRunSheet) {
+            GraphCreateRunSheet(viewModel: viewModel)
         }
         .confirmationDialog(
             "Save changes before closing?",
@@ -222,7 +230,7 @@ struct GraphWorkspaceView: View {
             } label: {
                 Label("Edit", systemImage: "slider.horizontal.3")
             }
-            Button("Create Run") { Task { await viewModel.createRun() } }
+            Button("Create Run") { Task { await viewModel.prepareCreateRun() } }
                 .buttonStyle(.borderedProminent)
                 .disabled(!viewModel.decision(.createRun).isEnabled)
                 .keyboardShortcut("r", modifiers: [.command, .shift])
@@ -396,6 +404,22 @@ struct GraphWorkspaceView: View {
                     ? Color.secondary : Color.red
             )
             Spacer()
+            let errorCount = viewModel.validationDiagnostics.filter {
+                $0.severity == .error
+            }.count
+            let warningCount = viewModel.validationDiagnostics.filter {
+                $0.severity == .warning
+            }.count
+            if errorCount > 0 || warningCount > 0 {
+                Button("\(errorCount) errors, \(warningCount) warnings") {
+                    viewModel.isShowingValidationPanel.toggle()
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(errorCount > 0 ? Color.red : Color.orange)
+                .accessibilityLabel(
+                    "Graph validation: \(errorCount) errors and \(warningCount) warnings"
+                )
+            }
             if let inspection = viewModel.inspection {
                 Text("stream \(inspection.summary.streamVersion)")
                     .foregroundStyle(.secondary)
@@ -545,6 +569,221 @@ private struct GraphNewDocumentSheet: View {
         .padding(20)
         .frame(width: 560, height: 600)
         .accessibilityLabel("New Graph Configuration")
+    }
+}
+
+private struct GraphValidationPanel: View {
+    @Bindable var viewModel: GraphWorkspaceViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Validation").font(.headline)
+                Spacer()
+                Button("Validate Again") { viewModel.validateDocument() }
+                Button {
+                    viewModel.isShowingValidationPanel = false
+                } label: {
+                    Image(systemName: "xmark")
+                }
+                .help("Close Validation Panel")
+                .accessibilityLabel("Close Validation Panel")
+            }
+            .padding(.horizontal, 12)
+            .frame(height: 34)
+            if viewModel.validationDiagnostics.isEmpty {
+                ContentUnavailableView(
+                    "No Validation Issues",
+                    systemImage: "checkmark.seal"
+                )
+            } else {
+                List(viewModel.validationDiagnostics) { diagnostic in
+                    Button {
+                        viewModel.selectValidationDiagnostic(diagnostic)
+                    } label: {
+                        HStack(alignment: .top, spacing: 8) {
+                            Image(
+                                systemName: diagnostic.severity == .error
+                                    ? "xmark.octagon.fill"
+                                    : "exclamationmark.triangle.fill"
+                            )
+                            .foregroundStyle(
+                                diagnostic.severity == .error
+                                    ? Color.red : Color.orange
+                            )
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(diagnostic.message)
+                                Text("\(diagnostic.code.rawValue) - \(diagnostic.suggestedAction)")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(
+                        "\(diagnostic.severity.rawValue): \(diagnostic.message)"
+                    )
+                    .accessibilityHint("Selects the affected graph element")
+                }
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Graph Validation Results")
+        .accessibilityAddTraits(.updatesFrequently)
+    }
+}
+
+private struct GraphCreateRunSheet: View {
+    @Bindable var viewModel: GraphWorkspaceViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Create Durable Run").font(.title2.weight(.semibold))
+            Form {
+                Section("Definition") {
+                    LabeledContent("Graph", value: viewModel.document?.name ?? "")
+                    LabeledContent(
+                        "Version",
+                        value: viewModel.document?.definitionVersion ?? ""
+                    )
+                    LabeledContent("Digest", value: definitionDigest)
+                    LabeledContent(
+                        "Validation",
+                        value: validationErrors.isEmpty
+                            ? "Passed" : "\(validationErrors.count) errors"
+                    )
+                    LabeledContent(
+                        "Estimated Nodes",
+                        value: "\(viewModel.document?.nodes.filter(\.nodeType.isExecutable).count ?? 0)"
+                    )
+                }
+                Section("Execution Backend") {
+                    Picker("Backend", selection: $viewModel.runCreationDraft.backend) {
+                        ForEach(GraphWorkspaceExecutionBackend.allCases) { backend in
+                            Text(backend.rawValue).tag(backend)
+                                .disabled(!backend.isConfigured)
+                        }
+                    }
+                    Text(compatibilitySummary)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Section("Workspace") {
+                    HStack {
+                        TextField(
+                            "Workspace Directory",
+                            text: Binding(
+                                get: { viewModel.runCreationDraft.workspaceDirectory ?? "" },
+                                set: { viewModel.runCreationDraft.workspaceDirectory = $0 }
+                            )
+                        )
+                        Button("Choose") {
+                            viewModel.runCreationDraft.workspaceDirectory =
+                                GraphWorkspaceFilePanels.chooseDirectory()?.path
+                        }
+                    }
+                }
+                if let inputs = viewModel.document?.graphInputs, !inputs.isEmpty {
+                    Section("Required Inputs") {
+                        ForEach(inputs) { input in
+                            if input.isSensitive {
+                                SecureField(
+                                    "\(input.name) Secret Reference",
+                                    text: Binding(
+                                        get: {
+                                            viewModel.runCreationDraft
+                                                .secretReferences[input.id] ?? ""
+                                        },
+                                        set: {
+                                            viewModel.runCreationDraft
+                                                .secretReferences[input.id] = $0
+                                            viewModel.runCreationInputDidChange()
+                                        }
+                                    )
+                                )
+                                Text("Enter a keychain or environment reference, not a secret value.")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            } else {
+                                TextField(
+                                    input.name,
+                                    text: Binding(
+                                        get: {
+                                            viewModel.runCreationDraft
+                                                .inputValues[input.id] ?? ""
+                                        },
+                                        set: {
+                                            viewModel.runCreationDraft
+                                                .inputValues[input.id] = $0
+                                            viewModel.runCreationInputDidChange()
+                                        }
+                                    )
+                                )
+                            }
+                        }
+                    }
+                }
+                if !validationWarnings.isEmpty {
+                    Section("Policy Warnings") {
+                        ForEach(validationWarnings) { warning in
+                            Label(warning.message, systemImage: "exclamationmark.triangle")
+                        }
+                    }
+                }
+            }
+            .formStyle(.grouped)
+            HStack {
+                Spacer()
+                Button("Cancel") { viewModel.isShowingCreateRunSheet = false }
+                    .keyboardShortcut(.cancelAction)
+                Button("Create Run") {
+                    Task { await viewModel.confirmCreateRun() }
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+                .disabled(!validationErrors.isEmpty || !inputsResolved)
+            }
+        }
+        .padding(20)
+        .frame(width: 620, height: 680)
+        .accessibilityLabel("Create Durable Graph Run")
+    }
+
+    private var definitionDigest: String {
+        guard let document = viewModel.document,
+              let digest = (try? document.semanticDigest())?.value else {
+            return "Unavailable"
+        }
+        return String(digest.prefix(16))
+    }
+
+    private var validationErrors: [GraphValidationDiagnostic] {
+        viewModel.validationDiagnostics.filter { $0.severity == .error }
+    }
+
+    private var validationWarnings: [GraphValidationDiagnostic] {
+        viewModel.validationDiagnostics.filter { $0.severity == .warning }
+    }
+
+    private var inputsResolved: Bool {
+        let required = viewModel.document?.graphInputs.filter {
+            $0.isRequired && $0.defaultValue == nil
+        } ?? []
+        return required.allSatisfy {
+            viewModel.runCreationDraft.resolvedInputIDs.contains($0.id)
+        }
+    }
+
+    private var compatibilitySummary: String {
+        switch viewModel.runCreationDraft.backend {
+        case .supervisedLocalProcess:
+            "Runs Local Process nodes with supervised PID identity, logs, artifacts, cancellation, timeout, and recovery."
+        case .deterministicTest:
+            "Runs Deterministic Test nodes in-process."
+        case .codex, .qwen, .ollama, .openClaw:
+            "This provider is visible for planning but is not configured in this task."
+        }
     }
 }
 
@@ -1197,6 +1436,100 @@ private struct GraphDefinitionInspector: View {
                     }
                 }
             }
+            Section("Graph Inputs") {
+                if document.graphInputs.isEmpty {
+                    Text("No graph inputs").foregroundStyle(.secondary)
+                }
+                ForEach(document.graphInputs) { input in
+                    VStack(alignment: .leading, spacing: 6) {
+                        TextField(
+                            "Input Name",
+                            text: graphInputBinding(input.id, \.name, fallback: input.name)
+                        )
+                        Picker(
+                            "Type",
+                            selection: graphInputBinding(
+                                input.id,
+                                \.dataType,
+                                fallback: input.dataType
+                            )
+                        ) {
+                            ForEach(GraphDefinitionDataType.allCases, id: \.rawValue) {
+                                Text($0.rawValue.replacingOccurrences(of: "_", with: " "))
+                                    .tag($0)
+                            }
+                        }
+                        Toggle(
+                            "Required",
+                            isOn: graphInputBinding(
+                                input.id,
+                                \.isRequired,
+                                fallback: input.isRequired
+                            )
+                        )
+                        Toggle(
+                            "Sensitive - use secret reference at run time",
+                            isOn: graphInputBinding(
+                                input.id,
+                                \.isSensitive,
+                                fallback: input.isSensitive
+                            )
+                        )
+                        LabeledContent("Stable ID", value: input.id)
+                        Button("Remove Graph Input", role: .destructive) {
+                            viewModel.removeGraphInput(input.id)
+                        }
+                    }
+                }
+                Button("Add Graph Input") { viewModel.addGraphInput() }
+            }
+            Section("Graph Outputs") {
+                if document.graphOutputs.isEmpty {
+                    Text("No graph outputs").foregroundStyle(.secondary)
+                }
+                ForEach(document.graphOutputs) { output in
+                    VStack(alignment: .leading, spacing: 6) {
+                        TextField(
+                            "Output Name",
+                            text: graphOutputBinding(output.id, \.name, fallback: output.name)
+                        )
+                        Picker(
+                            "Source Node",
+                            selection: graphOutputBinding(
+                                output.id,
+                                \.sourceNodeID,
+                                fallback: output.sourceNodeID
+                            )
+                        ) {
+                            ForEach(document.nodes.filter { !$0.outputs.isEmpty }) {
+                                Text($0.name).tag($0.id)
+                            }
+                        }
+                        Picker(
+                            "Source Output",
+                            selection: graphOutputBinding(
+                                output.id,
+                                \.sourceOutputID,
+                                fallback: output.sourceOutputID
+                            )
+                        ) {
+                            ForEach(
+                                document.nodes.first {
+                                    $0.id == output.sourceNodeID
+                                }?.outputs ?? []
+                            ) {
+                                Text($0.name).tag($0.id)
+                            }
+                        }
+                        LabeledContent("Stable ID", value: output.id)
+                        Button("Remove Graph Output", role: .destructive) {
+                            viewModel.removeGraphOutput(output.id)
+                        }
+                    }
+                }
+                Button("Add Graph Output") { viewModel.addGraphOutput() }
+                    .disabled(document.nodes.allSatisfy(\.outputs.isEmpty))
+            }
         } else {
             ContentUnavailableView("No Graph Open", systemImage: "doc")
         }
@@ -1649,6 +1982,51 @@ private struct GraphDefinitionInspector: View {
                 guard var edge = viewModel.selectedEdge else { return }
                 edge[keyPath: keyPath] = value
                 viewModel.updateSelectedEdge(edge)
+            }
+        )
+    }
+
+    private func graphInputBinding<Value>(
+        _ id: String,
+        _ keyPath: WritableKeyPath<GraphDefinitionInput, Value>,
+        fallback: Value
+    ) -> Binding<Value> {
+        Binding(
+            get: {
+                guard let input = viewModel.document?.graphInputs.first(where: {
+                    $0.id == id
+                }) else { return fallback }
+                return input[keyPath: keyPath]
+            },
+            set: { value in
+                guard var input = viewModel.document?.graphInputs.first(where: {
+                    $0.id == id
+                }) else { return }
+                input[keyPath: keyPath] = value
+                if input.isSensitive { input.defaultValue = nil }
+                viewModel.updateGraphInput(input)
+            }
+        )
+    }
+
+    private func graphOutputBinding<Value>(
+        _ id: String,
+        _ keyPath: WritableKeyPath<GraphDefinitionOutput, Value>,
+        fallback: Value
+    ) -> Binding<Value> {
+        Binding(
+            get: {
+                guard let output = viewModel.document?.graphOutputs.first(where: {
+                    $0.id == id
+                }) else { return fallback }
+                return output[keyPath: keyPath]
+            },
+            set: { value in
+                guard var output = viewModel.document?.graphOutputs.first(where: {
+                    $0.id == id
+                }) else { return }
+                output[keyPath: keyPath] = value
+                viewModel.updateGraphOutput(output)
             }
         )
     }

--- a/Sources/OpenIslandApp/Views/GraphWorkspaceView.swift
+++ b/Sources/OpenIslandApp/Views/GraphWorkspaceView.swift
@@ -515,6 +515,17 @@ private struct GraphNewDocumentSheet: View {
         VStack(alignment: .leading, spacing: 16) {
             Text("New Graph").font(.title2.weight(.semibold))
             Form {
+                Section("Template") {
+                    Picker("Graph Template", selection: $request.template) {
+                        ForEach(GraphWorkspaceTemplate.allCases) { template in
+                            Text(template.name).tag(template)
+                        }
+                    }
+                    Text(request.template.summary)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .accessibilityLabel("Template description: \(request.template.summary)")
+                }
                 Section("Identity") {
                     TextField("Graph Name", text: $request.name)
                         .accessibilityHint("The name shown in the workspace and run summary")
@@ -802,12 +813,26 @@ private struct GraphCanvasView: View {
         VStack(spacing: 0) {
             HStack {
                 Button {
+                    viewModel.automaticLayout()
+                } label: {
+                    Label("Auto Layout", systemImage: "rectangle.3.group")
+                }
+                .disabled(!isEditable || viewModel.document?.nodes.isEmpty != false)
+                .help("Arrange all graph nodes deterministically")
+                Button {
                     zoom = 0.75
                 } label: {
-                    Image(systemName: "arrow.up.left.and.arrow.down.right")
+                    Label("Fit", systemImage: "arrow.up.left.and.arrow.down.right")
                 }
                 .help("Fit Graph to View")
                 .accessibilityLabel("Fit Graph to View")
+                Button {
+                    zoom = 1
+                } label: {
+                    Label("Reset", systemImage: "1.magnifyingglass")
+                }
+                .help("Reset Graph Zoom to 100 Percent")
+                .accessibilityLabel("Reset Graph Zoom")
                 Slider(value: $zoom, in: 0.4...1.6, step: 0.05)
                     .frame(width: 140)
                     .accessibilityLabel("Graph zoom")
@@ -891,6 +916,7 @@ private struct GraphCanvasView: View {
                                     }
                                     .onEnded { _ in
                                         dragOrigins.removeValue(forKey: node.id)
+                                        viewModel.endUndoCoalescing()
                                     }
                             )
                         }

--- a/Sources/OpenIslandApp/Views/GraphWorkspaceView.swift
+++ b/Sources/OpenIslandApp/Views/GraphWorkspaceView.swift
@@ -215,7 +215,10 @@ struct GraphWorkspaceView: View {
                 Button("Delete Selection", role: .destructive) {
                     viewModel.deleteSelection()
                 }
-                .disabled(viewModel.selectedNodeIDs.isEmpty)
+                .disabled(
+                    viewModel.selectedNodeIDs.isEmpty
+                        && viewModel.selectedEdgeID == nil
+                )
             } label: {
                 Label("Edit", systemImage: "slider.horizontal.3")
             }
@@ -550,6 +553,8 @@ private struct GraphCanvasView: View {
     @Binding var zoom: Double
     let isEditable: Bool
     @State private var dragOrigins: [String: GraphCanvasPoint] = [:]
+    @State private var connectionDragSource: String?
+    @State private var connectionDragType: GraphDefinitionPortType = .dependency
 
     private let canvasSize = CGSize(width: 1_800, height: 1_200)
     private let origin = CGPoint(x: 180, y: 180)
@@ -587,7 +592,14 @@ private struct GraphCanvasView: View {
                         GraphEdgeCanvas(
                             document: document,
                             origin: origin,
-                            nodeSize: GraphNodeView.nodeSize
+                            nodeSize: GraphNodeView.nodeSize,
+                            selectedEdgeID: viewModel.selectedEdgeID
+                        )
+                        GraphEdgeSelectionOverlay(
+                            document: document,
+                            origin: origin,
+                            nodeSize: GraphNodeView.nodeSize,
+                            onSelect: viewModel.selectEdge
                         )
                         ForEach(document.nodes) { node in
                             let position = document.layout.position(nodeID: node.id)
@@ -601,11 +613,22 @@ private struct GraphCanvasView: View {
                                     .filter { $0.nodeID == node.id }
                                     .map(\.ordinal).max(),
                                 selected: viewModel.selectedNodeIDs.contains(node.id),
+                                connectionTargetHighlight: connectionTargetHighlight(
+                                    nodeID: node.id
+                                ),
                                 isEditable: isEditable,
                                 onSelect: { extending in
                                     viewModel.selectNode(node.id, extending: extending)
                                 },
-                                onDelete: { viewModel.deleteSelection() }
+                                onDelete: { viewModel.deleteSelection() },
+                                onConnectionDrag: { portType, phase in
+                                    handleConnectionDrag(
+                                        sourceNodeID: node.id,
+                                        portType: portType,
+                                        phase: phase,
+                                        document: document
+                                    )
+                                }
                             )
                             .position(
                                 x: origin.x + position.x
@@ -634,6 +657,7 @@ private struct GraphCanvasView: View {
                         }
                     }
                     .frame(width: canvasSize.width, height: canvasSize.height)
+                    .coordinateSpace(name: "graphCanvas")
                     .contentShape(Rectangle())
                     .onTapGesture { viewModel.selectCanvas() }
                     .contextMenu {
@@ -658,6 +682,10 @@ private struct GraphCanvasView: View {
                 .onDeleteCommand {
                     if isEditable { viewModel.deleteSelection() }
                 }
+                .onExitCommand {
+                    connectionDragSource = nil
+                    viewModel.cancelDependencyCreation()
+                }
             } else {
                 ContentUnavailableView {
                     Label(
@@ -680,12 +708,60 @@ private struct GraphCanvasView: View {
         }
         .accessibilityLabel("Graph canvas")
     }
+
+    private func connectionTargetHighlight(nodeID: String) -> Bool {
+        guard let source = connectionDragSource, source != nodeID else {
+            return false
+        }
+        return viewModel.canConnect(
+            sourceNodeID: source,
+            targetNodeID: nodeID,
+            portType: connectionDragType
+        ).isAllowed
+    }
+
+    private func handleConnectionDrag(
+        sourceNodeID: String,
+        portType: GraphDefinitionPortType,
+        phase: GraphConnectionDragPhase,
+        document: GraphDefinitionDocument
+    ) {
+        switch phase {
+        case .changed:
+            connectionDragSource = sourceNodeID
+            connectionDragType = portType
+        case let .ended(point):
+            let target = document.nodes.first { node in
+                guard node.id != sourceNodeID,
+                      let position = document.layout.position(nodeID: node.id) else {
+                    return false
+                }
+                return CGRect(
+                    x: origin.x + position.x,
+                    y: origin.y + position.y,
+                    width: GraphNodeView.nodeSize.width,
+                    height: GraphNodeView.nodeSize.height
+                ).contains(point)
+            }
+            if let target {
+                _ = viewModel.connectNodes(
+                    sourceNodeID: sourceNodeID,
+                    targetNodeID: target.id,
+                    portType: portType
+                )
+            } else {
+                viewModel.connectionGuidance = "Drop the connection on a highlighted node."
+            }
+            connectionDragSource = nil
+        }
+    }
 }
 
 private struct GraphEdgeCanvas: View {
     let document: GraphDefinitionDocument
     let origin: CGPoint
     let nodeSize: CGSize
+    let selectedEdgeID: String?
 
     var body: some View {
         Canvas { context, _ in
@@ -713,8 +789,11 @@ private struct GraphEdgeCanvas: View {
                 )
                 context.stroke(
                     path,
-                    with: .color(.secondary.opacity(0.65)),
-                    lineWidth: 1.5
+                    with: .color(
+                        edge.id == selectedEdgeID
+                            ? .accentColor : .secondary.opacity(0.65)
+                    ),
+                    lineWidth: edge.id == selectedEdgeID ? 3 : 1.5
                 )
                 var arrow = Path()
                 arrow.move(to: end)
@@ -729,6 +808,44 @@ private struct GraphEdgeCanvas: View {
     }
 }
 
+private struct GraphEdgeSelectionOverlay: View {
+    let document: GraphDefinitionDocument
+    let origin: CGPoint
+    let nodeSize: CGSize
+    let onSelect: (String) -> Void
+
+    var body: some View {
+        ForEach(document.edges) { edge in
+            if let source = document.layout.position(nodeID: edge.sourceNodeID),
+               let target = document.layout.position(nodeID: edge.targetNodeID) {
+                Button {
+                    onSelect(edge.id)
+                } label: {
+                    Image(systemName: edge.portType == .artifact ? "shippingbox" : "arrow.right")
+                        .font(.caption2)
+                        .frame(width: 24, height: 20)
+                }
+                .buttonStyle(.borderless)
+                .background(Color(nsColor: .controlBackgroundColor))
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+                .position(
+                    x: origin.x + (source.x + target.x + nodeSize.width) / 2,
+                    y: origin.y + (source.y + target.y + nodeSize.height) / 2
+                )
+                .help("Select \(edge.portType.rawValue) connection")
+                .accessibilityLabel(
+                    "Connection from \(edge.sourceNodeID) to \(edge.targetNodeID)"
+                )
+            }
+        }
+    }
+}
+
+private enum GraphConnectionDragPhase {
+    case changed(CGPoint)
+    case ended(CGPoint)
+}
+
 private struct GraphNodeView: View {
     static let nodeSize = CGSize(width: 210, height: 94)
 
@@ -736,9 +853,11 @@ private struct GraphNodeView: View {
     let state: ReconciledExecutionState?
     let attemptOrdinal: Int?
     let selected: Bool
+    let connectionTargetHighlight: Bool
     let isEditable: Bool
     let onSelect: (Bool) -> Void
     let onDelete: () -> Void
+    let onConnectionDrag: (GraphDefinitionPortType, GraphConnectionDragPhase) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 7) {
@@ -754,7 +873,11 @@ private struct GraphNodeView: View {
         .background(Color(nsColor: .controlBackgroundColor))
         .overlay {
             RoundedRectangle(cornerRadius: 6)
-                .stroke(selected ? Color.accentColor : Color.secondary.opacity(0.35), lineWidth: selected ? 2 : 1)
+                .stroke(
+                    selected || connectionTargetHighlight
+                        ? Color.accentColor : Color.secondary.opacity(0.35),
+                    lineWidth: selected || connectionTargetHighlight ? 2 : 1
+                )
         }
         .clipShape(RoundedRectangle(cornerRadius: 6))
         .contentShape(Rectangle())
@@ -810,7 +933,29 @@ private struct GraphNodeView: View {
                 .fill(Color.accentColor)
                 .frame(width: 8, height: 8)
                 .accessibilityLabel("Dependency output port")
+                .gesture(connectionGesture(.dependency))
+            if node.outputs.contains(where: { $0.portType == .artifact }) {
+                Circle()
+                    .fill(Color.green)
+                    .frame(width: 8, height: 8)
+                    .accessibilityLabel("Artifact output port")
+                    .gesture(connectionGesture(.artifact))
+            }
         }
+    }
+
+    private func connectionGesture(
+        _ portType: GraphDefinitionPortType
+    ) -> some Gesture {
+        DragGesture(minimumDistance: 4, coordinateSpace: .named("graphCanvas"))
+            .onChanged { value in
+                guard isEditable else { return }
+                onConnectionDrag(portType, .changed(value.location))
+            }
+            .onEnded { value in
+                guard isEditable else { return }
+                onConnectionDrag(portType, .ended(value.location))
+            }
     }
 }
 
@@ -841,7 +986,9 @@ private struct GraphDefinitionInspector: View {
 
     var body: some View {
         Form {
-            if let node = selectedNode {
+            if selectedEdge != nil {
+                edgeInspector
+            } else if let node = selectedNode {
                 Section("Identity") {
                     LabeledContent("Stable ID", value: node.id)
                     TextField(
@@ -918,10 +1065,23 @@ private struct GraphDefinitionInspector: View {
                             .accessibilityLabel("Remove dependency")
                         }
                     }
-                    Button("Add Dependency") {
-                        viewModel.connectSelectedNodes()
+                    Button(
+                        viewModel.dependencySourceNodeID == nil
+                            ? "Use as Dependency Source"
+                            : "Connect from \(viewModel.dependencySourceNodeID ?? "")"
+                    ) {
+                        if viewModel.dependencySourceNodeID == nil {
+                            viewModel.beginDependencyCreation(from: node.id)
+                        } else {
+                            viewModel.completeDependencyCreation(to: node.id)
+                        }
                     }
-                    .disabled(viewModel.selectedNodeIDs.count != 2)
+                    .keyboardShortcut("d", modifiers: [.command, .shift])
+                    if let guidance = viewModel.connectionGuidance {
+                        Text(guidance)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             } else {
                 graphInspector
@@ -932,6 +1092,72 @@ private struct GraphDefinitionInspector: View {
 
     private var selectedNode: GraphDefinitionDocumentNode? {
         viewModel.selectedNode
+    }
+
+    private var selectedEdge: GraphDefinitionEdge? {
+        viewModel.selectedEdge
+    }
+
+    @ViewBuilder
+    private var edgeInspector: some View {
+        if let edge = selectedEdge, let document = viewModel.document {
+            Section("Connection") {
+                LabeledContent("Stable ID", value: edge.id)
+                Picker(
+                    "Source",
+                    selection: edgeBinding(\.sourceNodeID, fallback: edge.sourceNodeID)
+                ) {
+                    ForEach(document.nodes.filter(\.nodeType.isExecutable)) {
+                        Text($0.name).tag($0.id)
+                    }
+                }
+                Picker(
+                    "Destination",
+                    selection: edgeBinding(\.targetNodeID, fallback: edge.targetNodeID)
+                ) {
+                    ForEach(document.nodes.filter(\.nodeType.isExecutable)) {
+                        Text($0.name).tag($0.id)
+                    }
+                }
+                LabeledContent("Port Type", value: edge.portType.rawValue)
+                Toggle(
+                    "Required",
+                    isOn: edgeBinding(\.isRequired, fallback: edge.isRequired)
+                )
+                if edge.portType != .dependency {
+                    let sourceOutputs = document.nodes.first {
+                        $0.id == edge.sourceNodeID
+                    }?.outputs.filter { $0.portType == edge.portType } ?? []
+                    let targetInputs = document.nodes.first {
+                        $0.id == edge.targetNodeID
+                    }?.inputs.filter { $0.portType == edge.portType } ?? []
+                    Picker(
+                        "Source Output",
+                        selection: edgeBinding(
+                            \.sourceOutputID,
+                            fallback: edge.sourceOutputID
+                        )
+                    ) {
+                        Text("Choose Output").tag(String?.none)
+                        ForEach(sourceOutputs) { Text($0.name).tag(Optional($0.id)) }
+                    }
+                    Picker(
+                        "Target Input",
+                        selection: edgeBinding(
+                            \.targetInputID,
+                            fallback: edge.targetInputID
+                        )
+                    ) {
+                        Text("Choose Input").tag(String?.none)
+                        ForEach(targetInputs) { Text($0.name).tag(Optional($0.id)) }
+                    }
+                }
+                Button("Delete Connection", role: .destructive) {
+                    viewModel.removeEdge(edge.id)
+                }
+                .keyboardShortcut(.delete, modifiers: [])
+            }
+        }
     }
 
     @ViewBuilder
@@ -1409,6 +1635,20 @@ private struct GraphDefinitionInspector: View {
                 }) else { return }
                 input[keyPath: keyPath] = value
                 viewModel.updateSelectedNodeInput(input)
+            }
+        )
+    }
+
+    private func edgeBinding<Value>(
+        _ keyPath: WritableKeyPath<GraphDefinitionEdge, Value>,
+        fallback: Value
+    ) -> Binding<Value> {
+        Binding(
+            get: { viewModel.selectedEdge?[keyPath: keyPath] ?? fallback },
+            set: { value in
+                guard var edge = viewModel.selectedEdge else { return }
+                edge[keyPath: keyPath] = value
+                viewModel.updateSelectedEdge(edge)
             }
         )
     }

--- a/Sources/OpenIslandApp/Views/GraphWorkspaceView.swift
+++ b/Sources/OpenIslandApp/Views/GraphWorkspaceView.swift
@@ -189,8 +189,16 @@ struct GraphWorkspaceView: View {
             .keyboardShortcut("v", modifiers: [.command, .shift])
 
             Menu {
-                Button("Add Node") { viewModel.addNode() }
-                    .keyboardShortcut("n", modifiers: [.command, .shift])
+                Menu("Add Node") {
+                    Button("Local Process") { viewModel.addNode(type: .localProcess) }
+                        .keyboardShortcut("n", modifiers: [.command, .shift])
+                    Button("Deterministic Test") { viewModel.addNode(type: .deterministicTest) }
+                    Button("Generic Agent") { viewModel.addNode(type: .genericAgent) }
+                    Divider()
+                    Button("Input Reference") { viewModel.addNode(type: .input) }
+                    Button("Output Reference") { viewModel.addNode(type: .output) }
+                    Button("Annotation") { viewModel.addNode(type: .annotation) }
+                }
                 Button("Connect Selected Nodes") {
                     viewModel.connectSelectedNodes()
                 }
@@ -626,6 +634,18 @@ private struct GraphCanvasView: View {
                         }
                     }
                     .frame(width: canvasSize.width, height: canvasSize.height)
+                    .contentShape(Rectangle())
+                    .onTapGesture { viewModel.selectCanvas() }
+                    .contextMenu {
+                        Menu("Add Node") {
+                            Button("Local Process") { viewModel.addNode(type: .localProcess) }
+                            Button("Deterministic Test") { viewModel.addNode(type: .deterministicTest) }
+                            Button("Generic Agent") { viewModel.addNode(type: .genericAgent) }
+                            Button("Input Reference") { viewModel.addNode(type: .input) }
+                            Button("Output Reference") { viewModel.addNode(type: .output) }
+                            Button("Annotation") { viewModel.addNode(type: .annotation) }
+                        }
+                    }
                     .scaleEffect(zoom, anchor: .topLeading)
                     .frame(
                         width: canvasSize.width * zoom,
@@ -641,12 +661,19 @@ private struct GraphCanvasView: View {
             } else {
                 ContentUnavailableView {
                     Label(
-                        "Empty Graph",
+                        "Add your first node",
                         systemImage: "point.3.connected.trianglepath.dotted"
                     )
                 } actions: {
                     if isEditable {
-                        Button("Add Node") { viewModel.addNode() }
+                        Menu("Add Node") {
+                            Button("Local Process") { viewModel.addNode(type: .localProcess) }
+                            Button("Deterministic Test") { viewModel.addNode(type: .deterministicTest) }
+                            Button("Generic Agent") { viewModel.addNode(type: .genericAgent) }
+                            Button("Input Reference") { viewModel.addNode(type: .input) }
+                            Button("Output Reference") { viewModel.addNode(type: .output) }
+                            Button("Annotation") { viewModel.addNode(type: .annotation) }
+                        }
                     }
                 }
             }
@@ -771,6 +798,9 @@ private struct GraphNodeView: View {
                 .font(.caption2)
                 .foregroundStyle(Color.secondary)
                 .lineLimit(1)
+            Text(node.nodeType.rawValue.replacingOccurrences(of: "_", with: " "))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
             Spacer()
             if let attemptOrdinal {
                 Text("attempt \(attemptOrdinal)")
@@ -811,76 +841,63 @@ private struct GraphDefinitionInspector: View {
 
     var body: some View {
         Form {
-            Section("Definition") {
-                LabeledContent("Graph ID", value: viewModel.document?.graphID ?? "")
-                LabeledContent("Version", value: viewModel.document?.definitionVersion ?? "")
-                LabeledContent("Nodes", value: "\(viewModel.document?.nodes.count ?? 0)")
-                LabeledContent("Edges", value: "\(viewModel.document?.edges.count ?? 0)")
-            }
             if let node = selectedNode {
-                Section("Selected Node") {
+                Section("Identity") {
                     LabeledContent("Stable ID", value: node.id)
                     TextField(
                         "Name",
                         text: Binding(
                             get: { selectedNode?.name ?? "" },
-                            set: { viewModel.updateSelectedNode(
-                                name: $0,
-                                description: selectedNode?.description ?? ""
-                            ) }
+                            set: { updateIdentity(name: $0) }
                         )
                     )
                     TextField(
                         "Description",
                         text: Binding(
                             get: { selectedNode?.description ?? "" },
-                            set: { viewModel.updateSelectedNode(
-                                name: selectedNode?.name ?? "",
-                                description: $0
-                            ) }
+                            set: { updateIdentity(description: $0) }
                         ),
                         axis: .vertical
                     )
+                    Picker(
+                        "Node Type",
+                        selection: Binding(
+                            get: { selectedNode?.nodeType ?? .localProcess },
+                            set: { viewModel.updateSelectedNodeType($0) }
+                        )
+                    ) {
+                        Text("Local Process").tag(GraphDefinitionNodeType.localProcess)
+                        Text("Deterministic Test").tag(GraphDefinitionNodeType.deterministicTest)
+                        Text("Generic Agent").tag(GraphDefinitionNodeType.genericAgent)
+                        Text("Input Reference").tag(GraphDefinitionNodeType.input)
+                        Text("Output Reference").tag(GraphDefinitionNodeType.output)
+                        Text("Annotation").tag(GraphDefinitionNodeType.annotation)
+                    }
                     TextField(
-                        "Capabilities",
+                        "Tags",
                         text: Binding(
-                            get: {
-                                selectedNode?.requiredCapabilities
-                                    .joined(separator: ", ") ?? ""
-                            },
-                            set: {
-                                viewModel.updateSelectedNodeExecution(
-                                    capabilities: $0.split(separator: ",")
-                                        .map { $0.trimmingCharacters(in: .whitespaces) }
-                                        .filter { !$0.isEmpty },
-                                    executionSeconds: selectedNode?
-                                        .timeoutPolicy.executionSeconds ?? 300
-                                )
-                            }
+                            get: { selectedNode?.tags.joined(separator: ", ") ?? "" },
+                            set: { updateIdentity(tags: csv($0)) }
                         )
                     )
-                    Stepper(
-                        "Timeout: \(node.timeoutPolicy.executionSeconds)s",
-                        value: Binding(
-                            get: { Int(selectedNode?.timeoutPolicy.executionSeconds ?? 300) },
-                            set: {
-                                viewModel.updateSelectedNodeExecution(
-                                    capabilities: selectedNode?.requiredCapabilities ?? [],
-                                    executionSeconds: UInt64(max(1, $0))
-                                )
-                            }
-                        ),
-                        in: 1...86_400
-                    )
                 }
-                Section("Execution Specification") {
-                    LabeledContent("Adapter", value: node.specification.adapterKind)
-                    LabeledContent("Operation", value: node.specification.operation)
-                    LabeledContent(
-                        "Workspace",
-                        value: node.workspace.root ?? "Not assigned"
-                    )
+                if node.nodeType == .localProcess {
+                    localProcessSection
+                } else {
+                    Section("Execution") {
+                        LabeledContent("Adapter", value: node.specification.adapterKind)
+                        LabeledContent("Operation", value: node.specification.operation)
+                        if node.nodeType == .genericAgent {
+                            Label("A provider adapter must be assigned before this node can run.", systemImage: "exclamationmark.triangle")
+                                .foregroundStyle(.orange)
+                        }
+                    }
                 }
+                capabilitiesSection
+                inputsSection
+                outputsSection
+                retrySection
+                timeoutSection
                 Section("Dependencies") {
                     let incoming = viewModel.document?.edges.filter {
                         $0.targetNodeID == node.id
@@ -901,20 +918,578 @@ private struct GraphDefinitionInspector: View {
                             .accessibilityLabel("Remove dependency")
                         }
                     }
+                    Button("Add Dependency") {
+                        viewModel.connectSelectedNodes()
+                    }
+                    .disabled(viewModel.selectedNodeIDs.count != 2)
                 }
             } else {
-                ContentUnavailableView(
-                    "No Node Selected",
-                    systemImage: "cursorarrow.click"
-                )
+                graphInspector
             }
         }
         .formStyle(.grouped)
     }
 
     private var selectedNode: GraphDefinitionDocumentNode? {
-        guard let nodeID = viewModel.selectedNodeID else { return nil }
-        return viewModel.document?.nodes.first { $0.id == nodeID }
+        viewModel.selectedNode
+    }
+
+    @ViewBuilder
+    private var graphInspector: some View {
+        if let document = viewModel.document {
+            Section("Graph") {
+                TextField(
+                    "Name",
+                    text: Binding(
+                        get: { viewModel.document?.name ?? "" },
+                        set: { viewModel.updateGraphIdentity(
+                            name: $0,
+                            description: viewModel.document?.description ?? ""
+                        ) }
+                    )
+                )
+                TextField(
+                    "Description",
+                    text: Binding(
+                        get: { viewModel.document?.description ?? "" },
+                        set: { viewModel.updateGraphIdentity(
+                            name: viewModel.document?.name ?? "",
+                            description: $0
+                        ) }
+                    ),
+                    axis: .vertical
+                )
+                LabeledContent("Graph ID", value: document.graphID)
+                LabeledContent("Definition Version", value: document.definitionVersion)
+                LabeledContent("State", value: viewModel.isDraft ? "Draft" : "Editable")
+                LabeledContent("Associated Runs", value: "\(viewModel.associatedRunCount)")
+                LabeledContent("Nodes", value: "\(document.nodes.count)")
+                LabeledContent("Edges", value: "\(document.edges.count)")
+                if viewModel.isDraft {
+                    Button("Create New Definition Version") {
+                        viewModel.createNewDefinitionVersion()
+                    }
+                }
+            }
+        } else {
+            ContentUnavailableView("No Graph Open", systemImage: "doc")
+        }
+    }
+
+    @ViewBuilder
+    private var localProcessSection: some View {
+        if let process = viewModel.selectedLocalProcessSpecification {
+            Section("Execution") {
+                HStack {
+                    TextField(
+                        "Executable Path",
+                        text: Binding(
+                            get: { viewModel.selectedLocalProcessSpecification?.executable ?? "" },
+                            set: { updateProcess(executable: $0) }
+                        )
+                    )
+                    Button("Choose") {
+                        if let url = GraphWorkspaceFilePanels.chooseExecutable() {
+                            updateProcess(executable: url.path)
+                        }
+                    }
+                    Button("Reveal") {
+                        NSWorkspace.shared.activateFileViewerSelecting([
+                            URL(fileURLWithPath: process.executable),
+                        ])
+                    }
+                }
+                HStack {
+                    TextField(
+                        "Workspace Directory",
+                        text: Binding(
+                            get: { selectedNode?.workspace.root ?? "" },
+                            set: { updateProcess(workspaceRoot: $0) }
+                        )
+                    )
+                    Button("Choose") {
+                        if let url = GraphWorkspaceFilePanels.chooseDirectory() {
+                            updateProcess(workspaceRoot: url.path)
+                        }
+                    }
+                }
+                TextField(
+                    "Working Directory (relative)",
+                    text: Binding(
+                        get: { viewModel.selectedLocalProcessSpecification?.workingDirectory ?? "." },
+                        set: { updateProcess(workingDirectory: $0) }
+                    )
+                )
+                Picker(
+                    "Environment Inheritance",
+                    selection: Binding(
+                        get: {
+                            viewModel.selectedLocalProcessSpecification?.inheritedEnvironment
+                                ?? GraphLocalProcessEnvironmentInheritance.none
+                        },
+                        set: { updateProcess(inheritedEnvironment: $0) }
+                    )
+                ) {
+                    Text("None").tag(GraphLocalProcessEnvironmentInheritance.none)
+                    Text("Allowlisted Only").tag(GraphLocalProcessEnvironmentInheritance.allowlisted)
+                }
+                TextField(
+                    "Allowed Environment Variables",
+                    text: Binding(
+                        get: { selectedNode?.environmentAllowlist.joined(separator: ", ") ?? "" },
+                        set: { updateProcess(environmentAllowlist: csv($0)) }
+                    )
+                )
+                Picker(
+                    "Standard Input",
+                    selection: Binding(
+                        get: { viewModel.selectedLocalProcessSpecification?.stdin ?? .nullDevice },
+                        set: { updateProcess(stdin: $0) }
+                    )
+                ) {
+                    Text("Null Device").tag(GraphLocalProcessStdinPolicy.nullDevice)
+                    Text("Closed").tag(GraphLocalProcessStdinPolicy.closed)
+                }
+                LabeledContent("Arguments") {
+                    Button("Add Argument") { viewModel.addSelectedNodeArgument() }
+                }
+                ForEach(Array(process.arguments.enumerated()), id: \.offset) { index, _ in
+                    HStack {
+                        TextField(
+                            "Argument \(index + 1)",
+                            text: Binding(
+                                get: {
+                                    let values = viewModel.selectedLocalProcessSpecification?.arguments ?? []
+                                    return values.indices.contains(index) ? values[index] : ""
+                                },
+                                set: { viewModel.updateSelectedNodeArgument(at: index, value: $0) }
+                            )
+                        )
+                        Button { viewModel.moveSelectedNodeArgument(from: index, offset: -1) } label: {
+                            Image(systemName: "arrow.up")
+                        }
+                        .disabled(index == 0)
+                        .help("Move Argument Up")
+                        Button { viewModel.moveSelectedNodeArgument(from: index, offset: 1) } label: {
+                            Image(systemName: "arrow.down")
+                        }
+                        .disabled(index == process.arguments.count - 1)
+                        .help("Move Argument Down")
+                        Button(role: .destructive) {
+                            viewModel.removeSelectedNodeArgument(at: index)
+                        } label: {
+                            Image(systemName: "minus.circle")
+                        }
+                        .help("Remove Argument")
+                    }
+                }
+            }
+        }
+    }
+
+    private var capabilitiesSection: some View {
+        Section("Capabilities") {
+            TextField(
+                "Required",
+                text: Binding(
+                    get: { selectedNode?.requiredCapabilities.joined(separator: ", ") ?? "" },
+                    set: { updateCapabilities(required: csv($0)) }
+                )
+            )
+            TextField(
+                "Preferred",
+                text: Binding(
+                    get: { selectedNode?.preferredCapabilities.joined(separator: ", ") ?? "" },
+                    set: { updateCapabilities(preferred: csv($0)) }
+                )
+            )
+            Picker(
+                "Executor Kind",
+                selection: Binding(
+                    get: { selectedNode?.executorKind ?? GraphDefinitionExecutorKind.none },
+                    set: { updateCapabilities(executor: $0) }
+                )
+            ) {
+                ForEach(GraphDefinitionExecutorKind.allCases, id: \.rawValue) {
+                    Text($0.displayName).tag($0)
+                }
+            }
+            TextField(
+                "Platform Constraints",
+                text: Binding(
+                    get: { selectedNode?.platformConstraints.joined(separator: ", ") ?? "" },
+                    set: { updateCapabilities(platforms: csv($0)) }
+                )
+            )
+        }
+    }
+
+    private var inputsSection: some View {
+        Section("Inputs") {
+            if selectedNode?.inputs.isEmpty != false {
+                Text("No declared inputs").foregroundStyle(.secondary)
+            }
+            ForEach(selectedNode?.inputs ?? []) { input in
+                VStack(alignment: .leading, spacing: 6) {
+                    TextField(
+                        "Input Name",
+                        text: inputBinding(input.id, \.name, fallback: input.name)
+                    )
+                    TextField(
+                        "Media Type",
+                        text: inputBinding(input.id, \.mediaType, fallback: input.mediaType)
+                    )
+                    Toggle(
+                        "Required",
+                        isOn: inputBinding(input.id, \.isRequired, fallback: input.isRequired)
+                    )
+                    Toggle(
+                        "Allow Multiple Providers",
+                        isOn: inputBinding(input.id, \.allowsMultiple, fallback: input.allowsMultiple)
+                    )
+                    LabeledContent("Stable ID", value: input.id)
+                    Button("Remove Input", role: .destructive) {
+                        viewModel.removeSelectedNodeInput(input.id)
+                    }
+                }
+            }
+            Button("Add Input") { viewModel.addSelectedNodeInput() }
+        }
+    }
+
+    private var outputsSection: some View {
+        Section("Outputs") {
+            if selectedNode?.outputs.isEmpty != false {
+                Text("No declared outputs").foregroundStyle(.secondary)
+            }
+            ForEach(selectedNode?.outputs ?? []) { output in
+                VStack(alignment: .leading, spacing: 6) {
+                    TextField(
+                        "Output Name",
+                        text: outputBinding(output.id, \.name, fallback: output.name)
+                    )
+                    TextField(
+                        "Relative Path",
+                        text: outputBinding(output.id, \.relativePath, fallback: output.relativePath)
+                    )
+                    TextField(
+                        "Media Type",
+                        text: outputBinding(output.id, \.mediaType, fallback: output.mediaType)
+                    )
+                    Picker(
+                        "Runtime Role",
+                        selection: outputBinding(output.id, \.role, fallback: output.role)
+                    ) {
+                        ForEach(GraphArtifactRole.allCases, id: \.rawValue) {
+                            Text($0.rawValue).tag($0)
+                        }
+                    }
+                    Toggle(
+                        "Required",
+                        isOn: outputBinding(output.id, \.isRequired, fallback: output.isRequired)
+                    )
+                    Stepper(
+                        "Maximum Size: \(output.maximumBytes / 1_024) KiB",
+                        value: outputBinding(output.id, \.maximumBytes, fallback: output.maximumBytes),
+                        in: 1_024...(1_024 * 1_024 * 1_024),
+                        step: 1_024
+                    )
+                    Picker(
+                        "Sensitivity",
+                        selection: outputBinding(output.id, \.sensitivity, fallback: output.sensitivity)
+                    ) {
+                        Text("Unspecified").tag(GraphArtifactSensitivity.unspecified)
+                        Text("Internal").tag(GraphArtifactSensitivity.internalUse)
+                        Text("Confidential").tag(GraphArtifactSensitivity.confidential)
+                        Text("Restricted").tag(GraphArtifactSensitivity.restricted)
+                        Text("Redacted").tag(GraphArtifactSensitivity.redacted)
+                    }
+                    Picker(
+                        "Downstream Visibility",
+                        selection: outputBinding(
+                            output.id,
+                            \.downstreamVisibility,
+                            fallback: output.downstreamVisibility
+                        )
+                    ) {
+                        Text("Whole Graph").tag(GraphArtifactDownstreamVisibility.graph)
+                        Text("Direct Dependents").tag(GraphArtifactDownstreamVisibility.directDependents)
+                        Text("Private to Node").tag(GraphArtifactDownstreamVisibility.privateToNode)
+                    }
+                    LabeledContent("Stable ID", value: output.id)
+                    Button("Remove Output", role: .destructive) {
+                        viewModel.removeSelectedNodeOutput(output.id)
+                    }
+                }
+            }
+            Button("Add Output") { viewModel.addSelectedNodeOutput() }
+        }
+    }
+
+    private var retrySection: some View {
+        Section("Retry") {
+            Toggle(
+                "Inherit Graph Default",
+                isOn: Binding(
+                    get: { selectedNode?.retryConfiguration.inheritsGraphDefault ?? true },
+                    set: { setRetryInheritance($0) }
+                )
+            )
+            if selectedNode?.retryConfiguration.inheritsGraphDefault == false {
+                let policy = retryPolicy
+                Stepper(
+                    "Maximum Attempts: \(policy.maximumAttempts)",
+                    value: Binding(
+                        get: { retryPolicy.maximumAttempts },
+                        set: { updateRetry(maximumAttempts: $0) }
+                    ),
+                    in: 1...20
+                )
+                TextField(
+                    "Retryable Categories",
+                    text: Binding(
+                        get: { retryPolicy.retryableFailureCategories.joined(separator: ", ") },
+                        set: { updateRetry(retryable: csv($0)) }
+                    )
+                )
+                TextField(
+                    "Non-Retryable Categories",
+                    text: Binding(
+                        get: { retryPolicy.nonRetryableFailureCategories.joined(separator: ", ") },
+                        set: { updateRetry(nonRetryable: csv($0)) }
+                    )
+                )
+                Stepper(
+                    "Base Delay: \(policy.initialBackoffSeconds)s",
+                    value: Binding(
+                        get: { retryPolicy.initialBackoffSeconds },
+                        set: { updateRetry(baseDelay: $0) }
+                    ),
+                    in: 0...3_600
+                )
+                Stepper(
+                    "Maximum Delay: \(policy.maximumBackoffSeconds)s",
+                    value: Binding(
+                        get: { retryPolicy.maximumBackoffSeconds },
+                        set: { updateRetry(maximumDelay: $0) }
+                    ),
+                    in: 0...86_400
+                )
+                Picker(
+                    "Timeout Failure",
+                    selection: Binding(
+                        get: { retryPolicy.timeoutBehavior },
+                        set: { updateRetry(timeoutBehavior: $0) }
+                    )
+                ) {
+                    Text("Retry").tag(GraphRetryTimeoutBehavior.retry)
+                    Text("Do Not Retry").tag(GraphRetryTimeoutBehavior.suppress)
+                }
+            }
+        }
+    }
+
+    private var timeoutSection: some View {
+        Section("Timeout") {
+            Toggle(
+                "Inherit Graph Default",
+                isOn: Binding(
+                    get: { selectedNode?.timeoutConfiguration.inheritsGraphDefault ?? true },
+                    set: { updateTimeout(inherits: $0) }
+                )
+            )
+            if selectedNode?.timeoutConfiguration.inheritsGraphDefault == false {
+                Stepper(
+                    "Execution: \(timeout.executionSeconds)s",
+                    value: Binding(
+                        get: { timeout.executionSeconds },
+                        set: { updateTimeout(execution: $0) }
+                    ),
+                    in: 1...86_400
+                )
+                Stepper(
+                    "Cancellation Grace: \(timeout.cancellationAcknowledgementSeconds)s",
+                    value: Binding(
+                        get: { timeout.cancellationAcknowledgementSeconds },
+                        set: { updateTimeout(cancellation: $0) }
+                    ),
+                    in: 1...3_600
+                )
+                Stepper(
+                    "Claim Timeout: \(timeout.claimSeconds)s",
+                    value: Binding(
+                        get: { timeout.claimSeconds },
+                        set: { updateTimeout(claim: $0) }
+                    ),
+                    in: 1...3_600
+                )
+            }
+        }
+    }
+
+    private var retryPolicy: GraphRetryPolicy {
+        selectedNode?.retryConfiguration.override
+            ?? viewModel.document?.schedulerPolicy.retryPolicy
+            ?? GraphRetryPolicy(maximumAttempts: 1, retryableFailureCategories: [])
+    }
+
+    private var timeout: GraphNodeTimeoutConfiguration {
+        selectedNode?.timeoutConfiguration ?? .init()
+    }
+
+    private func csv(_ value: String) -> [String] {
+        value.split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private func updateIdentity(
+        name: String? = nil,
+        description: String? = nil,
+        tags: [String]? = nil
+    ) {
+        guard let node = selectedNode else { return }
+        viewModel.updateSelectedNodeIdentity(
+            name: name ?? node.name,
+            description: description ?? node.description,
+            tags: tags ?? node.tags
+        )
+    }
+
+    private func updateCapabilities(
+        required: [String]? = nil,
+        preferred: [String]? = nil,
+        executor: GraphDefinitionExecutorKind? = nil,
+        platforms: [String]? = nil
+    ) {
+        guard let node = selectedNode else { return }
+        viewModel.updateSelectedNodeCapabilities(
+            required: required ?? node.requiredCapabilities,
+            preferred: preferred ?? node.preferredCapabilities,
+            executorKind: executor ?? node.executorKind,
+            platformConstraints: platforms ?? node.platformConstraints
+        )
+    }
+
+    private func updateProcess(
+        executable: String? = nil,
+        arguments: [String]? = nil,
+        workingDirectory: String? = nil,
+        inheritedEnvironment: GraphLocalProcessEnvironmentInheritance? = nil,
+        stdin: GraphLocalProcessStdinPolicy? = nil,
+        environmentAllowlist: [String]? = nil,
+        workspaceRoot: String? = nil
+    ) {
+        guard let process = viewModel.selectedLocalProcessSpecification,
+              let node = selectedNode else { return }
+        viewModel.updateSelectedLocalProcess(
+            executable: executable ?? process.executable,
+            arguments: arguments ?? process.arguments,
+            workingDirectory: workingDirectory ?? process.workingDirectory,
+            inheritedEnvironment: inheritedEnvironment ?? process.inheritedEnvironment,
+            stdin: stdin ?? process.stdin,
+            environmentAllowlist: environmentAllowlist ?? node.environmentAllowlist,
+            workspaceRoot: workspaceRoot ?? node.workspace.root
+        )
+    }
+
+    private func inputBinding<Value>(
+        _ id: String,
+        _ keyPath: WritableKeyPath<GraphNodeInputDefinition, Value>,
+        fallback: Value
+    ) -> Binding<Value> {
+        Binding(
+            get: {
+                viewModel.selectedNode?.inputs.first { $0.id == id }?[keyPath: keyPath]
+                    ?? fallback
+            },
+            set: { value in
+                guard var input = viewModel.selectedNode?.inputs.first(where: {
+                    $0.id == id
+                }) else { return }
+                input[keyPath: keyPath] = value
+                viewModel.updateSelectedNodeInput(input)
+            }
+        )
+    }
+
+    private func outputBinding<Value>(
+        _ id: String,
+        _ keyPath: WritableKeyPath<GraphNodeOutputDefinition, Value>,
+        fallback: Value
+    ) -> Binding<Value> {
+        Binding(
+            get: {
+                viewModel.selectedNode?.outputs.first { $0.id == id }?[keyPath: keyPath]
+                    ?? fallback
+            },
+            set: { value in
+                guard var output = viewModel.selectedNode?.outputs.first(where: {
+                    $0.id == id
+                }) else { return }
+                output[keyPath: keyPath] = value
+                viewModel.updateSelectedNodeOutput(output)
+            }
+        )
+    }
+
+    private func setRetryInheritance(_ inherits: Bool) {
+        viewModel.updateSelectedNodeRetry(
+            GraphNodeRetryConfiguration(
+                inheritsGraphDefault: inherits,
+                override: inherits ? nil : retryPolicy
+            )
+        )
+    }
+
+    private func updateRetry(
+        maximumAttempts: Int? = nil,
+        retryable: [String]? = nil,
+        nonRetryable: [String]? = nil,
+        baseDelay: UInt64? = nil,
+        maximumDelay: UInt64? = nil,
+        timeoutBehavior: GraphRetryTimeoutBehavior? = nil
+    ) {
+        let source = retryPolicy
+        let updated = GraphRetryPolicy(
+            maximumAttempts: maximumAttempts ?? source.maximumAttempts,
+            retryableFailureCategories: retryable
+                ?? source.retryableFailureCategories,
+            nonRetryableFailureCategories: nonRetryable
+                ?? source.nonRetryableFailureCategories,
+            initialBackoffSeconds: baseDelay ?? source.initialBackoffSeconds,
+            backoffMultiplier: source.backoffMultiplier,
+            maximumBackoffSeconds: maximumDelay ?? source.maximumBackoffSeconds,
+            jitterBasisPoints: source.jitterBasisPoints,
+            jitterSeed: source.jitterSeed,
+            timeoutBehavior: timeoutBehavior ?? source.timeoutBehavior,
+            cancellationBehavior: source.cancellationBehavior,
+            dependencyFailureBehavior: source.dependencyFailureBehavior
+        )
+        viewModel.updateSelectedNodeRetry(
+            GraphNodeRetryConfiguration(
+                inheritsGraphDefault: false,
+                override: updated
+            )
+        )
+    }
+
+    private func updateTimeout(
+        inherits: Bool? = nil,
+        execution: UInt64? = nil,
+        cancellation: UInt64? = nil,
+        claim: UInt64? = nil
+    ) {
+        let source = timeout
+        viewModel.updateSelectedNodeTimeout(
+            GraphNodeTimeoutConfiguration(
+                inheritsGraphDefault: inherits ?? source.inheritsGraphDefault,
+                executionSeconds: execution ?? source.executionSeconds,
+                cancellationAcknowledgementSeconds: cancellation
+                    ?? source.cancellationAcknowledgementSeconds,
+                claimSeconds: claim ?? source.claimSeconds
+            )
+        )
     }
 }
 
@@ -1207,6 +1782,14 @@ enum GraphWorkspaceFilePanels {
         let panel = NSOpenPanel()
         panel.canChooseFiles = false
         panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        return panel.runModal() == .OK ? panel.url : nil
+    }
+
+    static func chooseExecutable() -> URL? {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
         panel.allowsMultipleSelection = false
         return panel.runModal() == .OK ? panel.url : nil
     }

--- a/Sources/OpenIslandApp/Views/GraphWorkspaceView.swift
+++ b/Sources/OpenIslandApp/Views/GraphWorkspaceView.swift
@@ -110,6 +110,9 @@ struct GraphWorkspaceView: View {
             iconButton("folder", help: "Open Graph Definition") {
                 GraphWorkspaceFilePanels.openDefinition(viewModel)
             }
+            iconButton("books.vertical", help: "Open Compendium Example") {
+                viewModel.openBundledCompendium()
+            }
             iconButton("square.and.arrow.down", help: "Save Graph Definition") {
                 GraphWorkspaceFilePanels.saveDefinition(viewModel)
             }

--- a/Sources/OpenIslandApp/Views/GraphWorkspaceView.swift
+++ b/Sources/OpenIslandApp/Views/GraphWorkspaceView.swift
@@ -176,6 +176,11 @@ struct GraphWorkspaceView: View {
                     GraphWorkspaceFilePanels.saveAsDefinition(viewModel)
                 }
                 .keyboardShortcut("s", modifiers: [.command, .shift])
+                Button("Save as Template") {
+                    GraphWorkspaceFilePanels.saveTemplate(viewModel)
+                }
+                .disabled(viewModel.document == nil)
+                Divider()
                 Button("Revert to Saved") {
                     Task { await viewModel.revertDocument() }
                 }
@@ -304,7 +309,55 @@ struct GraphWorkspaceView: View {
 
     private var workspaceSidebar: some View {
         List {
-            Section("Workspace") {
+            Section("Graphs") {
+                Button {
+                    viewModel.presentNewGraphSheet()
+                } label: {
+                    Label("New Graph", systemImage: "plus.square")
+                }
+                Button {
+                    GraphWorkspaceFilePanels.openDefinition(viewModel)
+                } label: {
+                    Label("Open Saved Graph…", systemImage: "folder")
+                }
+                if viewModel.recentDocumentURLs.isEmpty {
+                    Text("No recent graphs")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(viewModel.recentDocumentURLs, id: \.path) { url in
+                        Button {
+                            Task { await viewModel.openDocument(url: url) }
+                        } label: {
+                            Label(url.deletingPathExtension().lastPathComponent, systemImage: "doc.text")
+                                .lineLimit(1)
+                        }
+                        .buttonStyle(.plain)
+                        .contextMenu {
+                            Button("Reveal in Finder") {
+                                NSWorkspace.shared.activateFileViewerSelecting([url])
+                            }
+                        }
+                    }
+                }
+            }
+            Section("Templates") {
+                ForEach(GraphWorkspaceTemplate.allCases.filter { $0 != .blank }) { template in
+                    Button {
+                        viewModel.openTemplate(template)
+                    } label: {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Label(template.name, systemImage: "square.grid.2x2")
+                            Text(template.summary)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            Section("Workspace Mode") {
                 ForEach(GraphWorkspaceMode.allCases) { mode in
                     Button {
                         viewModel.mode = mode
@@ -312,15 +365,13 @@ struct GraphWorkspaceView: View {
                         Label(mode.rawValue, systemImage: modeIcon(mode))
                     }
                     .buttonStyle(.plain)
-                    .accessibilityLabel("\(mode.rawValue) mode")
                 }
             }
             Section("Durable Runs") {
                 if viewModel.runs.isEmpty {
-                    ContentUnavailableView(
-                        "No Runs",
-                        systemImage: "point.3.connected.trianglepath.dotted"
-                    )
+                    Text("No durable runs")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 } else {
                     ForEach(viewModel.runs) { run in
                         Button {
@@ -339,9 +390,6 @@ struct GraphWorkspaceView: View {
                             }
                         }
                         .buttonStyle(.plain)
-                        .accessibilityLabel(
-                            "Run \(run.graphID), \(run.reconciledState.rawValue)"
-                        )
                     }
                 }
             }
@@ -359,7 +407,7 @@ struct GraphWorkspaceView: View {
                 onOpenRecent: { url in
                     Task { await viewModel.openDocument(url: url) }
                 },
-                onOpenExample: { viewModel.openBundledCompendium() }
+                onOpenTemplates: { viewModel.presentNewGraphSheet() }
             )
         } else {
             switch viewModel.mode {
@@ -474,7 +522,7 @@ private struct GraphWorkspaceEmptyState: View {
     let onNew: () -> Void
     let onOpen: () -> Void
     let onOpenRecent: (URL) -> Void
-    let onOpenExample: () -> Void
+    let onOpenTemplates: () -> Void
 
     var body: some View {
         ContentUnavailableView {
@@ -498,7 +546,7 @@ private struct GraphWorkspaceEmptyState: View {
                         }
                     }
                 }
-                Button("Open Example Graph", action: onOpenExample)
+                Button("Open Templates", action: onOpenTemplates)
             }
         }
         .accessibilityLabel("Empty Graph Workspace")
@@ -1298,6 +1346,10 @@ private struct GraphDefinitionInspector: View {
                         )
                     )
                 }
+                if node.nodeType.isExecutable {
+                    agentRuntimeSection
+                    workspaceSection
+                }
                 if node.nodeType == .localProcess {
                     localProcessSection
                 } else {
@@ -1567,6 +1619,73 @@ private struct GraphDefinitionInspector: View {
         }
     }
 
+    private var agentRuntimeSection: some View {
+        Section("Agent Runtime") {
+            Picker("Provider", selection: runtimeBinding(prefix: "provider:", fallback: "Local Process")) {
+                Text("Local Process").tag("Local Process")
+                Text("Ollama").tag("Ollama")
+                Text("Qwen").tag("Qwen")
+                Text("OpenClaw").tag("OpenClaw")
+                Text("Codex (not configured)").tag("Codex")
+                Text("Custom Provider").tag("Custom Provider")
+            }
+            TextField("Model", text: runtimeBinding(prefix: "model:", fallback: ""))
+                .textContentType(.none)
+            TextField("Agent / Profile", text: runtimeBinding(prefix: "agent:", fallback: ""))
+            Text("Provider, model, and agent profile are saved with the node and remain provider-neutral until an adapter binds them at run time.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var workspaceSection: some View {
+        Section("Workspace") {
+            HStack {
+                TextField(
+                    "Workspace Directory",
+                    text: Binding(
+                        get: { selectedNode?.workspace.root ?? "" },
+                        set: { viewModel.updateSelectedNodeWorkspace(root: $0) }
+                    )
+                )
+                Button("Choose…") {
+                    if let url = GraphWorkspaceFilePanels.chooseDirectory() {
+                        viewModel.updateSelectedNodeWorkspace(root: url.path)
+                    }
+                }
+            }
+            if let root = selectedNode?.workspace.root, !root.isEmpty {
+                Button("Reveal in Finder") {
+                    NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: root)
+                }
+            }
+            if selectedNode?.workspace.root == "/" {
+                Label("Using the filesystem root is unsafe. Choose a project directory before creating a run.", systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+            }
+        }
+    }
+
+    private func runtimeBinding(prefix: String, fallback: String) -> Binding<String> {
+        Binding(
+            get: {
+                selectedNode?.tags.first(where: { $0.hasPrefix(prefix) })
+                    .map { String($0.dropFirst(prefix.count)) } ?? fallback
+            },
+            set: { newValue in
+                let provider = prefix == "provider:" ? newValue : runtimeValue("provider:", fallback: "Local Process")
+                let model = prefix == "model:" ? newValue : runtimeValue("model:", fallback: "")
+                let agent = prefix == "agent:" ? newValue : runtimeValue("agent:", fallback: "")
+                viewModel.updateSelectedNodeRuntime(provider: provider, model: model, agentProfile: agent)
+            }
+        )
+    }
+
+    private func runtimeValue(_ prefix: String, fallback: String) -> String {
+        selectedNode?.tags.first(where: { $0.hasPrefix(prefix) })
+            .map { String($0.dropFirst(prefix.count)) } ?? fallback
+    }
+
     @ViewBuilder
     private var localProcessSection: some View {
         if let process = viewModel.selectedLocalProcessSpecification {
@@ -1588,20 +1707,6 @@ private struct GraphDefinitionInspector: View {
                         NSWorkspace.shared.activateFileViewerSelecting([
                             URL(fileURLWithPath: process.executable),
                         ])
-                    }
-                }
-                HStack {
-                    TextField(
-                        "Workspace Directory",
-                        text: Binding(
-                            get: { selectedNode?.workspace.root ?? "" },
-                            set: { updateProcess(workspaceRoot: $0) }
-                        )
-                    )
-                    Button("Choose") {
-                        if let url = GraphWorkspaceFilePanels.chooseDirectory() {
-                            updateProcess(workspaceRoot: url.path)
-                        }
                     }
                 }
                 TextField(
@@ -2684,6 +2789,20 @@ enum GraphWorkspaceFilePanels {
         let panel = NSSavePanel()
         panel.allowedContentTypes = [.json]
         panel.nameFieldStringValue = "\(viewModel.document?.graphID ?? "graph").openisland-graph.json"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        Task { await viewModel.saveAsDocument(url: url) }
+    }
+
+
+    static func saveTemplate(_ viewModel: GraphWorkspaceViewModel) {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.json]
+        panel.title = "Save Graph as Template"
+        panel.message = "Templates are ordinary Open Island graph documents that can be reopened and customized."
+        let base = viewModel.document?.name
+            .lowercased()
+            .replacingOccurrences(of: " ", with: "-") ?? "graph-template"
+        panel.nameFieldStringValue = "\(base).openisland-template.json"
         guard panel.runModal() == .OK, let url = panel.url else { return }
         Task { await viewModel.saveAsDocument(url: url) }
     }

--- a/Sources/OpenIslandApp/Views/GraphWorkspaceView.swift
+++ b/Sources/OpenIslandApp/Views/GraphWorkspaceView.swift
@@ -1310,6 +1310,7 @@ private struct GraphDefinitionInspector: View {
                 outputsSection
                 retrySection
                 timeoutSection
+                selectedNodeValidationSection
                 Section("Dependencies") {
                     let incoming = viewModel.document?.edges.filter {
                         $0.targetNodeID == node.id
@@ -1724,6 +1725,18 @@ private struct GraphDefinitionInspector: View {
                         "Media Type",
                         text: inputBinding(input.id, \.mediaType, fallback: input.mediaType)
                     )
+                    Picker(
+                        "Port Type",
+                        selection: inputBinding(
+                            input.id,
+                            \.portType,
+                            fallback: input.portType
+                        )
+                    ) {
+                        ForEach(GraphDefinitionPortType.allCases, id: \.rawValue) {
+                            Text($0.rawValue.capitalized).tag($0)
+                        }
+                    }
                     Toggle(
                         "Required",
                         isOn: inputBinding(input.id, \.isRequired, fallback: input.isRequired)
@@ -1732,6 +1745,17 @@ private struct GraphDefinitionInspector: View {
                         "Allow Multiple Providers",
                         isOn: inputBinding(input.id, \.allowsMultiple, fallback: input.allowsMultiple)
                     )
+                    Picker(
+                        "Binding Source",
+                        selection: inputBindingKind(input)
+                    ) {
+                        Text("Unbound").tag(GraphNodeInputBindingKind?.none)
+                        ForEach(GraphNodeInputBindingKind.allCases, id: \.rawValue) {
+                            Text($0.rawValue.replacingOccurrences(of: "_", with: " ").capitalized)
+                                .tag(Optional($0))
+                        }
+                    }
+                    inputBindingEditor(input)
                     LabeledContent("Stable ID", value: input.id)
                     Button("Remove Input", role: .destructive) {
                         viewModel.removeSelectedNodeInput(input.id)
@@ -1761,6 +1785,18 @@ private struct GraphDefinitionInspector: View {
                         "Media Type",
                         text: outputBinding(output.id, \.mediaType, fallback: output.mediaType)
                     )
+                    Picker(
+                        "Port Type",
+                        selection: outputBinding(
+                            output.id,
+                            \.portType,
+                            fallback: output.portType
+                        )
+                    ) {
+                        ForEach(GraphDefinitionPortType.allCases, id: \.rawValue) {
+                            Text($0.rawValue.capitalized).tag($0)
+                        }
+                    }
                     Picker(
                         "Runtime Role",
                         selection: outputBinding(output.id, \.role, fallback: output.role)
@@ -1852,6 +1888,15 @@ private struct GraphDefinitionInspector: View {
                     ),
                     in: 0...3_600
                 )
+                LabeledContent("Backoff Type", value: "Exponential")
+                Stepper(
+                    "Backoff Multiplier: \(policy.backoffMultiplier)x",
+                    value: Binding(
+                        get: { retryPolicy.backoffMultiplier },
+                        set: { updateRetry(multiplier: $0) }
+                    ),
+                    in: 1...10
+                )
                 Stepper(
                     "Maximum Delay: \(policy.maximumBackoffSeconds)s",
                     value: Binding(
@@ -1920,6 +1965,116 @@ private struct GraphDefinitionInspector: View {
 
     private var timeout: GraphNodeTimeoutConfiguration {
         selectedNode?.timeoutConfiguration ?? .init()
+    }
+
+    @ViewBuilder
+    private var selectedNodeValidationSection: some View {
+        if let nodeID = viewModel.selectedNodeID {
+            let diagnostics = viewModel.validationDiagnostics.filter {
+                $0.target.kind == .node && $0.target.id == nodeID
+            }
+            if !diagnostics.isEmpty {
+                Section("Validation") {
+                    ForEach(diagnostics) { diagnostic in
+                        Label(
+                            diagnostic.message,
+                            systemImage: diagnostic.severity == .error
+                                ? "xmark.octagon.fill"
+                                : "exclamationmark.triangle.fill"
+                        )
+                        .foregroundStyle(
+                            diagnostic.severity == .error
+                                ? Color.red : Color.orange
+                        )
+                        .accessibilityLabel(
+                            "\(diagnostic.severity.rawValue): \(diagnostic.message)"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func inputBindingEditor(
+        _ input: GraphNodeInputDefinition
+    ) -> some View {
+        switch currentInput(input.id)?.binding?.kind {
+        case .graphInput:
+            Picker(
+                "Graph Input",
+                selection: inputBindingValue(
+                    input,
+                    get: \.graphInputID,
+                    set: { $0.graphInputID = $1 }
+                )
+            ) {
+                Text("Choose Graph Input").tag(String?.none)
+                ForEach(viewModel.document?.graphInputs ?? []) {
+                    Text($0.name).tag(Optional($0.id))
+                }
+            }
+        case .upstreamArtifact, .upstreamArtifactCollection:
+            Menu("Connect Upstream Output") {
+                let nodes = viewModel.document?.nodes.filter {
+                    $0.id != viewModel.selectedNodeID
+                } ?? []
+                ForEach(nodes) { node in
+                    ForEach(node.outputs.filter {
+                        $0.portType == input.portType
+                    }) { output in
+                        Button("\(node.name) - \(output.name)") {
+                            guard let target = viewModel.selectedNodeID else { return }
+                            _ = viewModel.connectNodes(
+                                sourceNodeID: node.id,
+                                targetNodeID: target,
+                                portType: input.portType,
+                                sourceOutputID: output.id,
+                                targetInputID: input.id
+                            )
+                        }
+                        .disabled(!canConnect(
+                            node: node,
+                            output: output,
+                            input: input
+                        ))
+                    }
+                }
+            }
+            if let binding = currentInput(input.id)?.binding,
+               let source = binding.sourceNodeID,
+               let output = binding.sourceOutputID {
+                LabeledContent("Connected Output", value: "\(source).\(output)")
+            }
+        case .staticLiteral:
+            TextField(
+                "Literal Value",
+                text: inputLiteralBinding(input)
+            )
+        case .fileReference:
+            TextField(
+                "File Reference",
+                text: inputStringBinding(
+                    input,
+                    get: \.fileReference,
+                    set: { $0.fileReference = $1 }
+                )
+            )
+        case .secretReference:
+            TextField(
+                "Secret Reference",
+                text: inputStringBinding(
+                    input,
+                    get: \.secretReference,
+                    set: { $0.secretReference = $1 }
+                )
+            )
+            Text("Store only a keychain or environment reference here.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        case .none:
+            EmptyView()
+        }
     }
 
     private func csv(_ value: String) -> [String] {
@@ -1996,6 +2151,126 @@ private struct GraphDefinitionInspector: View {
                 viewModel.updateSelectedNodeInput(input)
             }
         )
+    }
+
+    private func currentInput(_ id: String) -> GraphNodeInputDefinition? {
+        viewModel.selectedNode?.inputs.first { $0.id == id }
+    }
+
+    private func inputBindingKind(
+        _ input: GraphNodeInputDefinition
+    ) -> Binding<GraphNodeInputBindingKind?> {
+        Binding(
+            get: { currentInput(input.id)?.binding?.kind },
+            set: { kind in
+                guard var updated = currentInput(input.id) else { return }
+                guard let kind else {
+                    updated.binding = nil
+                    viewModel.updateSelectedNodeInput(updated)
+                    return
+                }
+                if updated.binding?.kind != kind {
+                    switch kind {
+                    case .graphInput:
+                        updated.binding = GraphNodeInputBinding(
+                            kind: kind,
+                            graphInputID: viewModel.document?.graphInputs.first?.id
+                        )
+                    case .staticLiteral:
+                        updated.binding = GraphNodeInputBinding(
+                            kind: kind,
+                            literalValue: .string("")
+                        )
+                    case .fileReference:
+                        updated.binding = GraphNodeInputBinding(
+                            kind: kind,
+                            fileReference: ""
+                        )
+                    case .secretReference:
+                        updated.binding = GraphNodeInputBinding(
+                            kind: kind,
+                            secretReference: ""
+                        )
+                    case .upstreamArtifact:
+                        updated.binding = GraphNodeInputBinding(kind: kind)
+                    case .upstreamArtifactCollection:
+                        updated.allowsMultiple = true
+                        updated.binding = GraphNodeInputBinding(kind: kind)
+                    }
+                }
+                viewModel.updateSelectedNodeInput(updated)
+            }
+        )
+    }
+
+    private func inputBindingValue(
+        _ input: GraphNodeInputDefinition,
+        get: KeyPath<GraphNodeInputBinding, String?>,
+        set: @escaping (inout GraphNodeInputBinding, String?) -> Void
+    ) -> Binding<String?> {
+        Binding(
+            get: { currentInput(input.id)?.binding?[keyPath: get] },
+            set: { value in
+                guard var updated = currentInput(input.id),
+                      var binding = updated.binding else { return }
+                set(&binding, value)
+                updated.binding = binding
+                viewModel.updateSelectedNodeInput(updated)
+            }
+        )
+    }
+
+    private func inputStringBinding(
+        _ input: GraphNodeInputDefinition,
+        get: KeyPath<GraphNodeInputBinding, String?>,
+        set: @escaping (inout GraphNodeInputBinding, String?) -> Void
+    ) -> Binding<String> {
+        Binding(
+            get: { currentInput(input.id)?.binding?[keyPath: get] ?? "" },
+            set: { value in
+                guard var updated = currentInput(input.id),
+                      var binding = updated.binding else { return }
+                set(&binding, value)
+                updated.binding = binding
+                viewModel.updateSelectedNodeInput(updated)
+            }
+        )
+    }
+
+    private func inputLiteralBinding(
+        _ input: GraphNodeInputDefinition
+    ) -> Binding<String> {
+        Binding(
+            get: {
+                guard case let .string(value) = currentInput(input.id)?
+                    .binding?.literalValue else { return "" }
+                return value
+            },
+            set: { value in
+                guard var updated = currentInput(input.id),
+                      var binding = updated.binding else { return }
+                binding.literalValue = .string(value)
+                updated.binding = binding
+                viewModel.updateSelectedNodeInput(updated)
+            }
+        )
+    }
+
+    private func canConnect(
+        node: GraphDefinitionDocumentNode,
+        output: GraphNodeOutputDefinition,
+        input: GraphNodeInputDefinition
+    ) -> Bool {
+        guard let document = viewModel.document,
+              let target = viewModel.selectedNodeID else { return false }
+        return GraphConnectionEvaluator.evaluate(
+            document: document,
+            sourceNodeID: node.id,
+            targetNodeID: target,
+            portType: input.portType,
+            sourceOutputID: output.id,
+            targetInputID: input.id
+        ).isAllowed
     }
 
     private func edgeBinding<Value>(
@@ -2091,6 +2366,7 @@ private struct GraphDefinitionInspector: View {
         retryable: [String]? = nil,
         nonRetryable: [String]? = nil,
         baseDelay: UInt64? = nil,
+        multiplier: UInt64? = nil,
         maximumDelay: UInt64? = nil,
         timeoutBehavior: GraphRetryTimeoutBehavior? = nil
     ) {
@@ -2102,7 +2378,7 @@ private struct GraphDefinitionInspector: View {
             nonRetryableFailureCategories: nonRetryable
                 ?? source.nonRetryableFailureCategories,
             initialBackoffSeconds: baseDelay ?? source.initialBackoffSeconds,
-            backoffMultiplier: source.backoffMultiplier,
+            backoffMultiplier: multiplier ?? source.backoffMultiplier,
             maximumBackoffSeconds: maximumDelay ?? source.maximumBackoffSeconds,
             jitterBasisPoints: source.jitterBasisPoints,
             jitterSeed: source.jitterSeed,

--- a/Sources/OpenIslandApp/Views/GraphWorkspaceView.swift
+++ b/Sources/OpenIslandApp/Views/GraphWorkspaceView.swift
@@ -17,7 +17,7 @@ struct GraphWorkspaceWindowContent: View {
         GraphWorkspaceView(viewModel: viewModel)
             .onAppear {
                 model.newGraphDefinitionAction = { [weak viewModel] in
-                    viewModel?.newDocument()
+                    viewModel?.presentNewGraphSheet()
                 }
                 model.openGraphDefinitionAction = { [weak viewModel] in
                     guard let viewModel else { return }
@@ -32,7 +32,6 @@ struct GraphWorkspaceWindowContent: View {
 struct GraphWorkspaceView: View {
     @Bindable var viewModel: GraphWorkspaceViewModel
     @State private var canvasZoom = 1.0
-    @State private var isShowingNewGraph = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -75,12 +74,12 @@ struct GraphWorkspaceView: View {
         .background(Color(nsColor: .windowBackgroundColor))
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Graph Workspace")
-        .sheet(isPresented: $isShowingNewGraph) {
+        .sheet(isPresented: $viewModel.isShowingNewGraphSheet) {
             GraphNewDocumentSheet { request in
                 viewModel.newDocument(request: request)
-                isShowingNewGraph = false
+                viewModel.isShowingNewGraphSheet = false
             } onCancel: {
-                isShowingNewGraph = false
+                viewModel.isShowingNewGraphSheet = false
             }
         }
         .sheet(isPresented: $viewModel.isShowingCreateRunSheet) {
@@ -150,7 +149,7 @@ struct GraphWorkspaceView: View {
     private var definitionToolbar: some View {
         HStack(spacing: 6) {
             Button {
-                isShowingNewGraph = true
+                viewModel.presentNewGraphSheet()
             } label: {
                 Label("New Graph", systemImage: "doc.badge.plus")
             }
@@ -355,7 +354,7 @@ struct GraphWorkspaceView: View {
         if viewModel.document == nil && viewModel.mode == .definition {
             GraphWorkspaceEmptyState(
                 recentURLs: viewModel.recentDocumentURLs,
-                onNew: { isShowingNewGraph = true },
+                onNew: { viewModel.presentNewGraphSheet() },
                 onOpen: { GraphWorkspaceFilePanels.openDefinition(viewModel) },
                 onOpenRecent: { url in
                     Task { await viewModel.openDocument(url: url) }
@@ -567,9 +566,11 @@ private struct GraphNewDocumentSheet: View {
                 Spacer()
                 Button("Cancel", action: onCancel)
                     .keyboardShortcut(.cancelAction)
+                    .accessibilityLabel("Cancel New Graph")
                 Button("Create Graph") { onCreate(request) }
                     .buttonStyle(.borderedProminent)
                     .keyboardShortcut(.defaultAction)
+                    .accessibilityLabel("Create New Graph")
                     .disabled(
                         request.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                             || request.graphID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -579,6 +580,7 @@ private struct GraphNewDocumentSheet: View {
         }
         .padding(20)
         .frame(width: 560, height: 600)
+        .accessibilityElement(children: .contain)
         .accessibilityLabel("New Graph Configuration")
     }
 }
@@ -748,16 +750,19 @@ private struct GraphCreateRunSheet: View {
                 Spacer()
                 Button("Cancel") { viewModel.isShowingCreateRunSheet = false }
                     .keyboardShortcut(.cancelAction)
+                    .accessibilityLabel("Cancel Run Creation")
                 Button("Create Run") {
                     Task { await viewModel.confirmCreateRun() }
                 }
                 .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
+                .accessibilityLabel("Create Durable Run")
                 .disabled(!validationErrors.isEmpty || !inputsResolved)
             }
         }
         .padding(20)
         .frame(width: 620, height: 680)
+        .accessibilityElement(children: .contain)
         .accessibilityLabel("Create Durable Graph Run")
     }
 

--- a/Sources/OpenIslandApp/Views/GraphWorkspaceView.swift
+++ b/Sources/OpenIslandApp/Views/GraphWorkspaceView.swift
@@ -1,0 +1,991 @@
+import AppKit
+import OpenIslandCore
+import SwiftUI
+
+struct GraphWorkspaceWindowContent: View {
+    var model: AppModel
+    @State private var viewModel: GraphWorkspaceViewModel
+
+    init(model: AppModel, service: any GraphWorkspaceServicing) {
+        self.model = model
+        _viewModel = State(
+            initialValue: GraphWorkspaceViewModel(service: service)
+        )
+    }
+
+    var body: some View {
+        GraphWorkspaceView(viewModel: viewModel)
+            .onAppear {
+                model.newGraphDefinitionAction = { [weak viewModel] in
+                    viewModel?.newDocument()
+                }
+                model.openGraphDefinitionAction = { [weak viewModel] in
+                    guard let viewModel else { return }
+                    GraphWorkspaceFilePanels.openDefinition(viewModel)
+                }
+                viewModel.start()
+            }
+            .onDisappear { viewModel.stop() }
+    }
+}
+
+struct GraphWorkspaceView: View {
+    @Bindable var viewModel: GraphWorkspaceViewModel
+    @State private var canvasZoom = 1.0
+
+    var body: some View {
+        VStack(spacing: 0) {
+            workspaceToolbar
+            Divider()
+            NavigationSplitView {
+                workspaceSidebar
+                    .navigationSplitViewColumnWidth(
+                        min: 190,
+                        ideal: 220,
+                        max: 280
+                    )
+            } content: {
+                workspaceContent
+                    .navigationSplitViewColumnWidth(
+                        min: 560,
+                        ideal: 760
+                    )
+            } detail: {
+                workspaceInspector
+                    .navigationSplitViewColumnWidth(
+                        min: 260,
+                        ideal: 310,
+                        max: 380
+                    )
+            }
+            if viewModel.isShowingLogs {
+                Divider()
+                GraphLogViewer(viewModel: viewModel)
+                    .frame(minHeight: 170, idealHeight: 220, maxHeight: 300)
+            }
+            statusBar
+        }
+        .frame(minWidth: 1_000, idealWidth: 1_240, minHeight: 680, idealHeight: 780)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Graph Workspace")
+    }
+
+    private var workspaceToolbar: some View {
+        HStack(spacing: 10) {
+            Picker("Workspace mode", selection: $viewModel.mode) {
+                ForEach(GraphWorkspaceMode.allCases) { mode in
+                    Text(mode.rawValue).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+            .frame(width: 270)
+
+            Divider().frame(height: 20)
+
+            Text(viewModel.document?.name ?? "Graph Workspace")
+                .font(.headline)
+                .lineLimit(1)
+
+            Spacer()
+
+            switch viewModel.mode {
+            case .definition:
+                definitionToolbar
+            case .run:
+                runToolbar
+            case .history:
+                historyToolbar
+            }
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 46)
+    }
+
+    private var definitionToolbar: some View {
+        HStack(spacing: 6) {
+            iconButton("doc.badge.plus", help: "New Graph") {
+                viewModel.newDocument()
+            }
+            iconButton("folder", help: "Open Graph Definition") {
+                GraphWorkspaceFilePanels.openDefinition(viewModel)
+            }
+            iconButton("square.and.arrow.down", help: "Save Graph Definition") {
+                GraphWorkspaceFilePanels.saveDefinition(viewModel)
+            }
+            iconButton("checkmark.seal", help: "Validate Graph") {
+                viewModel.validateDocument()
+            }
+            iconButton("plus", help: "Add Node") { viewModel.addNode() }
+            iconButton("arrow.triangle.branch", help: "Connect Selected Nodes") {
+                viewModel.connectSelectedNodes()
+            }
+            .disabled(viewModel.selectedNodeIDs.count != 2)
+            iconButton("wand.and.stars", help: "Automatic Layout") {
+                viewModel.automaticLayout()
+            }
+            iconButton("trash", help: "Delete Selection", role: .destructive) {
+                viewModel.deleteSelection()
+            }
+            .disabled(viewModel.selectedNodeIDs.isEmpty)
+            Button("Create Run") { Task { await viewModel.createRun() } }
+                .buttonStyle(.borderedProminent)
+                .disabled(!viewModel.decision(.createRun).isEnabled)
+        }
+    }
+
+    private var runToolbar: some View {
+        HStack(spacing: 6) {
+            commandButton("play", "Start", .start) {
+                await viewModel.startRun()
+            }
+            commandButton("forward.frame", "Step", .step) {
+                await viewModel.step()
+            }
+            Button {
+                viewModel.run()
+            } label: {
+                Label("Run", systemImage: "play.fill")
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(!viewModel.decision(.run).isEnabled)
+            iconButton("pause.fill", help: "Pause Local Orchestration") {
+                viewModel.pauseOrchestration()
+            }
+            .disabled(!viewModel.decision(.pauseLocal).isEnabled)
+            Menu {
+                Button("Cancel Run", role: .destructive) {
+                    Task { await viewModel.cancelRun() }
+                }
+                .disabled(!viewModel.decision(.cancelRun).isEnabled)
+                Button("Cancel Selected Node", role: .destructive) {
+                    Task { await viewModel.cancelSelectedNode() }
+                }
+                .disabled(!viewModel.decision(.cancelNode).isEnabled)
+                Button("Retry Selected Node") {
+                    Task { await viewModel.retrySelectedNode() }
+                }
+                .disabled(!viewModel.decision(.retryNode).isEnabled)
+            } label: {
+                Label("Run Actions", systemImage: "ellipsis.circle")
+            }
+            iconButton("text.alignleft", help: "Open Logs") {
+                Task { await viewModel.openLogs() }
+            }
+            .disabled(!viewModel.decision(.openLogs).isEnabled)
+            iconButton("clock.arrow.circlepath", help: "Inspect History") {
+                Task { await viewModel.inspectHistory() }
+            }
+            .disabled(!viewModel.decision(.inspectHistory).isEnabled)
+            iconButton("square.and.arrow.up", help: "Export Run") {
+                GraphWorkspaceFilePanels.exportRun(viewModel)
+            }
+            .disabled(!viewModel.decision(.export).isEnabled)
+        }
+    }
+
+    private var historyToolbar: some View {
+        HStack(spacing: 8) {
+            Text("Replay boundary: head")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            iconButton("arrow.clockwise", help: "Refresh History") {
+                Task { await viewModel.refreshRunAndHistory() }
+            }
+            iconButton("square.and.arrow.up", help: "Export Run") {
+                GraphWorkspaceFilePanels.exportRun(viewModel)
+            }
+            .disabled(!viewModel.decision(.export).isEnabled)
+        }
+    }
+
+    private var workspaceSidebar: some View {
+        List {
+            Section("Workspace") {
+                ForEach(GraphWorkspaceMode.allCases) { mode in
+                    Button {
+                        viewModel.mode = mode
+                    } label: {
+                        Label(mode.rawValue, systemImage: modeIcon(mode))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("\(mode.rawValue) mode")
+                }
+            }
+            Section("Durable Runs") {
+                if viewModel.runs.isEmpty {
+                    ContentUnavailableView(
+                        "No Runs",
+                        systemImage: "point.3.connected.trianglepath.dotted"
+                    )
+                } else {
+                    ForEach(viewModel.runs) { run in
+                        Button {
+                            Task { await viewModel.openRun(run.runID) }
+                        } label: {
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(run.graphID)
+                                    .font(.callout.weight(.medium))
+                                    .lineLimit(1)
+                                HStack {
+                                    GraphStateBadge(state: run.reconciledState)
+                                    Text("v\(run.streamVersion)")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel(
+                            "Run \(run.graphID), \(run.reconciledState.rawValue)"
+                        )
+                    }
+                }
+            }
+        }
+        .listStyle(.sidebar)
+    }
+
+    @ViewBuilder
+    private var workspaceContent: some View {
+        switch viewModel.mode {
+        case .definition, .run:
+            GraphCanvasView(
+                viewModel: viewModel,
+                zoom: $canvasZoom,
+                isEditable: viewModel.mode == .definition
+            )
+        case .history:
+            GraphHistoryView(viewModel: viewModel)
+        }
+    }
+
+    @ViewBuilder
+    private var workspaceInspector: some View {
+        switch viewModel.mode {
+        case .definition:
+            GraphDefinitionInspector(viewModel: viewModel)
+        case .run:
+            GraphRunInspector(viewModel: viewModel)
+        case .history:
+            GraphHistoryInspector(viewModel: viewModel)
+        }
+    }
+
+    private var statusBar: some View {
+        HStack(spacing: 8) {
+            if viewModel.isLoading || viewModel.isOrchestrating {
+                ProgressView().controlSize(.small)
+            }
+            Text(
+                viewModel.errorMessage
+                    ?? viewModel.lastCommandResult?.reasonCode
+                    ?? "Ready"
+            )
+            .lineLimit(1)
+            .foregroundStyle(
+                viewModel.errorMessage == nil
+                    ? Color.secondary : Color.red
+            )
+            Spacer()
+            if let inspection = viewModel.inspection {
+                Text("stream \(inspection.summary.streamVersion)")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .font(.caption)
+        .padding(.horizontal, 12)
+        .frame(height: 26)
+        .background(Color(nsColor: .controlBackgroundColor))
+    }
+
+    private func iconButton(
+        _ systemName: String,
+        help: String,
+        role: ButtonRole? = nil,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(role: role, action: action) {
+            Image(systemName: systemName)
+        }
+        .buttonStyle(.borderless)
+        .help(help)
+        .accessibilityLabel(help)
+        .frame(width: 28, height: 28)
+    }
+
+    private func commandButton(
+        _ systemName: String,
+        _ title: String,
+        _ command: GraphWorkspaceCommand,
+        action: @escaping () async -> Void
+    ) -> some View {
+        Button {
+            Task { await action() }
+        } label: {
+            Label(title, systemImage: systemName)
+        }
+        .disabled(!viewModel.decision(command).isEnabled)
+        .help(viewModel.decision(command).reasonCode)
+    }
+
+    private func modeIcon(_ mode: GraphWorkspaceMode) -> String {
+        switch mode {
+        case .definition: "square.and.pencil"
+        case .run: "play.rectangle"
+        case .history: "clock.arrow.circlepath"
+        }
+    }
+}
+
+private struct GraphCanvasView: View {
+    @Bindable var viewModel: GraphWorkspaceViewModel
+    @Binding var zoom: Double
+    let isEditable: Bool
+    @State private var dragOrigins: [String: GraphCanvasPoint] = [:]
+
+    private let canvasSize = CGSize(width: 1_800, height: 1_200)
+    private let origin = CGPoint(x: 180, y: 180)
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Button {
+                    zoom = 0.75
+                } label: {
+                    Image(systemName: "arrow.up.left.and.arrow.down.right")
+                }
+                .help("Fit Graph to View")
+                .accessibilityLabel("Fit Graph to View")
+                Slider(value: $zoom, in: 0.4...1.6, step: 0.05)
+                    .frame(width: 140)
+                    .accessibilityLabel("Graph zoom")
+                Text("\(Int(zoom * 100))%")
+                    .font(.caption.monospacedDigit())
+                    .frame(width: 38, alignment: .trailing)
+                Spacer()
+                if viewModel.selectedNodeIDs.count > 1 {
+                    Text("\(viewModel.selectedNodeIDs.count) selected")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 10)
+            .frame(height: 34)
+            .background(Color(nsColor: .controlBackgroundColor))
+
+            if let document = viewModel.document, !document.nodes.isEmpty {
+                ScrollView([.horizontal, .vertical]) {
+                    ZStack(alignment: .topLeading) {
+                        GraphEdgeCanvas(
+                            document: document,
+                            origin: origin,
+                            nodeSize: GraphNodeView.nodeSize
+                        )
+                        ForEach(document.nodes) { node in
+                            let position = document.layout.position(nodeID: node.id)
+                                ?? GraphCanvasPoint(x: 0, y: 0)
+                            GraphNodeView(
+                                node: node,
+                                state: viewModel.inspection?.nodes.first {
+                                    $0.id == node.id
+                                }?.reconciledState,
+                                attemptOrdinal: viewModel.inspection?.attempts
+                                    .filter { $0.nodeID == node.id }
+                                    .map(\.ordinal).max(),
+                                selected: viewModel.selectedNodeIDs.contains(node.id),
+                                isEditable: isEditable,
+                                onSelect: { extending in
+                                    viewModel.selectNode(node.id, extending: extending)
+                                },
+                                onDelete: { viewModel.deleteSelection() }
+                            )
+                            .position(
+                                x: origin.x + position.x
+                                    + GraphNodeView.nodeSize.width / 2,
+                                y: origin.y + position.y
+                                    + GraphNodeView.nodeSize.height / 2
+                            )
+                            .gesture(
+                                DragGesture()
+                                    .onChanged { value in
+                                        guard isEditable else { return }
+                                        let start = dragOrigins[node.id] ?? position
+                                        dragOrigins[node.id] = start
+                                        viewModel.moveNode(
+                                            node.id,
+                                            to: GraphCanvasPoint(
+                                                x: start.x + value.translation.width / zoom,
+                                                y: start.y + value.translation.height / zoom
+                                            )
+                                        )
+                                    }
+                                    .onEnded { _ in
+                                        dragOrigins.removeValue(forKey: node.id)
+                                    }
+                            )
+                        }
+                    }
+                    .frame(width: canvasSize.width, height: canvasSize.height)
+                    .scaleEffect(zoom, anchor: .topLeading)
+                    .frame(
+                        width: canvasSize.width * zoom,
+                        height: canvasSize.height * zoom,
+                        alignment: .topLeading
+                    )
+                }
+                .background(Color(nsColor: .textBackgroundColor))
+                .focusable()
+                .onDeleteCommand {
+                    if isEditable { viewModel.deleteSelection() }
+                }
+            } else {
+                ContentUnavailableView {
+                    Label(
+                        "Empty Graph",
+                        systemImage: "point.3.connected.trianglepath.dotted"
+                    )
+                } actions: {
+                    if isEditable {
+                        Button("Add Node") { viewModel.addNode() }
+                    }
+                }
+            }
+        }
+        .accessibilityLabel("Graph canvas")
+    }
+}
+
+private struct GraphEdgeCanvas: View {
+    let document: GraphDefinitionDocument
+    let origin: CGPoint
+    let nodeSize: CGSize
+
+    var body: some View {
+        Canvas { context, _ in
+            for edge in document.edges {
+                guard let source = document.layout.position(
+                    nodeID: edge.sourceNodeID
+                ), let target = document.layout.position(
+                    nodeID: edge.targetNodeID
+                ) else { continue }
+                let start = CGPoint(
+                    x: origin.x + source.x + nodeSize.width,
+                    y: origin.y + source.y + nodeSize.height / 2
+                )
+                let end = CGPoint(
+                    x: origin.x + target.x,
+                    y: origin.y + target.y + nodeSize.height / 2
+                )
+                var path = Path()
+                path.move(to: start)
+                let middleX = (start.x + end.x) / 2
+                path.addCurve(
+                    to: end,
+                    control1: CGPoint(x: middleX, y: start.y),
+                    control2: CGPoint(x: middleX, y: end.y)
+                )
+                context.stroke(
+                    path,
+                    with: .color(.secondary.opacity(0.65)),
+                    lineWidth: 1.5
+                )
+                var arrow = Path()
+                arrow.move(to: end)
+                arrow.addLine(to: CGPoint(x: end.x - 9, y: end.y - 5))
+                arrow.addLine(to: CGPoint(x: end.x - 9, y: end.y + 5))
+                arrow.closeSubpath()
+                context.fill(arrow, with: .color(.secondary.opacity(0.8)))
+            }
+        }
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+}
+
+private struct GraphNodeView: View {
+    static let nodeSize = CGSize(width: 210, height: 94)
+
+    let node: GraphDefinitionDocumentNode
+    let state: ReconciledExecutionState?
+    let attemptOrdinal: Int?
+    let selected: Bool
+    let isEditable: Bool
+    let onSelect: (Bool) -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            nodeHeader
+            Text(node.id)
+                .font(.caption2.monospaced())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            portRow
+        }
+        .padding(10)
+        .frame(width: Self.nodeSize.width, height: Self.nodeSize.height)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .overlay {
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(selected ? Color.accentColor : Color.secondary.opacity(0.35), lineWidth: selected ? 2 : 1)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .contentShape(Rectangle())
+        .onTapGesture { onSelect(false) }
+        .contextMenu {
+            Button(selected ? "Remove from Selection" : "Add to Selection") {
+                onSelect(true)
+            }
+            if isEditable {
+                Button("Delete Node", role: .destructive) { onDelete() }
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            "Node \(node.name), ID \(node.id), state \(state?.rawValue ?? "definition")"
+        )
+        .accessibilityAddTraits(selected ? .isSelected : [])
+    }
+
+    private var capabilitySummary: String {
+        node.requiredCapabilities.joined(separator: ", ")
+    }
+
+    private var nodeHeader: some View {
+        HStack(alignment: .top) {
+            Text(node.name)
+                .font(.callout.weight(.semibold))
+                .lineLimit(2)
+            Spacer(minLength: 6)
+            if let state { GraphStateBadge(state: state) }
+        }
+    }
+
+    private var portRow: some View {
+        HStack {
+            Circle()
+                .fill(Color.secondary)
+                .frame(width: 8, height: 8)
+                .accessibilityLabel("Dependency input port")
+            Text(capabilitySummary)
+                .font(.caption2)
+                .foregroundStyle(Color.secondary)
+                .lineLimit(1)
+            Spacer()
+            if let attemptOrdinal {
+                Text("attempt \(attemptOrdinal)")
+                    .font(.caption2.monospacedDigit())
+            }
+            Circle()
+                .fill(Color.accentColor)
+                .frame(width: 8, height: 8)
+                .accessibilityLabel("Dependency output port")
+        }
+    }
+}
+
+struct GraphStateBadge: View {
+    let state: ReconciledExecutionState
+
+    var body: some View {
+        Text(state.rawValue)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(color)
+            .lineLimit(1)
+            .accessibilityLabel("State \(state.rawValue)")
+    }
+
+    private var color: Color {
+        switch state {
+        case .completed: .green
+        case .running: .blue
+        case .failed, .orphaned, .interrupted: .red
+        case .blocked, .cancelled: .orange
+        case .pending, .ready: .secondary
+        }
+    }
+}
+
+private struct GraphDefinitionInspector: View {
+    @Bindable var viewModel: GraphWorkspaceViewModel
+
+    var body: some View {
+        Form {
+            Section("Definition") {
+                LabeledContent("Graph ID", value: viewModel.document?.graphID ?? "")
+                LabeledContent("Version", value: viewModel.document?.definitionVersion ?? "")
+                LabeledContent("Nodes", value: "\(viewModel.document?.nodes.count ?? 0)")
+                LabeledContent("Edges", value: "\(viewModel.document?.edges.count ?? 0)")
+            }
+            if let node = selectedNode {
+                Section("Selected Node") {
+                    LabeledContent("Stable ID", value: node.id)
+                    TextField(
+                        "Name",
+                        text: Binding(
+                            get: { selectedNode?.name ?? "" },
+                            set: { viewModel.updateSelectedNode(
+                                name: $0,
+                                description: selectedNode?.description ?? ""
+                            ) }
+                        )
+                    )
+                    TextField(
+                        "Description",
+                        text: Binding(
+                            get: { selectedNode?.description ?? "" },
+                            set: { viewModel.updateSelectedNode(
+                                name: selectedNode?.name ?? "",
+                                description: $0
+                            ) }
+                        ),
+                        axis: .vertical
+                    )
+                    TextField(
+                        "Capabilities",
+                        text: Binding(
+                            get: {
+                                selectedNode?.requiredCapabilities
+                                    .joined(separator: ", ") ?? ""
+                            },
+                            set: {
+                                viewModel.updateSelectedNodeExecution(
+                                    capabilities: $0.split(separator: ",")
+                                        .map { $0.trimmingCharacters(in: .whitespaces) }
+                                        .filter { !$0.isEmpty },
+                                    executionSeconds: selectedNode?
+                                        .timeoutPolicy.executionSeconds ?? 300
+                                )
+                            }
+                        )
+                    )
+                    Stepper(
+                        "Timeout: \(node.timeoutPolicy.executionSeconds)s",
+                        value: Binding(
+                            get: { Int(selectedNode?.timeoutPolicy.executionSeconds ?? 300) },
+                            set: {
+                                viewModel.updateSelectedNodeExecution(
+                                    capabilities: selectedNode?.requiredCapabilities ?? [],
+                                    executionSeconds: UInt64(max(1, $0))
+                                )
+                            }
+                        ),
+                        in: 1...86_400
+                    )
+                }
+                Section("Execution Specification") {
+                    LabeledContent("Adapter", value: node.specification.adapterKind)
+                    LabeledContent("Operation", value: node.specification.operation)
+                    LabeledContent(
+                        "Workspace",
+                        value: node.workspace.root ?? "Not assigned"
+                    )
+                }
+                Section("Dependencies") {
+                    let incoming = viewModel.document?.edges.filter {
+                        $0.targetNodeID == node.id
+                    } ?? []
+                    if incoming.isEmpty {
+                        Text("No dependencies").foregroundStyle(.secondary)
+                    }
+                    ForEach(incoming) { edge in
+                        HStack {
+                            Text(edge.sourceNodeID)
+                            Spacer()
+                            Button {
+                                viewModel.removeEdge(edge.id)
+                            } label: {
+                                Image(systemName: "xmark")
+                            }
+                            .buttonStyle(.borderless)
+                            .accessibilityLabel("Remove dependency")
+                        }
+                    }
+                }
+            } else {
+                ContentUnavailableView(
+                    "No Node Selected",
+                    systemImage: "cursorarrow.click"
+                )
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    private var selectedNode: GraphDefinitionDocumentNode? {
+        guard let nodeID = viewModel.selectedNodeID else { return nil }
+        return viewModel.document?.nodes.first { $0.id == nodeID }
+    }
+}
+
+private struct GraphRunInspector: View {
+    @Bindable var viewModel: GraphWorkspaceViewModel
+
+    var body: some View {
+        Form {
+            if let inspection = viewModel.inspection {
+                Section("Run") {
+                    LabeledContent("Run ID", value: inspection.summary.runID)
+                    LabeledContent("State") {
+                        GraphStateBadge(state: inspection.summary.reconciledState)
+                    }
+                    LabeledContent("Stream", value: "\(inspection.summary.streamVersion)")
+                    LabeledContent("Artifacts", value: "\(inspection.summary.artifactCount)")
+                }
+                if let node = selectedNode(inspection) {
+                    Section("Node") {
+                        LabeledContent("Name", value: node.title)
+                        LabeledContent("State") {
+                            GraphStateBadge(state: node.reconciledState)
+                        }
+                        LabeledContent("Executor", value: node.executorID ?? "Unclaimed")
+                        LabeledContent(
+                            "Blockers",
+                            value: node.dependencyNodeIDs.joined(separator: ", ")
+                        )
+                    }
+                    if let attempt = inspection.attempts
+                        .filter({ $0.nodeID == node.id })
+                        .max(by: { $0.ordinal < $1.ordinal }) {
+                        Section("Attempt") {
+                            LabeledContent("Ordinal", value: "\(attempt.ordinal)")
+                            LabeledContent("Process identity", value: attempt.hasProcessIdentity ? "Recorded" : "Pending")
+                            LabeledContent("Reason", value: attempt.statusReason ?? "None")
+                            LabeledContent("Started", value: attempt.startedAt?.formatted() ?? "Pending")
+                            LabeledContent("Finished", value: attempt.finishedAt?.formatted() ?? "Pending")
+                        }
+                    }
+                    if let claim = inspection.scheduling?.claimHistory
+                        .filter({ $0.nodeID == node.id })
+                        .last {
+                        Section("Claim and Lease") {
+                            LabeledContent("Claim", value: claim.id)
+                            LabeledContent("Generation", value: "\(claim.leaseGeneration)")
+                            LabeledContent("Status", value: claim.status.rawValue)
+                            LabeledContent("Expires", value: claim.leaseExpiry.formatted())
+                        }
+                    }
+                }
+                Section("Artifacts") {
+                    ForEach(inspection.artifacts) { artifact in
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(artifact.logicalRole).font(.callout.weight(.medium))
+                            Text(artifact.digest).font(.caption2.monospaced()).lineLimit(1)
+                            Text("\(artifact.mediaType) · \(artifact.sensitivity.rawValue)")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            } else {
+                ContentUnavailableView(
+                    "No Run Selected",
+                    systemImage: "play.rectangle"
+                )
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    private func selectedNode(
+        _ inspection: GraphRunInspection
+    ) -> GraphNodeInspection? {
+        guard let id = viewModel.selectedNodeID else { return nil }
+        return inspection.nodes.first { $0.id == id }
+    }
+}
+
+private struct GraphHistoryView: View {
+    @Bindable var viewModel: GraphWorkspaceViewModel
+
+    var body: some View {
+        List {
+            if let history = viewModel.history {
+                ForEach(history.events) { event in
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            Text("#\(event.streamSequence)")
+                                .font(.caption.monospacedDigit())
+                                .foregroundStyle(.secondary)
+                            Text(event.eventType)
+                                .font(.callout.weight(.medium))
+                            Spacer()
+                            Text(event.occurredAt.formatted())
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        if let nodeID = event.nodeID {
+                            Text("node \(nodeID)")
+                                .font(.caption.monospaced())
+                        }
+                        Text("\(event.factClass.rawValue) · producer \(event.producerID)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, 4)
+                }
+            } else {
+                ContentUnavailableView(
+                    "No History",
+                    systemImage: "clock.arrow.circlepath"
+                )
+            }
+        }
+        .accessibilityLabel("Graph execution event history")
+    }
+}
+
+private struct GraphHistoryInspector: View {
+    @Bindable var viewModel: GraphWorkspaceViewModel
+
+    var body: some View {
+        Form {
+            if let explanation = viewModel.explanation {
+                Section("Causal Explanation") {
+                    LabeledContent("State", value: explanation.state.rawValue)
+                    Text(explanation.summary)
+                    if !explanation.blockingDependencyNodeIDs.isEmpty {
+                        LabeledContent(
+                            "Blocking dependencies",
+                            value: explanation.blockingDependencyNodeIDs
+                                .joined(separator: ", ")
+                        )
+                    }
+                }
+                Section("Reasons") {
+                    ForEach(explanation.reasons) { reason in
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(reason.code.rawValue).font(.caption.weight(.medium))
+                            Text(reason.message)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                if !explanation.ignoredInputs.isEmpty {
+                    Section("Ignored Evidence") {
+                        ForEach(explanation.ignoredInputs) { input in
+                            Text(input.message).font(.caption)
+                        }
+                    }
+                }
+                Section("Scheduler") {
+                    ForEach(
+                        viewModel.inspection?.scheduling?.records ?? [],
+                        id: \.id
+                    ) { record in
+                        Text(record.eventType).font(.caption)
+                    }
+                }
+            } else {
+                ContentUnavailableView(
+                    "No Explanation",
+                    systemImage: "point.topleft.down.to.point.bottomright.curvepath"
+                )
+            }
+        }
+        .formStyle(.grouped)
+    }
+}
+
+private struct GraphLogViewer: View {
+    @Bindable var viewModel: GraphWorkspaceViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 10) {
+                Picker("Log stream", selection: $viewModel.selectedLogChannel) {
+                    Text("stdout").tag(GraphProcessLogChannel.stdout)
+                    Text("stderr").tag(GraphProcessLogChannel.stderr)
+                }
+                .pickerStyle(.segmented)
+                .frame(width: 170)
+                Toggle("Follow", isOn: $viewModel.isFollowingLogs)
+                    .toggleStyle(.switch)
+                if let page = viewModel.logPage,
+                   !page.redactionLabels.isEmpty {
+                    Label(
+                        "Redacted: \(page.redactionLabels.joined(separator: ", "))",
+                        systemImage: "eye.slash"
+                    )
+                    .font(.caption)
+                }
+                Spacer()
+                Button {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(logText, forType: .string)
+                } label: {
+                    Image(systemName: "doc.on.doc")
+                }
+                .help("Copy Log Text")
+                .accessibilityLabel("Copy Log Text")
+                Button {
+                    Task { await viewModel.refreshLogs() }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .help("Refresh Logs")
+                .accessibilityLabel("Refresh Logs")
+                Button {
+                    viewModel.isShowingLogs = false
+                    viewModel.isFollowingLogs = false
+                } label: {
+                    Image(systemName: "xmark")
+                }
+                .help("Close Logs")
+                .accessibilityLabel("Close Logs")
+            }
+            .padding(.horizontal, 10)
+            .frame(height: 34)
+            ScrollView {
+                Text(logText.isEmpty ? "No log output for this stream." : logText)
+                    .font(.system(.caption, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(10)
+            }
+            .background(Color(nsColor: .textBackgroundColor))
+        }
+        .accessibilityLabel("Node process logs")
+    }
+
+    private var logText: String {
+        viewModel.logPage?.entries
+            .filter { $0.channel == viewModel.selectedLogChannel }
+            .map(\.text)
+            .joined() ?? ""
+    }
+}
+
+@MainActor
+enum GraphWorkspaceFilePanels {
+    static func openDefinition(_ viewModel: GraphWorkspaceViewModel) {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.json]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        Task { await viewModel.openDocument(url: url) }
+    }
+
+    static func saveDefinition(_ viewModel: GraphWorkspaceViewModel) {
+        if viewModel.documentURL != nil {
+            Task { await viewModel.saveDocument() }
+            return
+        }
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.json]
+        panel.nameFieldStringValue = "\(viewModel.document?.graphID ?? "graph").openisland-graph.json"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        Task { await viewModel.saveDocument(url: url) }
+    }
+
+    static func exportRun(_ viewModel: GraphWorkspaceViewModel) {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.json]
+        panel.nameFieldStringValue = "\(viewModel.inspection?.summary.runID ?? "graph-run").json"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        Task { await viewModel.exportRun(url: url) }
+    }
+}

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -94,6 +94,7 @@ private struct ConditionalDrawingGroup: ViewModifier {
 
 struct IslandPanelView: View {
     private static let headerControlButtonSize: CGFloat = 22
+    private static let graphWorkspaceButtonWidth: CGFloat = 118
     private static let headerControlSpacing: CGFloat = 8
     private static let headerHorizontalPadding: CGFloat = 18
     private static let headerTopPadding: CGFloat = 2
@@ -102,6 +103,7 @@ struct IslandPanelView: View {
     private static let minimumRightUsageLaneWidth: CGFloat = 58
 
     var model: AppModel
+    @Environment(\.openWindow) private var openWindow
     private var lang: LanguageManager { model.lang }
 
     @State private var isHovering = false
@@ -160,7 +162,9 @@ struct IslandPanelView: View {
     }
 
     private var openedHeaderButtonsWidth: CGFloat {
-        (Self.headerControlButtonSize * 3) + (Self.headerControlSpacing * 2)
+        Self.graphWorkspaceButtonWidth
+            + (Self.headerControlButtonSize * 3)
+            + (Self.headerControlSpacing * 3)
     }
 
     private var openedHeaderHorizontalPadding: CGFloat {
@@ -376,6 +380,27 @@ struct IslandPanelView: View {
 
     private var openedHeaderButtons: some View {
         HStack(spacing: Self.headerControlSpacing) {
+            Button {
+                openWindow(id: GraphWorkspaceEntryPoint.windowID)
+                model.showGraphWorkspace()
+            } label: {
+                Label(
+                    GraphWorkspaceEntryPoint.label,
+                    systemImage: "point.3.connected.trianglepath.dotted"
+                )
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.white.opacity(0.8))
+                .lineLimit(1)
+                .frame(
+                    width: Self.graphWorkspaceButtonWidth,
+                    height: Self.headerControlButtonSize
+                )
+                .background(.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 5))
+            }
+            .buttonStyle(.plain)
+            .help("Open Graph Workspace (Command-Shift-G)")
+            .accessibilityLabel(GraphWorkspaceEntryPoint.label)
+
             headerIconButton(
                 systemName: model.isSoundMuted ? "speaker.slash.fill" : "speaker.wave.2.fill",
                 tint: model.isSoundMuted ? .orange.opacity(0.92) : .white.opacity(0.62)

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1322,6 +1322,13 @@ private struct IslandSessionRow: View {
                 .padding(.bottom, 10)
         }
 
+        if presentation == .list, session.observability.metrics.eventCount > 0 {
+            observabilityDetails
+                .padding(.leading, detailLeadingInset)
+                .padding(.trailing, sideInset)
+                .padding(.bottom, 10)
+        }
+
         if let subagents = session.claudeMetadata?.activeSubagents,
            !subagents.isEmpty {
             VStack(alignment: .leading, spacing: 4) {
@@ -1392,6 +1399,130 @@ private struct IslandSessionRow: View {
             .padding(.leading, detailLeadingInset)
             .padding(.trailing, sideInset)
             .padding(.bottom, 10)
+        }
+    }
+
+    private var observabilityDetails: some View {
+        let metrics = session.observability.metrics
+        let timeline = Array(session.observability.timeline.suffix(4).reversed())
+
+        return VStack(alignment: .leading, spacing: 7) {
+            HStack(spacing: 12) {
+                observabilityMetric(
+                    systemName: "list.bullet.rectangle",
+                    value: "\(metrics.eventCount)",
+                    label: lang.t("observability.events")
+                )
+                observabilityMetric(
+                    systemName: "hammer",
+                    value: "\(metrics.toolEventCount)",
+                    label: lang.t("observability.tools")
+                )
+                observabilityMetric(
+                    systemName: "clock",
+                    value: observabilityElapsedText(metrics),
+                    label: lang.t("observability.elapsed")
+                )
+                Spacer(minLength: 0)
+            }
+
+            if !timeline.isEmpty {
+                HStack(spacing: 5) {
+                    Image(systemName: "waveform.path.ecg")
+                        .font(.system(size: 9.5, weight: .semibold))
+                    Text(lang.t("observability.timeline"))
+                        .font(.system(size: 10.5, weight: .semibold))
+                }
+                .foregroundStyle(.white.opacity(0.5))
+
+                ForEach(timeline) { event in
+                    HStack(alignment: .top, spacing: 7) {
+                        Image(systemName: observabilityIcon(for: event.kind))
+                            .font(.system(size: 9.5, weight: .semibold))
+                            .foregroundStyle(observabilityTint(for: event.kind))
+                            .frame(width: 12, height: 14)
+
+                        VStack(alignment: .leading, spacing: 1) {
+                            HStack(spacing: 6) {
+                                Text(event.title)
+                                    .font(.system(size: 10.5, weight: .medium))
+                                    .foregroundStyle(.white.opacity(0.72))
+                                    .lineLimit(1)
+                                Text(event.timestamp, style: .time)
+                                    .font(.system(size: 9.5, weight: .regular, design: .monospaced))
+                                    .foregroundStyle(.white.opacity(0.3))
+                            }
+
+                            if let detail = event.detail, !detail.isEmpty {
+                                Text(detail)
+                                    .font(.system(size: 10))
+                                    .foregroundStyle(.white.opacity(0.42))
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
+                            }
+                        }
+
+                        Spacer(minLength: 0)
+                    }
+                }
+            }
+        }
+    }
+
+    private func observabilityMetric(
+        systemName: String,
+        value: String,
+        label: String
+    ) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: systemName)
+                .font(.system(size: 9.5, weight: .semibold))
+            Text(value)
+                .font(.system(size: 10.5, weight: .semibold, design: .monospaced))
+            Text(label)
+                .font(.system(size: 10))
+        }
+        .foregroundStyle(.white.opacity(0.48))
+    }
+
+    private func observabilityElapsedText(_ metrics: AgentSessionMetrics) -> String {
+        let reference = session.phase == .completed
+            ? (metrics.lastEventAt ?? referenceDate)
+            : referenceDate
+        let totalSeconds = Int(metrics.elapsed(at: reference).rounded(.down))
+        if totalSeconds >= 3_600 {
+            return "\(totalSeconds / 3_600)h \((totalSeconds % 3_600) / 60)m"
+        }
+        if totalSeconds >= 60 {
+            return "\(totalSeconds / 60)m \(totalSeconds % 60)s"
+        }
+        return "\(totalSeconds)s"
+    }
+
+    private func observabilityIcon(for kind: AgentTimelineEventKind) -> String {
+        switch kind {
+        case .lifecycle: "play.circle"
+        case .status: "waveform"
+        case .prompt: "text.bubble"
+        case .tool: "hammer"
+        case .permission: "lock.shield"
+        case .question: "questionmark.bubble"
+        case .response: "text.quote"
+        case .completion: "checkmark.circle"
+        case .system: "gearshape"
+        }
+    }
+
+    private func observabilityTint(for kind: AgentTimelineEventKind) -> Color {
+        switch kind {
+        case .permission, .question:
+            IslandDesignPalette.Status.waitingAggregate
+        case .completion:
+            IslandDesignPalette.Status.completed
+        case .tool:
+            .cyan.opacity(0.8)
+        case .lifecycle, .status, .prompt, .response, .system:
+            .white.opacity(0.48)
         }
     }
 

--- a/Sources/OpenIslandCLI/OpenIslandCLI.swift
+++ b/Sources/OpenIslandCLI/OpenIslandCLI.swift
@@ -1,0 +1,51 @@
+import Darwin
+import Foundation
+import OpenIslandCore
+
+@main
+struct OpenIslandCLI {
+    static func main() async {
+        signal(SIGPIPE, SIG_IGN)
+        signal(SIGINT) { _ in
+            Darwin._exit(GraphCLIExitCode.interrupted.rawValue)
+        }
+
+        let stdout = GraphCLIFileDescriptorSink(
+            fileDescriptor: STDOUT_FILENO
+        )
+        let stderr = GraphCLIFileDescriptorSink(
+            fileDescriptor: STDERR_FILENO
+        )
+
+        do {
+            let environment = ProcessInfo.processInfo.environment
+            let databasePath = try environment[
+                "OPENISLAND_GRAPH_DATABASE_PATH"
+            ] ?? SQLiteGraphExecutionStore.defaultDatabasePath()
+            let store = try SQLiteGraphExecutionStore(
+                databasePath: databasePath
+            )
+            let inspector = DefaultGraphTemporalInspector(
+                readStore: store,
+                snapshotStore: store
+            )
+            let runner = GraphCLICommandRunner(
+                inspector: inspector,
+                stdout: stdout,
+                stderr: stderr
+            )
+            let code = await runner.run(
+                arguments: Array(CommandLine.arguments.dropFirst())
+            )
+            Darwin.exit(code.rawValue)
+        } catch {
+            _ = stderr.write(
+                Data(
+                    "error[persistence]: \(error.localizedDescription)\n"
+                        .utf8
+                )
+            )
+            Darwin.exit(GraphCLIExitCode.persistenceFailure.rawValue)
+        }
+    }
+}

--- a/Sources/OpenIslandCLI/OpenIslandCLI.swift
+++ b/Sources/OpenIslandCLI/OpenIslandCLI.swift
@@ -33,6 +33,20 @@ struct OpenIslandCLI {
                 eventStore: store,
                 readStore: store
             )
+            let orchestrator = DefaultGraphOrchestrationService(
+                eventStore: store,
+                schedulingRepository: DefaultGraphSchedulingRepository(
+                    eventStore: store
+                ),
+                executorRepository: DefaultGraphExecutorRepository(
+                    eventStore: store
+                ),
+                executor: DeterministicGraphExecutor(
+                    script: GraphDeterministicExecutionScript(
+                        attempts: []
+                    )
+                )
+            )
             let context = GraphCLIContextDiscovery.discover(
                 environment: environment,
                 workingDirectory: FileManager.default.currentDirectoryPath
@@ -40,6 +54,7 @@ struct OpenIslandCLI {
             let runner = GraphCLICommandRunner(
                 inspector: inspector,
                 mutator: mutator,
+                orchestrator: orchestrator,
                 stdout: stdout,
                 stderr: stderr,
                 context: context,

--- a/Sources/OpenIslandCLI/OpenIslandCLI.swift
+++ b/Sources/OpenIslandCLI/OpenIslandCLI.swift
@@ -29,10 +29,17 @@ struct OpenIslandCLI {
                 readStore: store,
                 snapshotStore: store
             )
+            let context = GraphCLIContextDiscovery.discover(
+                environment: environment,
+                workingDirectory: FileManager.default.currentDirectoryPath
+            )
             let runner = GraphCLICommandRunner(
                 inspector: inspector,
                 stdout: stdout,
-                stderr: stderr
+                stderr: stderr,
+                context: context,
+                telemetry: OSLogGraphCLITelemetrySink(),
+                isOutputTTY: isatty(STDOUT_FILENO) == 1
             )
             let code = await runner.run(
                 arguments: Array(CommandLine.arguments.dropFirst())

--- a/Sources/OpenIslandCLI/OpenIslandCLI.swift
+++ b/Sources/OpenIslandCLI/OpenIslandCLI.swift
@@ -29,12 +29,17 @@ struct OpenIslandCLI {
                 readStore: store,
                 snapshotStore: store
             )
+            let mutator = DefaultGraphMutationService(
+                eventStore: store,
+                readStore: store
+            )
             let context = GraphCLIContextDiscovery.discover(
                 environment: environment,
                 workingDirectory: FileManager.default.currentDirectoryPath
             )
             let runner = GraphCLICommandRunner(
                 inspector: inspector,
+                mutator: mutator,
                 stdout: stdout,
                 stderr: stderr,
                 context: context,

--- a/Sources/OpenIslandCLI/OpenIslandCLI.swift
+++ b/Sources/OpenIslandCLI/OpenIslandCLI.swift
@@ -25,9 +25,30 @@ struct OpenIslandCLI {
             let store = try SQLiteGraphExecutionStore(
                 databasePath: databasePath
             )
+            let processRuntimeRoot: URL
+            if let configuredRoot = environment[
+                "OPENISLAND_PROCESS_RUNTIME_ROOT"
+            ] {
+                processRuntimeRoot = URL(
+                    fileURLWithPath: configuredRoot,
+                    isDirectory: true
+                )
+            } else {
+                processRuntimeRoot = try GraphLocalProcessLaunchStore
+                    .defaultRootURL()
+            }
+            let launchStore = try GraphLocalProcessLaunchStore(
+                rootURL: processRuntimeRoot
+            )
+            let executor = SupervisedLocalProcessExecutor(
+                launchStore: launchStore
+            )
             let inspector = DefaultGraphTemporalInspector(
                 readStore: store,
-                snapshotStore: store
+                snapshotStore: store,
+                evidenceSource: GraphLocalProcessEvidenceSource(
+                    launchStore: launchStore
+                )
             )
             let mutator = DefaultGraphMutationService(
                 eventStore: store,
@@ -41,11 +62,8 @@ struct OpenIslandCLI {
                 executorRepository: DefaultGraphExecutorRepository(
                     eventStore: store
                 ),
-                executor: DeterministicGraphExecutor(
-                    script: GraphDeterministicExecutionScript(
-                        attempts: []
-                    )
-                )
+                executor: executor,
+                confirmationPolicy: LocalProcessExecutionConfirmationPolicy()
             )
             let context = GraphCLIContextDiscovery.discover(
                 environment: environment,

--- a/Sources/OpenIslandCore/AgentGraphExecutor.swift
+++ b/Sources/OpenIslandCore/AgentGraphExecutor.swift
@@ -1,0 +1,194 @@
+import Foundation
+
+/// Compatibility result produced by the recovered prototype executor.
+public struct AgentTaskExecutionResult: Sendable {
+    public let output: String
+
+    public init(output: String) {
+        self.output = output
+    }
+}
+
+public enum AgentGraphExecutionError: LocalizedError, Sendable {
+    case cyclicGraph
+    case stalledGraph
+
+    public var errorDescription: String? {
+        switch self {
+        case .cyclicGraph:
+            return "The task graph contains a dependency cycle."
+        case .stalledGraph:
+            return "The task graph cannot make further progress."
+        }
+    }
+}
+
+/// Recovered in-memory executor.
+///
+/// This actor remains useful for simulation and migration tests. It is not
+/// authoritative for process lifecycle because it has no attempt identity,
+/// heartbeat, exit, or replay boundary.
+public actor AgentGraphExecutor {
+    public typealias NodeRunner = @Sendable (
+        AgentTaskNode,
+        [AgentTaskNode]
+    ) async throws -> AgentTaskExecutionResult
+
+    public typealias GraphUpdateHandler = @Sendable (
+        AgentTaskGraph
+    ) async -> Void
+
+    private var graph: AgentTaskGraph
+    private let maximumParallelTasks: Int
+    private let runner: NodeRunner
+
+    public init(
+        graph: AgentTaskGraph,
+        maximumParallelTasks: Int = 3,
+        runner: @escaping NodeRunner
+    ) {
+        self.graph = graph
+        self.maximumParallelTasks = max(1, maximumParallelTasks)
+        self.runner = runner
+    }
+
+    public func snapshot() -> AgentTaskGraph {
+        graph
+    }
+
+    public func execute(
+        onUpdate: @escaping GraphUpdateHandler = { _ in }
+    ) async throws -> AgentTaskGraph {
+        guard !graph.containsCycle() else {
+            throw AgentGraphExecutionError.cyclicGraph
+        }
+
+        graph.refreshSchedulingStates()
+        await onUpdate(graph)
+
+        while graph.nodes.contains(where: {
+            !$0.state.isTerminal
+        }) {
+            let readyNodes = graph.nodes
+                .filter { $0.state == .ready }
+                .prefix(maximumParallelTasks)
+
+            guard !readyNodes.isEmpty else {
+                graph.refreshSchedulingStates()
+
+                if graph.nodes.contains(where: { $0.state == .ready }) {
+                    continue
+                }
+
+                throw AgentGraphExecutionError.stalledGraph
+            }
+
+            let batch = Array(readyNodes)
+
+            for node in batch {
+                updateNode(node.id) {
+                    $0.state = .running
+                    $0.startedAt = .now
+                    $0.errorMessage = nil
+                }
+            }
+
+            await onUpdate(graph)
+
+            let results = await withTaskGroup(
+                of: NodeOutcome.self,
+                returning: [NodeOutcome].self
+            ) { group in
+                for node in batch {
+                    let dependencies = graph.dependencies(of: node.id)
+                    let runner = self.runner
+
+                    group.addTask {
+                        do {
+                            let result = try await runner(
+                                node,
+                                dependencies
+                            )
+                            return .success(
+                                nodeID: node.id,
+                                result: result
+                            )
+                        } catch {
+                            return .failure(
+                                nodeID: node.id,
+                                message: error.localizedDescription
+                            )
+                        }
+                    }
+                }
+
+                var outcomes: [NodeOutcome] = []
+
+                for await outcome in group {
+                    outcomes.append(outcome)
+                }
+
+                return outcomes
+            }
+
+            for outcome in results {
+                switch outcome {
+                case let .success(nodeID, result):
+                    updateNode(nodeID) {
+                        $0.state = .completed
+                        $0.output = result.output
+                        $0.completedAt = .now
+                    }
+
+                case let .failure(nodeID, message):
+                    updateNode(nodeID) {
+                        $0.state = .failed
+                        $0.errorMessage = message
+                        $0.completedAt = .now
+                    }
+                }
+            }
+
+            graph.refreshSchedulingStates()
+            await onUpdate(graph)
+        }
+
+        return graph
+    }
+
+    private func updateNode(
+        _ nodeID: UUID,
+        mutation: (inout AgentTaskNode) -> Void
+    ) {
+        guard let index = graph.nodes.firstIndex(where: {
+            $0.id == nodeID
+        }) else {
+            return
+        }
+
+        mutation(&graph.nodes[index])
+        graph.updatedAt = .now
+    }
+}
+
+private enum NodeOutcome: Sendable {
+    case success(
+        nodeID: UUID,
+        result: AgentTaskExecutionResult
+    )
+    case failure(
+        nodeID: UUID,
+        message: String
+    )
+}
+
+private extension AgentTaskNodeState {
+    var isTerminal: Bool {
+        switch self {
+        case .completed, .failed, .cancelled:
+            return true
+        case .pending, .blocked, .ready, .running:
+            return false
+        }
+    }
+}

--- a/Sources/OpenIslandCore/AgentObservability.swift
+++ b/Sources/OpenIslandCore/AgentObservability.swift
@@ -1,0 +1,311 @@
+import Foundation
+
+public enum AgentTimelineEventKind: String, Codable, Sendable {
+    case lifecycle
+    case status
+    case prompt
+    case tool
+    case permission
+    case question
+    case response
+    case completion
+    case system
+}
+
+public struct AgentTimelineEvent: Equatable, Identifiable, Codable, Sendable {
+    public var id: UUID
+    public var timestamp: Date
+    public var kind: AgentTimelineEventKind
+    public var title: String
+    public var detail: String?
+    public var toolName: String?
+
+    public init(
+        id: UUID = UUID(),
+        timestamp: Date,
+        kind: AgentTimelineEventKind,
+        title: String,
+        detail: String? = nil,
+        toolName: String? = nil
+    ) {
+        self.id = id
+        self.timestamp = timestamp
+        self.kind = kind
+        self.title = title
+        self.detail = detail
+        self.toolName = toolName
+    }
+
+    fileprivate var semanticKey: String {
+        [kind.rawValue, title, detail ?? "", toolName ?? ""].joined(separator: "\u{1f}")
+    }
+}
+
+public struct AgentSessionMetrics: Equatable, Codable, Sendable {
+    public var startedAt: Date?
+    public var lastEventAt: Date?
+    public var eventCount: Int
+    public var toolEventCount: Int
+    public var attentionEventCount: Int
+    public var completionCount: Int
+
+    public init(
+        startedAt: Date? = nil,
+        lastEventAt: Date? = nil,
+        eventCount: Int = 0,
+        toolEventCount: Int = 0,
+        attentionEventCount: Int = 0,
+        completionCount: Int = 0
+    ) {
+        self.startedAt = startedAt
+        self.lastEventAt = lastEventAt
+        self.eventCount = eventCount
+        self.toolEventCount = toolEventCount
+        self.attentionEventCount = attentionEventCount
+        self.completionCount = completionCount
+    }
+
+    public func elapsed(at referenceDate: Date = .now) -> TimeInterval {
+        guard let startedAt else {
+            return 0
+        }
+
+        let endDate = max(lastEventAt ?? referenceDate, referenceDate)
+        return max(0, endDate.timeIntervalSince(startedAt))
+    }
+}
+
+public struct AgentSessionObservability: Equatable, Codable, Sendable {
+    public static let defaultTimelineLimit = 250
+
+    public var timeline: [AgentTimelineEvent]
+    public var metrics: AgentSessionMetrics
+
+    public init(
+        timeline: [AgentTimelineEvent] = [],
+        metrics: AgentSessionMetrics = AgentSessionMetrics()
+    ) {
+        self.timeline = timeline
+        self.metrics = metrics
+    }
+
+    public mutating func record(
+        _ event: AgentTimelineEvent,
+        timelineLimit: Int = Self.defaultTimelineLimit
+    ) {
+        if let lastIndex = timeline.indices.last,
+           timeline[lastIndex].semanticKey == event.semanticKey {
+            timeline[lastIndex].timestamp = max(timeline[lastIndex].timestamp, event.timestamp)
+            metrics.lastEventAt = max(metrics.lastEventAt ?? event.timestamp, event.timestamp)
+            return
+        }
+
+        timeline.append(event)
+        if timeline.count > max(1, timelineLimit) {
+            timeline.removeFirst(timeline.count - max(1, timelineLimit))
+        }
+
+        metrics.startedAt = min(metrics.startedAt ?? event.timestamp, event.timestamp)
+        metrics.lastEventAt = max(metrics.lastEventAt ?? event.timestamp, event.timestamp)
+        metrics.eventCount += 1
+
+        switch event.kind {
+        case .tool:
+            metrics.toolEventCount += 1
+        case .permission, .question:
+            metrics.attentionEventCount += 1
+        case .completion:
+            metrics.completionCount += 1
+        case .lifecycle, .status, .prompt, .response, .system:
+            break
+        }
+    }
+}
+
+public extension AgentEvent {
+    var sessionID: String {
+        switch self {
+        case let .sessionStarted(payload): payload.sessionID
+        case let .activityUpdated(payload): payload.sessionID
+        case let .permissionRequested(payload): payload.sessionID
+        case let .questionAsked(payload): payload.sessionID
+        case let .sessionCompleted(payload): payload.sessionID
+        case let .jumpTargetUpdated(payload): payload.sessionID
+        case let .sessionMetadataUpdated(payload): payload.sessionID
+        case let .claudeSessionMetadataUpdated(payload): payload.sessionID
+        case let .geminiSessionMetadataUpdated(payload): payload.sessionID
+        case let .openCodeSessionMetadataUpdated(payload): payload.sessionID
+        case let .cursorSessionMetadataUpdated(payload): payload.sessionID
+        case let .actionableStateResolved(payload): payload.sessionID
+        }
+    }
+
+    var timestamp: Date {
+        switch self {
+        case let .sessionStarted(payload): payload.timestamp
+        case let .activityUpdated(payload): payload.timestamp
+        case let .permissionRequested(payload): payload.timestamp
+        case let .questionAsked(payload): payload.timestamp
+        case let .sessionCompleted(payload): payload.timestamp
+        case let .jumpTargetUpdated(payload): payload.timestamp
+        case let .sessionMetadataUpdated(payload): payload.timestamp
+        case let .claudeSessionMetadataUpdated(payload): payload.timestamp
+        case let .geminiSessionMetadataUpdated(payload): payload.timestamp
+        case let .openCodeSessionMetadataUpdated(payload): payload.timestamp
+        case let .cursorSessionMetadataUpdated(payload): payload.timestamp
+        case let .actionableStateResolved(payload): payload.timestamp
+        }
+    }
+
+    var timelineEvent: AgentTimelineEvent? {
+        switch self {
+        case let .sessionStarted(payload):
+            return AgentTimelineEvent(
+                timestamp: payload.timestamp,
+                kind: .lifecycle,
+                title: "Session started",
+                detail: payload.summary
+            )
+        case let .activityUpdated(payload):
+            return AgentTimelineEvent(
+                timestamp: payload.timestamp,
+                kind: payload.phase == .completed ? .completion : .status,
+                title: payload.phase.displayName,
+                detail: payload.summary
+            )
+        case let .permissionRequested(payload):
+            return AgentTimelineEvent(
+                timestamp: payload.timestamp,
+                kind: .permission,
+                title: payload.request.title,
+                detail: nonEmpty(payload.request.affectedPath) ?? payload.request.summary,
+                toolName: payload.request.toolName
+            )
+        case let .questionAsked(payload):
+            return AgentTimelineEvent(
+                timestamp: payload.timestamp,
+                kind: .question,
+                title: "Question asked",
+                detail: payload.prompt.title
+            )
+        case let .sessionCompleted(payload):
+            return AgentTimelineEvent(
+                timestamp: payload.timestamp,
+                kind: .completion,
+                title: payload.isInterrupt == true ? "Interrupted" : "Completed",
+                detail: payload.summary
+            )
+        case let .jumpTargetUpdated(payload):
+            return AgentTimelineEvent(
+                timestamp: payload.timestamp,
+                kind: .system,
+                title: "Jump target updated",
+                detail: "\(payload.jumpTarget.terminalApp) · \(payload.jumpTarget.workspaceName)"
+            )
+        case let .sessionMetadataUpdated(payload):
+            return metadataTimelineEvent(
+                timestamp: payload.timestamp,
+                currentTool: payload.codexMetadata.currentTool,
+                toolPreview: payload.codexMetadata.currentCommandPreview,
+                userPrompt: payload.codexMetadata.lastUserPrompt,
+                assistantMessage: payload.codexMetadata.lastAssistantMessage
+            )
+        case let .claudeSessionMetadataUpdated(payload):
+            return metadataTimelineEvent(
+                timestamp: payload.timestamp,
+                currentTool: payload.claudeMetadata.currentTool,
+                toolPreview: payload.claudeMetadata.currentToolInputPreview,
+                userPrompt: payload.claudeMetadata.lastUserPrompt,
+                assistantMessage: payload.claudeMetadata.lastAssistantMessage
+            )
+        case let .geminiSessionMetadataUpdated(payload):
+            return metadataTimelineEvent(
+                timestamp: payload.timestamp,
+                currentTool: nil,
+                toolPreview: nil,
+                userPrompt: payload.geminiMetadata.lastUserPrompt,
+                assistantMessage: payload.geminiMetadata.lastAssistantMessage
+            )
+        case let .openCodeSessionMetadataUpdated(payload):
+            return metadataTimelineEvent(
+                timestamp: payload.timestamp,
+                currentTool: payload.openCodeMetadata.currentTool,
+                toolPreview: payload.openCodeMetadata.currentToolInputPreview,
+                userPrompt: payload.openCodeMetadata.lastUserPrompt,
+                assistantMessage: payload.openCodeMetadata.lastAssistantMessage
+            )
+        case let .cursorSessionMetadataUpdated(payload):
+            return metadataTimelineEvent(
+                timestamp: payload.timestamp,
+                currentTool: payload.cursorMetadata.currentTool,
+                toolPreview: payload.cursorMetadata.currentCommandPreview
+                    ?? payload.cursorMetadata.currentToolInputPreview,
+                userPrompt: payload.cursorMetadata.lastUserPrompt,
+                assistantMessage: payload.cursorMetadata.lastAssistantMessage
+            )
+        case let .actionableStateResolved(payload):
+            return AgentTimelineEvent(
+                timestamp: payload.timestamp,
+                kind: .status,
+                title: "Interaction resolved",
+                detail: payload.summary
+            )
+        }
+    }
+}
+
+private func metadataTimelineEvent(
+    timestamp: Date,
+    currentTool: String?,
+    toolPreview: String?,
+    userPrompt: String?,
+    assistantMessage: String?
+) -> AgentTimelineEvent? {
+    if let currentTool = nonEmpty(currentTool) {
+        return AgentTimelineEvent(
+            timestamp: timestamp,
+            kind: .tool,
+            title: "Using \(currentTool)",
+            detail: clipped(nonEmpty(toolPreview)),
+            toolName: currentTool
+        )
+    }
+
+    if let assistantMessage = clipped(nonEmpty(assistantMessage)) {
+        return AgentTimelineEvent(
+            timestamp: timestamp,
+            kind: .response,
+            title: "Assistant replied",
+            detail: assistantMessage
+        )
+    }
+
+    if let userPrompt = clipped(nonEmpty(userPrompt)) {
+        return AgentTimelineEvent(
+            timestamp: timestamp,
+            kind: .prompt,
+            title: "Prompt received",
+            detail: userPrompt
+        )
+    }
+
+    return nil
+}
+
+private func nonEmpty(_ value: String?) -> String? {
+    guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+          !value.isEmpty else {
+        return nil
+    }
+    return value
+}
+
+private func clipped(_ value: String?, limit: Int = 240) -> String? {
+    guard let value else {
+        return nil
+    }
+    guard value.count > limit else {
+        return value
+    }
+    return "\(value.prefix(limit))…"
+}

--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -373,6 +373,7 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
     public var geminiMetadata: GeminiSessionMetadata?
     public var openCodeMetadata: OpenCodeSessionMetadata?
     public var cursorMetadata: CursorSessionMetadata?
+    public var observability: AgentSessionObservability
 
     /// Whether this session originates from a remote (SSH) connection.
     public var isRemote: Bool = false
@@ -418,7 +419,8 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
         claudeMetadata: ClaudeSessionMetadata? = nil,
         geminiMetadata: GeminiSessionMetadata? = nil,
         openCodeMetadata: OpenCodeSessionMetadata? = nil,
-        cursorMetadata: CursorSessionMetadata? = nil
+        cursorMetadata: CursorSessionMetadata? = nil,
+        observability: AgentSessionObservability = AgentSessionObservability()
     ) {
         self.id = id
         self.title = title
@@ -437,6 +439,7 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
         self.geminiMetadata = geminiMetadata
         self.openCodeMetadata = openCodeMetadata
         self.cursorMetadata = cursorMetadata
+        self.observability = observability
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -457,6 +460,7 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
         case geminiMetadata
         case openCodeMetadata
         case cursorMetadata
+        case observability
     }
 
     public init(from decoder: any Decoder) throws {
@@ -478,6 +482,8 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
         geminiMetadata = try container.decodeIfPresent(GeminiSessionMetadata.self, forKey: .geminiMetadata)
         openCodeMetadata = try container.decodeIfPresent(OpenCodeSessionMetadata.self, forKey: .openCodeMetadata)
         cursorMetadata = try container.decodeIfPresent(CursorSessionMetadata.self, forKey: .cursorMetadata)
+        observability = try container.decodeIfPresent(AgentSessionObservability.self, forKey: .observability)
+            ?? AgentSessionObservability()
     }
 
     public func encode(to encoder: any Encoder) throws {
@@ -499,6 +505,7 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
         try container.encodeIfPresent(geminiMetadata, forKey: .geminiMetadata)
         try container.encodeIfPresent(openCodeMetadata, forKey: .openCodeMetadata)
         try container.encodeIfPresent(cursorMetadata, forKey: .cursorMetadata)
+        try container.encode(observability, forKey: .observability)
     }
 }
 
@@ -524,17 +531,17 @@ public extension AgentSession {
     /// signals; non-hook sessions use process polling.
     var isVisibleInIsland: Bool {
         if isDemoSession { return true }
-        if phase.requiresAttention { return true }
-        // Codex.app sessions stay visible while the desktop app is running,
-        // except when the thread was archived/ended or the row has gone stale.
+        // Codex.app is a multi-thread host process, so app-level liveness is
+        // not evidence that an individual idle or completed thread is active.
         // Checked before isHookManaged because a Codex.app session may also
         // be hook-managed (when both hook and rediscovery converge on it).
         if isCodexAppSession {
             if isSessionEnded {
                 return false
             }
-            return isProcessAlive
+            return isProcessAlive && (phase == .running || phase.requiresAttention)
         }
+        if phase.requiresAttention { return true }
         if isHookManaged { return !isSessionEnded }
         if isProcessAlive { return true }
         return false

--- a/Sources/OpenIslandCore/AgentTaskGraph.swift
+++ b/Sources/OpenIslandCore/AgentTaskGraph.swift
@@ -1,0 +1,189 @@
+import Foundation
+
+/// Recovered graph-prototype state.
+///
+/// This type remains a compatibility model while authoritative execution
+/// lifecycle moves into the run/attempt/process model. New adapters should
+/// not persist process truth in this enum.
+public enum AgentTaskNodeState: String, Codable, CaseIterable, Sendable {
+    case pending
+    case blocked
+    case ready
+    case running
+    case completed
+    case failed
+    case cancelled
+}
+
+public enum AgentExecutionKind: String, Codable, CaseIterable, Sendable {
+    case codex
+    case gemini
+    case openCode
+    case ollama
+    case openClaw
+    case human
+}
+
+public struct AgentTaskNode: Identifiable, Codable, Equatable, Sendable {
+    public let id: UUID
+    public var title: String
+    public var instructions: String
+    public var executionKind: AgentExecutionKind
+    public var agentProfile: String?
+    public var state: AgentTaskNodeState
+    public var output: String?
+    public var errorMessage: String?
+    public var startedAt: Date?
+    public var completedAt: Date?
+
+    public init(
+        id: UUID = UUID(),
+        title: String,
+        instructions: String,
+        executionKind: AgentExecutionKind,
+        agentProfile: String? = nil,
+        state: AgentTaskNodeState = .pending,
+        output: String? = nil,
+        errorMessage: String? = nil,
+        startedAt: Date? = nil,
+        completedAt: Date? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.instructions = instructions
+        self.executionKind = executionKind
+        self.agentProfile = agentProfile
+        self.state = state
+        self.output = output
+        self.errorMessage = errorMessage
+        self.startedAt = startedAt
+        self.completedAt = completedAt
+    }
+}
+
+public struct AgentTaskEdge: Identifiable, Codable, Equatable, Sendable {
+    public let id: UUID
+    public let sourceNodeID: UUID
+    public let destinationNodeID: UUID
+
+    public init(
+        id: UUID = UUID(),
+        sourceNodeID: UUID,
+        destinationNodeID: UUID
+    ) {
+        self.id = id
+        self.sourceNodeID = sourceNodeID
+        self.destinationNodeID = destinationNodeID
+    }
+}
+
+public struct AgentTaskGraph: Identifiable, Codable, Equatable, Sendable {
+    public let id: UUID
+    public var title: String
+    public var nodes: [AgentTaskNode]
+    public var edges: [AgentTaskEdge]
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        title: String,
+        nodes: [AgentTaskNode] = [],
+        edges: [AgentTaskEdge] = [],
+        createdAt: Date = .now,
+        updatedAt: Date = .now
+    ) {
+        self.id = id
+        self.title = title
+        self.nodes = nodes
+        self.edges = edges
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    public func dependencies(of nodeID: UUID) -> [AgentTaskNode] {
+        let dependencyIDs = edges
+            .filter { $0.destinationNodeID == nodeID }
+            .map(\.sourceNodeID)
+
+        return nodes.filter { dependencyIDs.contains($0.id) }
+    }
+
+    public func dependents(of nodeID: UUID) -> [AgentTaskNode] {
+        let dependentIDs = edges
+            .filter { $0.sourceNodeID == nodeID }
+            .map(\.destinationNodeID)
+
+        return nodes.filter { dependentIDs.contains($0.id) }
+    }
+
+    public func node(withID nodeID: UUID) -> AgentTaskNode? {
+        nodes.first { $0.id == nodeID }
+    }
+
+    public func isReady(_ node: AgentTaskNode) -> Bool {
+        guard node.state == .pending
+                || node.state == .blocked
+                || node.state == .ready else {
+            return false
+        }
+
+        let dependencies = dependencies(of: node.id)
+        return dependencies.allSatisfy { $0.state == .completed }
+    }
+
+    public func containsCycle() -> Bool {
+        var visiting: Set<UUID> = []
+        var visited: Set<UUID> = []
+
+        func visit(_ nodeID: UUID) -> Bool {
+            if visiting.contains(nodeID) {
+                return true
+            }
+
+            if visited.contains(nodeID) {
+                return false
+            }
+
+            visiting.insert(nodeID)
+
+            for dependent in dependents(of: nodeID) {
+                if visit(dependent.id) {
+                    return true
+                }
+            }
+
+            visiting.remove(nodeID)
+            visited.insert(nodeID)
+            return false
+        }
+
+        return nodes.contains { visit($0.id) }
+    }
+
+    public mutating func refreshSchedulingStates() {
+        for index in nodes.indices {
+            switch nodes[index].state {
+            case .completed, .failed, .cancelled, .running:
+                continue
+
+            case .pending, .blocked, .ready:
+                let dependencies = dependencies(of: nodes[index].id)
+
+                if dependencies.contains(where: {
+                    $0.state == .failed || $0.state == .cancelled
+                }) {
+                    nodes[index].state = .blocked
+                } else if dependencies.allSatisfy({
+                    $0.state == .completed
+                }) {
+                    nodes[index].state = .ready
+                } else {
+                    nodes[index].state = .blocked
+                }
+            }
+        }
+
+        updatedAt = .now
+    }
+}

--- a/Sources/OpenIslandCore/ClaudeSessionRegistry.swift
+++ b/Sources/OpenIslandCore/ClaudeSessionRegistry.swift
@@ -11,6 +11,7 @@ public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
     public var firstSeenAt: Date?
     public var jumpTarget: JumpTarget?
     public var claudeMetadata: ClaudeSessionMetadata?
+    public var observability: AgentSessionObservability?
 
     public init(
         sessionID: String,
@@ -22,7 +23,8 @@ public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
         updatedAt: Date,
         firstSeenAt: Date? = nil,
         jumpTarget: JumpTarget? = nil,
-        claudeMetadata: ClaudeSessionMetadata? = nil
+        claudeMetadata: ClaudeSessionMetadata? = nil,
+        observability: AgentSessionObservability? = nil
     ) {
         self.sessionID = sessionID
         self.title = title
@@ -34,6 +36,7 @@ public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
         self.firstSeenAt = firstSeenAt
         self.jumpTarget = jumpTarget
         self.claudeMetadata = claudeMetadata
+        self.observability = observability
     }
 
     public init(session: AgentSession) {
@@ -47,7 +50,8 @@ public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
             updatedAt: session.updatedAt,
             firstSeenAt: session.firstSeenAt,
             jumpTarget: session.jumpTarget,
-            claudeMetadata: session.claudeMetadata
+            claudeMetadata: session.claudeMetadata,
+            observability: session.observability
         )
     }
 
@@ -63,7 +67,8 @@ public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
             updatedAt: updatedAt,
             firstSeenAt: firstSeenAt,
             jumpTarget: jumpTarget,
-            claudeMetadata: claudeMetadata
+            claudeMetadata: claudeMetadata,
+            observability: observability ?? AgentSessionObservability()
         )
     }
 
@@ -84,6 +89,7 @@ public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
         case firstSeenAt
         case jumpTarget
         case claudeMetadata
+        case observability
     }
 
     public init(from decoder: any Decoder) throws {
@@ -98,6 +104,7 @@ public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
         firstSeenAt = try container.decodeIfPresent(Date.self, forKey: .firstSeenAt)
         jumpTarget = try container.decodeIfPresent(JumpTarget.self, forKey: .jumpTarget)
         claudeMetadata = try container.decodeIfPresent(ClaudeSessionMetadata.self, forKey: .claudeMetadata)
+        observability = try container.decodeIfPresent(AgentSessionObservability.self, forKey: .observability)
     }
 
     public func encode(to encoder: any Encoder) throws {
@@ -112,6 +119,7 @@ public struct ClaudeTrackedSessionRecord: Equatable, Codable, Sendable {
         try container.encodeIfPresent(firstSeenAt, forKey: .firstSeenAt)
         try container.encodeIfPresent(jumpTarget, forKey: .jumpTarget)
         try container.encodeIfPresent(claudeMetadata, forKey: .claudeMetadata)
+        try container.encodeIfPresent(observability, forKey: .observability)
     }
 }
 

--- a/Sources/OpenIslandCore/CodexSessionTracking.swift
+++ b/Sources/OpenIslandCore/CodexSessionTracking.swift
@@ -157,7 +157,9 @@ public extension CodexTrackedSessionRecord {
     }
 
     var shouldRestoreToLiveState: Bool {
-        origin != .demo && !LegacyMockSessionIDs.all.contains(sessionID)
+        origin != .demo
+            && !LegacyMockSessionIDs.all.contains(sessionID)
+            && phase != .completed
     }
 }
 

--- a/Sources/OpenIslandCore/CodexSessionTracking.swift
+++ b/Sources/OpenIslandCore/CodexSessionTracking.swift
@@ -45,6 +45,7 @@ public struct CodexTrackedSessionRecord: Equatable, Codable, Sendable {
     public var updatedAt: Date
     public var jumpTarget: JumpTarget?
     public var codexMetadata: CodexSessionMetadata?
+    public var observability: AgentSessionObservability?
 
     public init(
         sessionID: String,
@@ -55,7 +56,8 @@ public struct CodexTrackedSessionRecord: Equatable, Codable, Sendable {
         phase: SessionPhase,
         updatedAt: Date,
         jumpTarget: JumpTarget? = nil,
-        codexMetadata: CodexSessionMetadata? = nil
+        codexMetadata: CodexSessionMetadata? = nil,
+        observability: AgentSessionObservability? = nil
     ) {
         self.sessionID = sessionID
         self.title = title
@@ -66,6 +68,7 @@ public struct CodexTrackedSessionRecord: Equatable, Codable, Sendable {
         self.updatedAt = updatedAt
         self.jumpTarget = jumpTarget
         self.codexMetadata = codexMetadata
+        self.observability = observability
     }
 
     public init(session: AgentSession) {
@@ -78,7 +81,8 @@ public struct CodexTrackedSessionRecord: Equatable, Codable, Sendable {
             phase: session.phase,
             updatedAt: session.updatedAt,
             jumpTarget: session.jumpTarget,
-            codexMetadata: session.codexMetadata
+            codexMetadata: session.codexMetadata,
+            observability: session.observability
         )
     }
 
@@ -93,7 +97,8 @@ public struct CodexTrackedSessionRecord: Equatable, Codable, Sendable {
             summary: summary,
             updatedAt: updatedAt,
             jumpTarget: jumpTarget,
-            codexMetadata: codexMetadata
+            codexMetadata: codexMetadata,
+            observability: observability ?? AgentSessionObservability()
         )
         // Re-derive the Codex.app flag from the persisted terminalApp so
         // restarted sessions continue to use app-level liveness rather than
@@ -112,6 +117,7 @@ public struct CodexTrackedSessionRecord: Equatable, Codable, Sendable {
         case updatedAt
         case jumpTarget
         case codexMetadata
+        case observability
     }
 
     public init(from decoder: any Decoder) throws {
@@ -125,6 +131,7 @@ public struct CodexTrackedSessionRecord: Equatable, Codable, Sendable {
         updatedAt = try container.decode(Date.self, forKey: .updatedAt)
         jumpTarget = try container.decodeIfPresent(JumpTarget.self, forKey: .jumpTarget)
         codexMetadata = try container.decodeIfPresent(CodexSessionMetadata.self, forKey: .codexMetadata)
+        observability = try container.decodeIfPresent(AgentSessionObservability.self, forKey: .observability)
     }
 
     public func encode(to encoder: any Encoder) throws {
@@ -138,6 +145,7 @@ public struct CodexTrackedSessionRecord: Equatable, Codable, Sendable {
         try container.encode(updatedAt, forKey: .updatedAt)
         try container.encodeIfPresent(jumpTarget, forKey: .jumpTarget)
         try container.encodeIfPresent(codexMetadata, forKey: .codexMetadata)
+        try container.encodeIfPresent(observability, forKey: .observability)
     }
 }
 

--- a/Sources/OpenIslandCore/CursorSessionRegistry.swift
+++ b/Sources/OpenIslandCore/CursorSessionRegistry.swift
@@ -10,6 +10,7 @@ public struct CursorTrackedSessionRecord: Equatable, Codable, Sendable {
     public var updatedAt: Date
     public var jumpTarget: JumpTarget?
     public var cursorMetadata: CursorSessionMetadata?
+    public var observability: AgentSessionObservability?
 
     public init(
         sessionID: String,
@@ -20,7 +21,8 @@ public struct CursorTrackedSessionRecord: Equatable, Codable, Sendable {
         phase: SessionPhase,
         updatedAt: Date,
         jumpTarget: JumpTarget? = nil,
-        cursorMetadata: CursorSessionMetadata? = nil
+        cursorMetadata: CursorSessionMetadata? = nil,
+        observability: AgentSessionObservability? = nil
     ) {
         self.sessionID = sessionID
         self.title = title
@@ -31,6 +33,7 @@ public struct CursorTrackedSessionRecord: Equatable, Codable, Sendable {
         self.updatedAt = updatedAt
         self.jumpTarget = jumpTarget
         self.cursorMetadata = cursorMetadata
+        self.observability = observability
     }
 
     public init(session: AgentSession) {
@@ -43,7 +46,8 @@ public struct CursorTrackedSessionRecord: Equatable, Codable, Sendable {
             phase: session.phase,
             updatedAt: session.updatedAt,
             jumpTarget: session.jumpTarget,
-            cursorMetadata: session.cursorMetadata
+            cursorMetadata: session.cursorMetadata,
+            observability: session.observability
         )
     }
 
@@ -58,7 +62,8 @@ public struct CursorTrackedSessionRecord: Equatable, Codable, Sendable {
             summary: summary,
             updatedAt: updatedAt,
             jumpTarget: jumpTarget,
-            cursorMetadata: cursorMetadata
+            cursorMetadata: cursorMetadata,
+            observability: observability ?? AgentSessionObservability()
         )
     }
 

--- a/Sources/OpenIslandCore/DeterministicGraphExecutor.swift
+++ b/Sources/OpenIslandCore/DeterministicGraphExecutor.swift
@@ -102,12 +102,20 @@ public struct GraphDeterministicExecutionScript:
         nodeID: String,
         ordinal: Int
     ) -> GraphDeterministicAttemptScript {
+        configuredAttempt(nodeID: nodeID, ordinal: ordinal)
+            ?? GraphDeterministicAttemptScript(
+                nodeID: nodeID,
+                attemptOrdinal: ordinal
+            )
+    }
+
+    public func configuredAttempt(
+        nodeID: String,
+        ordinal: Int
+    ) -> GraphDeterministicAttemptScript? {
         attempts.first {
             $0.nodeID == nodeID && $0.attemptOrdinal == ordinal
-        } ?? GraphDeterministicAttemptScript(
-            nodeID: nodeID,
-            attemptOrdinal: ordinal
-        )
+        }
     }
 }
 
@@ -212,8 +220,12 @@ public struct DeterministicGraphExecutor:
     ) async throws -> GraphExecutorCollectResultResponse {
         let attempt = scriptedAttempt(request.context)
         let (status, failure) = terminalStatus(attempt)
+        let roles = script.configuredAttempt(
+            nodeID: request.context.identity.nodeID,
+            ordinal: request.context.identity.attemptOrdinal
+        ) == nil ? specificationArtifactRoles(request.context) : attempt.artifactRoles
         let artifacts = status == .succeeded
-            ? attempt.artifactRoles.map {
+            ? roles.map {
                 artifact(role: $0, context: request.context)
             }
             : []
@@ -377,5 +389,16 @@ public struct DeterministicGraphExecutor:
                 opaqueReference: digest
             )
         )
+    }
+
+    private func specificationArtifactRoles(
+        _ context: GraphExecutorCommandContext
+    ) -> [GraphArtifactRole] {
+        guard case let .string(value) = context.specification.parameters[
+            "artifactRole"
+        ], let role = GraphArtifactRole(rawValue: value) else {
+            return [.nodeOutput]
+        }
+        return [role]
     }
 }

--- a/Sources/OpenIslandCore/DeterministicGraphExecutor.swift
+++ b/Sources/OpenIslandCore/DeterministicGraphExecutor.swift
@@ -1,0 +1,381 @@
+import CryptoKit
+import Foundation
+
+public enum GraphDeterministicTerminalOutcome:
+    String,
+    Codable,
+    Sendable
+{
+    case succeed
+    case retryableFailure = "retryable_failure"
+    case nonRetryableFailure = "non_retryable_failure"
+    case remainRunning = "remain_running"
+    case interrupted
+}
+
+public enum GraphDeterministicCancellationBehavior:
+    String,
+    Codable,
+    Sendable
+{
+    case acknowledge
+    case ignoreUntilTimeout = "ignore_until_timeout"
+}
+
+public enum GraphDeterministicCrashPoint: String, Codable, Sendable {
+    case afterAttemptStartPersistence = "after_attempt_start_persistence"
+    case afterAcceptingStart = "after_accepting_start"
+}
+
+public struct GraphDeterministicAttemptScript:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public var id: String { "\(nodeID)#\(attemptOrdinal)" }
+
+    public let nodeID: String
+    public let attemptOrdinal: Int
+    public let runningPollCount: Int
+    public let terminalOutcome: GraphDeterministicTerminalOutcome
+    public let failureCategory: String?
+    public let cancellationBehavior: GraphDeterministicCancellationBehavior
+    public let crashPoint: GraphDeterministicCrashPoint?
+    public let artifactRoles: [GraphArtifactRole]
+    public let duplicateObservations: Bool
+    public let staleLeaseGenerationOffset: Int
+
+    public init(
+        nodeID: String,
+        attemptOrdinal: Int,
+        runningPollCount: Int = 0,
+        terminalOutcome: GraphDeterministicTerminalOutcome = .succeed,
+        failureCategory: String? = nil,
+        cancellationBehavior: GraphDeterministicCancellationBehavior =
+            .acknowledge,
+        crashPoint: GraphDeterministicCrashPoint? = nil,
+        artifactRoles: [GraphArtifactRole] = [.nodeOutput],
+        duplicateObservations: Bool = false,
+        staleLeaseGenerationOffset: Int = 0
+    ) {
+        self.nodeID = nodeID
+        self.attemptOrdinal = attemptOrdinal
+        self.runningPollCount = max(0, runningPollCount)
+        self.terminalOutcome = terminalOutcome
+        self.failureCategory = failureCategory
+        self.cancellationBehavior = cancellationBehavior
+        self.crashPoint = crashPoint
+        self.artifactRoles = artifactRoles.sorted {
+            $0.rawValue < $1.rawValue
+        }
+        self.duplicateObservations = duplicateObservations
+        self.staleLeaseGenerationOffset = min(
+            0,
+            staleLeaseGenerationOffset
+        )
+    }
+}
+
+public struct GraphDeterministicExecutionScript:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let schemaVersion: Int
+    public let attempts: [GraphDeterministicAttemptScript]
+
+    public init(
+        schemaVersion: Int = 1,
+        attempts: [GraphDeterministicAttemptScript]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.attempts = attempts.sorted {
+            if $0.nodeID != $1.nodeID {
+                return $0.nodeID < $1.nodeID
+            }
+            return $0.attemptOrdinal < $1.attemptOrdinal
+        }
+    }
+
+    public func attempt(
+        nodeID: String,
+        ordinal: Int
+    ) -> GraphDeterministicAttemptScript {
+        attempts.first {
+            $0.nodeID == nodeID && $0.attemptOrdinal == ordinal
+        } ?? GraphDeterministicAttemptScript(
+            nodeID: nodeID,
+            attemptOrdinal: ordinal
+        )
+    }
+}
+
+public struct DeterministicGraphExecutor:
+    GraphExecutorAdapter,
+    Sendable
+{
+    public let capabilities: GraphExecutorCapabilities
+    public let script: GraphDeterministicExecutionScript
+
+    public init(
+        executorID: String = "openisland.deterministic",
+        capabilityIdentity: String = "deterministic-v1",
+        capabilities: [String] = ["compendium"],
+        script: GraphDeterministicExecutionScript
+    ) {
+        self.capabilities = GraphExecutorCapabilities(
+            executorID: executorID,
+            capabilityIdentity: capabilityIdentity,
+            capabilities: capabilities,
+            hostID: "in-process"
+        )
+        self.script = script
+    }
+
+    public func prepare(
+        _ request: GraphExecutorPrepareRequest
+    ) async throws -> GraphExecutorPrepareResponse {
+        GraphExecutorPrepareResponse(
+            observation: observation(
+                operation: .prepare,
+                status: .accepted,
+                context: request.context
+            )
+        )
+    }
+
+    public func start(
+        _ request: GraphExecutorStartRequest
+    ) async throws -> GraphExecutorStartResponse {
+        let attempt = scriptedAttempt(request.context)
+        if attempt.crashPoint == .afterAttemptStartPersistence {
+            throw GraphExecutorAdapterError.simulatedCrash(
+                GraphDeterministicCrashPoint
+                    .afterAttemptStartPersistence.rawValue
+            )
+        }
+        return GraphExecutorStartResponse(
+            observation: observation(
+                operation: .start,
+                status: attempt.crashPoint == .afterAcceptingStart
+                    ? .accepted
+                    : .started,
+                context: request.context,
+                script: attempt
+            )
+        )
+    }
+
+    public func observe(
+        _ request: GraphExecutorObserveRequest
+    ) async throws -> GraphExecutorObserveResponse {
+        let attempt = scriptedAttempt(request.context)
+        let status: GraphExecutorResponseStatus
+        let failure: GraphExecutorFailure?
+        if request.context.priorObservationCount
+            < attempt.runningPollCount {
+            status = .stillRunning
+            failure = nil
+        } else {
+            (status, failure) = terminalStatus(attempt)
+        }
+        return GraphExecutorObserveResponse(
+            observation: observation(
+                operation: .observe,
+                status: status,
+                context: request.context,
+                script: attempt,
+                failure: failure
+            )
+        )
+    }
+
+    public func requestCancellation(
+        _ request: GraphExecutorCancellationRequest
+    ) async throws -> GraphExecutorCancellationResponse {
+        let attempt = scriptedAttempt(request.context)
+        return GraphExecutorCancellationResponse(
+            observation: observation(
+                operation: .requestCancellation,
+                status: attempt.cancellationBehavior == .acknowledge
+                    ? .cancelled
+                    : .stillRunning,
+                context: request.context,
+                script: attempt
+            )
+        )
+    }
+
+    public func collectResult(
+        _ request: GraphExecutorCollectResultRequest
+    ) async throws -> GraphExecutorCollectResultResponse {
+        let attempt = scriptedAttempt(request.context)
+        let (status, failure) = terminalStatus(attempt)
+        let artifacts = status == .succeeded
+            ? attempt.artifactRoles.map {
+                artifact(role: $0, context: request.context)
+            }
+            : []
+        return GraphExecutorCollectResultResponse(
+            observation: observation(
+                operation: .collectResult,
+                status: status,
+                context: request.context,
+                script: attempt,
+                failure: failure,
+                artifacts: artifacts
+            )
+        )
+    }
+
+    public func cleanup(
+        _ request: GraphExecutorCleanupRequest
+    ) async throws -> GraphExecutorCleanupResponse {
+        GraphExecutorCleanupResponse(
+            observation: observation(
+                operation: .cleanup,
+                status: .accepted,
+                context: request.context
+            )
+        )
+    }
+
+    public func recover(
+        _ request: GraphExecutorRecoverRequest
+    ) async throws -> GraphExecutorRecoverResponse {
+        GraphExecutorRecoverResponse(
+            observation: observation(
+                operation: .recover,
+                status: .started,
+                context: request.context,
+                script: scriptedAttempt(request.context)
+            )
+        )
+    }
+
+    private func scriptedAttempt(
+        _ context: GraphExecutorCommandContext
+    ) -> GraphDeterministicAttemptScript {
+        script.attempt(
+            nodeID: context.identity.nodeID,
+            ordinal: context.identity.attemptOrdinal
+        )
+    }
+
+    private func terminalStatus(
+        _ attempt: GraphDeterministicAttemptScript
+    ) -> (GraphExecutorResponseStatus, GraphExecutorFailure?) {
+        switch attempt.terminalOutcome {
+        case .succeed:
+            (.succeeded, nil)
+        case .retryableFailure:
+            (
+                .failed,
+                GraphExecutorFailure(
+                    category: attempt.failureCategory ?? "transient",
+                    retryable: true
+                )
+            )
+        case .nonRetryableFailure:
+            (
+                .failed,
+                GraphExecutorFailure(
+                    category: attempt.failureCategory ?? "invalid_input",
+                    retryable: false
+                )
+            )
+        case .remainRunning:
+            (.stillRunning, nil)
+        case .interrupted:
+            (.interrupted, nil)
+        }
+    }
+
+    private func observation(
+        operation: GraphExecutorOperation,
+        status: GraphExecutorResponseStatus,
+        context: GraphExecutorCommandContext,
+        script: GraphDeterministicAttemptScript? = nil,
+        failure: GraphExecutorFailure? = nil,
+        artifacts: [GraphExecutorProducedArtifact] = []
+    ) -> GraphExecutorObservation {
+        let scripted = script ?? scriptedAttempt(context)
+        let identity = fencedIdentity(
+            context.identity,
+            generationOffset: scripted.staleLeaseGenerationOffset
+        )
+        let count = scripted.duplicateObservations
+            ? 0
+            : context.priorObservationCount
+        let material = [
+            identity.runID,
+            identity.nodeID,
+            String(identity.attemptOrdinal),
+            identity.claimID,
+            String(identity.leaseGeneration),
+            operation.rawValue,
+            String(count),
+            status.rawValue,
+        ].joined(separator: "|")
+        return GraphExecutorObservation(
+            id: "det-\(DefaultGraphMutationService.stableID(material))",
+            operation: operation,
+            identity: identity,
+            status: status,
+            observedAt: context.logicalTime,
+            failure: failure,
+            artifacts: artifacts
+        )
+    }
+
+    private func fencedIdentity(
+        _ identity: GraphExecutorInteractionIdentity,
+        generationOffset: Int
+    ) -> GraphExecutorInteractionIdentity {
+        let generation = generationOffset < 0
+            ? identity.leaseGeneration
+                .subtractingReportingOverflow(
+                    UInt64(-generationOffset)
+                ).partialValue
+            : identity.leaseGeneration
+        return GraphExecutorInteractionIdentity(
+            runID: identity.runID,
+            nodeID: identity.nodeID,
+            attemptID: identity.attemptID,
+            attemptOrdinal: identity.attemptOrdinal,
+            claimID: identity.claimID,
+            leaseGeneration: generation,
+            executorID: identity.executorID
+        )
+    }
+
+    private func artifact(
+        role: GraphArtifactRole,
+        context: GraphExecutorCommandContext
+    ) -> GraphExecutorProducedArtifact {
+        let material = [
+            context.identity.runID,
+            context.identity.nodeID,
+            String(context.identity.attemptOrdinal),
+            context.specification.operation,
+            role.rawValue,
+            context.inputArtifacts.map(\.id).joined(separator: ","),
+        ].joined(separator: "|")
+        let digest = SHA256.hash(data: Data(material.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+        return GraphExecutorProducedArtifact(
+            contentDigest: GraphContentDigest(
+                algorithm: "sha256",
+                value: digest
+            ),
+            mediaType: "application/json",
+            role: role,
+            storage: GraphArtifactStorageLocator(
+                scheme: "deterministic",
+                opaqueReference: digest
+            )
+        )
+    }
+}

--- a/Sources/OpenIslandCore/GraphAttemptLifecycle.swift
+++ b/Sources/OpenIslandCore/GraphAttemptLifecycle.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+public enum GraphAttemptLifecyclePhase:
+    String,
+    Codable,
+    CaseIterable,
+    Sendable
+{
+    case created
+    case claimed
+    case startRequested = "start_requested"
+    case started
+    case running
+    case cancellationRequested = "cancellation_requested"
+    case terminal
+    case claimReleased = "claim_released"
+}
+
+public struct GraphAttemptLifecycleRecord:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public var id: String { attemptID }
+
+    public let attemptID: String
+    public let nodeID: String
+    public let ordinal: Int
+    public var phase: GraphAttemptLifecyclePhase
+    public var claimID: String?
+    public var leaseGeneration: UInt64?
+    public var executorID: String?
+    public var updatedAt: Date
+
+    public init(
+        attemptID: String,
+        nodeID: String,
+        ordinal: Int,
+        phase: GraphAttemptLifecyclePhase,
+        claimID: String? = nil,
+        leaseGeneration: UInt64? = nil,
+        executorID: String? = nil,
+        updatedAt: Date
+    ) {
+        self.attemptID = attemptID
+        self.nodeID = nodeID
+        self.ordinal = ordinal
+        self.phase = phase
+        self.claimID = claimID
+        self.leaseGeneration = leaseGeneration
+        self.executorID = executorID
+        self.updatedAt = updatedAt
+    }
+}

--- a/Sources/OpenIslandCore/GraphAuthoringDefinition.swift
+++ b/Sources/OpenIslandCore/GraphAuthoringDefinition.swift
@@ -1,0 +1,264 @@
+import Foundation
+
+public enum GraphDefinitionNodeType: String, Codable, CaseIterable, Sendable {
+    case localProcess = "local_process"
+    case deterministicTest = "deterministic_test"
+    case genericAgent = "generic_agent"
+    case input
+    case output
+    case annotation
+
+    public var isExecutable: Bool {
+        switch self {
+        case .localProcess, .deterministicTest, .genericAgent:
+            true
+        case .input, .output, .annotation:
+            false
+        }
+    }
+
+    public var isRunnable: Bool {
+        self == .localProcess || self == .deterministicTest
+    }
+}
+
+public enum GraphDefinitionExecutorKind: String, Codable, CaseIterable, Sendable {
+    case supervisedLocalProcess = "local_process"
+    case deterministicTest = "deterministic"
+    case unboundAgent = "generic_agent"
+    case none
+
+    public var displayName: String {
+        switch self {
+        case .supervisedLocalProcess: "Supervised Local Process"
+        case .deterministicTest: "Deterministic Test Executor"
+        case .unboundAgent: "Generic Agent (not configured)"
+        case .none: "No Executor"
+        }
+    }
+}
+
+public enum GraphDefinitionPortType: String, Codable, CaseIterable, Sendable {
+    case dependency
+    case artifact
+    case stream
+    case signal
+}
+
+public enum GraphNodeInputBindingKind: String, Codable, CaseIterable, Sendable {
+    case graphInput = "graph_input"
+    case upstreamArtifact = "upstream_artifact"
+    case upstreamArtifactCollection = "upstream_artifact_collection"
+    case staticLiteral = "static_literal"
+    case fileReference = "file_reference"
+    case secretReference = "secret_reference"
+}
+
+public struct GraphNodeInputBinding: Equatable, Codable, Sendable {
+    public var kind: GraphNodeInputBindingKind
+    public var graphInputID: String?
+    public var sourceNodeID: String?
+    public var sourceOutputID: String?
+    public var literalValue: GraphJSONValue?
+    public var fileReference: String?
+    public var secretReference: String?
+
+    public init(
+        kind: GraphNodeInputBindingKind,
+        graphInputID: String? = nil,
+        sourceNodeID: String? = nil,
+        sourceOutputID: String? = nil,
+        literalValue: GraphJSONValue? = nil,
+        fileReference: String? = nil,
+        secretReference: String? = nil
+    ) {
+        self.kind = kind
+        self.graphInputID = graphInputID
+        self.sourceNodeID = sourceNodeID
+        self.sourceOutputID = sourceOutputID
+        self.literalValue = literalValue
+        self.fileReference = fileReference
+        self.secretReference = secretReference
+    }
+}
+
+public struct GraphNodeInputDefinition:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public let id: String
+    public var name: String
+    public var portType: GraphDefinitionPortType
+    public var mediaType: String
+    public var isRequired: Bool
+    public var allowsMultiple: Bool
+    public var binding: GraphNodeInputBinding?
+
+    public init(
+        id: String,
+        name: String,
+        portType: GraphDefinitionPortType = .artifact,
+        mediaType: String = "application/octet-stream",
+        isRequired: Bool = true,
+        allowsMultiple: Bool = false,
+        binding: GraphNodeInputBinding? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.portType = portType
+        self.mediaType = mediaType
+        self.isRequired = isRequired
+        self.allowsMultiple = allowsMultiple
+        self.binding = binding
+    }
+}
+
+public enum GraphArtifactDownstreamVisibility: String, Codable, Sendable {
+    case graph
+    case directDependents = "direct_dependents"
+    case privateToNode = "private_to_node"
+}
+
+public struct GraphNodeOutputDefinition:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public let id: String
+    public var name: String
+    public var portType: GraphDefinitionPortType
+    public var role: GraphArtifactRole
+    public var relativePath: String
+    public var mediaType: String
+    public var isRequired: Bool
+    public var maximumBytes: Int
+    public var sensitivity: GraphArtifactSensitivity
+    public var downstreamVisibility: GraphArtifactDownstreamVisibility
+
+    public init(
+        id: String,
+        name: String,
+        portType: GraphDefinitionPortType = .artifact,
+        role: GraphArtifactRole = .nodeOutput,
+        relativePath: String,
+        mediaType: String = "application/octet-stream",
+        isRequired: Bool = true,
+        maximumBytes: Int = 64 * 1_024 * 1_024,
+        sensitivity: GraphArtifactSensitivity = .internalUse,
+        downstreamVisibility: GraphArtifactDownstreamVisibility = .graph
+    ) {
+        self.id = id
+        self.name = name
+        self.portType = portType
+        self.role = role
+        self.relativePath = relativePath
+        self.mediaType = mediaType
+        self.isRequired = isRequired
+        self.maximumBytes = max(1, maximumBytes)
+        self.sensitivity = sensitivity
+        self.downstreamVisibility = downstreamVisibility
+    }
+}
+
+public struct GraphNodeRetryConfiguration: Equatable, Codable, Sendable {
+    public var inheritsGraphDefault: Bool
+    public var override: GraphRetryPolicy?
+
+    public init(
+        inheritsGraphDefault: Bool = true,
+        override: GraphRetryPolicy? = nil
+    ) {
+        self.inheritsGraphDefault = inheritsGraphDefault
+        self.override = override
+    }
+
+    public func effective(graphDefault: GraphRetryPolicy) -> GraphRetryPolicy {
+        inheritsGraphDefault ? graphDefault : (override ?? graphDefault)
+    }
+}
+
+public struct GraphNodeTimeoutConfiguration: Equatable, Codable, Sendable {
+    public var inheritsGraphDefault: Bool
+    public var executionSeconds: UInt64
+    public var cancellationAcknowledgementSeconds: UInt64
+    public var claimSeconds: UInt64
+
+    public init(
+        inheritsGraphDefault: Bool = true,
+        executionSeconds: UInt64 = 300,
+        cancellationAcknowledgementSeconds: UInt64 = 10,
+        claimSeconds: UInt64 = 30
+    ) {
+        self.inheritsGraphDefault = inheritsGraphDefault
+        self.executionSeconds = executionSeconds
+        self.cancellationAcknowledgementSeconds = cancellationAcknowledgementSeconds
+        self.claimSeconds = claimSeconds
+    }
+}
+
+public enum GraphDefinitionDataType: String, Codable, CaseIterable, Sendable {
+    case text
+    case json
+    case fileReference = "file_reference"
+    case directoryReference = "directory_reference"
+    case artifactReference = "artifact_reference"
+    case number
+    case boolean
+}
+
+public struct GraphDefinitionInput:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public let id: String
+    public var name: String
+    public var dataType: GraphDefinitionDataType
+    public var isRequired: Bool
+    public var isSensitive: Bool
+    public var defaultValue: GraphJSONValue?
+
+    public init(
+        id: String,
+        name: String,
+        dataType: GraphDefinitionDataType,
+        isRequired: Bool = true,
+        isSensitive: Bool = false,
+        defaultValue: GraphJSONValue? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.dataType = dataType
+        self.isRequired = isRequired
+        self.isSensitive = isSensitive
+        self.defaultValue = defaultValue
+    }
+}
+
+public struct GraphDefinitionOutput:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public let id: String
+    public var name: String
+    public var sourceNodeID: String
+    public var sourceOutputID: String
+
+    public init(
+        id: String,
+        name: String,
+        sourceNodeID: String,
+        sourceOutputID: String
+    ) {
+        self.id = id
+        self.name = name
+        self.sourceNodeID = sourceNodeID
+        self.sourceOutputID = sourceOutputID
+    }
+}

--- a/Sources/OpenIslandCore/GraphAuthoringDefinition.swift
+++ b/Sources/OpenIslandCore/GraphAuthoringDefinition.swift
@@ -18,13 +18,14 @@ public enum GraphDefinitionNodeType: String, Codable, CaseIterable, Sendable {
     }
 
     public var isRunnable: Bool {
-        self == .localProcess || self == .deterministicTest
+        isExecutable
     }
 }
 
 public enum GraphDefinitionExecutorKind: String, Codable, CaseIterable, Sendable {
     case supervisedLocalProcess = "local_process"
     case deterministicTest = "deterministic"
+    case openAICompatible = "openai_compatible"
     case unboundAgent = "generic_agent"
     case none
 
@@ -32,6 +33,7 @@ public enum GraphDefinitionExecutorKind: String, Codable, CaseIterable, Sendable
         switch self {
         case .supervisedLocalProcess: "Supervised Local Process"
         case .deterministicTest: "Deterministic Test Executor"
+        case .openAICompatible: "OpenAI-Compatible HTTP Executor"
         case .unboundAgent: "Generic Agent (not configured)"
         case .none: "No Executor"
         }

--- a/Sources/OpenIslandCore/GraphAuthoringDefinition.swift
+++ b/Sources/OpenIslandCore/GraphAuthoringDefinition.swift
@@ -262,3 +262,136 @@ public struct GraphDefinitionOutput:
         self.sourceOutputID = sourceOutputID
     }
 }
+
+public enum GraphConnectionRejection: String, Codable, Sendable {
+    case sourceMissing = "source_missing"
+    case targetMissing = "target_missing"
+    case selfEdge = "self_edge"
+    case duplicateEdge = "duplicate_edge"
+    case cycle
+    case nonExecutableDependency = "non_executable_dependency"
+    case sourcePortMissing = "source_port_missing"
+    case targetPortMissing = "target_port_missing"
+    case incompatiblePortType = "incompatible_port_type"
+    case incompatibleMediaType = "incompatible_media_type"
+    case multipleProvidersNotAllowed = "multiple_providers_not_allowed"
+}
+
+public struct GraphConnectionDecision: Equatable, Sendable {
+    public let isAllowed: Bool
+    public let rejection: GraphConnectionRejection?
+    public let message: String
+
+    public static let allowed = GraphConnectionDecision(
+        isAllowed: true,
+        rejection: nil,
+        message: "Connection is valid."
+    )
+
+    public static func rejected(
+        _ rejection: GraphConnectionRejection,
+        _ message: String
+    ) -> GraphConnectionDecision {
+        GraphConnectionDecision(
+            isAllowed: false,
+            rejection: rejection,
+            message: message
+        )
+    }
+}
+
+public enum GraphConnectionEvaluator {
+    public static func evaluate(
+        document: GraphDefinitionDocument,
+        sourceNodeID: String,
+        targetNodeID: String,
+        portType: GraphDefinitionPortType,
+        sourceOutputID: String? = nil,
+        targetInputID: String? = nil
+    ) -> GraphConnectionDecision {
+        guard let source = document.nodes.first(where: { $0.id == sourceNodeID }) else {
+            return .rejected(.sourceMissing, "The source node no longer exists.")
+        }
+        guard let target = document.nodes.first(where: { $0.id == targetNodeID }) else {
+            return .rejected(.targetMissing, "The target node no longer exists.")
+        }
+        guard sourceNodeID != targetNodeID else {
+            return .rejected(.selfEdge, "A node cannot depend on itself.")
+        }
+        guard !document.edges.contains(where: {
+            $0.sourceNodeID == sourceNodeID
+                && $0.targetNodeID == targetNodeID
+                && $0.portType == portType
+                && $0.sourceOutputID == sourceOutputID
+                && $0.targetInputID == targetInputID
+        }) else {
+            return .rejected(.duplicateEdge, "This connection already exists.")
+        }
+        if portType == .dependency {
+            guard source.nodeType.isExecutable, target.nodeType.isExecutable else {
+                return .rejected(
+                    .nonExecutableDependency,
+                    "Reference and annotation nodes cannot enter execution dependencies."
+                )
+            }
+        } else {
+            guard let sourceOutputID,
+                  let output = source.outputs.first(where: { $0.id == sourceOutputID }) else {
+                return .rejected(.sourcePortMissing, "Choose a declared source output.")
+            }
+            guard let targetInputID,
+                  let input = target.inputs.first(where: { $0.id == targetInputID }) else {
+                return .rejected(.targetPortMissing, "Choose a declared target input.")
+            }
+            guard output.portType == portType, input.portType == portType else {
+                return .rejected(
+                    .incompatiblePortType,
+                    "The selected ports do not both use \(portType.rawValue)."
+                )
+            }
+            if portType == .artifact,
+               !mediaTypesAreCompatible(output.mediaType, input.mediaType) {
+                return .rejected(
+                    .incompatibleMediaType,
+                    "Output \(output.mediaType) cannot bind to input \(input.mediaType)."
+                )
+            }
+            if !input.allowsMultiple,
+               document.edges.contains(where: {
+                   $0.targetNodeID == targetNodeID
+                       && $0.targetInputID == targetInputID
+               }) {
+                return .rejected(
+                    .multipleProvidersNotAllowed,
+                    "The target input accepts only one provider."
+                )
+            }
+        }
+
+        var candidate = document
+        candidate.edges.append(
+            GraphDefinitionEdge(
+                sourceNodeID: sourceNodeID,
+                targetNodeID: targetNodeID,
+                portType: portType,
+                sourceOutputID: sourceOutputID,
+                targetInputID: targetInputID
+            )
+        )
+        guard candidate.topologicalNodeIDs() != nil else {
+            return .rejected(.cycle, "This connection would create a cycle.")
+        }
+        return .allowed
+    }
+
+    private static func mediaTypesAreCompatible(
+        _ source: String,
+        _ target: String
+    ) -> Bool {
+        source == target
+            || source == "application/octet-stream"
+            || target == "application/octet-stream"
+            || source == "*/*"
+            || target == "*/*"
+    }
+}

--- a/Sources/OpenIslandCore/GraphCLI.swift
+++ b/Sources/OpenIslandCore/GraphCLI.swift
@@ -156,6 +156,7 @@ public struct GraphCLIInvocation: Equatable, Sendable {
     public let toSequence: UInt64?
     public let checkpointID: String?
     public let withoutLiveEvidence: Bool
+    public let requireLiveEvidence: Bool
     public let exportFormat: GraphCLIExportFormat
     public let emitCompletionRecord: Bool
 
@@ -178,6 +179,7 @@ public struct GraphCLIInvocation: Equatable, Sendable {
         toSequence: UInt64? = nil,
         checkpointID: String? = nil,
         withoutLiveEvidence: Bool = false,
+        requireLiveEvidence: Bool = false,
         exportFormat: GraphCLIExportFormat = .json,
         emitCompletionRecord: Bool = false
     ) {
@@ -199,6 +201,7 @@ public struct GraphCLIInvocation: Equatable, Sendable {
         self.toSequence = toSequence
         self.checkpointID = checkpointID
         self.withoutLiveEvidence = withoutLiveEvidence
+        self.requireLiveEvidence = requireLiveEvidence
         self.exportFormat = exportFormat
         self.emitCompletionRecord = emitCompletionRecord
     }
@@ -275,6 +278,7 @@ public enum GraphCLIParser {
             "--include-artifacts",
             "--dry-run",
             "--without-live-evidence",
+            "--require-live-evidence",
             "--emit-completion-record",
         ])
         var index = 0
@@ -475,6 +479,12 @@ public enum GraphCLIParser {
                 "--emit-completion-record requires --output jsonl."
             )
         }
+        if flags.contains("--without-live-evidence"),
+           flags.contains("--require-live-evidence") {
+            throw GraphCLIArgumentError.invalid(
+                "--without-live-evidence and --require-live-evidence are mutually exclusive."
+            )
+        }
 
         return .invocation(
             GraphCLIInvocation(
@@ -500,6 +510,8 @@ public enum GraphCLIParser {
                     try singleValue("--checkpoint", values),
                 withoutLiveEvidence:
                     flags.contains("--without-live-evidence"),
+                requireLiveEvidence:
+                    flags.contains("--require-live-evidence"),
                 exportFormat: exportFormat,
                 emitCompletionRecord:
                     flags.contains("--emit-completion-record")
@@ -522,7 +534,8 @@ public enum GraphCLIParser {
     Filters: --node --attempt --state --event-type --since --until
              --after-sequence --limit
     Safety: --no-color --quiet --include-diagnostics --include-artifacts
-            --without-live-evidence --emit-completion-record
+            --without-live-evidence --require-live-evidence
+            --emit-completion-record
     """
 
     private static func singleValue(
@@ -765,8 +778,21 @@ public struct GraphReplayOutput:
     public let projectedAttempts: [GraphStateOutput]
     public let reconciledAttempts: [GraphStateOutput]
     public let evidence: GraphEvidenceInspection
+    public let unknownEvents: [GraphUnknownEventOutput]
     public let replayDiagnostics: [GraphReplayDiagnostic]
     public let repositoryDiagnostics: [GraphRepositoryDiagnostic]
+}
+
+public struct GraphUnknownEventOutput:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let eventID: String
+    public let eventType: String
+    public let streamSequence: UInt64
+    public let payloadVersion: Int
+    public let redactions: [GraphRedactionRecord]
 }
 
 public struct GraphStateOutput:
@@ -1101,7 +1127,9 @@ public struct GraphCLICommandRunner: Sendable {
                 ),
                 evidenceMode: invocation.withoutLiveEvidence
                     ? .withoutLiveEvidence
-                    : .configured
+                    : invocation.requireLiveEvidence
+                        ? .requireAvailable
+                        : .configured
             )
             let output = try replayOutput(replay)
             let code = try emit(
@@ -1563,6 +1591,25 @@ public struct GraphCLICommandRunner: Sendable {
                     GraphStateOutput(id: $0.id, state: $0.state)
                 }.sorted { $0.id < $1.id },
             evidence: replay.evidence,
+            unknownEvents: replay.projected.unknownEvents.map {
+                GraphUnknownEventOutput(
+                    eventID: $0.id,
+                    eventType: $0.eventType,
+                    streamSequence: $0.streamSequence,
+                    payloadVersion: $0.payloadVersion,
+                    redactions: [
+                        GraphRedactionRecord(
+                            field: "payload",
+                            reason: .unsupportedPayload
+                        ),
+                    ]
+                )
+            }.sorted {
+                if $0.streamSequence != $1.streamSequence {
+                    return $0.streamSequence < $1.streamSequence
+                }
+                return $0.eventID < $1.eventID
+            },
             replayDiagnostics: replay.replayDiagnostics,
             repositoryDiagnostics: replay.repositoryDiagnostics
         )

--- a/Sources/OpenIslandCore/GraphCLI.swift
+++ b/Sources/OpenIslandCore/GraphCLI.swift
@@ -1,0 +1,1609 @@
+import Darwin
+import Foundation
+
+public enum GraphCLIOutputMode: String, Codable, CaseIterable, Sendable {
+    case text
+    case json
+    case jsonl
+}
+
+public enum GraphCLIExitCode: Int32, Codable, CaseIterable, Sendable {
+    case success = 0
+    case invalidArguments = 2
+    case notFound = 3
+    case incompatibleSchema = 4
+    case corruptHistory = 5
+    case persistenceFailure = 6
+    case evidenceUnavailable = 7
+    case partialResult = 8
+    case interrupted = 130
+
+    public var category: String {
+        switch self {
+        case .success:
+            "success"
+        case .invalidArguments:
+            "invalid_arguments"
+        case .notFound:
+            "not_found"
+        case .incompatibleSchema:
+            "incompatible_schema"
+        case .corruptHistory:
+            "corrupt_history"
+        case .persistenceFailure:
+            "persistence_failure"
+        case .evidenceUnavailable:
+            "evidence_unavailable"
+        case .partialResult:
+            "partial_result"
+        case .interrupted:
+            "interrupted"
+        }
+    }
+}
+
+public enum GraphCLIWriteResult: Equatable, Sendable {
+    case written
+    case brokenPipe
+    case failed(String)
+}
+
+public protocol GraphCLIOutputSink: Sendable {
+    func write(_ data: Data) -> GraphCLIWriteResult
+}
+
+public struct GraphCLIFileDescriptorSink:
+    GraphCLIOutputSink,
+    Sendable
+{
+    public let fileDescriptor: Int32
+
+    public init(fileDescriptor: Int32) {
+        self.fileDescriptor = fileDescriptor
+    }
+
+    public func write(_ data: Data) -> GraphCLIWriteResult {
+        guard fcntl(fileDescriptor, F_SETNOSIGPIPE, 1) != -1 else {
+            return .failed("Unable to configure output descriptor.")
+        }
+
+        return data.withUnsafeBytes { buffer in
+            guard let base = buffer.baseAddress else {
+                return .written
+            }
+            var offset = 0
+
+            while offset < buffer.count {
+                let count = Darwin.write(
+                    fileDescriptor,
+                    base.advanced(by: offset),
+                    buffer.count - offset
+                )
+
+                if count > 0 {
+                    offset += count
+                } else if count == -1, errno == EINTR {
+                    continue
+                } else if count == -1, errno == EPIPE {
+                    return .brokenPipe
+                } else {
+                    return .failed(
+                        String(cString: strerror(errno))
+                    )
+                }
+            }
+
+            return .written
+        }
+    }
+}
+
+public enum GraphCLIExportFormat: String, Codable, Sendable {
+    case json
+    case jsonl
+    case mermaid
+}
+
+public enum GraphCLICommand: Equatable, Sendable {
+    case list
+    case inspect(runID: String)
+    case history(runID: String)
+    case explain(runID: String, nodeID: String?)
+    case checkpointList(runID: String)
+    case replay(runID: String)
+    case diff(left: GraphTemporalReference, right: GraphTemporalReference)
+    case export(runID: String)
+
+    public var name: String {
+        switch self {
+        case .list:
+            "graph.list"
+        case .inspect:
+            "graph.inspect"
+        case .history:
+            "graph.history"
+        case .explain:
+            "graph.explain"
+        case .checkpointList:
+            "graph.checkpoint.list"
+        case .replay:
+            "graph.replay"
+        case .diff:
+            "graph.diff"
+        case .export:
+            "graph.export"
+        }
+    }
+}
+
+public struct GraphCLIInvocation: Equatable, Sendable {
+    public let command: GraphCLICommand
+    public let output: GraphCLIOutputMode
+    public let quiet: Bool
+    public let noColor: Bool
+    public let schemaVersion: Int
+    public let nodeID: String?
+    public let attemptID: String?
+    public let state: ReconciledExecutionState?
+    public let eventTypes: Set<String>
+    public let since: Date?
+    public let until: Date?
+    public let afterSequence: UInt64
+    public let limit: Int
+    public let includeDiagnostics: Bool
+    public let includeArtifacts: Bool
+    public let toSequence: UInt64?
+    public let checkpointID: String?
+    public let withoutLiveEvidence: Bool
+    public let exportFormat: GraphCLIExportFormat
+    public let emitCompletionRecord: Bool
+
+    public init(
+        command: GraphCLICommand,
+        output: GraphCLIOutputMode = .text,
+        quiet: Bool = false,
+        noColor: Bool = false,
+        schemaVersion: Int = GraphCLIOutputSchema.currentVersion,
+        nodeID: String? = nil,
+        attemptID: String? = nil,
+        state: ReconciledExecutionState? = nil,
+        eventTypes: Set<String> = [],
+        since: Date? = nil,
+        until: Date? = nil,
+        afterSequence: UInt64 = 0,
+        limit: Int = 100,
+        includeDiagnostics: Bool = false,
+        includeArtifacts: Bool = false,
+        toSequence: UInt64? = nil,
+        checkpointID: String? = nil,
+        withoutLiveEvidence: Bool = false,
+        exportFormat: GraphCLIExportFormat = .json,
+        emitCompletionRecord: Bool = false
+    ) {
+        self.command = command
+        self.output = output
+        self.quiet = quiet
+        self.noColor = noColor
+        self.schemaVersion = schemaVersion
+        self.nodeID = nodeID
+        self.attemptID = attemptID
+        self.state = state
+        self.eventTypes = eventTypes
+        self.since = since
+        self.until = until
+        self.afterSequence = afterSequence
+        self.limit = limit
+        self.includeDiagnostics = includeDiagnostics
+        self.includeArtifacts = includeArtifacts
+        self.toSequence = toSequence
+        self.checkpointID = checkpointID
+        self.withoutLiveEvidence = withoutLiveEvidence
+        self.exportFormat = exportFormat
+        self.emitCompletionRecord = emitCompletionRecord
+    }
+}
+
+public enum GraphCLIOutputSchema {
+    public static let currentVersion = 1
+}
+
+public enum GraphCLIArgumentError: Error, Equatable, Sendable {
+    case invalid(String)
+    case unsupportedSchema(found: Int, supported: Int)
+}
+
+extension GraphCLIArgumentError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .invalid(message):
+            message
+        case let .unsupportedSchema(found, supported):
+            "Output schema version \(found) is unsupported; current version is \(supported)."
+        }
+    }
+}
+
+public enum GraphCLIParseResult: Equatable, Sendable {
+    case invocation(GraphCLIInvocation)
+    case help(String)
+}
+
+public enum GraphCLIParser {
+    public static func parse(
+        _ arguments: [String]
+    ) throws -> GraphCLIParseResult {
+        if arguments.isEmpty || arguments == ["--help"]
+            || arguments == ["help"] {
+            return .help(usage)
+        }
+        guard arguments.first == "graph" else {
+            throw GraphCLIArgumentError.invalid(
+                "Expected the read-only `graph` command."
+            )
+        }
+        if arguments.count == 1 || arguments[1] == "--help"
+            || arguments[1] == "help" {
+            return .help(usage)
+        }
+
+        let tokens = Array(arguments.dropFirst(2))
+        let commandToken = arguments[1]
+        var positional: [String] = []
+        var values: [String: [String]] = [:]
+        var flags = Set<String>()
+        var outputWasExplicit = false
+        let valueOptions = Set([
+            "--output",
+            "--schema-version",
+            "--node",
+            "--attempt",
+            "--state",
+            "--event-type",
+            "--since",
+            "--until",
+            "--after-sequence",
+            "--limit",
+            "--to-sequence",
+            "--checkpoint",
+            "--format",
+        ])
+        let flagOptions = Set([
+            "--no-color",
+            "--quiet",
+            "--include-diagnostics",
+            "--include-artifacts",
+            "--dry-run",
+            "--without-live-evidence",
+            "--emit-completion-record",
+        ])
+        var index = 0
+
+        while index < tokens.count {
+            let token = tokens[index]
+
+            if valueOptions.contains(token) {
+                guard index + 1 < tokens.count else {
+                    throw GraphCLIArgumentError.invalid(
+                        "Option \(token) requires a value."
+                    )
+                }
+                values[token, default: []].append(tokens[index + 1])
+                outputWasExplicit = outputWasExplicit || token == "--output"
+                index += 2
+            } else if flagOptions.contains(token) {
+                flags.insert(token)
+                index += 1
+            } else if token == "--help" {
+                return .help(usage)
+            } else if token.hasPrefix("--") {
+                throw GraphCLIArgumentError.invalid(
+                    "Unknown option \(token)."
+                )
+            } else {
+                positional.append(token)
+                index += 1
+            }
+        }
+
+        let output = try singleValue("--output", values).map {
+            guard let mode = GraphCLIOutputMode(rawValue: $0) else {
+                throw GraphCLIArgumentError.invalid(
+                    "Output must be text, json, or jsonl."
+                )
+            }
+            return mode
+        }
+        let optionNodeID = try singleValue("--node", values)
+        let requestedSchema = try parseInt(
+            singleValue("--schema-version", values),
+            option: "--schema-version"
+        ) ?? GraphCLIOutputSchema.currentVersion
+        guard requestedSchema == GraphCLIOutputSchema.currentVersion else {
+            throw GraphCLIArgumentError.unsupportedSchema(
+                found: requestedSchema,
+                supported: GraphCLIOutputSchema.currentVersion
+            )
+        }
+        let state = try singleValue("--state", values).map {
+            guard let state = ReconciledExecutionState(rawValue: $0) else {
+                throw GraphCLIArgumentError.invalid(
+                    "Unknown graph state \($0)."
+                )
+            }
+            return state
+        }
+        let since = try parseDate(
+            singleValue("--since", values),
+            option: "--since"
+        )
+        let until = try parseDate(
+            singleValue("--until", values),
+            option: "--until"
+        )
+        if let since, let until, since > until {
+            throw GraphCLIArgumentError.invalid(
+                "--since must not be later than --until."
+            )
+        }
+        let afterSequence = try parseUInt64(
+            singleValue("--after-sequence", values),
+            option: "--after-sequence"
+        ) ?? 0
+        let toSequence = try parseUInt64(
+            singleValue("--to-sequence", values),
+            option: "--to-sequence"
+        )
+        let limit = try parseInt(
+            singleValue("--limit", values),
+            option: "--limit"
+        ) ?? 100
+        guard (1...1_000_000).contains(limit) else {
+            throw GraphCLIArgumentError.invalid(
+                "--limit must be between 1 and 1000000."
+            )
+        }
+        let exportFormat = try singleValue("--format", values).map {
+            guard let format = GraphCLIExportFormat(rawValue: $0) else {
+                throw GraphCLIArgumentError.invalid(
+                    "Export format must be json, jsonl, or mermaid."
+                )
+            }
+            return format
+        } ?? .json
+        let command: GraphCLICommand
+
+        switch commandToken {
+        case "list":
+            try requirePositionals(positional, count: 0, command: "list")
+            command = .list
+        case "inspect":
+            try requirePositionals(
+                positional,
+                count: 1,
+                command: "inspect"
+            )
+            command = .inspect(runID: positional[0])
+        case "history":
+            try requirePositionals(
+                positional,
+                count: 1,
+                command: "history"
+            )
+            command = .history(runID: positional[0])
+        case "explain":
+            guard (1...2).contains(positional.count) else {
+                throw GraphCLIArgumentError.invalid(
+                    "Usage: openisland graph explain <run-id> [node-id]"
+                )
+            }
+            if positional.count == 2, optionNodeID != nil {
+                throw GraphCLIArgumentError.invalid(
+                    "Specify the explanation node either positionally or with --node, not both."
+                )
+            }
+            command = .explain(
+                runID: positional[0],
+                nodeID: positional.count == 2
+                    ? positional[1]
+                    : optionNodeID
+            )
+        case "checkpoint":
+            guard positional.count == 2, positional[0] == "list" else {
+                throw GraphCLIArgumentError.invalid(
+                    "Usage: openisland graph checkpoint list <run-id>"
+                )
+            }
+            command = .checkpointList(runID: positional[1])
+        case "replay":
+            try requirePositionals(
+                positional,
+                count: 1,
+                command: "replay"
+            )
+            guard flags.contains("--dry-run") else {
+                throw GraphCLIArgumentError.invalid(
+                    "`graph replay` requires --dry-run."
+                )
+            }
+            if toSequence != nil,
+               try singleValue("--checkpoint", values) != nil {
+                throw GraphCLIArgumentError.invalid(
+                    "Use either --to-sequence or --checkpoint, not both."
+                )
+            }
+            command = .replay(runID: positional[0])
+        case "diff":
+            try requirePositionals(
+                positional,
+                count: 2,
+                command: "diff"
+            )
+            command = .diff(
+                left: try parseReference(positional[0]),
+                right: try parseReference(positional[1])
+            )
+        case "export":
+            try requirePositionals(
+                positional,
+                count: 1,
+                command: "export"
+            )
+            command = .export(runID: positional[0])
+        default:
+            throw GraphCLIArgumentError.invalid(
+                "Unknown graph command \(commandToken)."
+            )
+        }
+
+        var resolvedOutput = output ?? .text
+        if case .export = command, !outputWasExplicit {
+            switch exportFormat {
+            case .json:
+                resolvedOutput = .json
+            case .jsonl:
+                resolvedOutput = .jsonl
+            case .mermaid:
+                resolvedOutput = .text
+            }
+        }
+        if flags.contains("--emit-completion-record"),
+           resolvedOutput != .jsonl {
+            throw GraphCLIArgumentError.invalid(
+                "--emit-completion-record requires --output jsonl."
+            )
+        }
+
+        return .invocation(
+            GraphCLIInvocation(
+                command: command,
+                output: resolvedOutput,
+                quiet: flags.contains("--quiet"),
+                noColor: flags.contains("--no-color"),
+                schemaVersion: requestedSchema,
+                nodeID: optionNodeID,
+                attemptID: try singleValue("--attempt", values),
+                state: state,
+                eventTypes: Set(values["--event-type"] ?? []),
+                since: since,
+                until: until,
+                afterSequence: afterSequence,
+                limit: limit,
+                includeDiagnostics:
+                    flags.contains("--include-diagnostics"),
+                includeArtifacts:
+                    flags.contains("--include-artifacts"),
+                toSequence: toSequence,
+                checkpointID:
+                    try singleValue("--checkpoint", values),
+                withoutLiveEvidence:
+                    flags.contains("--without-live-evidence"),
+                exportFormat: exportFormat,
+                emitCompletionRecord:
+                    flags.contains("--emit-completion-record")
+            )
+        )
+    }
+
+    public static let usage = """
+    Usage:
+      openisland graph list [options]
+      openisland graph inspect <run-id> [options]
+      openisland graph history <run-id> [options]
+      openisland graph explain <run-id> [node-id] [options]
+      openisland graph checkpoint list <run-id> [options]
+      openisland graph replay <run-id> --dry-run [options]
+      openisland graph diff <run|run@sequence|run#checkpoint> <reference> [options]
+      openisland graph export <run-id> --format json|jsonl|mermaid [options]
+
+    Stable output: --output text|json|jsonl --schema-version 1
+    Filters: --node --attempt --state --event-type --since --until
+             --after-sequence --limit
+    Safety: --no-color --quiet --include-diagnostics --include-artifacts
+            --without-live-evidence --emit-completion-record
+    """
+
+    private static func singleValue(
+        _ option: String,
+        _ values: [String: [String]]
+    ) throws -> String? {
+        guard let found = values[option] else {
+            return nil
+        }
+        guard found.count == 1 else {
+            throw GraphCLIArgumentError.invalid(
+                "Option \(option) may only be provided once."
+            )
+        }
+        return found[0]
+    }
+
+    private static func requirePositionals(
+        _ positional: [String],
+        count: Int,
+        command: String
+    ) throws {
+        guard positional.count == count else {
+            throw GraphCLIArgumentError.invalid(
+                "Command \(command) expected \(count) positional argument(s)."
+            )
+        }
+    }
+
+    private static func parseInt(
+        _ value: String?,
+        option: String
+    ) throws -> Int? {
+        guard let value else {
+            return nil
+        }
+        guard let result = Int(value) else {
+            throw GraphCLIArgumentError.invalid(
+                "\(option) requires an integer."
+            )
+        }
+        return result
+    }
+
+    private static func parseUInt64(
+        _ value: String?,
+        option: String
+    ) throws -> UInt64? {
+        guard let value else {
+            return nil
+        }
+        guard let result = UInt64(value) else {
+            throw GraphCLIArgumentError.invalid(
+                "\(option) requires a nonnegative integer."
+            )
+        }
+        return result
+    }
+
+    private static func parseDate(
+        _ value: String?,
+        option: String
+    ) throws -> Date? {
+        guard let value else {
+            return nil
+        }
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [
+            .withInternetDateTime,
+            .withFractionalSeconds,
+        ]
+        let standard = ISO8601DateFormatter()
+        standard.formatOptions = [.withInternetDateTime]
+
+        guard let result = fractional.date(from: value)
+                ?? standard.date(from: value) else {
+            throw GraphCLIArgumentError.invalid(
+                "\(option) requires an ISO 8601 UTC date."
+            )
+        }
+        return result
+    }
+
+    private static func parseReference(
+        _ value: String
+    ) throws -> GraphTemporalReference {
+        if let marker = value.lastIndex(of: "#") {
+            let runID = String(value[..<marker])
+            let checkpoint = String(value[value.index(after: marker)...])
+            guard !runID.isEmpty, !checkpoint.isEmpty else {
+                throw GraphCLIArgumentError.invalid(
+                    "Invalid checkpoint reference \(value)."
+                )
+            }
+            return GraphTemporalReference(
+                runID: runID,
+                boundary: .checkpoint(checkpoint)
+            )
+        }
+        if let marker = value.lastIndex(of: "@") {
+            let runID = String(value[..<marker])
+            let sequenceText = String(
+                value[value.index(after: marker)...]
+            )
+            guard !runID.isEmpty,
+                  let sequence = UInt64(sequenceText) else {
+                throw GraphCLIArgumentError.invalid(
+                    "Invalid stream reference \(value)."
+                )
+            }
+            return GraphTemporalReference(
+                runID: runID,
+                boundary: .sequence(sequence)
+            )
+        }
+        guard !value.isEmpty else {
+            throw GraphCLIArgumentError.invalid(
+                "Run reference may not be empty."
+            )
+        }
+        return GraphTemporalReference(runID: value)
+    }
+}
+
+public struct GraphCLICompletionRecord:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let schemaVersion: Int
+    public let recordType: String
+    public let command: String
+    public let status: String
+    public let exitCode: Int32
+    public let resultCount: Int
+    public let eventCount: Int
+    public let lastSequence: UInt64?
+
+    public init(
+        schemaVersion: Int = GraphCLIOutputSchema.currentVersion,
+        command: String,
+        status: String,
+        exitCode: Int32,
+        resultCount: Int,
+        eventCount: Int,
+        lastSequence: UInt64?
+    ) {
+        self.schemaVersion = schemaVersion
+        self.recordType = "completion"
+        self.command = command
+        self.status = status
+        self.exitCode = exitCode
+        self.resultCount = resultCount
+        self.eventCount = eventCount
+        self.lastSequence = lastSequence
+    }
+}
+
+public struct GraphCLIOutputDiagnostic:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let category: String
+    public let severity: String
+    public let message: String
+}
+
+public struct GraphCLIOutputDocument<Payload: Encodable>: Encodable {
+    public let schemaVersion: Int
+    public let command: String
+    public let resultCount: Int
+    public let eventCount: Int
+    public let result: Payload
+    public let diagnostics: [GraphCLIOutputDiagnostic]?
+
+    public init(
+        schemaVersion: Int = GraphCLIOutputSchema.currentVersion,
+        command: String,
+        resultCount: Int,
+        eventCount: Int,
+        result: Payload,
+        diagnostics: [GraphCLIOutputDiagnostic]? = nil
+    ) {
+        self.schemaVersion = schemaVersion
+        self.command = command
+        self.resultCount = resultCount
+        self.eventCount = eventCount
+        self.result = result
+        self.diagnostics = diagnostics
+    }
+}
+
+public struct GraphCLIJSONLRecord<Payload: Encodable>: Encodable {
+    public let schemaVersion: Int
+    public let command: String
+    public let recordType: String
+    public let ordinal: Int
+    public let payload: Payload
+
+    public init(
+        schemaVersion: Int = GraphCLIOutputSchema.currentVersion,
+        command: String,
+        recordType: String,
+        ordinal: Int,
+        payload: Payload
+    ) {
+        self.schemaVersion = schemaVersion
+        self.command = command
+        self.recordType = recordType
+        self.ordinal = ordinal
+        self.payload = payload
+    }
+}
+
+public struct GraphReplayOutput:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let runID: String
+    public let boundary: UInt64
+    public let headVersion: UInt64
+    public let snapshotDisposition: GraphSnapshotDisposition
+    public let snapshotStreamVersion: UInt64?
+    public let replayedEventCount: Int
+    public let projectedRunState: ReconciledExecutionState
+    public let reconciledRunState: ReconciledExecutionState
+    public let projectedNodes: [GraphStateOutput]
+    public let reconciledNodes: [GraphStateOutput]
+    public let projectedAttempts: [GraphStateOutput]
+    public let reconciledAttempts: [GraphStateOutput]
+    public let evidence: GraphEvidenceInspection
+    public let replayDiagnostics: [GraphReplayDiagnostic]
+    public let repositoryDiagnostics: [GraphRepositoryDiagnostic]
+}
+
+public struct GraphStateOutput:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let id: String
+    public let state: ReconciledExecutionState
+}
+
+public struct GraphMermaidExport:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let format: String
+    public let content: String
+
+    public init(content: String) {
+        self.format = "mermaid"
+        self.content = content
+    }
+}
+
+public enum GraphMermaidExporter {
+    public static func render(_ inspection: GraphRunInspection) -> String {
+        let nodes = inspection.nodes.sorted { $0.id < $1.id }
+        let attempts = inspection.attempts.sorted {
+            if $0.nodeID != $1.nodeID {
+                return $0.nodeID < $1.nodeID
+            }
+            if $0.ordinal != $1.ordinal {
+                return $0.ordinal < $1.ordinal
+            }
+            return $0.id < $1.id
+        }
+        let artifacts = inspection.artifacts.sorted { $0.id < $1.id }
+        let nodeNames = Dictionary(
+            uniqueKeysWithValues: nodes.enumerated().map {
+                ($0.element.id, "node_\($0.offset)")
+            }
+        )
+        let attemptNames = Dictionary(
+            uniqueKeysWithValues: attempts.enumerated().map {
+                ($0.element.id, "attempt_\($0.offset)")
+            }
+        )
+        var lines = ["flowchart TD"]
+
+        for node in nodes {
+            guard let identifier = nodeNames[node.id] else {
+                continue
+            }
+            lines.append(
+                "  \(identifier)[\"\(escape(node.title))\\n\(escape(node.reconciledState.rawValue))\"]"
+            )
+            lines.append(
+                "  class \(identifier) state_\(node.reconciledState.rawValue)"
+            )
+        }
+        for node in nodes {
+            guard let target = nodeNames[node.id] else {
+                continue
+            }
+            for dependency in node.dependencyNodeIDs.sorted() {
+                if let source = nodeNames[dependency] {
+                    lines.append(
+                        "  \(source) -->|dependency| \(target)"
+                    )
+                }
+            }
+        }
+        for attempt in attempts {
+            guard let identifier = attemptNames[attempt.id] else {
+                continue
+            }
+            lines.append(
+                "  \(identifier)((\"\(escape(attempt.id))\\n\(escape(attempt.reconciledState.rawValue))\"))"
+            )
+            lines.append(
+                "  class \(identifier) state_\(attempt.reconciledState.rawValue)"
+            )
+            if let node = nodeNames[attempt.nodeID] {
+                lines.append("  \(node) -.->|attempt| \(identifier)")
+            }
+        }
+        for (index, artifact) in artifacts.enumerated() {
+            let identifier = "artifact_\(index)"
+            lines.append(
+                "  \(identifier)[/\"\(escape(artifact.logicalRole))\"/]"
+            )
+            if let attempt = attemptNames[artifact.producingAttemptID] {
+                lines.append(
+                    "  \(attempt) ==>|provenance| \(identifier)"
+                )
+            }
+        }
+        for state in ReconciledExecutionState.allCases {
+            lines.append(
+                "  classDef state_\(state.rawValue) stroke-width:2px"
+            )
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private static func escape(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "\r", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+    }
+}
+
+public struct GraphCLICommandRunner: Sendable {
+    private let inspector: any GraphTemporalInspecting
+    private let stdout: any GraphCLIOutputSink
+    private let stderr: any GraphCLIOutputSink
+
+    public init(
+        inspector: any GraphTemporalInspecting,
+        stdout: any GraphCLIOutputSink,
+        stderr: any GraphCLIOutputSink
+    ) {
+        self.inspector = inspector
+        self.stdout = stdout
+        self.stderr = stderr
+    }
+
+    public func run(arguments: [String]) async -> GraphCLIExitCode {
+        let parsed: GraphCLIParseResult
+
+        do {
+            parsed = try GraphCLIParser.parse(arguments)
+        } catch let error as GraphCLIArgumentError {
+            let code: GraphCLIExitCode
+            if case .unsupportedSchema = error {
+                code = .incompatibleSchema
+            } else {
+                code = .invalidArguments
+            }
+            writeError(error.localizedDescription, code: code)
+            return code
+        } catch {
+            writeError(
+                error.localizedDescription,
+                code: .invalidArguments
+            )
+            return .invalidArguments
+        }
+
+        switch parsed {
+        case let .help(text):
+            _ = stdout.write(Data((text + "\n").utf8))
+            return .success
+        case let .invocation(invocation):
+            guard !invocation.quiet else {
+                return await executeQuiet(invocation)
+            }
+
+            do {
+                return try await execute(invocation)
+            } catch {
+                let code = exitCode(for: error)
+                writeError(error.localizedDescription, code: code)
+                return code
+            }
+        }
+    }
+
+    private func executeQuiet(
+        _ invocation: GraphCLIInvocation
+    ) async -> GraphCLIExitCode {
+        do {
+            _ = try await execute(invocation, suppressOutput: true)
+            return .success
+        } catch {
+            let code = exitCode(for: error)
+            writeError(error.localizedDescription, code: code)
+            return code
+        }
+    }
+
+    private func execute(
+        _ invocation: GraphCLIInvocation,
+        suppressOutput: Bool = false
+    ) async throws -> GraphCLIExitCode {
+        switch invocation.command {
+        case .list:
+            var summaries = try await inspector.listRuns(
+                state: invocation.state,
+                limit: invocation.limit
+            )
+            summaries = filterSummaries(summaries, invocation)
+            return try emit(
+                summaries,
+                recordType: "run",
+                text: renderSummaries(summaries),
+                invocation: invocation,
+                resultCount: summaries.count,
+                eventCount: 0,
+                suppressOutput: suppressOutput
+            )
+        case let .inspect(runID):
+            let inspection = try await inspector.inspect(
+                runID: runID,
+                includeArtifacts: invocation.includeArtifacts,
+                includeDiagnostics: invocation.includeDiagnostics
+            )
+            let filtered = filterInspection(inspection, invocation)
+            return try emit(
+                filtered,
+                records: [filtered],
+                recordType: "inspection",
+                text: renderInspection(filtered),
+                invocation: invocation,
+                resultCount: 1,
+                eventCount: 0,
+                suppressOutput: suppressOutput,
+                diagnostics: diagnostics(filtered)
+            )
+        case let .history(runID):
+            return try await emitHistory(
+                runID: runID,
+                invocation: invocation,
+                suppressOutput: suppressOutput
+            )
+        case let .explain(runID, positionalNodeID):
+            let explanation = try await inspector.explain(
+                runID: runID,
+                nodeID: invocation.nodeID ?? positionalNodeID
+            )
+            return try emit(
+                explanation,
+                records: [explanation],
+                recordType: "explanation",
+                text: renderExplanation(explanation),
+                invocation: invocation,
+                resultCount: 1,
+                eventCount: 0,
+                suppressOutput: suppressOutput
+            )
+        case let .checkpointList(runID):
+            let checkpoints = try await inspector.checkpoints(
+                runID: runID
+            )
+            return try emit(
+                checkpoints,
+                recordType: "checkpoint",
+                text: renderCheckpoints(checkpoints),
+                invocation: invocation,
+                resultCount: checkpoints.count,
+                eventCount: 0,
+                suppressOutput: suppressOutput
+            )
+        case let .replay(runID):
+            let boundary: GraphReplayBoundary
+            if let sequence = invocation.toSequence {
+                boundary = .sequence(sequence)
+            } else if let checkpoint = invocation.checkpointID {
+                boundary = .checkpoint(checkpoint)
+            } else {
+                boundary = .head
+            }
+            let replay = try await inspector.replay(
+                reference: GraphTemporalReference(
+                    runID: runID,
+                    boundary: boundary
+                ),
+                evidenceMode: invocation.withoutLiveEvidence
+                    ? .withoutLiveEvidence
+                    : .configured
+            )
+            let output = try replayOutput(replay)
+            return try emit(
+                output,
+                records: [output],
+                recordType: "replay",
+                text: renderReplay(output),
+                invocation: invocation,
+                resultCount: 1,
+                eventCount: replay.replayedEventCount,
+                suppressOutput: suppressOutput,
+                diagnostics: invocation.includeDiagnostics
+                    ? diagnostics(replay)
+                    : []
+            )
+        case let .diff(left, right):
+            let diff = try await inspector.diff(
+                left: left,
+                right: right
+            )
+            return try emit(
+                diff,
+                records: diff.changes,
+                recordType: "change",
+                text: renderDiff(diff),
+                invocation: invocation,
+                resultCount: diff.changes.count,
+                eventCount: 0,
+                suppressOutput: suppressOutput
+            )
+        case let .export(runID):
+            let inspection = try await inspector.inspect(
+                runID: runID,
+                includeArtifacts: true,
+                includeDiagnostics: invocation.includeDiagnostics
+            )
+            return try emitExport(
+                inspection,
+                invocation: invocation,
+                suppressOutput: suppressOutput
+            )
+        }
+    }
+
+    private func emitHistory(
+        runID: String,
+        invocation: GraphCLIInvocation,
+        suppressOutput: Bool
+    ) async throws -> GraphCLIExitCode {
+        var cursor = invocation.afterSequence
+        var remaining = invocation.limit
+        var records: [GraphInspectionEventRecord] = []
+        var emitted = 0
+        var ordinal = 0
+        var hasMore = true
+
+        while remaining > 0, hasMore {
+            let page = try await inspector.eventPage(
+                runID: runID,
+                filter: GraphInspectionEventFilter(
+                    nodeID: invocation.nodeID,
+                    attemptID: invocation.attemptID,
+                    eventTypes: invocation.eventTypes,
+                    since: invocation.since,
+                    until: invocation.until,
+                    afterSequence: cursor,
+                    limit: min(remaining, 256)
+                )
+            )
+            cursor = page.scannedThroughSequence
+            hasMore = page.hasMore
+            remaining -= page.events.count
+
+            if suppressOutput {
+                emitted += page.events.count
+                continue
+            }
+
+            switch invocation.output {
+            case .json:
+                records.append(contentsOf: page.events)
+            case .text:
+                for event in page.events {
+                    let result = writeLine(renderEvent(event))
+                    if result == .brokenPipe {
+                        return .success
+                    }
+                    try requireWrite(result)
+                    emitted += 1
+                }
+            case .jsonl:
+                for event in page.events {
+                    ordinal += 1
+                    let record = GraphCLIJSONLRecord(
+                        command: invocation.command.name,
+                        recordType: "event",
+                        ordinal: ordinal,
+                        payload: event
+                    )
+                    let result = writeLine(
+                        try encodeString(record)
+                    )
+                    if result == .brokenPipe {
+                        return .success
+                    }
+                    try requireWrite(result)
+                    emitted += 1
+                }
+            }
+
+            if page.events.isEmpty, !page.hasMore {
+                break
+            }
+        }
+
+        if suppressOutput {
+            return .success
+        }
+        if invocation.output == .json {
+            emitted = records.count
+            let document = GraphCLIOutputDocument(
+                command: invocation.command.name,
+                resultCount: records.count,
+                eventCount: records.count,
+                result: records
+            )
+            let result = writeLine(try encodeString(document))
+            if result == .brokenPipe {
+                return .success
+            }
+            try requireWrite(result)
+        }
+        if invocation.output == .jsonl,
+           invocation.emitCompletionRecord {
+            let completion = GraphCLICompletionRecord(
+                command: invocation.command.name,
+                status: GraphCLIExitCode.success.category,
+                exitCode: GraphCLIExitCode.success.rawValue,
+                resultCount: emitted,
+                eventCount: emitted,
+                lastSequence: cursor
+            )
+            let result = writeLine(try encodeString(completion))
+            if result != .brokenPipe {
+                try requireWrite(result)
+            }
+        }
+        return .success
+    }
+
+    private func emit<Payload: Encodable, Record: Encodable>(
+        _ payload: Payload,
+        records: [Record],
+        recordType: String,
+        text: String,
+        invocation: GraphCLIInvocation,
+        resultCount: Int,
+        eventCount: Int,
+        suppressOutput: Bool,
+        diagnostics: [GraphCLIOutputDiagnostic] = []
+    ) throws -> GraphCLIExitCode {
+        guard !suppressOutput else {
+            return .success
+        }
+        let result: GraphCLIWriteResult
+
+        switch invocation.output {
+        case .text:
+            result = stdout.write(Data(text.utf8))
+        case .json:
+            result = writeLine(
+                try encodeString(
+                    GraphCLIOutputDocument(
+                        command: invocation.command.name,
+                        resultCount: resultCount,
+                        eventCount: eventCount,
+                        result: payload,
+                        diagnostics: diagnostics.isEmpty
+                            ? nil
+                            : diagnostics
+                    )
+                )
+            )
+        case .jsonl:
+            var ordinal = 0
+            for recordPayload in records {
+                ordinal += 1
+                let line = try encodeString(
+                    GraphCLIJSONLRecord(
+                        command: invocation.command.name,
+                        recordType: recordType,
+                        ordinal: ordinal,
+                        payload: recordPayload
+                    )
+                )
+                let writeResult = writeLine(line)
+                if writeResult == .brokenPipe {
+                    return .success
+                }
+                try requireWrite(writeResult)
+            }
+            if invocation.emitCompletionRecord {
+                let completion = GraphCLICompletionRecord(
+                    command: invocation.command.name,
+                    status: GraphCLIExitCode.success.category,
+                    exitCode: GraphCLIExitCode.success.rawValue,
+                    resultCount: resultCount,
+                    eventCount: eventCount,
+                    lastSequence: nil
+                )
+                let writeResult = writeLine(
+                    try encodeString(completion)
+                )
+                if writeResult != .brokenPipe {
+                    try requireWrite(writeResult)
+                }
+            }
+            return .success
+        }
+
+        if result == .brokenPipe {
+            return .success
+        }
+        try requireWrite(result)
+        return .success
+    }
+
+    private func emit<Payload: Encodable>(
+        _ payload: [Payload],
+        recordType: String,
+        text: String,
+        invocation: GraphCLIInvocation,
+        resultCount: Int,
+        eventCount: Int,
+        suppressOutput: Bool
+    ) throws -> GraphCLIExitCode {
+        try emit(
+            payload,
+            records: payload,
+            recordType: recordType,
+            text: text,
+            invocation: invocation,
+            resultCount: resultCount,
+            eventCount: eventCount,
+            suppressOutput: suppressOutput
+        )
+    }
+
+    private func emitExport(
+        _ inspection: GraphRunInspection,
+        invocation: GraphCLIInvocation,
+        suppressOutput: Bool
+    ) throws -> GraphCLIExitCode {
+        switch invocation.exportFormat {
+        case .json, .jsonl:
+            let records: [GraphExportEntity] =
+                inspection.nodes.map {
+                    GraphExportEntity(
+                        kind: "node",
+                        id: $0.id,
+                        state: $0.reconciledState.rawValue,
+                        role: nil
+                    )
+                }
+                + inspection.attempts.map {
+                    GraphExportEntity(
+                        kind: "attempt",
+                        id: $0.id,
+                        state: $0.reconciledState.rawValue,
+                        role: nil
+                    )
+                }
+                + inspection.artifacts.map {
+                    GraphExportEntity(
+                        kind: "artifact",
+                        id: $0.id,
+                        state: nil,
+                        role: $0.logicalRole
+                    )
+                }
+            return try emit(
+                inspection,
+                records: records,
+                recordType: "graph_entity",
+                text: renderInspection(inspection),
+                invocation: invocation,
+                resultCount: records.count,
+                eventCount: 0,
+                suppressOutput: suppressOutput,
+                diagnostics: diagnostics(inspection)
+            )
+        case .mermaid:
+            let mermaid = GraphMermaidExporter.render(inspection)
+            return try emit(
+                GraphMermaidExport(content: mermaid),
+                records: [GraphMermaidExport(content: mermaid)],
+                recordType: "mermaid",
+                text: mermaid,
+                invocation: invocation,
+                resultCount: 1,
+                eventCount: 0,
+                suppressOutput: suppressOutput
+            )
+        }
+    }
+
+    private func filterSummaries(
+        _ summaries: [GraphRunInspectionSummary],
+        _ invocation: GraphCLIInvocation
+    ) -> [GraphRunInspectionSummary] {
+        summaries.filter {
+            invocation.state == nil
+                || $0.reconciledState == invocation.state
+        }
+    }
+
+    private func filterInspection(
+        _ inspection: GraphRunInspection,
+        _ invocation: GraphCLIInvocation
+    ) -> GraphRunInspection {
+        let nodes = inspection.nodes.filter {
+            (invocation.nodeID == nil || $0.id == invocation.nodeID)
+                && (invocation.state == nil
+                    || $0.reconciledState == invocation.state)
+        }
+        let attempts = inspection.attempts.filter {
+            (invocation.nodeID == nil
+                || $0.nodeID == invocation.nodeID)
+                && (invocation.attemptID == nil
+                    || $0.id == invocation.attemptID)
+                && (invocation.state == nil
+                    || $0.reconciledState == invocation.state)
+        }
+        let artifacts = inspection.artifacts.filter {
+            invocation.nodeID == nil
+                || $0.producingNodeID == invocation.nodeID
+        }
+        return GraphRunInspection(
+            summary: inspection.summary,
+            nodes: nodes,
+            attempts: attempts,
+            checkpoints: inspection.checkpoints,
+            artifacts: artifacts,
+            artifactsIncluded: inspection.artifactsIncluded,
+            parentRunID: inspection.parentRunID,
+            parentCheckpoint: inspection.parentCheckpoint,
+            checkpointNamespace: inspection.checkpointNamespace,
+            graphDefinitionVersion:
+                inspection.graphDefinitionVersion,
+            graphDefinitionDigest:
+                inspection.graphDefinitionDigest,
+            replayDiagnostics: inspection.replayDiagnostics,
+            repositoryDiagnostics: inspection.repositoryDiagnostics
+        )
+    }
+
+    private func replayOutput(
+        _ replay: GraphTemporalReplayResult
+    ) throws -> GraphReplayOutput {
+        guard let projectedRun = replay.projected.run else {
+            throw GraphInspectionError.corruptHistory(
+                "Run \(replay.runID) has no run projection."
+            )
+        }
+        return GraphReplayOutput(
+            runID: replay.runID,
+            boundary: replay.boundary,
+            headVersion: replay.headVersion,
+            snapshotDisposition: replay.snapshotDisposition,
+            snapshotStreamVersion: replay.snapshotStreamVersion,
+            replayedEventCount: replay.replayedEventCount,
+            projectedRunState: projectedRun.state,
+            reconciledRunState:
+                replay.reconciled?.run.state
+                    ?? projectedRun.state,
+            projectedNodes: replay.projected.nodes.map {
+                GraphStateOutput(id: $0.id, state: $0.state)
+            }.sorted { $0.id < $1.id },
+            reconciledNodes: (replay.reconciled?.nodes ?? []).map {
+                GraphStateOutput(id: $0.id, state: $0.state)
+            }.sorted { $0.id < $1.id },
+            projectedAttempts: replay.projected.attempts.map {
+                GraphStateOutput(id: $0.id, state: $0.state)
+            }.sorted { $0.id < $1.id },
+            reconciledAttempts:
+                (replay.reconciled?.attempts ?? []).map {
+                    GraphStateOutput(id: $0.id, state: $0.state)
+                }.sorted { $0.id < $1.id },
+            evidence: replay.evidence,
+            replayDiagnostics: replay.replayDiagnostics,
+            repositoryDiagnostics: replay.repositoryDiagnostics
+        )
+    }
+
+    private func diagnostics(
+        _ inspection: GraphRunInspection
+    ) -> [GraphCLIOutputDiagnostic] {
+        inspection.replayDiagnostics.map {
+            GraphCLIOutputDiagnostic(
+                category: $0.category.rawValue,
+                severity: $0.severity.rawValue,
+                message: $0.message
+            )
+        } + inspection.repositoryDiagnostics.map {
+            GraphCLIOutputDiagnostic(
+                category: $0.category.rawValue,
+                severity: "information",
+                message: $0.message
+            )
+        }
+    }
+
+    private func diagnostics(
+        _ replay: GraphTemporalReplayResult
+    ) -> [GraphCLIOutputDiagnostic] {
+        replay.replayDiagnostics.map {
+            GraphCLIOutputDiagnostic(
+                category: $0.category.rawValue,
+                severity: $0.severity.rawValue,
+                message: $0.message
+            )
+        } + replay.repositoryDiagnostics.map {
+            GraphCLIOutputDiagnostic(
+                category: $0.category.rawValue,
+                severity: "information",
+                message: $0.message
+            )
+        }
+    }
+
+    private func renderSummaries(
+        _ summaries: [GraphRunInspectionSummary]
+    ) -> String {
+        guard !summaries.isEmpty else {
+            return "No graph runs.\n"
+        }
+        return summaries.map {
+            "\($0.runID)  \($0.reconciledState.rawValue)  v\($0.streamVersion)  \($0.nodeCount) nodes"
+        }.joined(separator: "\n") + "\n"
+    }
+
+    private func renderInspection(
+        _ inspection: GraphRunInspection
+    ) -> String {
+        var lines = [
+            "\(inspection.summary.runID)  \(inspection.summary.reconciledState.rawValue)  v\(inspection.summary.streamVersion)",
+        ]
+        for node in inspection.nodes {
+            lines.append(
+                "  \(node.id)  \(node.reconciledState.rawValue)  \(node.title)"
+            )
+        }
+        for attempt in inspection.attempts {
+            lines.append(
+                "    \(attempt.id)  attempt \(attempt.ordinal)  \(attempt.reconciledState.rawValue)"
+            )
+        }
+        if inspection.artifactsIncluded {
+            for artifact in inspection.artifacts {
+                lines.append(
+                    "    artifact \(artifact.id)  \(artifact.logicalRole)"
+                )
+            }
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private func renderEvent(
+        _ event: GraphInspectionEventRecord
+    ) -> String {
+        "\(event.streamSequence)  \(event.eventType)  \(event.id)"
+    }
+
+    private func renderExplanation(
+        _ explanation: GraphCausalExplanation
+    ) -> String {
+        var lines = [explanation.summary]
+        for reason in explanation.reasons {
+            lines.append("  \(reason.code.rawValue): \(reason.message)")
+        }
+        for requirement in explanation.readinessRequirements {
+            lines.append("  requires: \(requirement)")
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private func renderCheckpoints(
+        _ checkpoints: [GraphCheckpointReference]
+    ) -> String {
+        guard !checkpoints.isEmpty else {
+            return "No checkpoints.\n"
+        }
+        return checkpoints.map {
+            "\($0.checkpointID)  v\($0.streamVersion)  \($0.namespace)"
+        }.joined(separator: "\n") + "\n"
+    }
+
+    private func renderReplay(_ replay: GraphReplayOutput) -> String {
+        "\(replay.runID)  boundary v\(replay.boundary)/\(replay.headVersion)  projected \(replay.projectedRunState.rawValue)  reconciled \(replay.reconciledRunState.rawValue)  snapshot \(replay.snapshotDisposition.rawValue)\n"
+    }
+
+    private func renderDiff(_ diff: GraphTemporalDiffResult) -> String {
+        guard !diff.changes.isEmpty else {
+            return "No semantic changes.\n"
+        }
+        return diff.changes.map {
+            "\($0.category.rawValue) \($0.entityID).\($0.field): \($0.left ?? "<absent>") -> \($0.right ?? "<absent>")"
+        }.joined(separator: "\n") + "\n"
+    }
+
+    private func writeLine(_ string: String) -> GraphCLIWriteResult {
+        stdout.write(Data((string + (string.hasSuffix("\n") ? "" : "\n")).utf8))
+    }
+
+    private func requireWrite(
+        _ result: GraphCLIWriteResult
+    ) throws {
+        if case let .failed(message) = result {
+            throw GraphInspectionError.persistence(
+                "Unable to write command output: \(message)"
+            )
+        }
+    }
+
+    private func writeError(
+        _ message: String?,
+        code: GraphCLIExitCode
+    ) {
+        let safe = (message ?? "Unknown error")
+            .replacingOccurrences(of: "\r", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+        _ = stderr.write(
+            Data("error[\(code.category)]: \(safe)\n".utf8)
+        )
+    }
+
+    private func exitCode(for error: Error) -> GraphCLIExitCode {
+        guard let error = error as? GraphInspectionError else {
+            return .persistenceFailure
+        }
+        switch error {
+        case .runNotFound, .checkpointNotFound:
+            return .notFound
+        case .incompatibleSchema:
+            return .incompatibleSchema
+        case .invalidBoundary, .corruptHistory:
+            return .corruptHistory
+        case .persistence:
+            return .persistenceFailure
+        case .evidenceUnavailable:
+            return .evidenceUnavailable
+        }
+    }
+
+    private func encodeString<Value: Encodable>(
+        _ value: Value
+    ) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return String(
+            decoding: try encoder.encode(value),
+            as: UTF8.self
+        )
+    }
+}
+
+public struct GraphExportEntity:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let kind: String
+    public let id: String
+    public let state: String?
+    public let role: String?
+}

--- a/Sources/OpenIslandCore/GraphCLI.swift
+++ b/Sources/OpenIslandCore/GraphCLI.swift
@@ -16,6 +16,12 @@ public enum GraphCLIExitCode: Int32, Codable, CaseIterable, Sendable {
     case persistenceFailure = 6
     case evidenceUnavailable = 7
     case partialResult = 8
+    case optimisticConflict = 9
+    case policyDenied = 10
+    case staleExecutor = 11
+    case adapterUnavailable = 12
+    case executionTerminalFailure = 13
+    case cancellation = 14
     case interrupted = 130
 
     public var category: String {
@@ -36,6 +42,18 @@ public enum GraphCLIExitCode: Int32, Codable, CaseIterable, Sendable {
             "evidence_unavailable"
         case .partialResult:
             "partial_result"
+        case .optimisticConflict:
+            "optimistic_conflict"
+        case .policyDenied:
+            "policy_denied"
+        case .staleExecutor:
+            "stale_executor"
+        case .adapterUnavailable:
+            "adapter_unavailable"
+        case .executionTerminalFailure:
+            "execution_terminal_failure"
+        case .cancellation:
+            "cancellation"
         case .interrupted:
             "interrupted"
         }
@@ -106,6 +124,10 @@ public enum GraphCLIExportFormat: String, Codable, Sendable {
 }
 
 public enum GraphCLICommand: Equatable, Sendable {
+    case create(runID: String, definitionPath: String)
+    case start(runID: String)
+    case cancel(runID: String)
+    case retry(runID: String, nodeID: String)
     case list
     case inspect(runID: String)
     case history(runID: String)
@@ -117,6 +139,14 @@ public enum GraphCLICommand: Equatable, Sendable {
 
     public var name: String {
         switch self {
+        case .create:
+            "graph.create"
+        case .start:
+            "graph.start"
+        case .cancel:
+            "graph.cancel"
+        case .retry:
+            "graph.retry"
         case .list:
             "graph.list"
         case .inspect:
@@ -159,6 +189,12 @@ public struct GraphCLIInvocation: Equatable, Sendable {
     public let requireLiveEvidence: Bool
     public let exportFormat: GraphCLIExportFormat
     public let emitCompletionRecord: Bool
+    public let idempotencyKey: String?
+    public let expectedVersion: UInt64?
+    public let requestedBy: String
+    public let reason: String?
+    public let dryRun: Bool
+    public let logicalTime: Date?
 
     public init(
         command: GraphCLICommand,
@@ -181,7 +217,13 @@ public struct GraphCLIInvocation: Equatable, Sendable {
         withoutLiveEvidence: Bool = false,
         requireLiveEvidence: Bool = false,
         exportFormat: GraphCLIExportFormat = .json,
-        emitCompletionRecord: Bool = false
+        emitCompletionRecord: Bool = false,
+        idempotencyKey: String? = nil,
+        expectedVersion: UInt64? = nil,
+        requestedBy: String = "openisland.cli",
+        reason: String? = nil,
+        dryRun: Bool = false,
+        logicalTime: Date? = nil
     ) {
         self.command = command
         self.output = output
@@ -204,6 +246,12 @@ public struct GraphCLIInvocation: Equatable, Sendable {
         self.requireLiveEvidence = requireLiveEvidence
         self.exportFormat = exportFormat
         self.emitCompletionRecord = emitCompletionRecord
+        self.idempotencyKey = idempotencyKey
+        self.expectedVersion = expectedVersion
+        self.requestedBy = requestedBy
+        self.reason = reason
+        self.dryRun = dryRun
+        self.logicalTime = logicalTime
     }
 }
 
@@ -271,6 +319,12 @@ public enum GraphCLIParser {
             "--to-sequence",
             "--checkpoint",
             "--format",
+            "--run-id",
+            "--idempotency-key",
+            "--expected-version",
+            "--requested-by",
+            "--reason",
+            "--logical-time",
         ])
         let flagOptions = Set([
             "--no-color",
@@ -380,8 +434,81 @@ public enum GraphCLIParser {
             return format
         } ?? .json
         let command: GraphCLICommand
+        let runIDOption = try singleValue("--run-id", values)
+        let idempotencyKey = try singleValue(
+            "--idempotency-key",
+            values
+        )
+        let expectedVersion = try parseUInt64(
+            singleValue("--expected-version", values),
+            option: "--expected-version"
+        )
+        let requestedBy = try singleValue("--requested-by", values)
+            ?? "openisland.cli"
+        let reason = try singleValue("--reason", values)
+        let logicalTime = try parseDate(
+            singleValue("--logical-time", values),
+            option: "--logical-time"
+        )
 
         switch commandToken {
+        case "create":
+            try requirePositionals(
+                positional,
+                count: 1,
+                command: "create"
+            )
+            guard let runIDOption, idempotencyKey != nil else {
+                throw GraphCLIArgumentError.invalid(
+                    "`graph create` requires --run-id and --idempotency-key."
+                )
+            }
+            command = .create(
+                runID: runIDOption,
+                definitionPath: positional[0]
+            )
+        case "start":
+            try requirePositionals(
+                positional,
+                count: 1,
+                command: "start"
+            )
+            guard idempotencyKey != nil else {
+                throw GraphCLIArgumentError.invalid(
+                    "`graph start` requires --idempotency-key."
+                )
+            }
+            command = .start(runID: positional[0])
+        case "cancel":
+            try requirePositionals(
+                positional,
+                count: 1,
+                command: "cancel"
+            )
+            guard idempotencyKey != nil else {
+                throw GraphCLIArgumentError.invalid(
+                    "`graph cancel` requires --idempotency-key."
+                )
+            }
+            command = .cancel(runID: positional[0])
+        case "retry":
+            guard (1...2).contains(positional.count) else {
+                throw GraphCLIArgumentError.invalid(
+                    "Usage: openisland graph retry <run-id> <node-id>"
+                )
+            }
+            let retryNodeID = positional.count == 2
+                ? positional[1]
+                : optionNodeID
+            guard let retryNodeID, idempotencyKey != nil else {
+                throw GraphCLIArgumentError.invalid(
+                    "`graph retry` requires a node and --idempotency-key."
+                )
+            }
+            command = .retry(
+                runID: positional[0],
+                nodeID: retryNodeID
+            )
         case "list":
             try requirePositionals(positional, count: 0, command: "list")
             command = .list
@@ -518,13 +645,23 @@ public enum GraphCLIParser {
                     flags.contains("--require-live-evidence"),
                 exportFormat: exportFormat,
                 emitCompletionRecord:
-                    flags.contains("--emit-completion-record")
+                    flags.contains("--emit-completion-record"),
+                idempotencyKey: idempotencyKey,
+                expectedVersion: expectedVersion,
+                requestedBy: requestedBy,
+                reason: reason,
+                dryRun: flags.contains("--dry-run"),
+                logicalTime: logicalTime
             )
         )
     }
 
     public static let usage = """
     Usage:
+      openisland graph create <definition.json> --run-id <run-id> --idempotency-key <key> [options]
+      openisland graph start <run-id> --idempotency-key <key> [options]
+      openisland graph cancel <run-id> [--node <node-id>] --idempotency-key <key> [options]
+      openisland graph retry <run-id> <node-id> --idempotency-key <key> [options]
       openisland graph list [options]
       openisland graph inspect <run-id> [options]
       openisland graph history <run-id> [options]
@@ -540,6 +677,8 @@ public enum GraphCLIParser {
     Safety: --no-color --quiet --include-diagnostics --include-artifacts
             --without-live-evidence --require-live-evidence
             --emit-completion-record
+    Mutation: --idempotency-key --expected-version --dry-run
+              --requested-by --reason --logical-time
     """
 
     private static func singleValue(
@@ -916,6 +1055,8 @@ public enum GraphMermaidExporter {
 
 public struct GraphCLICommandRunner: Sendable {
     private let inspector: any GraphTemporalInspecting
+    private let mutator: (any GraphMutating)?
+    private let definitionLoader: any GraphExecutableDefinitionLoading
     private let stdout: any GraphCLIOutputSink
     private let stderr: any GraphCLIOutputSink
     private let context: GraphCLIExecutionContext?
@@ -925,6 +1066,9 @@ public struct GraphCLICommandRunner: Sendable {
 
     public init(
         inspector: any GraphTemporalInspecting,
+        mutator: (any GraphMutating)? = nil,
+        definitionLoader: any GraphExecutableDefinitionLoading =
+            FileGraphExecutableDefinitionLoader(),
         stdout: any GraphCLIOutputSink,
         stderr: any GraphCLIOutputSink,
         context: GraphCLIExecutionContext? = nil,
@@ -935,6 +1079,8 @@ public struct GraphCLICommandRunner: Sendable {
         isOutputTTY: Bool = true
     ) {
         self.inspector = inspector
+        self.mutator = mutator
+        self.definitionLoader = definitionLoader
         self.stdout = stdout
         self.stderr = stderr
         self.context = context
@@ -1026,6 +1172,80 @@ public struct GraphCLICommandRunner: Sendable {
         suppressOutput: Bool = false
     ) async throws -> GraphCLICommandOutcome {
         switch invocation.command {
+        case let .create(runID, definitionPath):
+            let mutator = try requireMutator()
+            let report = try await mutator.create(
+                GraphCreateRequest(
+                    runID: runID,
+                    definition: try definitionLoader.load(
+                        path: definitionPath
+                    ),
+                    idempotencyKey: invocation.idempotencyKey!,
+                    expectedVersion: invocation.expectedVersion,
+                    dryRun: invocation.dryRun,
+                    occurredAt: invocation.logicalTime ?? Date(),
+                    producer: mutationProducer
+                )
+            )
+            return try emitMutation(
+                report,
+                invocation: invocation,
+                suppressOutput: suppressOutput
+            )
+        case let .start(runID):
+            let report = try await requireMutator().start(
+                GraphStartRequest(
+                    runID: runID,
+                    idempotencyKey: invocation.idempotencyKey!,
+                    expectedVersion: invocation.expectedVersion,
+                    requestedBy: invocation.requestedBy,
+                    dryRun: invocation.dryRun,
+                    occurredAt: invocation.logicalTime ?? Date(),
+                    producer: mutationProducer
+                )
+            )
+            return try emitMutation(
+                report,
+                invocation: invocation,
+                suppressOutput: suppressOutput
+            )
+        case let .cancel(runID):
+            let report = try await requireMutator().cancel(
+                GraphCancelMutationRequest(
+                    runID: runID,
+                    nodeID: invocation.nodeID,
+                    idempotencyKey: invocation.idempotencyKey!,
+                    expectedVersion: invocation.expectedVersion,
+                    requestedBy: invocation.requestedBy,
+                    reason: invocation.reason,
+                    dryRun: invocation.dryRun,
+                    occurredAt: invocation.logicalTime ?? Date(),
+                    producer: mutationProducer
+                )
+            )
+            return try emitMutation(
+                report,
+                invocation: invocation,
+                suppressOutput: suppressOutput
+            )
+        case let .retry(runID, nodeID):
+            let report = try await requireMutator().retry(
+                GraphRetryMutationRequest(
+                    runID: runID,
+                    nodeID: nodeID,
+                    idempotencyKey: invocation.idempotencyKey!,
+                    expectedVersion: invocation.expectedVersion,
+                    requestedBy: invocation.requestedBy,
+                    dryRun: invocation.dryRun,
+                    occurredAt: invocation.logicalTime ?? Date(),
+                    producer: mutationProducer
+                )
+            )
+            return try emitMutation(
+                report,
+                invocation: invocation,
+                suppressOutput: suppressOutput
+            )
         case .list:
             var summaries = try await inspector.listRuns(
                 state: invocation.state,
@@ -1344,6 +1564,53 @@ public struct GraphCLICommandRunner: Sendable {
             resultCount: emitted,
             eventCount: emitted,
             replayBoundary: cursor
+        )
+    }
+
+    private var mutationProducer: GraphExecutionProducer {
+        GraphExecutionProducer(
+            id: "openisland.graph.cli",
+            kind: .user,
+            instanceID: context?.terminalGraph.nodeID
+        )
+    }
+
+    private func requireMutator() throws -> any GraphMutating {
+        guard let mutator else {
+            throw GraphMutationError.persistence(
+                "mutation service is unavailable."
+            )
+        }
+        return mutator
+    }
+
+    private func emitMutation(
+        _ report: GraphMutationReport,
+        invocation: GraphCLIInvocation,
+        suppressOutput: Bool
+    ) throws -> GraphCLICommandOutcome {
+        let text = [
+            "Operation: \(report.operation)",
+            "Status: \(report.status.rawValue)",
+            "Run: \(report.runID)",
+            "Version: \(report.previousVersion) -> \(report.streamVersion)",
+            "Events: \(report.eventTypes.joined(separator: ", "))",
+        ].joined(separator: "\n") + "\n"
+        let code = try emit(
+            report,
+            records: [report],
+            recordType: "mutation",
+            text: text,
+            invocation: invocation,
+            resultCount: 1,
+            eventCount: report.eventTypes.count,
+            suppressOutput: suppressOutput
+        )
+        return GraphCLICommandOutcome(
+            exitCode: code,
+            resultCount: 1,
+            eventCount: report.eventTypes.count,
+            replayBoundary: report.streamVersion
         )
     }
 
@@ -1909,6 +2176,20 @@ public struct GraphCLICommandRunner: Sendable {
     }
 
     private func exitCode(for error: Error) -> GraphCLIExitCode {
+        if let error = error as? GraphMutationError {
+            switch error {
+            case .invalidRequest:
+                return .invalidArguments
+            case .notFound:
+                return .notFound
+            case .optimisticConflict, .idempotencyConflict:
+                return .optimisticConflict
+            case .policyDenied:
+                return .policyDenied
+            case .persistence:
+                return .persistenceFailure
+            }
+        }
         guard let error = error as? GraphInspectionError else {
             return .persistenceFailure
         }

--- a/Sources/OpenIslandCore/GraphCLI.swift
+++ b/Sources/OpenIslandCore/GraphCLI.swift
@@ -208,7 +208,8 @@ public struct GraphCLIInvocation: Equatable, Sendable {
 }
 
 public enum GraphCLIOutputSchema {
-    public static let currentVersion = 1
+    public static let minimumSupportedVersion = 1
+    public static let currentVersion = 2
 }
 
 public enum GraphCLIArgumentError: Error, Equatable, Sendable {
@@ -323,7 +324,10 @@ public enum GraphCLIParser {
             singleValue("--schema-version", values),
             option: "--schema-version"
         ) ?? GraphCLIOutputSchema.currentVersion
-        guard requestedSchema == GraphCLIOutputSchema.currentVersion else {
+        guard requestedSchema
+                >= GraphCLIOutputSchema.minimumSupportedVersion,
+              requestedSchema
+                <= GraphCLIOutputSchema.currentVersion else {
             throw GraphCLIArgumentError.unsupportedSchema(
                 found: requestedSchema,
                 supported: GraphCLIOutputSchema.currentVersion
@@ -1075,9 +1079,13 @@ public struct GraphCLICommandRunner: Sendable {
                 suppressOutput: suppressOutput
             )
         case let .explain(runID, positionalNodeID):
-            let explanation = try await inspector.explain(
+            let inspectedExplanation = try await inspector.explain(
                 runID: runID,
                 nodeID: invocation.nodeID ?? positionalNodeID
+            )
+            let explanation = filterExplanation(
+                inspectedExplanation,
+                invocation
             )
             let code = try emit(
                 explanation,
@@ -1155,9 +1163,9 @@ public struct GraphCLICommandRunner: Sendable {
                     output.reconciledRunState.rawValue
             )
         case let .diff(left, right):
-            let diff = try await inspector.diff(
-                left: left,
-                right: right
+            let diff = filterDiff(
+                try await inspector.diff(left: left, right: right),
+                invocation
             )
             let code = try emit(
                 diff,
@@ -1174,10 +1182,13 @@ public struct GraphCLICommandRunner: Sendable {
                 resultCount: diff.changes.count
             )
         case let .export(runID):
-            let inspection = try await inspector.inspect(
-                runID: runID,
-                includeArtifacts: true,
-                includeDiagnostics: invocation.includeDiagnostics
+            let inspection = filterInspection(
+                try await inspector.inspect(
+                    runID: runID,
+                    includeArtifacts: true,
+                    includeDiagnostics: invocation.includeDiagnostics
+                ),
+                invocation
             )
             let code = try emitExport(
                 inspection,
@@ -1254,6 +1265,7 @@ public struct GraphCLICommandRunner: Sendable {
                 for event in page.events {
                     ordinal += 1
                     let record = GraphCLIJSONLRecord(
+                        schemaVersion: invocation.schemaVersion,
                         command: invocation.command.name,
                         recordType: "event",
                         ordinal: ordinal,
@@ -1292,6 +1304,7 @@ public struct GraphCLICommandRunner: Sendable {
         if invocation.output == .json {
             emitted = records.count
             let document = GraphCLIOutputDocument(
+                schemaVersion: invocation.schemaVersion,
                 command: invocation.command.name,
                 resultCount: records.count,
                 eventCount: records.count,
@@ -1312,6 +1325,7 @@ public struct GraphCLICommandRunner: Sendable {
         if invocation.output == .jsonl,
            invocation.emitCompletionRecord {
             let completion = GraphCLICompletionRecord(
+                schemaVersion: invocation.schemaVersion,
                 command: invocation.command.name,
                 status: GraphCLIExitCode.success.category,
                 exitCode: GraphCLIExitCode.success.rawValue,
@@ -1356,6 +1370,7 @@ public struct GraphCLICommandRunner: Sendable {
             result = writeLine(
                 try encodeString(
                     GraphCLIOutputDocument(
+                        schemaVersion: invocation.schemaVersion,
                         command: invocation.command.name,
                         resultCount: resultCount,
                         eventCount: eventCount,
@@ -1373,6 +1388,7 @@ public struct GraphCLICommandRunner: Sendable {
                 ordinal += 1
                 let line = try encodeString(
                     GraphCLIJSONLRecord(
+                        schemaVersion: invocation.schemaVersion,
                         command: invocation.command.name,
                         recordType: recordType,
                         ordinal: ordinal,
@@ -1388,6 +1404,7 @@ public struct GraphCLICommandRunner: Sendable {
             }
             if invocation.emitCompletionRecord {
                 let completion = GraphCLICompletionRecord(
+                    schemaVersion: invocation.schemaVersion,
                     command: invocation.command.name,
                     status: GraphCLIExitCode.success.category,
                     exitCode: GraphCLIExitCode.success.rawValue,
@@ -1539,6 +1556,13 @@ public struct GraphCLICommandRunner: Sendable {
             invocation.nodeID == nil
                 || $0.producingNodeID == invocation.nodeID
         }
+        let scheduling = invocation.schemaVersion >= 2
+            ? filteredScheduling(
+                inspection.scheduling,
+                nodeID: invocation.nodeID,
+                attemptID: invocation.attemptID
+            )
+            : nil
         return GraphRunInspection(
             summary: inspection.summary,
             nodes: nodes,
@@ -1553,8 +1577,104 @@ public struct GraphCLICommandRunner: Sendable {
                 inspection.graphDefinitionVersion,
             graphDefinitionDigest:
                 inspection.graphDefinitionDigest,
+            scheduling: scheduling,
             replayDiagnostics: inspection.replayDiagnostics,
             repositoryDiagnostics: inspection.repositoryDiagnostics
+        )
+    }
+
+    private func filteredScheduling(
+        _ scheduling: GraphSchedulingInspection?,
+        nodeID: String?,
+        attemptID: String?
+    ) -> GraphSchedulingInspection? {
+        guard let scheduling else { return nil }
+        guard nodeID != nil || attemptID != nil else { return scheduling }
+        let nodeMatches: (String) -> Bool = {
+            nodeID == nil || $0 == nodeID
+        }
+        let attemptMatches: (String?) -> Bool = {
+            attemptID == nil || $0 == attemptID
+        }
+        return GraphSchedulingInspection(
+            schemaVersion: scheduling.schemaVersion,
+            latestEvaluation: scheduling.latestEvaluation,
+            currentPolicy: scheduling.currentPolicy,
+            activeClaims: scheduling.activeClaims.filter {
+                nodeMatches($0.nodeID)
+            },
+            claimHistory: scheduling.claimHistory.filter {
+                nodeMatches($0.nodeID)
+            },
+            retries: scheduling.retries.filter {
+                nodeMatches($0.nodeID)
+                    && attemptMatches($0.failedAttemptID)
+            },
+            pendingCancellations:
+                scheduling.pendingCancellations.filter {
+                    nodeMatches($0.nodeID)
+                        && attemptMatches($0.attemptID)
+                },
+            cancellationHistory:
+                scheduling.cancellationHistory.filter {
+                    nodeMatches($0.nodeID)
+                        && attemptMatches($0.attemptID)
+                },
+            timeouts: scheduling.timeouts.filter {
+                nodeMatches($0.nodeID)
+                    && attemptMatches($0.attemptID)
+            },
+            reasonCodes: scheduling.reasonCodes,
+            records: scheduling.records.filter {
+                ($0.nodeID == nil || nodeMatches($0.nodeID!))
+                    && attemptMatches($0.attemptID)
+            }
+        )
+    }
+
+    private func filterExplanation(
+        _ explanation: GraphCausalExplanation,
+        _ invocation: GraphCLIInvocation
+    ) -> GraphCausalExplanation {
+        guard invocation.schemaVersion == 1 else { return explanation }
+        return GraphCausalExplanation(
+            runID: explanation.runID,
+            nodeID: explanation.nodeID,
+            state: explanation.state,
+            summary: explanation.summary,
+            reasons: explanation.reasons,
+            edges: explanation.edges,
+            shortestCausalChain: explanation.shortestCausalChain,
+            causalPredecessorNodeIDs:
+                explanation.causalPredecessorNodeIDs,
+            blockingDependencyNodeIDs:
+                explanation.blockingDependencyNodeIDs,
+            readinessRequirements: explanation.readinessRequirements,
+            schedulerReasons: nil,
+            ignoredInputs: explanation.ignoredInputs
+        )
+    }
+
+    private func filterDiff(
+        _ diff: GraphTemporalDiffResult,
+        _ invocation: GraphCLIInvocation
+    ) -> GraphTemporalDiffResult {
+        guard invocation.schemaVersion == 1 else { return diff }
+        let schedulingCategories: Set<GraphTemporalChangeCategory> = [
+            .scheduler,
+            .claim,
+            .retry,
+            .cancellation,
+            .timeout,
+        ]
+        return GraphTemporalDiffResult(
+            left: diff.left,
+            right: diff.right,
+            leftBoundary: diff.leftBoundary,
+            rightBoundary: diff.rightBoundary,
+            changes: diff.changes.filter {
+                !schedulingCategories.contains($0.category)
+            }
         )
     }
 
@@ -1678,6 +1798,28 @@ public struct GraphCLICommandRunner: Sendable {
                 "    \(attempt.id)  attempt \(attempt.ordinal)  \(attempt.reconciledState.rawValue)"
             )
         }
+        if let scheduling = inspection.scheduling {
+            for claim in scheduling.activeClaims {
+                lines.append(
+                    "    claim \(claim.id)  \(claim.nodeID)  generation \(claim.leaseGeneration)  expires \(graphCLIISO8601(claim.leaseExpiry))"
+                )
+            }
+            for retry in scheduling.retries {
+                lines.append(
+                    "    retry \(retry.nodeID)#\(retry.nextAttemptOrdinal)  eligible \(graphCLIISO8601(retry.eligibleAt))"
+                )
+            }
+            for cancellation in scheduling.pendingCancellations {
+                lines.append(
+                    "    cancellation \(cancellation.id)  \(cancellation.state.rawValue)"
+                )
+            }
+            for timeout in scheduling.timeouts {
+                lines.append(
+                    "    timeout \(timeout.id)  \(timeout.kind.rawValue)"
+                )
+            }
+        }
         if inspection.artifactsIncluded {
             for artifact in inspection.artifacts {
                 lines.append(
@@ -1703,6 +1845,9 @@ public struct GraphCLICommandRunner: Sendable {
         }
         for requirement in explanation.readinessRequirements {
             lines.append("  requires: \(requirement)")
+        }
+        for reason in explanation.schedulerReasons ?? [] {
+            lines.append("  scheduler: \(reason.rawValue)")
         }
         return lines.joined(separator: "\n") + "\n"
     }
@@ -1844,6 +1989,10 @@ private struct GraphCLICommandOutcome: Sendable {
         self.snapshotDisposition = snapshotDisposition
         self.reconciliationOutcome = reconciliationOutcome
     }
+}
+
+private func graphCLIISO8601(_ date: Date) -> String {
+    ISO8601DateFormatter().string(from: date)
 }
 
 public struct GraphExportEntity:

--- a/Sources/OpenIslandCore/GraphCLI.swift
+++ b/Sources/OpenIslandCore/GraphCLI.swift
@@ -128,6 +128,8 @@ public enum GraphCLICommand: Equatable, Sendable {
     case start(runID: String)
     case cancel(runID: String)
     case retry(runID: String, nodeID: String)
+    case step(runID: String)
+    case run(runID: String)
     case list
     case inspect(runID: String)
     case history(runID: String)
@@ -147,6 +149,10 @@ public enum GraphCLICommand: Equatable, Sendable {
             "graph.cancel"
         case .retry:
             "graph.retry"
+        case .step:
+            "graph.step"
+        case .run:
+            "graph.run"
         case .list:
             "graph.list"
         case .inspect:
@@ -195,6 +201,7 @@ public struct GraphCLIInvocation: Equatable, Sendable {
     public let reason: String?
     public let dryRun: Bool
     public let logicalTime: Date?
+    public let cycleLimit: Int
 
     public init(
         command: GraphCLICommand,
@@ -223,7 +230,8 @@ public struct GraphCLIInvocation: Equatable, Sendable {
         requestedBy: String = "openisland.cli",
         reason: String? = nil,
         dryRun: Bool = false,
-        logicalTime: Date? = nil
+        logicalTime: Date? = nil,
+        cycleLimit: Int = 100
     ) {
         self.command = command
         self.output = output
@@ -252,6 +260,7 @@ public struct GraphCLIInvocation: Equatable, Sendable {
         self.reason = reason
         self.dryRun = dryRun
         self.logicalTime = logicalTime
+        self.cycleLimit = cycleLimit
     }
 }
 
@@ -325,6 +334,7 @@ public enum GraphCLIParser {
             "--requested-by",
             "--reason",
             "--logical-time",
+            "--cycle-limit",
         ])
         let flagOptions = Set([
             "--no-color",
@@ -450,6 +460,15 @@ public enum GraphCLIParser {
             singleValue("--logical-time", values),
             option: "--logical-time"
         )
+        let cycleLimit = try parseInt(
+            singleValue("--cycle-limit", values),
+            option: "--cycle-limit"
+        ) ?? 100
+        guard (1...10_000).contains(cycleLimit) else {
+            throw GraphCLIArgumentError.invalid(
+                "--cycle-limit must be between 1 and 10000."
+            )
+        }
 
         switch commandToken {
         case "create":
@@ -509,6 +528,20 @@ public enum GraphCLIParser {
                 runID: positional[0],
                 nodeID: retryNodeID
             )
+        case "step":
+            try requirePositionals(
+                positional,
+                count: 1,
+                command: "step"
+            )
+            command = .step(runID: positional[0])
+        case "run":
+            try requirePositionals(
+                positional,
+                count: 1,
+                command: "run"
+            )
+            command = .run(runID: positional[0])
         case "list":
             try requirePositionals(positional, count: 0, command: "list")
             command = .list
@@ -651,7 +684,8 @@ public enum GraphCLIParser {
                 requestedBy: requestedBy,
                 reason: reason,
                 dryRun: flags.contains("--dry-run"),
-                logicalTime: logicalTime
+                logicalTime: logicalTime,
+                cycleLimit: cycleLimit
             )
         )
     }
@@ -662,6 +696,8 @@ public enum GraphCLIParser {
       openisland graph start <run-id> --idempotency-key <key> [options]
       openisland graph cancel <run-id> [--node <node-id>] --idempotency-key <key> [options]
       openisland graph retry <run-id> <node-id> --idempotency-key <key> [options]
+      openisland graph step <run-id> [options]
+      openisland graph run <run-id> [--cycle-limit <count>] [options]
       openisland graph list [options]
       openisland graph inspect <run-id> [options]
       openisland graph history <run-id> [options]
@@ -1056,6 +1092,7 @@ public enum GraphMermaidExporter {
 public struct GraphCLICommandRunner: Sendable {
     private let inspector: any GraphTemporalInspecting
     private let mutator: (any GraphMutating)?
+    private let orchestrator: (any GraphOrchestrating)?
     private let definitionLoader: any GraphExecutableDefinitionLoading
     private let stdout: any GraphCLIOutputSink
     private let stderr: any GraphCLIOutputSink
@@ -1067,6 +1104,7 @@ public struct GraphCLICommandRunner: Sendable {
     public init(
         inspector: any GraphTemporalInspecting,
         mutator: (any GraphMutating)? = nil,
+        orchestrator: (any GraphOrchestrating)? = nil,
         definitionLoader: any GraphExecutableDefinitionLoading =
             FileGraphExecutableDefinitionLoader(),
         stdout: any GraphCLIOutputSink,
@@ -1080,6 +1118,7 @@ public struct GraphCLICommandRunner: Sendable {
     ) {
         self.inspector = inspector
         self.mutator = mutator
+        self.orchestrator = orchestrator
         self.definitionLoader = definitionLoader
         self.stdout = stdout
         self.stderr = stderr
@@ -1242,6 +1281,35 @@ public struct GraphCLICommandRunner: Sendable {
                 )
             )
             return try emitMutation(
+                report,
+                invocation: invocation,
+                suppressOutput: suppressOutput
+            )
+        case let .step(runID):
+            let report = try await requireOrchestrator().step(
+                GraphOrchestrationStepRequest(
+                    runID: runID,
+                    logicalTime: invocation.logicalTime ?? Date(),
+                    expectedVersion: invocation.expectedVersion,
+                    dryRun: invocation.dryRun
+                )
+            )
+            return try emitCycle(
+                report,
+                invocation: invocation,
+                suppressOutput: suppressOutput
+            )
+        case let .run(runID):
+            let report = try await requireOrchestrator().run(
+                GraphOrchestrationRunRequest(
+                    runID: runID,
+                    cycleLimit: invocation.cycleLimit,
+                    expectedVersion: invocation.expectedVersion,
+                    dryRun: invocation.dryRun,
+                    logicalTime: invocation.logicalTime
+                )
+            )
+            return try emitRun(
                 report,
                 invocation: invocation,
                 suppressOutput: suppressOutput
@@ -1584,6 +1652,15 @@ public struct GraphCLICommandRunner: Sendable {
         return mutator
     }
 
+    private func requireOrchestrator() throws -> any GraphOrchestrating {
+        guard let orchestrator else {
+            throw GraphOrchestrationError.adapterUnavailable(
+                "orchestration service is unavailable."
+            )
+        }
+        return orchestrator
+    }
+
     private func emitMutation(
         _ report: GraphMutationReport,
         invocation: GraphCLIInvocation,
@@ -1614,6 +1691,92 @@ public struct GraphCLICommandRunner: Sendable {
         )
     }
 
+    private func emitCycle(
+        _ report: GraphOrchestrationCycleReport,
+        invocation: GraphCLIInvocation,
+        suppressOutput: Bool
+    ) throws -> GraphCLICommandOutcome {
+        let text = "\(report.runID)  \(report.status.rawValue)  v\(report.previousVersion)->v\(report.streamVersion)  \(report.runState.rawValue)\n"
+        let executionCode = executionExitCode(
+            report.runState,
+            status: report.status
+        )
+        let writeCode = try emit(
+            report,
+            records: [report],
+            recordType: "orchestration_cycle",
+            text: text,
+            invocation: invocation,
+            resultCount: 1,
+            eventCount: report.persistedEventCount,
+            suppressOutput: suppressOutput,
+            completionExitCode: executionCode
+        )
+        let code = writeCode == .success
+            ? executionCode
+            : writeCode
+        return GraphCLICommandOutcome(
+            exitCode: code,
+            resultCount: 1,
+            eventCount: report.persistedEventCount,
+            replayBoundary: report.streamVersion,
+            reconciliationOutcome: report.runState.rawValue
+        )
+    }
+
+    private func emitRun(
+        _ report: GraphOrchestrationRunReport,
+        invocation: GraphCLIInvocation,
+        suppressOutput: Bool
+    ) throws -> GraphCLICommandOutcome {
+        let text = "\(report.runID)  \(report.status.rawValue)  \(report.cycles.count) cycles  v\(report.finalVersion)  \(report.finalState.rawValue)\n"
+        let eventCount = report.cycles.reduce(0) {
+            $0 + $1.persistedEventCount
+        }
+        let executionCode = executionExitCode(
+            report.finalState,
+            status: report.status
+        )
+        let writeCode = try emit(
+            report,
+            records: report.cycles,
+            recordType: "orchestration_cycle",
+            text: text,
+            invocation: invocation,
+            resultCount: report.cycles.count,
+            eventCount: eventCount,
+            suppressOutput: suppressOutput,
+            completionExitCode: executionCode
+        )
+        let code = writeCode == .success
+            ? executionCode
+            : writeCode
+        return GraphCLICommandOutcome(
+            exitCode: code,
+            resultCount: report.cycles.count,
+            eventCount: eventCount,
+            replayBoundary: report.finalVersion,
+            reconciliationOutcome: report.finalState.rawValue
+        )
+    }
+
+    private func executionExitCode(
+        _ state: ReconciledExecutionState,
+        status: GraphOrchestrationCycleStatus
+    ) -> GraphCLIExitCode {
+        if status == .adapterUnavailable {
+            return .adapterUnavailable
+        }
+        switch state {
+        case .failed, .interrupted, .orphaned, .blocked:
+            return .executionTerminalFailure
+        case .cancelled:
+            return .cancellation
+        case .pending, .ready, .running, .completed:
+            return .success
+        }
+    }
+
     private func emit<Payload: Encodable, Record: Encodable>(
         _ payload: Payload,
         records: [Record],
@@ -1623,7 +1786,8 @@ public struct GraphCLICommandRunner: Sendable {
         resultCount: Int,
         eventCount: Int,
         suppressOutput: Bool,
-        diagnostics: [GraphCLIOutputDiagnostic] = []
+        diagnostics: [GraphCLIOutputDiagnostic] = [],
+        completionExitCode: GraphCLIExitCode = .success
     ) throws -> GraphCLIExitCode {
         guard !suppressOutput else {
             return .success
@@ -1673,8 +1837,8 @@ public struct GraphCLICommandRunner: Sendable {
                 let completion = GraphCLICompletionRecord(
                     schemaVersion: invocation.schemaVersion,
                     command: invocation.command.name,
-                    status: GraphCLIExitCode.success.category,
-                    exitCode: GraphCLIExitCode.success.rawValue,
+                    status: completionExitCode.category,
+                    exitCode: completionExitCode.rawValue,
                     resultCount: resultCount,
                     eventCount: eventCount,
                     lastSequence: nil,
@@ -2176,6 +2340,22 @@ public struct GraphCLICommandRunner: Sendable {
     }
 
     private func exitCode(for error: Error) -> GraphCLIExitCode {
+        if let error = error as? GraphOrchestrationError {
+            switch error {
+            case .notFound:
+                return .notFound
+            case .invalidDefinition:
+                return .invalidArguments
+            case .optimisticConflict:
+                return .optimisticConflict
+            case .staleExecutor:
+                return .staleExecutor
+            case .adapterUnavailable:
+                return .adapterUnavailable
+            case .persistence:
+                return .persistenceFailure
+            }
+        }
         if let error = error as? GraphMutationError {
             switch error {
             case .invalidRequest:

--- a/Sources/OpenIslandCore/GraphCLI.swift
+++ b/Sources/OpenIslandCore/GraphCLI.swift
@@ -102,6 +102,7 @@ public enum GraphCLIExportFormat: String, Codable, Sendable {
     case json
     case jsonl
     case mermaid
+    case terminalWorkspacePlan = "terminal-workspace-plan"
 }
 
 public enum GraphCLICommand: Equatable, Sendable {
@@ -365,7 +366,7 @@ public enum GraphCLIParser {
         let exportFormat = try singleValue("--format", values).map {
             guard let format = GraphCLIExportFormat(rawValue: $0) else {
                 throw GraphCLIArgumentError.invalid(
-                    "Export format must be json, jsonl, or mermaid."
+                    "Export format must be json, jsonl, mermaid, or terminal-workspace-plan."
                 )
             }
             return format
@@ -464,6 +465,8 @@ public enum GraphCLIParser {
                 resolvedOutput = .jsonl
             case .mermaid:
                 resolvedOutput = .text
+            case .terminalWorkspacePlan:
+                resolvedOutput = .json
             }
         }
         if flags.contains("--emit-completion-record"),
@@ -513,7 +516,7 @@ public enum GraphCLIParser {
       openisland graph checkpoint list <run-id> [options]
       openisland graph replay <run-id> --dry-run [options]
       openisland graph diff <run|run@sequence|run#checkpoint> <reference> [options]
-      openisland graph export <run-id> --format json|jsonl|mermaid [options]
+      openisland graph export <run-id> --format json|jsonl|mermaid|terminal-workspace-plan [options]
 
     Stable output: --output text|json|jsonl --schema-version 1
     Filters: --node --attempt --state --event-type --since --until
@@ -657,6 +660,7 @@ public struct GraphCLICompletionRecord:
     public let resultCount: Int
     public let eventCount: Int
     public let lastSequence: UInt64?
+    public let context: GraphCLIExecutionContext?
 
     public init(
         schemaVersion: Int = GraphCLIOutputSchema.currentVersion,
@@ -665,7 +669,8 @@ public struct GraphCLICompletionRecord:
         exitCode: Int32,
         resultCount: Int,
         eventCount: Int,
-        lastSequence: UInt64?
+        lastSequence: UInt64?,
+        context: GraphCLIExecutionContext? = nil
     ) {
         self.schemaVersion = schemaVersion
         self.recordType = "completion"
@@ -675,6 +680,7 @@ public struct GraphCLICompletionRecord:
         self.resultCount = resultCount
         self.eventCount = eventCount
         self.lastSequence = lastSequence
+        self.context = context
     }
 }
 
@@ -695,6 +701,7 @@ public struct GraphCLIOutputDocument<Payload: Encodable>: Encodable {
     public let eventCount: Int
     public let result: Payload
     public let diagnostics: [GraphCLIOutputDiagnostic]?
+    public let context: GraphCLIExecutionContext?
 
     public init(
         schemaVersion: Int = GraphCLIOutputSchema.currentVersion,
@@ -702,7 +709,8 @@ public struct GraphCLIOutputDocument<Payload: Encodable>: Encodable {
         resultCount: Int,
         eventCount: Int,
         result: Payload,
-        diagnostics: [GraphCLIOutputDiagnostic]? = nil
+        diagnostics: [GraphCLIOutputDiagnostic]? = nil,
+        context: GraphCLIExecutionContext? = nil
     ) {
         self.schemaVersion = schemaVersion
         self.command = command
@@ -710,6 +718,7 @@ public struct GraphCLIOutputDocument<Payload: Encodable>: Encodable {
         self.eventCount = eventCount
         self.result = result
         self.diagnostics = diagnostics
+        self.context = context
     }
 }
 
@@ -719,19 +728,22 @@ public struct GraphCLIJSONLRecord<Payload: Encodable>: Encodable {
     public let recordType: String
     public let ordinal: Int
     public let payload: Payload
+    public let context: GraphCLIExecutionContext?
 
     public init(
         schemaVersion: Int = GraphCLIOutputSchema.currentVersion,
         command: String,
         recordType: String,
         ordinal: Int,
-        payload: Payload
+        payload: Payload,
+        context: GraphCLIExecutionContext? = nil
     ) {
         self.schemaVersion = schemaVersion
         self.command = command
         self.recordType = recordType
         self.ordinal = ordinal
         self.payload = payload
+        self.context = context
     }
 }
 
@@ -876,18 +888,33 @@ public struct GraphCLICommandRunner: Sendable {
     private let inspector: any GraphTemporalInspecting
     private let stdout: any GraphCLIOutputSink
     private let stderr: any GraphCLIOutputSink
+    private let context: GraphCLIExecutionContext?
+    private let telemetry: any GraphCLITelemetrySink
+    private let clock: any GraphCLIMonotonicClock
+    private let isOutputTTY: Bool
 
     public init(
         inspector: any GraphTemporalInspecting,
         stdout: any GraphCLIOutputSink,
-        stderr: any GraphCLIOutputSink
+        stderr: any GraphCLIOutputSink,
+        context: GraphCLIExecutionContext? = nil,
+        telemetry: any GraphCLITelemetrySink =
+            NoopGraphCLITelemetrySink(),
+        clock: any GraphCLIMonotonicClock =
+            SystemGraphCLIMonotonicClock(),
+        isOutputTTY: Bool = true
     ) {
         self.inspector = inspector
         self.stdout = stdout
         self.stderr = stderr
+        self.context = context
+        self.telemetry = telemetry
+        self.clock = clock
+        self.isOutputTTY = isOutputTTY
     }
 
     public func run(arguments: [String]) async -> GraphCLIExitCode {
+        let started = clock.nowNanoseconds()
         let parsed: GraphCLIParseResult
 
         do {
@@ -900,11 +927,25 @@ public struct GraphCLICommandRunner: Sendable {
                 code = .invalidArguments
             }
             writeError(error.localizedDescription, code: code)
+            recordTelemetry(
+                command: "graph.invalid",
+                output: .text,
+                outcome: GraphCLICommandOutcome(exitCode: code),
+                started: started
+            )
             return code
         } catch {
             writeError(
                 error.localizedDescription,
                 code: .invalidArguments
+            )
+            recordTelemetry(
+                command: "graph.invalid",
+                output: .text,
+                outcome: GraphCLICommandOutcome(
+                    exitCode: .invalidArguments
+                ),
+                started: started
             )
             return .invalidArguments
         }
@@ -912,39 +953,48 @@ public struct GraphCLICommandRunner: Sendable {
         switch parsed {
         case let .help(text):
             _ = stdout.write(Data((text + "\n").utf8))
+            recordTelemetry(
+                command: "graph.help",
+                output: .text,
+                outcome: GraphCLICommandOutcome(exitCode: .success),
+                started: started
+            )
             return .success
         case let .invocation(invocation):
-            guard !invocation.quiet else {
-                return await executeQuiet(invocation)
-            }
-
             do {
-                return try await execute(invocation)
+                let outcome = invocation.quiet
+                    ? try await execute(
+                        invocation,
+                        suppressOutput: true
+                    )
+                    : try await execute(invocation)
+                recordTelemetry(
+                    command: invocation.command.name,
+                    output: invocation.output,
+                    outcome: outcome,
+                    started: started
+                )
+                return outcome.exitCode
             } catch {
                 let code = exitCode(for: error)
                 writeError(error.localizedDescription, code: code)
+                recordTelemetry(
+                    command: invocation.command.name,
+                    output: invocation.output,
+                    outcome: GraphCLICommandOutcome(
+                        exitCode: code
+                    ),
+                    started: started
+                )
                 return code
             }
-        }
-    }
-
-    private func executeQuiet(
-        _ invocation: GraphCLIInvocation
-    ) async -> GraphCLIExitCode {
-        do {
-            _ = try await execute(invocation, suppressOutput: true)
-            return .success
-        } catch {
-            let code = exitCode(for: error)
-            writeError(error.localizedDescription, code: code)
-            return code
         }
     }
 
     private func execute(
         _ invocation: GraphCLIInvocation,
         suppressOutput: Bool = false
-    ) async throws -> GraphCLIExitCode {
+    ) async throws -> GraphCLICommandOutcome {
         switch invocation.command {
         case .list:
             var summaries = try await inspector.listRuns(
@@ -952,7 +1002,7 @@ public struct GraphCLICommandRunner: Sendable {
                 limit: invocation.limit
             )
             summaries = filterSummaries(summaries, invocation)
-            return try emit(
+            let code = try emit(
                 summaries,
                 recordType: "run",
                 text: renderSummaries(summaries),
@@ -961,6 +1011,10 @@ public struct GraphCLICommandRunner: Sendable {
                 eventCount: 0,
                 suppressOutput: suppressOutput
             )
+            return GraphCLICommandOutcome(
+                exitCode: code,
+                resultCount: summaries.count
+            )
         case let .inspect(runID):
             let inspection = try await inspector.inspect(
                 runID: runID,
@@ -968,7 +1022,7 @@ public struct GraphCLICommandRunner: Sendable {
                 includeDiagnostics: invocation.includeDiagnostics
             )
             let filtered = filterInspection(inspection, invocation)
-            return try emit(
+            let code = try emit(
                 filtered,
                 records: [filtered],
                 recordType: "inspection",
@@ -978,6 +1032,15 @@ public struct GraphCLICommandRunner: Sendable {
                 eventCount: 0,
                 suppressOutput: suppressOutput,
                 diagnostics: diagnostics(filtered)
+            )
+            return GraphCLICommandOutcome(
+                exitCode: code,
+                resultCount: 1,
+                replayBoundary: filtered.summary.streamVersion,
+                snapshotDisposition:
+                    filtered.summary.snapshotDisposition,
+                reconciliationOutcome:
+                    filtered.summary.reconciledState.rawValue
             )
         case let .history(runID):
             return try await emitHistory(
@@ -990,7 +1053,7 @@ public struct GraphCLICommandRunner: Sendable {
                 runID: runID,
                 nodeID: invocation.nodeID ?? positionalNodeID
             )
-            return try emit(
+            let code = try emit(
                 explanation,
                 records: [explanation],
                 recordType: "explanation",
@@ -1000,11 +1063,16 @@ public struct GraphCLICommandRunner: Sendable {
                 eventCount: 0,
                 suppressOutput: suppressOutput
             )
+            return GraphCLICommandOutcome(
+                exitCode: code,
+                resultCount: 1,
+                reconciliationOutcome: explanation.state.rawValue
+            )
         case let .checkpointList(runID):
             let checkpoints = try await inspector.checkpoints(
                 runID: runID
             )
-            return try emit(
+            let code = try emit(
                 checkpoints,
                 recordType: "checkpoint",
                 text: renderCheckpoints(checkpoints),
@@ -1012,6 +1080,10 @@ public struct GraphCLICommandRunner: Sendable {
                 resultCount: checkpoints.count,
                 eventCount: 0,
                 suppressOutput: suppressOutput
+            )
+            return GraphCLICommandOutcome(
+                exitCode: code,
+                resultCount: checkpoints.count
             )
         case let .replay(runID):
             let boundary: GraphReplayBoundary
@@ -1032,7 +1104,7 @@ public struct GraphCLICommandRunner: Sendable {
                     : .configured
             )
             let output = try replayOutput(replay)
-            return try emit(
+            let code = try emit(
                 output,
                 records: [output],
                 recordType: "replay",
@@ -1045,12 +1117,21 @@ public struct GraphCLICommandRunner: Sendable {
                     ? diagnostics(replay)
                     : []
             )
+            return GraphCLICommandOutcome(
+                exitCode: code,
+                resultCount: 1,
+                eventCount: replay.replayedEventCount,
+                replayBoundary: replay.boundary,
+                snapshotDisposition: replay.snapshotDisposition,
+                reconciliationOutcome:
+                    output.reconciledRunState.rawValue
+            )
         case let .diff(left, right):
             let diff = try await inspector.diff(
                 left: left,
                 right: right
             )
-            return try emit(
+            let code = try emit(
                 diff,
                 records: diff.changes,
                 recordType: "change",
@@ -1060,16 +1141,32 @@ public struct GraphCLICommandRunner: Sendable {
                 eventCount: 0,
                 suppressOutput: suppressOutput
             )
+            return GraphCLICommandOutcome(
+                exitCode: code,
+                resultCount: diff.changes.count
+            )
         case let .export(runID):
             let inspection = try await inspector.inspect(
                 runID: runID,
                 includeArtifacts: true,
                 includeDiagnostics: invocation.includeDiagnostics
             )
-            return try emitExport(
+            let code = try emitExport(
                 inspection,
                 invocation: invocation,
                 suppressOutput: suppressOutput
+            )
+            return GraphCLICommandOutcome(
+                exitCode: code,
+                resultCount:
+                    inspection.nodes.count
+                        + inspection.attempts.count
+                        + inspection.artifacts.count,
+                replayBoundary: inspection.summary.streamVersion,
+                snapshotDisposition:
+                    inspection.summary.snapshotDisposition,
+                reconciliationOutcome:
+                    inspection.summary.reconciledState.rawValue
             )
         }
     }
@@ -1078,7 +1175,7 @@ public struct GraphCLICommandRunner: Sendable {
         runID: String,
         invocation: GraphCLIInvocation,
         suppressOutput: Bool
-    ) async throws -> GraphCLIExitCode {
+    ) async throws -> GraphCLICommandOutcome {
         var cursor = invocation.afterSequence
         var remaining = invocation.limit
         var records: [GraphInspectionEventRecord] = []
@@ -1115,7 +1212,12 @@ public struct GraphCLICommandRunner: Sendable {
                 for event in page.events {
                     let result = writeLine(renderEvent(event))
                     if result == .brokenPipe {
-                        return .success
+                        return GraphCLICommandOutcome(
+                            exitCode: .success,
+                            resultCount: emitted,
+                            eventCount: emitted,
+                            replayBoundary: cursor
+                        )
                     }
                     try requireWrite(result)
                     emitted += 1
@@ -1127,13 +1229,19 @@ public struct GraphCLICommandRunner: Sendable {
                         command: invocation.command.name,
                         recordType: "event",
                         ordinal: ordinal,
-                        payload: event
+                        payload: event,
+                        context: context
                     )
                     let result = writeLine(
                         try encodeString(record)
                     )
                     if result == .brokenPipe {
-                        return .success
+                        return GraphCLICommandOutcome(
+                            exitCode: .success,
+                            resultCount: emitted,
+                            eventCount: emitted,
+                            replayBoundary: cursor
+                        )
                     }
                     try requireWrite(result)
                     emitted += 1
@@ -1146,7 +1254,12 @@ public struct GraphCLICommandRunner: Sendable {
         }
 
         if suppressOutput {
-            return .success
+            return GraphCLICommandOutcome(
+                exitCode: .success,
+                resultCount: emitted,
+                eventCount: emitted,
+                replayBoundary: cursor
+            )
         }
         if invocation.output == .json {
             emitted = records.count
@@ -1154,11 +1267,17 @@ public struct GraphCLICommandRunner: Sendable {
                 command: invocation.command.name,
                 resultCount: records.count,
                 eventCount: records.count,
-                result: records
+                result: records,
+                context: context
             )
             let result = writeLine(try encodeString(document))
             if result == .brokenPipe {
-                return .success
+                return GraphCLICommandOutcome(
+                    exitCode: .success,
+                    resultCount: emitted,
+                    eventCount: emitted,
+                    replayBoundary: cursor
+                )
             }
             try requireWrite(result)
         }
@@ -1170,14 +1289,20 @@ public struct GraphCLICommandRunner: Sendable {
                 exitCode: GraphCLIExitCode.success.rawValue,
                 resultCount: emitted,
                 eventCount: emitted,
-                lastSequence: cursor
+                lastSequence: cursor,
+                context: context
             )
             let result = writeLine(try encodeString(completion))
             if result != .brokenPipe {
                 try requireWrite(result)
             }
         }
-        return .success
+        return GraphCLICommandOutcome(
+            exitCode: .success,
+            resultCount: emitted,
+            eventCount: emitted,
+            replayBoundary: cursor
+        )
     }
 
     private func emit<Payload: Encodable, Record: Encodable>(
@@ -1209,7 +1334,8 @@ public struct GraphCLICommandRunner: Sendable {
                         result: payload,
                         diagnostics: diagnostics.isEmpty
                             ? nil
-                            : diagnostics
+                            : diagnostics,
+                        context: context
                     )
                 )
             )
@@ -1222,7 +1348,8 @@ public struct GraphCLICommandRunner: Sendable {
                         command: invocation.command.name,
                         recordType: recordType,
                         ordinal: ordinal,
-                        payload: recordPayload
+                        payload: recordPayload,
+                        context: context
                     )
                 )
                 let writeResult = writeLine(line)
@@ -1238,7 +1365,8 @@ public struct GraphCLICommandRunner: Sendable {
                     exitCode: GraphCLIExitCode.success.rawValue,
                     resultCount: resultCount,
                     eventCount: eventCount,
-                    lastSequence: nil
+                    lastSequence: nil,
+                    context: context
                 )
                 let writeResult = writeLine(
                     try encodeString(completion)
@@ -1330,6 +1458,22 @@ public struct GraphCLICommandRunner: Sendable {
                 text: mermaid,
                 invocation: invocation,
                 resultCount: 1,
+                eventCount: 0,
+                suppressOutput: suppressOutput
+            )
+        case .terminalWorkspacePlan:
+            let plan = GraphTerminalWorkspacePlanBuilder.build(
+                inspection: inspection,
+                workspaceContext: context?.workspace
+            )
+            return try emit(
+                plan,
+                records: [plan],
+                recordType: "terminal_workspace_plan",
+                text: renderWorkspacePlan(plan),
+                invocation: invocation,
+                resultCount:
+                    plan.terminals.count + plan.connections.count,
                 eventCount: 0,
                 suppressOutput: suppressOutput
             )
@@ -1540,6 +1684,12 @@ public struct GraphCLICommandRunner: Sendable {
         }.joined(separator: "\n") + "\n"
     }
 
+    private func renderWorkspacePlan(
+        _ plan: GraphTerminalWorkspacePlan
+    ) -> String {
+        "\(plan.planID)  \(plan.terminals.count) terminals  \(plan.connections.count) connections  authority \(plan.authority)\n"
+    }
+
     private func writeLine(_ string: String) -> GraphCLIWriteResult {
         stdout.write(Data((string + (string.hasSuffix("\n") ? "" : "\n")).utf8))
     }
@@ -1584,6 +1734,33 @@ public struct GraphCLICommandRunner: Sendable {
         }
     }
 
+    private func recordTelemetry(
+        command: String,
+        output: GraphCLIOutputMode,
+        outcome: GraphCLICommandOutcome,
+        started: UInt64
+    ) {
+        let ended = clock.nowNanoseconds()
+        let duration = ended >= started ? ended - started : 0
+        telemetry.record(
+            GraphCLITelemetryRecord(
+                command: command,
+                outputMode: output,
+                durationMilliseconds: duration / 1_000_000,
+                exitCategory: outcome.exitCode.category,
+                resultCount: outcome.resultCount,
+                eventCount: outcome.eventCount,
+                replayBoundary: outcome.replayBoundary,
+                snapshotDisposition: outcome.snapshotDisposition,
+                reconciliationOutcome:
+                    outcome.reconciliationOutcome,
+                terminalGraphDetected:
+                    context?.terminalGraph.detected ?? false,
+                pipedOutput: !isOutputTTY
+            )
+        )
+    }
+
     private func encodeString<Value: Encodable>(
         _ value: Value
     ) throws -> String {
@@ -1594,6 +1771,31 @@ public struct GraphCLICommandRunner: Sendable {
             decoding: try encoder.encode(value),
             as: UTF8.self
         )
+    }
+}
+
+private struct GraphCLICommandOutcome: Sendable {
+    let exitCode: GraphCLIExitCode
+    let resultCount: Int
+    let eventCount: Int
+    let replayBoundary: UInt64?
+    let snapshotDisposition: GraphSnapshotDisposition?
+    let reconciliationOutcome: String?
+
+    init(
+        exitCode: GraphCLIExitCode,
+        resultCount: Int = 0,
+        eventCount: Int = 0,
+        replayBoundary: UInt64? = nil,
+        snapshotDisposition: GraphSnapshotDisposition? = nil,
+        reconciliationOutcome: String? = nil
+    ) {
+        self.exitCode = exitCode
+        self.resultCount = resultCount
+        self.eventCount = eventCount
+        self.replayBoundary = replayBoundary
+        self.snapshotDisposition = snapshotDisposition
+        self.reconciliationOutcome = reconciliationOutcome
     }
 }
 

--- a/Sources/OpenIslandCore/GraphCLITelemetry.swift
+++ b/Sources/OpenIslandCore/GraphCLITelemetry.swift
@@ -1,0 +1,95 @@
+import Foundation
+import OSLog
+
+public struct GraphCLITelemetryRecord:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let schemaVersion: Int
+    public let command: String
+    public let outputMode: GraphCLIOutputMode
+    public let durationMilliseconds: UInt64
+    public let exitCategory: String
+    public let resultCount: Int
+    public let eventCount: Int
+    public let replayBoundary: UInt64?
+    public let snapshotDisposition: GraphSnapshotDisposition?
+    public let reconciliationOutcome: String?
+    public let terminalGraphDetected: Bool
+    public let pipedOutput: Bool
+
+    public init(
+        schemaVersion: Int = 1,
+        command: String,
+        outputMode: GraphCLIOutputMode,
+        durationMilliseconds: UInt64,
+        exitCategory: String,
+        resultCount: Int,
+        eventCount: Int,
+        replayBoundary: UInt64?,
+        snapshotDisposition: GraphSnapshotDisposition?,
+        reconciliationOutcome: String?,
+        terminalGraphDetected: Bool,
+        pipedOutput: Bool
+    ) {
+        self.schemaVersion = schemaVersion
+        self.command = command
+        self.outputMode = outputMode
+        self.durationMilliseconds = durationMilliseconds
+        self.exitCategory = exitCategory
+        self.resultCount = resultCount
+        self.eventCount = eventCount
+        self.replayBoundary = replayBoundary
+        self.snapshotDisposition = snapshotDisposition
+        self.reconciliationOutcome = reconciliationOutcome
+        self.terminalGraphDetected = terminalGraphDetected
+        self.pipedOutput = pipedOutput
+    }
+}
+
+public protocol GraphCLITelemetrySink: Sendable {
+    func record(_ record: GraphCLITelemetryRecord)
+}
+
+public struct NoopGraphCLITelemetrySink:
+    GraphCLITelemetrySink,
+    Sendable
+{
+    public init() {}
+
+    public func record(_ record: GraphCLITelemetryRecord) {}
+}
+
+public struct OSLogGraphCLITelemetrySink:
+    GraphCLITelemetrySink,
+    Sendable
+{
+    private let logger = Logger(
+        subsystem: "app.openisland",
+        category: "GraphCLI"
+    )
+
+    public init() {}
+
+    public func record(_ record: GraphCLITelemetryRecord) {
+        logger.info(
+            "command=\(record.command, privacy: .public) output=\(record.outputMode.rawValue, privacy: .public) duration_ms=\(record.durationMilliseconds) exit=\(record.exitCategory, privacy: .public) results=\(record.resultCount) events=\(record.eventCount) tg=\(record.terminalGraphDetected) piped=\(record.pipedOutput)"
+        )
+    }
+}
+
+public protocol GraphCLIMonotonicClock: Sendable {
+    func nowNanoseconds() -> UInt64
+}
+
+public struct SystemGraphCLIMonotonicClock:
+    GraphCLIMonotonicClock,
+    Sendable
+{
+    public init() {}
+
+    public func nowNanoseconds() -> UInt64 {
+        DispatchTime.now().uptimeNanoseconds
+    }
+}

--- a/Sources/OpenIslandCore/GraphDefinitionDocument.swift
+++ b/Sources/OpenIslandCore/GraphDefinitionDocument.swift
@@ -350,19 +350,99 @@ public struct GraphDefinitionEdge:
     Sendable,
     Identifiable
 {
-    public var id: String { "\(sourceNodeID)->\(targetNodeID):\(portType.rawValue)" }
-    public let sourceNodeID: String
-    public let targetNodeID: String
-    public let portType: GraphDefinitionPortType
+    public var id: String { edgeID }
+    public let edgeID: String
+    public var sourceNodeID: String
+    public var targetNodeID: String
+    public var portType: GraphDefinitionPortType
+    public var sourceOutputID: String?
+    public var targetInputID: String?
+    public var isRequired: Bool
 
     public init(
+        edgeID: String? = nil,
         sourceNodeID: String,
         targetNodeID: String,
-        portType: GraphDefinitionPortType = .dependency
+        portType: GraphDefinitionPortType = .dependency,
+        sourceOutputID: String? = nil,
+        targetInputID: String? = nil,
+        isRequired: Bool = true
     ) {
+        self.edgeID = edgeID ?? Self.stableID(
+            sourceNodeID: sourceNodeID,
+            targetNodeID: targetNodeID,
+            portType: portType,
+            sourceOutputID: sourceOutputID,
+            targetInputID: targetInputID
+        )
         self.sourceNodeID = sourceNodeID
         self.targetNodeID = targetNodeID
         self.portType = portType
+        self.sourceOutputID = sourceOutputID
+        self.targetInputID = targetInputID
+        self.isRequired = isRequired
+    }
+
+    private static func stableID(
+        sourceNodeID: String,
+        targetNodeID: String,
+        portType: GraphDefinitionPortType,
+        sourceOutputID: String?,
+        targetInputID: String?
+    ) -> String {
+        [
+            sourceNodeID,
+            targetNodeID,
+            portType.rawValue,
+            sourceOutputID ?? "none",
+            targetInputID ?? "none",
+        ].joined(separator: "->")
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case edgeID
+        case sourceNodeID
+        case targetNodeID
+        case portType
+        case sourceOutputID
+        case targetInputID
+        case isRequired
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            edgeID: try container.decodeIfPresent(String.self, forKey: .edgeID),
+            sourceNodeID: try container.decode(String.self, forKey: .sourceNodeID),
+            targetNodeID: try container.decode(String.self, forKey: .targetNodeID),
+            portType: try container.decodeIfPresent(
+                GraphDefinitionPortType.self,
+                forKey: .portType
+            ) ?? .dependency,
+            sourceOutputID: try container.decodeIfPresent(
+                String.self,
+                forKey: .sourceOutputID
+            ),
+            targetInputID: try container.decodeIfPresent(
+                String.self,
+                forKey: .targetInputID
+            ),
+            isRequired: try container.decodeIfPresent(
+                Bool.self,
+                forKey: .isRequired
+            ) ?? true
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(edgeID, forKey: .edgeID)
+        try container.encode(sourceNodeID, forKey: .sourceNodeID)
+        try container.encode(targetNodeID, forKey: .targetNodeID)
+        try container.encode(portType, forKey: .portType)
+        try container.encodeIfPresent(sourceOutputID, forKey: .sourceOutputID)
+        try container.encodeIfPresent(targetInputID, forKey: .targetInputID)
+        try container.encode(isRequired, forKey: .isRequired)
     }
 }
 

--- a/Sources/OpenIslandCore/GraphDefinitionDocument.swift
+++ b/Sources/OpenIslandCore/GraphDefinitionDocument.swift
@@ -113,40 +113,235 @@ public struct GraphDefinitionDocumentNode:
     public let id: String
     public var name: String
     public var description: String
+    public var nodeType: GraphDefinitionNodeType
+    public var tags: [String]
     public var requiredCapabilities: [String]
+    public var preferredCapabilities: [String]
+    public var executorKind: GraphDefinitionExecutorKind
+    public var platformConstraints: [String]
     public var specification: GraphImmutableExecutionSpecification
     public var workspace: GraphExecutionWorkspaceContext
     public var environmentAllowlist: [String]
     public var inputArtifactRoles: [GraphArtifactRole]
+    public var inputs: [GraphNodeInputDefinition]
+    public var outputs: [GraphNodeOutputDefinition]
+    public var retryConfiguration: GraphNodeRetryConfiguration
     public var timeoutPolicy: GraphExecutionTimeoutPolicy
+    public var timeoutConfiguration: GraphNodeTimeoutConfiguration
 
     public init(
         id: String,
         name: String,
         description: String = "",
+        nodeType: GraphDefinitionNodeType? = nil,
+        tags: [String] = [],
         requiredCapabilities: [String],
+        preferredCapabilities: [String] = [],
+        executorKind: GraphDefinitionExecutorKind? = nil,
+        platformConstraints: [String] = [],
         specification: GraphImmutableExecutionSpecification,
         workspace: GraphExecutionWorkspaceContext = .init(),
         environmentAllowlist: [String] = [],
         inputArtifactRoles: [GraphArtifactRole] = [.nodeOutput],
-        timeoutPolicy: GraphExecutionTimeoutPolicy
+        inputs: [GraphNodeInputDefinition] = [],
+        outputs: [GraphNodeOutputDefinition] = [],
+        retryConfiguration: GraphNodeRetryConfiguration = .init(),
+        timeoutPolicy: GraphExecutionTimeoutPolicy,
+        timeoutConfiguration: GraphNodeTimeoutConfiguration? = nil
     ) {
         self.id = id
         self.name = name
         self.description = description
+        let inferredType = nodeType ?? Self.inferNodeType(specification)
+        self.nodeType = inferredType
+        self.tags = tags.sorted()
         self.requiredCapabilities = requiredCapabilities.sorted()
+        self.preferredCapabilities = preferredCapabilities.sorted()
+        self.executorKind = executorKind
+            ?? Self.inferExecutorKind(specification, nodeType: inferredType)
+        self.platformConstraints = platformConstraints.sorted()
         self.specification = specification
         self.workspace = workspace
         self.environmentAllowlist = environmentAllowlist.sorted()
         self.inputArtifactRoles = inputArtifactRoles.sorted {
             $0.rawValue < $1.rawValue
         }
+        self.inputs = inputs.sorted { $0.id < $1.id }
+        self.outputs = outputs.isEmpty
+            ? Self.inferOutputs(specification) : outputs.sorted { $0.id < $1.id }
+        self.retryConfiguration = retryConfiguration
         self.timeoutPolicy = timeoutPolicy
+        self.timeoutConfiguration = timeoutConfiguration
+            ?? GraphNodeTimeoutConfiguration(
+                executionSeconds: timeoutPolicy.executionSeconds,
+                cancellationAcknowledgementSeconds:
+                    timeoutPolicy.cancellationAcknowledgementSeconds
+            )
+    }
+
+    private static func inferNodeType(
+        _ specification: GraphImmutableExecutionSpecification
+    ) -> GraphDefinitionNodeType {
+        switch specification.adapterKind {
+        case GraphLocalProcessSpecification.adapterKind: .localProcess
+        case "deterministic": .deterministicTest
+        case "generic_agent": .genericAgent
+        default: .genericAgent
+        }
+    }
+
+    private static func inferExecutorKind(
+        _ specification: GraphImmutableExecutionSpecification,
+        nodeType: GraphDefinitionNodeType
+    ) -> GraphDefinitionExecutorKind {
+        switch specification.adapterKind {
+        case GraphLocalProcessSpecification.adapterKind: .supervisedLocalProcess
+        case "deterministic": .deterministicTest
+        case "generic_agent": .unboundAgent
+        default: nodeType.isExecutable ? .unboundAgent : .none
+        }
+    }
+
+    private static func inferOutputs(
+        _ specification: GraphImmutableExecutionSpecification
+    ) -> [GraphNodeOutputDefinition] {
+        guard specification.adapterKind == GraphLocalProcessSpecification.adapterKind,
+              let process = try? GraphLocalProcessSpecification(
+                immutableSpecification: specification
+              ) else { return [] }
+        return process.outputArtifacts.map { declaration in
+            GraphNodeOutputDefinition(
+                id: declaration.stableID,
+                name: declaration.role.rawValue,
+                role: declaration.role,
+                relativePath: declaration.relativePath,
+                mediaType: declaration.mediaType,
+                isRequired: declaration.required,
+                maximumBytes: declaration.maximumBytes,
+                sensitivity: declaration.sensitivity,
+                downstreamVisibility: declaration.downstreamVisibility ?? .graph
+            )
+        }.sorted { $0.id < $1.id }
     }
 }
 
-public enum GraphDefinitionPortType: String, Codable, Sendable {
-    case dependency
+extension GraphDefinitionDocumentNode {
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case description
+        case nodeType
+        case tags
+        case requiredCapabilities
+        case preferredCapabilities
+        case executorKind
+        case platformConstraints
+        case specification
+        case workspace
+        case environmentAllowlist
+        case inputArtifactRoles
+        case inputs
+        case outputs
+        case retryConfiguration
+        case timeoutPolicy
+        case timeoutConfiguration
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let specification = try container.decode(
+            GraphImmutableExecutionSpecification.self,
+            forKey: .specification
+        )
+        let timeoutPolicy = try container.decode(
+            GraphExecutionTimeoutPolicy.self,
+            forKey: .timeoutPolicy
+        )
+        self.init(
+            id: try container.decode(String.self, forKey: .id),
+            name: try container.decode(String.self, forKey: .name),
+            description: try container.decodeIfPresent(
+                String.self,
+                forKey: .description
+            ) ?? "",
+            nodeType: try container.decodeIfPresent(
+                GraphDefinitionNodeType.self,
+                forKey: .nodeType
+            ),
+            tags: try container.decodeIfPresent(
+                [String].self,
+                forKey: .tags
+            ) ?? [],
+            requiredCapabilities: try container.decode(
+                [String].self,
+                forKey: .requiredCapabilities
+            ),
+            preferredCapabilities: try container.decodeIfPresent(
+                [String].self,
+                forKey: .preferredCapabilities
+            ) ?? [],
+            executorKind: try container.decodeIfPresent(
+                GraphDefinitionExecutorKind.self,
+                forKey: .executorKind
+            ),
+            platformConstraints: try container.decodeIfPresent(
+                [String].self,
+                forKey: .platformConstraints
+            ) ?? [],
+            specification: specification,
+            workspace: try container.decodeIfPresent(
+                GraphExecutionWorkspaceContext.self,
+                forKey: .workspace
+            ) ?? .init(),
+            environmentAllowlist: try container.decodeIfPresent(
+                [String].self,
+                forKey: .environmentAllowlist
+            ) ?? [],
+            inputArtifactRoles: try container.decodeIfPresent(
+                [GraphArtifactRole].self,
+                forKey: .inputArtifactRoles
+            ) ?? [.nodeOutput],
+            inputs: try container.decodeIfPresent(
+                [GraphNodeInputDefinition].self,
+                forKey: .inputs
+            ) ?? [],
+            outputs: try container.decodeIfPresent(
+                [GraphNodeOutputDefinition].self,
+                forKey: .outputs
+            ) ?? [],
+            retryConfiguration: try container.decodeIfPresent(
+                GraphNodeRetryConfiguration.self,
+                forKey: .retryConfiguration
+            ) ?? .init(),
+            timeoutPolicy: timeoutPolicy,
+            timeoutConfiguration: try container.decodeIfPresent(
+                GraphNodeTimeoutConfiguration.self,
+                forKey: .timeoutConfiguration
+            )
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+        try container.encode(description, forKey: .description)
+        try container.encode(nodeType, forKey: .nodeType)
+        try container.encode(tags.sorted(), forKey: .tags)
+        try container.encode(requiredCapabilities.sorted(), forKey: .requiredCapabilities)
+        try container.encode(preferredCapabilities.sorted(), forKey: .preferredCapabilities)
+        try container.encode(executorKind, forKey: .executorKind)
+        try container.encode(platformConstraints.sorted(), forKey: .platformConstraints)
+        try container.encode(specification, forKey: .specification)
+        try container.encode(workspace, forKey: .workspace)
+        try container.encode(environmentAllowlist.sorted(), forKey: .environmentAllowlist)
+        try container.encode(inputArtifactRoles, forKey: .inputArtifactRoles)
+        try container.encode(inputs.sorted { $0.id < $1.id }, forKey: .inputs)
+        try container.encode(outputs.sorted { $0.id < $1.id }, forKey: .outputs)
+        try container.encode(retryConfiguration, forKey: .retryConfiguration)
+        try container.encode(timeoutPolicy, forKey: .timeoutPolicy)
+        try container.encode(timeoutConfiguration, forKey: .timeoutConfiguration)
+    }
 }
 
 public struct GraphDefinitionEdge:
@@ -177,6 +372,8 @@ public struct GraphDefinitionDocument: Equatable, Sendable {
     public var definitionVersion: String
     public var name: String
     public var description: String
+    public var graphInputs: [GraphDefinitionInput]
+    public var graphOutputs: [GraphDefinitionOutput]
     public var nodes: [GraphDefinitionDocumentNode]
     public var edges: [GraphDefinitionEdge]
     public var schedulerPolicy: GraphSchedulerPolicy
@@ -192,6 +389,8 @@ public struct GraphDefinitionDocument: Equatable, Sendable {
         definitionVersion: String,
         name: String,
         description: String = "",
+        graphInputs: [GraphDefinitionInput] = [],
+        graphOutputs: [GraphDefinitionOutput] = [],
         nodes: [GraphDefinitionDocumentNode],
         edges: [GraphDefinitionEdge],
         schedulerPolicy: GraphSchedulerPolicy,
@@ -206,6 +405,8 @@ public struct GraphDefinitionDocument: Equatable, Sendable {
         self.definitionVersion = definitionVersion
         self.name = name
         self.description = description
+        self.graphInputs = graphInputs.sorted { $0.id < $1.id }
+        self.graphOutputs = graphOutputs.sorted { $0.id < $1.id }
         self.nodes = nodes.sorted { $0.id < $1.id }
         self.edges = edges.sorted { $0.id < $1.id }
         self.schedulerPolicy = schedulerPolicy
@@ -323,12 +524,36 @@ public struct GraphDefinitionDocument: Equatable, Sendable {
 
     public func executableDefinition() throws -> GraphExecutableDefinition {
         let digest = try semanticDigest()
-        let schedulingNodes = nodes.map { node in
+        let executableNodes = nodes.filter(\.nodeType.isExecutable)
+        let executableNodeIDs = Set(executableNodes.map(\.id))
+        var nodeRetryPolicies = schedulerPolicy.nodeRetryPolicies ?? [:]
+        for node in executableNodes where !node.retryConfiguration.inheritsGraphDefault {
+            nodeRetryPolicies[node.id] = node.retryConfiguration.effective(
+                graphDefault: schedulerPolicy.retryPolicy
+            )
+        }
+        let executablePolicy = GraphSchedulerPolicy(
+            schemaVersion: schedulerPolicy.schemaVersion,
+            policyID: schedulerPolicy.policyID,
+            version: schedulerPolicy.version,
+            retryPolicy: schedulerPolicy.retryPolicy,
+            nodeRetryPolicies: nodeRetryPolicies.isEmpty ? nil : nodeRetryPolicies,
+            defaultLeaseDurationSeconds: schedulerPolicy.defaultLeaseDurationSeconds,
+            claimAcquisitionTimeoutSeconds: schedulerPolicy.claimAcquisitionTimeoutSeconds,
+            attemptExecutionTimeoutSeconds: schedulerPolicy.attemptExecutionTimeoutSeconds,
+            cancellationAcknowledgementTimeoutSeconds:
+                schedulerPolicy.cancellationAcknowledgementTimeoutSeconds,
+            allowExpiredLeaseTakeover: schedulerPolicy.allowExpiredLeaseTakeover,
+            schedulingEnabled: schedulerPolicy.schedulingEnabled
+        )
+        let schedulingNodes = executableNodes.map { node in
             GraphSchedulingDefinitionNode(
                 id: node.id,
                 title: node.name,
                 dependencyNodeIDs: edges.filter {
                     $0.targetNodeID == node.id
+                        && executableNodeIDs.contains($0.sourceNodeID)
+                        && [.dependency, .artifact].contains($0.portType)
                 }.map(\.sourceNodeID),
                 requiredCapabilities: node.requiredCapabilities
             )
@@ -340,8 +565,8 @@ public struct GraphDefinitionDocument: Equatable, Sendable {
                 digest: digest,
                 nodes: schedulingNodes
             ),
-            schedulerPolicy: schedulerPolicy,
-            executions: nodes.map { node in
+            schedulerPolicy: executablePolicy,
+            executions: executableNodes.map { node in
                 GraphNodeExecutionDefinition(
                     nodeID: node.id,
                     capabilityRequirement: node.requiredCapabilities,
@@ -359,6 +584,8 @@ public struct GraphDefinitionDocument: Equatable, Sendable {
         let semantic = GraphDefinitionSemanticContent(
             graphID: graphID,
             definitionVersion: definitionVersion,
+            graphInputs: graphInputs,
+            graphOutputs: graphOutputs,
             nodes: nodes,
             edges: edges,
             schedulerPolicy: schedulerPolicy,
@@ -409,7 +636,7 @@ public struct GraphDefinitionDocument: Equatable, Sendable {
 extension GraphDefinitionDocument: Codable {
     private static let knownKeys: Set<String> = [
         "schemaVersion", "graphID", "definitionVersion", "name",
-        "description", "nodes", "edges", "schedulerPolicy",
+        "description", "graphInputs", "graphOutputs", "nodes", "edges", "schedulerPolicy",
         "policyReferences", "layout", "metadata", "sourceRepository",
     ]
 
@@ -429,6 +656,14 @@ extension GraphDefinitionDocument: Codable {
             String.self,
             forKey: key("description")
         ) ?? ""
+        graphInputs = try container.decodeIfPresent(
+            [GraphDefinitionInput].self,
+            forKey: key("graphInputs")
+        )?.sorted { $0.id < $1.id } ?? []
+        graphOutputs = try container.decodeIfPresent(
+            [GraphDefinitionOutput].self,
+            forKey: key("graphOutputs")
+        )?.sorted { $0.id < $1.id } ?? []
         nodes = try container.decode(
             [GraphDefinitionDocumentNode].self,
             forKey: key("nodes")
@@ -480,6 +715,8 @@ extension GraphDefinitionDocument: Codable {
         try container.encode(definitionVersion, forKey: key("definitionVersion"))
         try container.encode(name, forKey: key("name"))
         try container.encode(description, forKey: key("description"))
+        try container.encode(graphInputs.sorted { $0.id < $1.id }, forKey: key("graphInputs"))
+        try container.encode(graphOutputs.sorted { $0.id < $1.id }, forKey: key("graphOutputs"))
         try container.encode(nodes.sorted { $0.id < $1.id }, forKey: key("nodes"))
         try container.encode(edges.sorted { $0.id < $1.id }, forKey: key("edges"))
         try container.encode(schedulerPolicy, forKey: key("schedulerPolicy"))
@@ -504,6 +741,8 @@ private struct GraphDocumentCodingKey: CodingKey {
 private struct GraphDefinitionSemanticContent: Codable {
     let graphID: String
     let definitionVersion: String
+    let graphInputs: [GraphDefinitionInput]
+    let graphOutputs: [GraphDefinitionOutput]
     let nodes: [GraphDefinitionDocumentNode]
     let edges: [GraphDefinitionEdge]
     let schedulerPolicy: GraphSchedulerPolicy

--- a/Sources/OpenIslandCore/GraphDefinitionDocument.swift
+++ b/Sources/OpenIslandCore/GraphDefinitionDocument.swift
@@ -197,6 +197,7 @@ public struct GraphDefinitionDocumentNode:
         switch specification.adapterKind {
         case GraphLocalProcessSpecification.adapterKind: .supervisedLocalProcess
         case "deterministic": .deterministicTest
+        case "openai_compatible": .openAICompatible
         case "generic_agent": .unboundAgent
         default: nodeType.isExecutable ? .unboundAgent : .none
         }

--- a/Sources/OpenIslandCore/GraphDefinitionDocument.swift
+++ b/Sources/OpenIslandCore/GraphDefinitionDocument.swift
@@ -1,0 +1,767 @@
+import CryptoKit
+import Foundation
+
+public enum GraphDefinitionDocumentSchema {
+    public static let currentVersion = 1
+    public static let layoutVersion = 1
+}
+
+public struct GraphDefinitionDocumentMetadata:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let createdAt: Date
+    public var modifiedAt: Date
+    public let createdBy: String
+    public var modifiedBy: String
+
+    public init(
+        createdAt: Date,
+        modifiedAt: Date,
+        createdBy: String,
+        modifiedBy: String
+    ) {
+        self.createdAt = createdAt
+        self.modifiedAt = modifiedAt
+        self.createdBy = createdBy
+        self.modifiedBy = modifiedBy
+    }
+}
+
+public struct GraphSourceRepositoryContext:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let repositoryPath: String?
+    public let remoteURL: String?
+    public let revision: String?
+
+    public init(
+        repositoryPath: String? = nil,
+        remoteURL: String? = nil,
+        revision: String? = nil
+    ) {
+        self.repositoryPath = repositoryPath
+        self.remoteURL = remoteURL
+        self.revision = revision
+    }
+}
+
+public struct GraphCanvasPoint: Equatable, Codable, Sendable {
+    public var x: Double
+    public var y: Double
+
+    public init(x: Double, y: Double) {
+        self.x = x
+        self.y = y
+    }
+}
+
+public struct GraphNodeLayoutMetadata:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public var id: String { nodeID }
+    public let nodeID: String
+    public var position: GraphCanvasPoint
+    public var groupID: String?
+
+    public init(
+        nodeID: String,
+        position: GraphCanvasPoint,
+        groupID: String? = nil
+    ) {
+        self.nodeID = nodeID
+        self.position = position
+        self.groupID = groupID
+    }
+}
+
+public struct GraphLayoutMetadata: Equatable, Codable, Sendable {
+    public let schemaVersion: Int
+    public var nodes: [GraphNodeLayoutMetadata]
+    public var zoom: Double
+    public var pan: GraphCanvasPoint
+
+    public init(
+        schemaVersion: Int = GraphDefinitionDocumentSchema.layoutVersion,
+        nodes: [GraphNodeLayoutMetadata] = [],
+        zoom: Double = 1,
+        pan: GraphCanvasPoint = GraphCanvasPoint(x: 0, y: 0)
+    ) {
+        self.schemaVersion = schemaVersion
+        self.nodes = nodes.sorted { $0.nodeID < $1.nodeID }
+        self.zoom = min(2.5, max(0.25, zoom))
+        self.pan = pan
+    }
+
+    public func position(nodeID: String) -> GraphCanvasPoint? {
+        nodes.first { $0.nodeID == nodeID }?.position
+    }
+}
+
+public struct GraphDefinitionDocumentNode:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public let id: String
+    public var name: String
+    public var description: String
+    public var requiredCapabilities: [String]
+    public var specification: GraphImmutableExecutionSpecification
+    public var workspace: GraphExecutionWorkspaceContext
+    public var environmentAllowlist: [String]
+    public var inputArtifactRoles: [GraphArtifactRole]
+    public var timeoutPolicy: GraphExecutionTimeoutPolicy
+
+    public init(
+        id: String,
+        name: String,
+        description: String = "",
+        requiredCapabilities: [String],
+        specification: GraphImmutableExecutionSpecification,
+        workspace: GraphExecutionWorkspaceContext = .init(),
+        environmentAllowlist: [String] = [],
+        inputArtifactRoles: [GraphArtifactRole] = [.nodeOutput],
+        timeoutPolicy: GraphExecutionTimeoutPolicy
+    ) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.requiredCapabilities = requiredCapabilities.sorted()
+        self.specification = specification
+        self.workspace = workspace
+        self.environmentAllowlist = environmentAllowlist.sorted()
+        self.inputArtifactRoles = inputArtifactRoles.sorted {
+            $0.rawValue < $1.rawValue
+        }
+        self.timeoutPolicy = timeoutPolicy
+    }
+}
+
+public enum GraphDefinitionPortType: String, Codable, Sendable {
+    case dependency
+}
+
+public struct GraphDefinitionEdge:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public var id: String { "\(sourceNodeID)->\(targetNodeID):\(portType.rawValue)" }
+    public let sourceNodeID: String
+    public let targetNodeID: String
+    public let portType: GraphDefinitionPortType
+
+    public init(
+        sourceNodeID: String,
+        targetNodeID: String,
+        portType: GraphDefinitionPortType = .dependency
+    ) {
+        self.sourceNodeID = sourceNodeID
+        self.targetNodeID = targetNodeID
+        self.portType = portType
+    }
+}
+
+public struct GraphDefinitionDocument: Equatable, Sendable {
+    public let schemaVersion: Int
+    public var graphID: String
+    public var definitionVersion: String
+    public var name: String
+    public var description: String
+    public var nodes: [GraphDefinitionDocumentNode]
+    public var edges: [GraphDefinitionEdge]
+    public var schedulerPolicy: GraphSchedulerPolicy
+    public var policyReferences: [String]
+    public var layout: GraphLayoutMetadata
+    public var metadata: GraphDefinitionDocumentMetadata
+    public var sourceRepository: GraphSourceRepositoryContext?
+    public var extensionFields: [String: GraphJSONValue]
+
+    public init(
+        schemaVersion: Int = GraphDefinitionDocumentSchema.currentVersion,
+        graphID: String,
+        definitionVersion: String,
+        name: String,
+        description: String = "",
+        nodes: [GraphDefinitionDocumentNode],
+        edges: [GraphDefinitionEdge],
+        schedulerPolicy: GraphSchedulerPolicy,
+        policyReferences: [String] = [],
+        layout: GraphLayoutMetadata = GraphLayoutMetadata(),
+        metadata: GraphDefinitionDocumentMetadata,
+        sourceRepository: GraphSourceRepositoryContext? = nil,
+        extensionFields: [String: GraphJSONValue] = [:]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.graphID = graphID
+        self.definitionVersion = definitionVersion
+        self.name = name
+        self.description = description
+        self.nodes = nodes.sorted { $0.id < $1.id }
+        self.edges = edges.sorted { $0.id < $1.id }
+        self.schedulerPolicy = schedulerPolicy
+        self.policyReferences = policyReferences.sorted()
+        self.layout = layout
+        self.metadata = metadata
+        self.sourceRepository = sourceRepository
+        self.extensionFields = extensionFields
+    }
+
+    public static func empty(
+        graphID: String = UUID().uuidString.lowercased(),
+        now: Date = Date(),
+        author: String = NSUserName()
+    ) -> GraphDefinitionDocument {
+        GraphDefinitionDocument(
+            graphID: graphID,
+            definitionVersion: "1",
+            name: "Untitled Graph",
+            nodes: [],
+            edges: [],
+            schedulerPolicy: GraphSchedulerPolicy(
+                policyID: "default-local-policy",
+                version: "1",
+                retryPolicy: GraphRetryPolicy(
+                    maximumAttempts: 2,
+                    retryableFailureCategories: [
+                        "execution_failure",
+                        "process_exit_unobserved",
+                        "timeout",
+                    ],
+                    nonRetryableFailureCategories: [
+                        "artifact_collection_failure",
+                        "invalid_process_specification",
+                    ]
+                )
+            ),
+            metadata: GraphDefinitionDocumentMetadata(
+                createdAt: now,
+                modifiedAt: now,
+                createdBy: author,
+                modifiedBy: author
+            )
+        )
+    }
+
+    public func validate() throws {
+        guard schemaVersion <= GraphDefinitionDocumentSchema.currentVersion else {
+            throw GraphDefinitionDocumentError.unsupportedSchema(schemaVersion)
+        }
+        guard !graphID.isEmpty else {
+            throw GraphDefinitionDocumentError.missingGraphID
+        }
+        let nodeIDs = nodes.map(\.id)
+        guard Set(nodeIDs).count == nodeIDs.count else {
+            throw GraphDefinitionDocumentError.duplicateNodeID(
+                Dictionary(grouping: nodeIDs, by: { $0 })
+                    .first { $0.value.count > 1 }?.key ?? "unknown"
+            )
+        }
+        guard nodes.allSatisfy({ !$0.id.isEmpty && !$0.name.isEmpty }) else {
+            throw GraphDefinitionDocumentError.invalidNode
+        }
+        let edgeIDs = edges.map(\.id)
+        guard Set(edgeIDs).count == edgeIDs.count else {
+            throw GraphDefinitionDocumentError.duplicateEdge(
+                Dictionary(grouping: edgeIDs, by: { $0 })
+                    .first { $0.value.count > 1 }?.key ?? "unknown"
+            )
+        }
+        let known = Set(nodeIDs)
+        for edge in edges {
+            guard edge.sourceNodeID != edge.targetNodeID else {
+                throw GraphDefinitionDocumentError.selfDependency(
+                    edge.sourceNodeID
+                )
+            }
+            guard known.contains(edge.sourceNodeID) else {
+                throw GraphDefinitionDocumentError.unknownNodeReference(
+                    edge.sourceNodeID
+                )
+            }
+            guard known.contains(edge.targetNodeID) else {
+                throw GraphDefinitionDocumentError.unknownNodeReference(
+                    edge.targetNodeID
+                )
+            }
+        }
+        let layoutIDs = layout.nodes.map(\.nodeID)
+        guard Set(layoutIDs).count == layoutIDs.count,
+              Set(layoutIDs).isSubset(of: known) else {
+            throw GraphDefinitionDocumentError.invalidLayout
+        }
+        guard topologicalNodeIDs() != nil else {
+            throw GraphDefinitionDocumentError.cycle
+        }
+        for node in nodes {
+            if node.specification.adapterKind
+                == GraphLocalProcessSpecification.adapterKind {
+                let specification = try GraphLocalProcessSpecification(
+                    immutableSpecification: node.specification
+                )
+                for key in specification.environment.keys
+                    where Self.isSensitiveKey(key) {
+                    throw GraphDefinitionDocumentError.embeddedSecret(key)
+                }
+                for key in specification.logPolicy.sensitiveEnvironmentKeys
+                    where specification.environment[key] != nil {
+                    throw GraphDefinitionDocumentError.embeddedSecret(key)
+                }
+            }
+        }
+        try executableDefinition().validate()
+    }
+
+    public func executableDefinition() throws -> GraphExecutableDefinition {
+        let digest = try semanticDigest()
+        let schedulingNodes = nodes.map { node in
+            GraphSchedulingDefinitionNode(
+                id: node.id,
+                title: node.name,
+                dependencyNodeIDs: edges.filter {
+                    $0.targetNodeID == node.id
+                }.map(\.sourceNodeID),
+                requiredCapabilities: node.requiredCapabilities
+            )
+        }
+        return GraphExecutableDefinition(
+            scheduling: GraphSchedulingDefinition(
+                graphID: graphID,
+                version: definitionVersion,
+                digest: digest,
+                nodes: schedulingNodes
+            ),
+            schedulerPolicy: schedulerPolicy,
+            executions: nodes.map { node in
+                GraphNodeExecutionDefinition(
+                    nodeID: node.id,
+                    capabilityRequirement: node.requiredCapabilities,
+                    specification: node.specification,
+                    workspace: node.workspace,
+                    environmentAllowlist: node.environmentAllowlist,
+                    inputArtifactRoles: node.inputArtifactRoles,
+                    timeoutPolicy: node.timeoutPolicy
+                )
+            }
+        )
+    }
+
+    public func semanticDigest() throws -> GraphContentDigest {
+        let semantic = GraphDefinitionSemanticContent(
+            graphID: graphID,
+            definitionVersion: definitionVersion,
+            nodes: nodes,
+            edges: edges,
+            schedulerPolicy: schedulerPolicy,
+            policyReferences: policyReferences,
+            sourceRepository: sourceRepository
+        )
+        let data = try GraphDefinitionDocumentCodec.encoder().encode(semantic)
+        return GraphContentDigest(
+            algorithm: "sha256",
+            value: SHA256.hash(data: data)
+                .map { String(format: "%02x", $0) }
+                .joined()
+        )
+    }
+
+    public func topologicalNodeIDs() -> [String]? {
+        var incoming = Dictionary(
+            uniqueKeysWithValues: nodes.map { ($0.id, 0) }
+        )
+        var outgoing: [String: [String]] = [:]
+        for edge in edges {
+            incoming[edge.targetNodeID, default: 0] += 1
+            outgoing[edge.sourceNodeID, default: []].append(edge.targetNodeID)
+        }
+        var ready = incoming.filter { $0.value == 0 }.map(\.key).sorted()
+        var result: [String] = []
+        while !ready.isEmpty {
+            let nodeID = ready.removeFirst()
+            result.append(nodeID)
+            for dependent in outgoing[nodeID, default: []].sorted() {
+                incoming[dependent, default: 0] -= 1
+                if incoming[dependent] == 0 {
+                    ready.append(dependent)
+                    ready.sort()
+                }
+            }
+        }
+        return result.count == nodes.count ? result : nil
+    }
+
+    private static func isSensitiveKey(_ key: String) -> Bool {
+        let normalized = key.lowercased()
+        return ["secret", "password", "api_key", "access_token", "private_key"]
+            .contains { normalized.contains($0) }
+    }
+}
+
+extension GraphDefinitionDocument: Codable {
+    private static let knownKeys: Set<String> = [
+        "schemaVersion", "graphID", "definitionVersion", "name",
+        "description", "nodes", "edges", "schedulerPolicy",
+        "policyReferences", "layout", "metadata", "sourceRepository",
+    ]
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: GraphDocumentCodingKey.self)
+        func key(_ value: String) -> GraphDocumentCodingKey {
+            GraphDocumentCodingKey(stringValue: value)!
+        }
+        schemaVersion = try container.decode(Int.self, forKey: key("schemaVersion"))
+        graphID = try container.decode(String.self, forKey: key("graphID"))
+        definitionVersion = try container.decode(
+            String.self,
+            forKey: key("definitionVersion")
+        )
+        name = try container.decode(String.self, forKey: key("name"))
+        description = try container.decodeIfPresent(
+            String.self,
+            forKey: key("description")
+        ) ?? ""
+        nodes = try container.decode(
+            [GraphDefinitionDocumentNode].self,
+            forKey: key("nodes")
+        ).sorted { $0.id < $1.id }
+        edges = try container.decode(
+            [GraphDefinitionEdge].self,
+            forKey: key("edges")
+        ).sorted { $0.id < $1.id }
+        schedulerPolicy = try container.decode(
+            GraphSchedulerPolicy.self,
+            forKey: key("schedulerPolicy")
+        )
+        policyReferences = try container.decodeIfPresent(
+            [String].self,
+            forKey: key("policyReferences")
+        )?.sorted() ?? []
+        layout = try container.decodeIfPresent(
+            GraphLayoutMetadata.self,
+            forKey: key("layout")
+        ) ?? GraphLayoutMetadata()
+        metadata = try container.decode(
+            GraphDefinitionDocumentMetadata.self,
+            forKey: key("metadata")
+        )
+        sourceRepository = try container.decodeIfPresent(
+            GraphSourceRepositoryContext.self,
+            forKey: key("sourceRepository")
+        )
+        extensionFields = try Dictionary(
+            uniqueKeysWithValues: container.allKeys.compactMap { codingKey in
+                guard !Self.knownKeys.contains(codingKey.stringValue) else {
+                    return nil
+                }
+                return (
+                    codingKey.stringValue,
+                    try container.decode(GraphJSONValue.self, forKey: codingKey)
+                )
+            }
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: GraphDocumentCodingKey.self)
+        func key(_ value: String) -> GraphDocumentCodingKey {
+            GraphDocumentCodingKey(stringValue: value)!
+        }
+        try container.encode(schemaVersion, forKey: key("schemaVersion"))
+        try container.encode(graphID, forKey: key("graphID"))
+        try container.encode(definitionVersion, forKey: key("definitionVersion"))
+        try container.encode(name, forKey: key("name"))
+        try container.encode(description, forKey: key("description"))
+        try container.encode(nodes.sorted { $0.id < $1.id }, forKey: key("nodes"))
+        try container.encode(edges.sorted { $0.id < $1.id }, forKey: key("edges"))
+        try container.encode(schedulerPolicy, forKey: key("schedulerPolicy"))
+        try container.encode(policyReferences.sorted(), forKey: key("policyReferences"))
+        try container.encode(layout, forKey: key("layout"))
+        try container.encode(metadata, forKey: key("metadata"))
+        try container.encodeIfPresent(sourceRepository, forKey: key("sourceRepository"))
+        for (name, value) in extensionFields where !Self.knownKeys.contains(name) {
+            try container.encode(value, forKey: key(name))
+        }
+    }
+}
+
+private struct GraphDocumentCodingKey: CodingKey {
+    let stringValue: String
+    let intValue: Int? = nil
+
+    init?(stringValue: String) { self.stringValue = stringValue }
+    init?(intValue: Int) { return nil }
+}
+
+private struct GraphDefinitionSemanticContent: Codable {
+    let graphID: String
+    let definitionVersion: String
+    let nodes: [GraphDefinitionDocumentNode]
+    let edges: [GraphDefinitionEdge]
+    let schedulerPolicy: GraphSchedulerPolicy
+    let policyReferences: [String]
+    let sourceRepository: GraphSourceRepositoryContext?
+}
+
+public enum GraphDefinitionDocumentError: Error, Equatable, Sendable {
+    case unsupportedSchema(Int)
+    case missingGraphID
+    case invalidNode
+    case duplicateNodeID(String)
+    case unknownNodeReference(String)
+    case selfDependency(String)
+    case duplicateEdge(String)
+    case cycle
+    case invalidLayout
+    case nodeNotFound(String)
+    case edgeNotFound(String)
+    case embeddedSecret(String)
+}
+
+extension GraphDefinitionDocumentError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .unsupportedSchema(version):
+            "Graph document schema \(version) is unsupported."
+        case .missingGraphID:
+            "Graph document requires a stable graph ID."
+        case .invalidNode:
+            "Every graph node requires a stable ID and name."
+        case let .duplicateNodeID(id):
+            "Graph document contains duplicate node ID \(id)."
+        case let .unknownNodeReference(id):
+            "Graph edge references unknown node \(id)."
+        case let .selfDependency(id):
+            "Node \(id) cannot depend on itself."
+        case let .duplicateEdge(id):
+            "Graph document contains duplicate edge \(id)."
+        case .cycle:
+            "Graph dependencies must form a directed acyclic graph."
+        case .invalidLayout:
+            "Graph layout references invalid or duplicate nodes."
+        case let .nodeNotFound(id):
+            "Graph node \(id) was not found."
+        case let .edgeNotFound(id):
+            "Graph edge \(id) was not found."
+        case let .embeddedSecret(key):
+            "Graph definitions cannot embed sensitive value \(key)."
+        }
+    }
+}
+
+public enum GraphDefinitionDocumentEditor {
+    public static func addNode(
+        _ node: GraphDefinitionDocumentNode,
+        to document: inout GraphDefinitionDocument,
+        position: GraphCanvasPoint? = nil,
+        modifiedAt: Date,
+        modifiedBy: String
+    ) throws {
+        guard !document.nodes.contains(where: { $0.id == node.id }) else {
+            throw GraphDefinitionDocumentError.duplicateNodeID(node.id)
+        }
+        document.nodes.append(node)
+        document.nodes.sort { $0.id < $1.id }
+        if let position {
+            document.layout.nodes.append(
+                GraphNodeLayoutMetadata(nodeID: node.id, position: position)
+            )
+            document.layout.nodes.sort { $0.nodeID < $1.nodeID }
+        }
+        touch(&document, at: modifiedAt, by: modifiedBy)
+        try document.validate()
+    }
+
+    public static func removeNode(
+        id: String,
+        from document: inout GraphDefinitionDocument,
+        modifiedAt: Date,
+        modifiedBy: String
+    ) throws {
+        guard document.nodes.contains(where: { $0.id == id }) else {
+            throw GraphDefinitionDocumentError.nodeNotFound(id)
+        }
+        document.nodes.removeAll { $0.id == id }
+        document.edges.removeAll {
+            $0.sourceNodeID == id || $0.targetNodeID == id
+        }
+        document.layout.nodes.removeAll { $0.nodeID == id }
+        touch(&document, at: modifiedAt, by: modifiedBy)
+        try document.validate()
+    }
+
+    public static func renameNode(
+        id: String,
+        name: String,
+        description: String,
+        in document: inout GraphDefinitionDocument,
+        modifiedAt: Date,
+        modifiedBy: String
+    ) throws {
+        guard let index = document.nodes.firstIndex(where: { $0.id == id }) else {
+            throw GraphDefinitionDocumentError.nodeNotFound(id)
+        }
+        document.nodes[index].name = name
+        document.nodes[index].description = description
+        touch(&document, at: modifiedAt, by: modifiedBy)
+        try document.validate()
+    }
+
+    public static func addEdge(
+        _ edge: GraphDefinitionEdge,
+        to document: inout GraphDefinitionDocument,
+        modifiedAt: Date,
+        modifiedBy: String
+    ) throws {
+        guard !document.edges.contains(where: { $0.id == edge.id }) else {
+            throw GraphDefinitionDocumentError.duplicateEdge(edge.id)
+        }
+        document.edges.append(edge)
+        document.edges.sort { $0.id < $1.id }
+        do {
+            try document.validate()
+        } catch {
+            document.edges.removeAll { $0.id == edge.id }
+            throw error
+        }
+        touch(&document, at: modifiedAt, by: modifiedBy)
+    }
+
+    public static func removeEdge(
+        id: String,
+        from document: inout GraphDefinitionDocument,
+        modifiedAt: Date,
+        modifiedBy: String
+    ) throws {
+        guard document.edges.contains(where: { $0.id == id }) else {
+            throw GraphDefinitionDocumentError.edgeNotFound(id)
+        }
+        document.edges.removeAll { $0.id == id }
+        touch(&document, at: modifiedAt, by: modifiedBy)
+        try document.validate()
+    }
+
+    public static func setPosition(
+        nodeID: String,
+        position: GraphCanvasPoint,
+        in document: inout GraphDefinitionDocument,
+        modifiedAt: Date,
+        modifiedBy: String
+    ) throws {
+        guard document.nodes.contains(where: { $0.id == nodeID }) else {
+            throw GraphDefinitionDocumentError.nodeNotFound(nodeID)
+        }
+        if let index = document.layout.nodes.firstIndex(where: {
+            $0.nodeID == nodeID
+        }) {
+            document.layout.nodes[index].position = position
+        } else {
+            document.layout.nodes.append(
+                GraphNodeLayoutMetadata(nodeID: nodeID, position: position)
+            )
+            document.layout.nodes.sort { $0.nodeID < $1.nodeID }
+        }
+        touch(&document, at: modifiedAt, by: modifiedBy)
+    }
+
+    public static func applyAutomaticLayout(
+        to document: inout GraphDefinitionDocument,
+        modifiedAt: Date,
+        modifiedBy: String
+    ) throws {
+        guard let order = document.topologicalNodeIDs() else {
+            throw GraphDefinitionDocumentError.cycle
+        }
+        var depth: [String: Int] = [:]
+        for nodeID in order {
+            let dependencies = document.edges.filter {
+                $0.targetNodeID == nodeID
+            }.map(\.sourceNodeID)
+            depth[nodeID] = dependencies.map { depth[$0, default: 0] + 1 }
+                .max() ?? 0
+        }
+        let grouped = Dictionary(grouping: order) { depth[$0, default: 0] }
+        document.layout.nodes = grouped.keys.sorted().flatMap { column in
+            grouped[column, default: []].sorted().enumerated().map {
+                index, nodeID in
+                GraphNodeLayoutMetadata(
+                    nodeID: nodeID,
+                    position: GraphCanvasPoint(
+                        x: Double(column) * 280,
+                        y: Double(index) * 150
+                    )
+                )
+            }
+        }.sorted { $0.nodeID < $1.nodeID }
+        touch(&document, at: modifiedAt, by: modifiedBy)
+    }
+
+    private static func touch(
+        _ document: inout GraphDefinitionDocument,
+        at date: Date,
+        by author: String
+    ) {
+        document.metadata.modifiedAt = date
+        document.metadata.modifiedBy = author
+    }
+}
+
+public enum GraphDefinitionDocumentCodec {
+    public static func encoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [
+            .prettyPrinted,
+            .sortedKeys,
+            .withoutEscapingSlashes,
+        ]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    public static func decoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
+    public static func encode(
+        _ document: GraphDefinitionDocument
+    ) throws -> Data {
+        try document.validate()
+        return try encoder().encode(document)
+    }
+
+    public static func decode(_ data: Data) throws
+        -> GraphDefinitionDocument
+    {
+        let document = try decoder().decode(
+            GraphDefinitionDocument.self,
+            from: data
+        )
+        try document.validate()
+        return document
+    }
+
+    public static func load(url: URL) throws -> GraphDefinitionDocument {
+        try decode(Data(contentsOf: url))
+    }
+
+    public static func save(
+        _ document: GraphDefinitionDocument,
+        to url: URL
+    ) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try encode(document).write(to: url, options: .atomic)
+    }
+}

--- a/Sources/OpenIslandCore/GraphDefinitionLoader.swift
+++ b/Sources/OpenIslandCore/GraphDefinitionLoader.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public protocol GraphExecutableDefinitionLoading: Sendable {
+    func load(path: String) throws -> GraphExecutableDefinition
+}
+
+public struct FileGraphExecutableDefinitionLoader:
+    GraphExecutableDefinitionLoading,
+    Sendable
+{
+    public init() {}
+
+    public func load(path: String) throws -> GraphExecutableDefinition {
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let definition = try JSONDecoder().decode(
+            GraphExecutableDefinition.self,
+            from: data
+        )
+        try definition.validate()
+        return definition
+    }
+}

--- a/Sources/OpenIslandCore/GraphDefinitionValidator.swift
+++ b/Sources/OpenIslandCore/GraphDefinitionValidator.swift
@@ -17,6 +17,7 @@ public enum GraphValidationCode: String, Codable, CaseIterable, Sendable {
     case missingExecutionSpecification = "missing_execution_specification"
     case executableMissing = "executable_missing"
     case executableNotAbsolute = "executable_not_absolute"
+    case invalidArgumentToken = "invalid_argument_token"
     case invalidWorkingDirectory = "invalid_working_directory"
     case invalidArtifactPath = "invalid_artifact_path"
     case artifactPathEscapesWorkspace = "artifact_path_escapes_workspace"
@@ -279,6 +280,57 @@ public enum GraphDefinitionValidator {
             append(.error, .invalidWorkingDirectory, target,
                    "The configured workspace is unavailable.", "Choose an existing workspace directory.")
         }
+        validateLocalProcessArguments(
+            process,
+            node: node,
+            target: target,
+            append: append
+        )
+    }
+
+    private static func validateLocalProcessArguments(
+        _ process: GraphLocalProcessSpecification,
+        node: GraphDefinitionDocumentNode,
+        target: GraphValidationTarget,
+        append: (
+            GraphValidationSeverity,
+            GraphValidationCode,
+            GraphValidationTarget,
+            String,
+            String
+        ) -> Void
+    ) {
+        let outputRoles = Set(process.outputArtifacts.map(\.role))
+        let inputRoles = Set(node.inputArtifactRoles)
+        let invalid = process.arguments.filter { argument in
+            guard argument.hasPrefix("${"), argument.hasSuffix("}") else {
+                return false
+            }
+            if argument == "${workspace}" { return false }
+            if argument.hasPrefix("${artifact:") {
+                let value = String(argument.dropFirst(11).dropLast())
+                guard let role = GraphArtifactRole(rawValue: value) else {
+                    return true
+                }
+                return !outputRoles.contains(role)
+            }
+            if argument.hasPrefix("${input:") {
+                let value = String(argument.dropFirst(8).dropLast())
+                guard let role = GraphArtifactRole(rawValue: value) else {
+                    return true
+                }
+                return !inputRoles.contains(role)
+            }
+            return true
+        }
+        guard !invalid.isEmpty else { return }
+        append(
+            .error,
+            .invalidArgumentToken,
+            target,
+            "Arguments reference unavailable runtime paths: \(invalid.joined(separator: ", ")).",
+            "Use ${input:role} for upstream artifacts and ${artifact:role} for outputs declared by this node."
+        )
     }
 
     private static func validateInputs(

--- a/Sources/OpenIslandCore/GraphDefinitionValidator.swift
+++ b/Sources/OpenIslandCore/GraphDefinitionValidator.swift
@@ -223,7 +223,7 @@ public enum GraphDefinitionValidator {
         if !node.nodeType.isRunnable || !context.supportedExecutors.contains(node.executorKind) {
             append(.error, .unsupportedExecutorKind, target,
                    "Executor \(node.executorKind.displayName) is not runnable in this workspace.",
-                   "Choose Supervised Local Process or Deterministic Test Executor.")
+                   "Choose an executor configured and supported by this workspace.")
         }
         if let available = context.availableCapabilities,
            !Set(node.requiredCapabilities).isSubset(of: available) {

--- a/Sources/OpenIslandCore/GraphDefinitionValidator.swift
+++ b/Sources/OpenIslandCore/GraphDefinitionValidator.swift
@@ -1,0 +1,453 @@
+import Foundation
+
+public enum GraphValidationSeverity: String, Codable, CaseIterable, Sendable {
+    case error
+    case warning
+}
+
+public enum GraphValidationCode: String, Codable, CaseIterable, Sendable {
+    case emptyGraph = "empty_graph"
+    case missingGraphName = "missing_graph_name"
+    case duplicateNodeID = "duplicate_node_id"
+    case invalidNodeID = "invalid_node_id"
+    case cycle
+    case selfDependency = "self_dependency"
+    case duplicateEdge = "duplicate_edge"
+    case unknownNodeReference = "unknown_node_reference"
+    case missingExecutionSpecification = "missing_execution_specification"
+    case executableMissing = "executable_missing"
+    case executableNotAbsolute = "executable_not_absolute"
+    case invalidWorkingDirectory = "invalid_working_directory"
+    case invalidArtifactPath = "invalid_artifact_path"
+    case artifactPathEscapesWorkspace = "artifact_path_escapes_workspace"
+    case missingRequiredInput = "missing_required_input"
+    case incompatibleTypedPorts = "incompatible_typed_ports"
+    case sourceOutputNotDeclared = "source_output_not_declared"
+    case danglingBinding = "dangling_binding"
+    case multipleProviders = "multiple_providers"
+    case outputRoleCollision = "output_role_collision"
+    case invalidRetryPolicy = "invalid_retry_policy"
+    case invalidTimeoutPolicy = "invalid_timeout_policy"
+    case unsupportedExecutorKind = "unsupported_executor_kind"
+    case noTerminalNode = "no_terminal_or_output_node"
+    case unreachableNode = "unreachable_node"
+    case impossibleCapabilityRequirements = "impossible_capability_requirements"
+    case immutableDefinitionMutationAttempt = "immutable_definition_mutation_attempt"
+    case sensitiveLiteral = "sensitive_literal"
+}
+
+public enum GraphValidationTargetKind: String, Codable, Sendable {
+    case graph
+    case node
+    case edge
+    case graphInput = "graph_input"
+    case graphOutput = "graph_output"
+}
+
+public struct GraphValidationTarget: Equatable, Codable, Sendable {
+    public let kind: GraphValidationTargetKind
+    public let id: String?
+
+    public init(kind: GraphValidationTargetKind, id: String? = nil) {
+        self.kind = kind
+        self.id = id
+    }
+}
+
+public struct GraphValidationDiagnostic:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public var id: String {
+        "\(severity.rawValue):\(code.rawValue):\(target.kind.rawValue):\(target.id ?? "graph")"
+    }
+
+    public let severity: GraphValidationSeverity
+    public let code: GraphValidationCode
+    public let target: GraphValidationTarget
+    public let message: String
+    public let suggestedAction: String
+
+    public init(
+        severity: GraphValidationSeverity,
+        code: GraphValidationCode,
+        target: GraphValidationTarget,
+        message: String,
+        suggestedAction: String
+    ) {
+        self.severity = severity
+        self.code = code
+        self.target = target
+        self.message = message
+        self.suggestedAction = suggestedAction
+    }
+}
+
+public struct GraphDefinitionValidationContext: Equatable, Sendable {
+    public var supportedExecutors: Set<GraphDefinitionExecutorKind>
+    public var availableCapabilities: Set<String>?
+    public var availableExecutablePaths: Set<String>?
+    public var availableDirectoryPaths: Set<String>?
+    public var resolvedGraphInputIDs: Set<String>
+    public var immutableDefinitionDigest: GraphContentDigest?
+
+    public init(
+        supportedExecutors: Set<GraphDefinitionExecutorKind> = [
+            .supervisedLocalProcess,
+            .deterministicTest,
+        ],
+        availableCapabilities: Set<String>? = nil,
+        availableExecutablePaths: Set<String>? = nil,
+        availableDirectoryPaths: Set<String>? = nil,
+        resolvedGraphInputIDs: Set<String> = [],
+        immutableDefinitionDigest: GraphContentDigest? = nil
+    ) {
+        self.supportedExecutors = supportedExecutors
+        self.availableCapabilities = availableCapabilities
+        self.availableExecutablePaths = availableExecutablePaths
+        self.availableDirectoryPaths = availableDirectoryPaths
+        self.resolvedGraphInputIDs = resolvedGraphInputIDs
+        self.immutableDefinitionDigest = immutableDefinitionDigest
+    }
+}
+
+public enum GraphDefinitionValidator {
+    public static func validate(
+        _ document: GraphDefinitionDocument,
+        context: GraphDefinitionValidationContext = .init()
+    ) -> [GraphValidationDiagnostic] {
+        var result: [GraphValidationDiagnostic] = []
+        func append(
+            _ severity: GraphValidationSeverity,
+            _ code: GraphValidationCode,
+            _ target: GraphValidationTarget,
+            _ message: String,
+            _ action: String
+        ) {
+            result.append(
+                GraphValidationDiagnostic(
+                    severity: severity,
+                    code: code,
+                    target: target,
+                    message: message,
+                    suggestedAction: action
+                )
+            )
+        }
+
+        if document.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            append(.error, .missingGraphName, .init(kind: .graph),
+                   "The graph has no name.", "Enter a graph name in the graph inspector.")
+        }
+        let executableNodes = document.nodes.filter(\.nodeType.isExecutable)
+        if executableNodes.isEmpty {
+            append(.error, .emptyGraph, .init(kind: .graph),
+                   "The graph has no executable nodes.", "Add a Local Process or Deterministic Test node.")
+        }
+
+        let groupedIDs = Dictionary(grouping: document.nodes, by: \.id)
+        for (id, nodes) in groupedIDs where nodes.count > 1 {
+            append(.error, .duplicateNodeID, .init(kind: .node, id: id),
+                   "Node ID \(id) is duplicated.", "Assign a unique stable node ID.")
+        }
+        for node in document.nodes where !isValidIdentifier(node.id) {
+            append(.error, .invalidNodeID, .init(kind: .node, id: node.id),
+                   "Node ID \(node.id) contains unsupported characters.",
+                   "Use letters, numbers, period, underscore, or hyphen.")
+        }
+
+        let known = Set(document.nodes.map(\.id))
+        let semanticEdges = Dictionary(grouping: document.edges) {
+            "\($0.sourceNodeID)|\($0.targetNodeID)|\($0.portType.rawValue)|\($0.sourceOutputID ?? "")|\($0.targetInputID ?? "")"
+        }
+        for (_, edges) in semanticEdges where edges.count > 1 {
+            let edge = edges[0]
+            append(.error, .duplicateEdge, .init(kind: .edge, id: edge.id),
+                   "The same connection is declared more than once.", "Delete the duplicate connection.")
+        }
+        for edge in document.edges {
+            let target = GraphValidationTarget(kind: .edge, id: edge.id)
+            if edge.sourceNodeID == edge.targetNodeID {
+                append(.error, .selfDependency, target,
+                       "A node cannot depend on itself.", "Choose a different destination.")
+            }
+            if !known.contains(edge.sourceNodeID) || !known.contains(edge.targetNodeID) {
+                append(.error, .unknownNodeReference, target,
+                       "The connection references a node that does not exist.", "Delete or reconnect the edge.")
+                continue
+            }
+            if edge.portType != .dependency {
+                validateTypedEdge(edge, document: document, append: append)
+            }
+        }
+        if document.topologicalNodeIDs() == nil {
+            append(.error, .cycle, .init(kind: .graph),
+                   "Graph connections contain a cycle.", "Remove one dependency from the cycle.")
+        }
+
+        for node in executableNodes {
+            validateExecutableNode(node, document: document, context: context, append: append)
+        }
+        validateGraphInputs(document, context: context, append: append)
+        validateGraphOutputs(document, append: append)
+        validateReachability(document, append: append)
+
+        if let immutable = context.immutableDefinitionDigest,
+           let current = try? document.semanticDigest(), current != immutable {
+            append(.error, .immutableDefinitionMutationAttempt, .init(kind: .graph),
+                   "This semantic edit differs from the immutable definition used by an existing run.",
+                   "Create a new definition version before creating another run.")
+        }
+
+        return result.sorted {
+            if $0.severity != $1.severity { return $0.severity.rawValue < $1.severity.rawValue }
+            if $0.code != $1.code { return $0.code.rawValue < $1.code.rawValue }
+            return ($0.target.id ?? "") < ($1.target.id ?? "")
+        }
+    }
+
+    private static func validateExecutableNode(
+        _ node: GraphDefinitionDocumentNode,
+        document: GraphDefinitionDocument,
+        context: GraphDefinitionValidationContext,
+        append: (GraphValidationSeverity, GraphValidationCode, GraphValidationTarget, String, String) -> Void
+    ) {
+        let target = GraphValidationTarget(kind: .node, id: node.id)
+        if node.specification.adapterKind.isEmpty || node.specification.operation.isEmpty {
+            append(.error, .missingExecutionSpecification, target,
+                   "Node \(node.name) has no execution specification.", "Configure the node's executor.")
+        }
+        if !node.nodeType.isRunnable || !context.supportedExecutors.contains(node.executorKind) {
+            append(.error, .unsupportedExecutorKind, target,
+                   "Executor \(node.executorKind.displayName) is not runnable in this workspace.",
+                   "Choose Supervised Local Process or Deterministic Test Executor.")
+        }
+        if let available = context.availableCapabilities,
+           !Set(node.requiredCapabilities).isSubset(of: available) {
+            append(.error, .impossibleCapabilityRequirements, target,
+                   "No available executor satisfies all required capabilities.",
+                   "Change required capabilities or choose a compatible executor.")
+        }
+        if node.timeoutPolicy.executionSeconds < 1
+            || node.timeoutPolicy.cancellationAcknowledgementSeconds < 1
+            || node.timeoutConfiguration.claimSeconds < 1 {
+            append(.error, .invalidTimeoutPolicy, target,
+                   "Timeout values must be greater than zero.", "Set valid execution, cancellation, and claim timeouts.")
+        }
+        let retry = node.retryConfiguration.effective(
+            graphDefault: document.schedulerPolicy.retryPolicy
+        )
+        if retry.maximumAttempts < 1
+            || retry.maximumBackoffSeconds < retry.initialBackoffSeconds {
+            append(.error, .invalidRetryPolicy, target,
+                   "Retry attempts or backoff bounds are invalid.", "Correct the retry policy in the node inspector.")
+        }
+        validateInputs(node, document: document, append: append)
+        validateOutputs(node, append: append)
+
+        guard node.nodeType == .localProcess else { return }
+        guard let process = try? GraphLocalProcessSpecification(
+            immutableSpecification: node.specification
+        ) else {
+            append(.error, .missingExecutionSpecification, target,
+                   "The local-process specification cannot be decoded.", "Reconfigure the Execution section.")
+            return
+        }
+        if process.executable.isEmpty {
+            append(.error, .executableMissing, target,
+                   "No executable is selected.", "Choose an executable file.")
+        } else if !process.executable.hasPrefix("/") {
+            append(.error, .executableNotAbsolute, target,
+                   "Executable paths must be absolute.", "Choose the executable with the file picker.")
+        } else if let available = context.availableExecutablePaths,
+                  !available.contains(process.executable) {
+            append(.error, .executableMissing, target,
+                   "The configured executable is unavailable.", "Choose an executable that exists and is runnable.")
+        }
+        if process.workingDirectory.hasPrefix("/") || pathEscapes(process.workingDirectory) {
+            append(.error, .invalidWorkingDirectory, target,
+                   "The working directory must stay inside the workspace.", "Use a relative working directory without '..'.")
+        }
+        if node.workspace.root?.isEmpty != false {
+            append(.error, .invalidWorkingDirectory, target,
+                   "A local process requires a workspace directory.", "Choose a workspace directory.")
+        } else if let available = context.availableDirectoryPaths,
+                  let root = node.workspace.root,
+                  !available.contains(root) {
+            append(.error, .invalidWorkingDirectory, target,
+                   "The configured workspace is unavailable.", "Choose an existing workspace directory.")
+        }
+    }
+
+    private static func validateInputs(
+        _ node: GraphDefinitionDocumentNode,
+        document: GraphDefinitionDocument,
+        append: (GraphValidationSeverity, GraphValidationCode, GraphValidationTarget, String, String) -> Void
+    ) {
+        for input in node.inputs {
+            let target = GraphValidationTarget(kind: .node, id: node.id)
+            let incoming = document.edges.filter {
+                $0.targetNodeID == node.id && $0.targetInputID == input.id
+            }
+            if input.isRequired && input.binding == nil && incoming.isEmpty {
+                append(.error, .missingRequiredInput, target,
+                       "Required input \(input.name) has no binding.", "Connect an output or configure another input source.")
+            }
+            if !input.allowsMultiple && incoming.count > 1 {
+                append(.error, .multipleProviders, target,
+                       "Input \(input.name) has multiple providers.", "Keep one provider or allow a collection.")
+            }
+            if let binding = input.binding {
+                switch binding.kind {
+                case .upstreamArtifact, .upstreamArtifactCollection:
+                    guard let sourceID = binding.sourceNodeID,
+                          let outputID = binding.sourceOutputID,
+                          document.nodes.first(where: { $0.id == sourceID })?
+                            .outputs.contains(where: { $0.id == outputID }) == true else {
+                        append(.error, .danglingBinding, target,
+                               "Input \(input.name) references a missing upstream output.", "Reconnect the input.")
+                        continue
+                    }
+                case .graphInput:
+                    if !document.graphInputs.contains(where: {
+                        $0.id == binding.graphInputID
+                    }) {
+                        append(.error, .danglingBinding, target,
+                               "Input \(input.name) references a missing graph input.", "Choose an existing graph input.")
+                    }
+                case .fileReference, .staticLiteral, .secretReference:
+                    break
+                }
+            }
+        }
+    }
+
+    private static func validateOutputs(
+        _ node: GraphDefinitionDocumentNode,
+        append: (GraphValidationSeverity, GraphValidationCode, GraphValidationTarget, String, String) -> Void
+    ) {
+        let grouped = Dictionary(grouping: node.outputs, by: \.role)
+        for (_, values) in grouped where values.count > 1 {
+            append(.error, .outputRoleCollision, .init(kind: .node, id: node.id),
+                   "Runtime artifact roles must be unique within a node.", "Assign a distinct runtime role to each output.")
+        }
+        for output in node.outputs {
+            if output.relativePath.isEmpty || output.relativePath.hasPrefix("/") {
+                append(.error, .invalidArtifactPath, .init(kind: .node, id: node.id),
+                       "Output \(output.name) needs a relative path.", "Choose a path inside the workspace.")
+            } else if pathEscapes(output.relativePath) {
+                append(.error, .artifactPathEscapesWorkspace, .init(kind: .node, id: node.id),
+                       "Output \(output.name) escapes the workspace.", "Remove '..' path components.")
+            }
+        }
+    }
+
+    private static func validateTypedEdge(
+        _ edge: GraphDefinitionEdge,
+        document: GraphDefinitionDocument,
+        append: (GraphValidationSeverity, GraphValidationCode, GraphValidationTarget, String, String) -> Void
+    ) {
+        let target = GraphValidationTarget(kind: .edge, id: edge.id)
+        guard let source = document.nodes.first(where: { $0.id == edge.sourceNodeID }),
+              let outputID = edge.sourceOutputID,
+              let output = source.outputs.first(where: { $0.id == outputID }) else {
+            append(.error, .sourceOutputNotDeclared, target,
+                   "The connection has no declared source output.", "Choose a source output in the connection inspector.")
+            return
+        }
+        guard let destination = document.nodes.first(where: { $0.id == edge.targetNodeID }),
+              let inputID = edge.targetInputID,
+              let input = destination.inputs.first(where: { $0.id == inputID }) else {
+            append(.error, .danglingBinding, target,
+                   "The connection has no declared target input.", "Choose a target input in the connection inspector.")
+            return
+        }
+        if output.portType != edge.portType || input.portType != edge.portType
+            || (edge.portType == .artifact
+                && !mediaTypesAreCompatible(output.mediaType, input.mediaType)) {
+            append(.error, .incompatibleTypedPorts, target,
+                   "The selected ports are not type-compatible.", "Choose matching port and media types.")
+        }
+    }
+
+    private static func validateGraphInputs(
+        _ document: GraphDefinitionDocument,
+        context: GraphDefinitionValidationContext,
+        append: (GraphValidationSeverity, GraphValidationCode, GraphValidationTarget, String, String) -> Void
+    ) {
+        for input in document.graphInputs {
+            let target = GraphValidationTarget(kind: .graphInput, id: input.id)
+            if input.isSensitive && input.defaultValue != nil {
+                append(.error, .sensitiveLiteral, target,
+                       "Sensitive graph inputs cannot persist literal defaults.", "Use a secret reference at run creation.")
+            }
+            if input.isRequired && input.defaultValue == nil
+                && !context.resolvedGraphInputIDs.contains(input.id) {
+                append(.error, .missingRequiredInput, target,
+                       "Required graph input \(input.name) is unresolved.", "Provide a value in Create Run.")
+            }
+        }
+    }
+
+    private static func validateGraphOutputs(
+        _ document: GraphDefinitionDocument,
+        append: (GraphValidationSeverity, GraphValidationCode, GraphValidationTarget, String, String) -> Void
+    ) {
+        for output in document.graphOutputs {
+            guard document.nodes.first(where: { $0.id == output.sourceNodeID })?
+                .outputs.contains(where: { $0.id == output.sourceOutputID }) == true else {
+                append(.error, .danglingBinding, .init(kind: .graphOutput, id: output.id),
+                       "Graph output \(output.name) references a missing node output.", "Choose a declared node output.")
+                continue
+            }
+        }
+        let executable = document.nodes.filter(\.nodeType.isExecutable)
+        let outgoing = Set(document.edges.map(\.sourceNodeID))
+        if !executable.isEmpty && executable.allSatisfy({ outgoing.contains($0.id) })
+            && document.graphOutputs.isEmpty {
+            append(.warning, .noTerminalNode, .init(kind: .graph),
+                   "The graph has no terminal node or declared graph output.", "Declare a graph output or remove the trailing dependency.")
+        }
+    }
+
+    private static func validateReachability(
+        _ document: GraphDefinitionDocument,
+        append: (GraphValidationSeverity, GraphValidationCode, GraphValidationTarget, String, String) -> Void
+    ) {
+        let executable = document.nodes.filter(\.nodeType.isExecutable)
+        let incoming = Set(document.edges.map(\.targetNodeID))
+        let roots = executable.filter { !incoming.contains($0.id) }.map(\.id).sorted()
+        guard let primary = roots.first else { return }
+        var reached: Set<String> = [primary]
+        var changed = true
+        while changed {
+            changed = false
+            for edge in document.edges where reached.contains(edge.sourceNodeID) {
+                if reached.insert(edge.targetNodeID).inserted { changed = true }
+            }
+        }
+        for node in executable where !reached.contains(node.id) {
+            append(.warning, .unreachableNode, .init(kind: .node, id: node.id),
+                   "Node \(node.name) is disconnected from the primary component.", "Connect it or keep it as an intentional independent component.")
+        }
+    }
+
+    private static func isValidIdentifier(_ value: String) -> Bool {
+        !value.isEmpty && value.unicodeScalars.allSatisfy {
+            CharacterSet.alphanumerics.contains($0)
+                || ".-_".unicodeScalars.contains($0)
+        }
+    }
+
+    private static func pathEscapes(_ value: String) -> Bool {
+        value.split(separator: "/").contains("..")
+    }
+
+    private static func mediaTypesAreCompatible(_ lhs: String, _ rhs: String) -> Bool {
+        lhs == rhs || lhs == "*/*" || rhs == "*/*"
+            || lhs == "application/octet-stream"
+            || rhs == "application/octet-stream"
+    }
+}

--- a/Sources/OpenIslandCore/GraphExecutionDefinition.swift
+++ b/Sources/OpenIslandCore/GraphExecutionDefinition.swift
@@ -1,0 +1,193 @@
+import Foundation
+
+public enum GraphExecutableDefinitionSchema {
+    public static let currentVersion = 1
+}
+
+public enum GraphArtifactRole: String, Codable, CaseIterable, Sendable {
+    case nodeOutput = "node_output"
+    case executionLog = "execution_log"
+    case structuredResult = "structured_result"
+    case diagnostic
+}
+
+public struct GraphExecutionWorkspaceContext:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let root: String?
+    public let writableRelativePaths: [String]
+
+    public init(
+        root: String? = nil,
+        writableRelativePaths: [String] = []
+    ) {
+        self.root = root
+        self.writableRelativePaths = writableRelativePaths.sorted()
+    }
+}
+
+public struct GraphExecutionTimeoutPolicy: Equatable, Codable, Sendable {
+    public let executionSeconds: UInt64
+    public let cancellationAcknowledgementSeconds: UInt64
+
+    public init(
+        executionSeconds: UInt64,
+        cancellationAcknowledgementSeconds: UInt64
+    ) {
+        self.executionSeconds = max(1, executionSeconds)
+        self.cancellationAcknowledgementSeconds = max(
+            1,
+            cancellationAcknowledgementSeconds
+        )
+    }
+}
+
+public struct GraphImmutableExecutionSpecification:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let schemaVersion: Int
+    public let adapterKind: String
+    public let operation: String
+    public let parameters: [String: GraphJSONValue]
+
+    public init(
+        schemaVersion: Int = GraphExecutableDefinitionSchema.currentVersion,
+        adapterKind: String,
+        operation: String,
+        parameters: [String: GraphJSONValue] = [:]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.adapterKind = adapterKind
+        self.operation = operation
+        self.parameters = parameters
+    }
+}
+
+public struct GraphNodeExecutionDefinition:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public var id: String { nodeID }
+
+    public let nodeID: String
+    public let capabilityRequirement: [String]
+    public let specification: GraphImmutableExecutionSpecification
+    public let workspace: GraphExecutionWorkspaceContext
+    public let environmentAllowlist: [String]
+    public let inputArtifactRoles: [GraphArtifactRole]
+    public let timeoutPolicy: GraphExecutionTimeoutPolicy
+
+    public init(
+        nodeID: String,
+        capabilityRequirement: [String],
+        specification: GraphImmutableExecutionSpecification,
+        workspace: GraphExecutionWorkspaceContext =
+            GraphExecutionWorkspaceContext(),
+        environmentAllowlist: [String] = [],
+        inputArtifactRoles: [GraphArtifactRole] = [.nodeOutput],
+        timeoutPolicy: GraphExecutionTimeoutPolicy
+    ) {
+        self.nodeID = nodeID
+        self.capabilityRequirement = capabilityRequirement.sorted()
+        self.specification = specification
+        self.workspace = workspace
+        self.environmentAllowlist = environmentAllowlist.sorted()
+        self.inputArtifactRoles = inputArtifactRoles.sorted {
+            $0.rawValue < $1.rawValue
+        }
+        self.timeoutPolicy = timeoutPolicy
+    }
+}
+
+public enum GraphExecutableDefinitionError: Error, Equatable, Sendable {
+    case unsupportedSchema(Int)
+    case duplicateNodeID(String)
+    case missingExecutionSpecification(String)
+    case unknownExecutionNode(String)
+    case capabilityMismatch(String)
+}
+
+extension GraphExecutableDefinitionError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .unsupportedSchema(version):
+            "Executable graph schema version \(version) is unsupported."
+        case let .duplicateNodeID(nodeID):
+            "Executable graph contains duplicate node \(nodeID)."
+        case let .missingExecutionSpecification(nodeID):
+            "Node \(nodeID) has no execution specification."
+        case let .unknownExecutionNode(nodeID):
+            "Execution specification references unknown node \(nodeID)."
+        case let .capabilityMismatch(nodeID):
+            "Node \(nodeID) capability requirements do not match scheduling."
+        }
+    }
+}
+
+public struct GraphExecutableDefinition: Equatable, Codable, Sendable {
+    public let schemaVersion: Int
+    public let scheduling: GraphSchedulingDefinition
+    public let schedulerPolicy: GraphSchedulerPolicy
+    public let executions: [GraphNodeExecutionDefinition]
+
+    public init(
+        schemaVersion: Int = GraphExecutableDefinitionSchema.currentVersion,
+        scheduling: GraphSchedulingDefinition,
+        schedulerPolicy: GraphSchedulerPolicy,
+        executions: [GraphNodeExecutionDefinition]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.scheduling = scheduling
+        self.schedulerPolicy = schedulerPolicy
+        self.executions = executions.sorted { $0.nodeID < $1.nodeID }
+    }
+
+    public func validate() throws {
+        guard schemaVersion <= GraphExecutableDefinitionSchema.currentVersion
+        else {
+            throw GraphExecutableDefinitionError.unsupportedSchema(
+                schemaVersion
+            )
+        }
+        let schedulingIDs = scheduling.nodes.map(\.id)
+        guard Set(schedulingIDs).count == schedulingIDs.count else {
+            let duplicate = Dictionary(grouping: schedulingIDs, by: { $0 })
+                .first { $0.value.count > 1 }?.key ?? "unknown"
+            throw GraphExecutableDefinitionError.duplicateNodeID(duplicate)
+        }
+        let executionByNode = Dictionary(
+            grouping: executions,
+            by: \.nodeID
+        )
+        for node in scheduling.nodes {
+            guard let matches = executionByNode[node.id], !matches.isEmpty else {
+                throw GraphExecutableDefinitionError
+                    .missingExecutionSpecification(node.id)
+            }
+            guard matches.count == 1 else {
+                throw GraphExecutableDefinitionError.duplicateNodeID(node.id)
+            }
+            guard matches[0].capabilityRequirement
+                    == node.requiredCapabilities else {
+                throw GraphExecutableDefinitionError.capabilityMismatch(node.id)
+            }
+        }
+        for execution in executions
+            where !schedulingIDs.contains(execution.nodeID) {
+            throw GraphExecutableDefinitionError
+                .unknownExecutionNode(execution.nodeID)
+        }
+    }
+
+    public func execution(
+        for nodeID: String
+    ) -> GraphNodeExecutionDefinition? {
+        executions.first { $0.nodeID == nodeID }
+    }
+}

--- a/Sources/OpenIslandCore/GraphExecutionEventStore.swift
+++ b/Sources/OpenIslandCore/GraphExecutionEventStore.swift
@@ -1,0 +1,251 @@
+import Foundation
+
+public enum GraphExecutionPersistenceError: Error, Equatable, Sendable {
+    case invalidRunID(expected: String, actual: String)
+    case expectedVersionConflict(
+        runID: String,
+        expected: UInt64,
+        actual: UInt64
+    )
+    case eventIDCollision(eventID: String)
+    case sequenceGap(expected: UInt64, actual: UInt64)
+    case sequenceConflict(runID: String, sequence: UInt64)
+    case unsupportedSchemaVersion(
+        artifact: String,
+        found: Int,
+        supported: Int
+    )
+    case corruptRecord(String)
+    case storageFailure(String)
+}
+
+extension GraphExecutionPersistenceError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .invalidRunID(expected, actual):
+            return "Expected run \(expected), found \(actual)."
+        case let .expectedVersionConflict(runID, expected, actual):
+            return "Run \(runID) expected stream version \(expected), found \(actual)."
+        case let .eventIDCollision(eventID):
+            return "Event ID \(eventID) was reused with different content."
+        case let .sequenceGap(expected, actual):
+            return "Expected stream sequence \(expected), found \(actual)."
+        case let .sequenceConflict(runID, sequence):
+            return "Run \(runID) already contains a different event at sequence \(sequence)."
+        case let .unsupportedSchemaVersion(artifact, found, supported):
+            return "\(artifact) schema version \(found) exceeds supported version \(supported)."
+        case let .corruptRecord(message):
+            return "Corrupt graph execution record: \(message)"
+        case let .storageFailure(message):
+            return "Graph execution storage failed: \(message)"
+        }
+    }
+}
+
+public struct GraphExecutionAppendResult: Equatable, Sendable {
+    public let previousVersion: UInt64
+    public let newVersion: UInt64
+    public let appendedCount: Int
+    public let deduplicatedCount: Int
+
+    public init(
+        previousVersion: UInt64,
+        newVersion: UInt64,
+        appendedCount: Int,
+        deduplicatedCount: Int
+    ) {
+        self.previousVersion = previousVersion
+        self.newVersion = newVersion
+        self.appendedCount = appendedCount
+        self.deduplicatedCount = deduplicatedCount
+    }
+}
+
+public struct GraphExecutionEventStream: Equatable, Sendable {
+    public let runID: String
+    public let afterVersion: UInt64
+    public let currentVersion: UInt64
+    public let events: [GraphExecutionEventEnvelope]
+
+    public init(
+        runID: String,
+        afterVersion: UInt64,
+        currentVersion: UInt64,
+        events: [GraphExecutionEventEnvelope]
+    ) {
+        self.runID = runID
+        self.afterVersion = afterVersion
+        self.currentVersion = currentVersion
+        self.events = events
+    }
+}
+
+public protocol GraphExecutionEventStore: Sendable {
+    func append(
+        _ events: [GraphExecutionEventEnvelope],
+        to runID: String,
+        expectedVersion: UInt64
+    ) async throws -> GraphExecutionAppendResult
+
+    func read(
+        runID: String,
+        afterVersion: UInt64
+    ) async throws -> GraphExecutionEventStream
+}
+
+public actor InMemoryGraphExecutionEventStore:
+    GraphExecutionEventStore
+{
+    private var streams: [String: [GraphExecutionEventEnvelope]] = [:]
+    private var eventsByID: [String: GraphExecutionEventEnvelope] = [:]
+
+    public init() {}
+
+    public func append(
+        _ events: [GraphExecutionEventEnvelope],
+        to runID: String,
+        expectedVersion: UInt64
+    ) throws -> GraphExecutionAppendResult {
+        let normalized = try Self.normalize(events)
+        let current = streams[runID] ?? []
+        let currentVersion = current.last?.streamSequence ?? 0
+
+        for event in normalized where event.runID != runID {
+            throw GraphExecutionPersistenceError.invalidRunID(
+                expected: runID,
+                actual: event.runID
+            )
+        }
+
+        for event in normalized {
+            guard event.schemaVersion
+                    <= GraphExecutionSchema.eventEnvelopeVersion else {
+                throw GraphExecutionPersistenceError
+                    .unsupportedSchemaVersion(
+                        artifact: "event envelope",
+                        found: event.schemaVersion,
+                        supported: GraphExecutionSchema.eventEnvelopeVersion
+                    )
+            }
+
+            if let existing = eventsByID[event.id],
+               existing != event {
+                throw GraphExecutionPersistenceError.eventIDCollision(
+                    eventID: event.id
+                )
+            }
+        }
+
+        let newEvents = normalized.filter {
+            eventsByID[$0.id] == nil
+        }
+        let duplicateCount = events.count - newEvents.count
+
+        if newEvents.isEmpty {
+            return GraphExecutionAppendResult(
+                previousVersion: currentVersion,
+                newVersion: currentVersion,
+                appendedCount: 0,
+                deduplicatedCount: duplicateCount
+            )
+        }
+
+        guard expectedVersion == currentVersion else {
+            throw GraphExecutionPersistenceError
+                .expectedVersionConflict(
+                    runID: runID,
+                    expected: expectedVersion,
+                    actual: currentVersion
+                )
+        }
+
+        var expectedSequence = currentVersion + 1
+
+        for event in newEvents {
+            guard event.streamSequence == expectedSequence else {
+                if current.contains(where: {
+                    $0.streamSequence == event.streamSequence
+                }) {
+                    throw GraphExecutionPersistenceError
+                        .sequenceConflict(
+                            runID: runID,
+                            sequence: event.streamSequence
+                        )
+                }
+
+                throw GraphExecutionPersistenceError.sequenceGap(
+                    expected: expectedSequence,
+                    actual: event.streamSequence
+                )
+            }
+
+            expectedSequence += 1
+        }
+
+        var updated = current
+        updated.append(contentsOf: newEvents)
+        streams[runID] = updated
+
+        for event in newEvents {
+            eventsByID[event.id] = event
+        }
+
+        return GraphExecutionAppendResult(
+            previousVersion: currentVersion,
+            newVersion: updated.last?.streamSequence ?? currentVersion,
+            appendedCount: newEvents.count,
+            deduplicatedCount: duplicateCount
+        )
+    }
+
+    public func read(
+        runID: String,
+        afterVersion: UInt64
+    ) throws -> GraphExecutionEventStream {
+        let stream = streams[runID] ?? []
+        let currentVersion = stream.last?.streamSequence ?? 0
+        let events = stream.filter {
+            $0.streamSequence > afterVersion
+        }
+
+        if afterVersion < currentVersion,
+           let first = events.first,
+           first.streamSequence != afterVersion + 1 {
+            throw GraphExecutionPersistenceError.corruptRecord(
+                "Run \(runID) has a gap after sequence \(afterVersion)."
+            )
+        }
+
+        return GraphExecutionEventStream(
+            runID: runID,
+            afterVersion: afterVersion,
+            currentVersion: currentVersion,
+            events: events
+        )
+    }
+
+    private static func normalize(
+        _ events: [GraphExecutionEventEnvelope]
+    ) throws -> [GraphExecutionEventEnvelope] {
+        var byID: [String: GraphExecutionEventEnvelope] = [:]
+
+        for event in events {
+            if let existing = byID[event.id],
+               existing != event {
+                throw GraphExecutionPersistenceError.eventIDCollision(
+                    eventID: event.id
+                )
+            }
+
+            byID[event.id] = event
+        }
+
+        return byID.values.sorted {
+            if $0.streamSequence != $1.streamSequence {
+                return $0.streamSequence < $1.streamSequence
+            }
+
+            return $0.id < $1.id
+        }
+    }
+}

--- a/Sources/OpenIslandCore/GraphExecutionEventStore.swift
+++ b/Sources/OpenIslandCore/GraphExecutionEventStore.swift
@@ -96,7 +96,7 @@ public protocol GraphExecutionEventStore: Sendable {
 public actor InMemoryGraphExecutionEventStore:
     GraphExecutionEventStore
 {
-    private var streams: [String: [GraphExecutionEventEnvelope]] = [:]
+    package var streams: [String: [GraphExecutionEventEnvelope]] = [:]
     private var eventsByID: [String: GraphExecutionEventEnvelope] = [:]
 
     public init() {}

--- a/Sources/OpenIslandCore/GraphExecutionHistory.swift
+++ b/Sources/OpenIslandCore/GraphExecutionHistory.swift
@@ -266,9 +266,26 @@ public struct GraphAttemptCreatedPayload: Equatable, Codable, Sendable {
 
 public struct GraphAttemptStartingPayload: Equatable, Codable, Sendable {
     public let reason: String?
+    public let identity: GraphExecutorInteractionIdentity?
 
-    public init(reason: String? = nil) {
+    public init(
+        reason: String? = nil,
+        identity: GraphExecutorInteractionIdentity? = nil
+    ) {
         self.reason = reason
+        self.identity = identity
+    }
+}
+
+public struct GraphExecutorObservationPayload:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let observation: GraphExecutorObservation
+
+    public init(observation: GraphExecutorObservation) {
+        self.observation = observation
     }
 }
 
@@ -404,6 +421,8 @@ public enum GraphExecutionEventType: String, CaseIterable, Codable, Sendable {
     case processIdentityObserved = "graph.process.identity.observed"
     case heartbeatObserved = "graph.executor.heartbeat.observed"
     case processExitObserved = "graph.process.exit.observed"
+    case executorObservationRecorded =
+        "graph.executor.observation.recorded"
     case attemptCompleted = "graph.attempt.completed"
     case attemptFailed = "graph.attempt.failed"
     case attemptInterrupted = "graph.attempt.interrupted"
@@ -498,6 +517,7 @@ public enum GraphExecutionEventPayload: Equatable, Sendable {
     case processIdentityObserved(GraphProcessIdentityObservedPayload)
     case heartbeatObserved(GraphHeartbeatObservedPayload)
     case processExitObserved(GraphProcessExitObservedPayload)
+    case executorObservationRecorded(GraphExecutorObservationPayload)
     case attemptCompleted(GraphAttemptTerminalPayload)
     case attemptFailed(GraphAttemptTerminalPayload)
     case attemptInterrupted(GraphAttemptTerminalPayload)
@@ -546,6 +566,8 @@ public enum GraphExecutionEventPayload: Equatable, Sendable {
             GraphExecutionEventType.heartbeatObserved.rawValue
         case .processExitObserved:
             GraphExecutionEventType.processExitObserved.rawValue
+        case .executorObservationRecorded:
+            GraphExecutionEventType.executorObservationRecorded.rawValue
         case .attemptCompleted:
             GraphExecutionEventType.attemptCompleted.rawValue
         case .attemptFailed:
@@ -614,7 +636,8 @@ public enum GraphExecutionEventPayload: Equatable, Sendable {
             .command
         case .processIdentityObserved,
              .heartbeatObserved,
-             .processExitObserved:
+             .processExitObserved,
+             .executorObservationRecorded:
             .observation
         case .attemptCompleted,
              .attemptFailed,
@@ -844,6 +867,10 @@ extension GraphExecutionEventEnvelope: Codable {
             return .processExitObserved(
                 try GraphProcessExitObservedPayload(from: decoder)
             )
+        case .executorObservationRecorded:
+            return .executorObservationRecorded(
+                try GraphExecutorObservationPayload(from: decoder)
+            )
         case .attemptCompleted:
             return .attemptCompleted(
                 try GraphAttemptTerminalPayload(from: decoder)
@@ -978,6 +1005,8 @@ extension GraphExecutionEventEnvelope: Codable {
         case let .heartbeatObserved(value):
             try value.encode(to: encoder)
         case let .processExitObserved(value):
+            try value.encode(to: encoder)
+        case let .executorObservationRecorded(value):
             try value.encode(to: encoder)
         case let .attemptCompleted(value):
             try value.encode(to: encoder)

--- a/Sources/OpenIslandCore/GraphExecutionHistory.swift
+++ b/Sources/OpenIslandCore/GraphExecutionHistory.swift
@@ -1,0 +1,785 @@
+import Foundation
+
+public enum GraphExecutionSchema {
+    public static let eventEnvelopeVersion = 1
+    public static let eventPayloadVersion = 1
+    public static let snapshotVersion = 1
+    public static let artifactReferenceVersion = 1
+}
+
+public enum GraphExecutionProducerKind: String, Codable, Sendable {
+    case application
+    case executor
+    case processAdapter
+    case importer
+    case user
+    case test
+}
+
+public struct GraphExecutionProducer: Equatable, Codable, Sendable {
+    public let id: String
+    public let kind: GraphExecutionProducerKind
+    public let instanceID: String?
+
+    public init(
+        id: String,
+        kind: GraphExecutionProducerKind,
+        instanceID: String? = nil
+    ) {
+        self.id = id
+        self.kind = kind
+        self.instanceID = instanceID
+    }
+}
+
+public struct GraphExecutionTelemetryContext: Equatable, Codable, Sendable {
+    public let traceID: String?
+    public let spanID: String?
+    public let traceFlags: String?
+    public let traceState: String?
+    public let attributes: [String: String]
+
+    public init(
+        traceID: String? = nil,
+        spanID: String? = nil,
+        traceFlags: String? = nil,
+        traceState: String? = nil,
+        attributes: [String: String] = [:]
+    ) {
+        self.traceID = traceID
+        self.spanID = spanID
+        self.traceFlags = traceFlags
+        self.traceState = traceState
+        self.attributes = attributes
+    }
+}
+
+public struct GraphExecutionIntegrityMetadata: Equatable, Codable, Sendable {
+    public let digestAlgorithm: String
+    public let digest: String
+    public let signatureAlgorithm: String?
+    public let signature: String?
+
+    public init(
+        digestAlgorithm: String,
+        digest: String,
+        signatureAlgorithm: String? = nil,
+        signature: String? = nil
+    ) {
+        self.digestAlgorithm = digestAlgorithm
+        self.digest = digest
+        self.signatureAlgorithm = signatureAlgorithm
+        self.signature = signature
+    }
+}
+
+public struct GraphContentDigest: Equatable, Codable, Sendable {
+    public let algorithm: String
+    public let value: String
+
+    public init(algorithm: String, value: String) {
+        self.algorithm = algorithm
+        self.value = value
+    }
+}
+
+public struct GraphArtifactStorageLocator: Equatable, Codable, Sendable {
+    public let scheme: String
+    public let opaqueReference: String
+
+    public init(scheme: String, opaqueReference: String) {
+        self.scheme = scheme
+        self.opaqueReference = opaqueReference
+    }
+}
+
+public enum GraphArtifactSensitivity: String, Codable, Sendable {
+    case unspecified
+    case internalUse
+    case confidential
+    case restricted
+    case redacted
+}
+
+public struct GraphArtifactReference: Equatable, Identifiable, Codable, Sendable {
+    public let schemaVersion: Int
+    public let id: String
+    public let contentDigest: GraphContentDigest
+    public let mediaType: String
+    public let logicalRole: String
+    public let producingRunID: String
+    public let producingNodeID: String
+    public let producingAttemptID: String
+    public let createdAt: Date
+    public let storage: GraphArtifactStorageLocator
+    public let sensitivity: GraphArtifactSensitivity
+
+    public init(
+        schemaVersion: Int = GraphExecutionSchema.artifactReferenceVersion,
+        id: String,
+        contentDigest: GraphContentDigest,
+        mediaType: String,
+        logicalRole: String,
+        producingRunID: String,
+        producingNodeID: String,
+        producingAttemptID: String,
+        createdAt: Date,
+        storage: GraphArtifactStorageLocator,
+        sensitivity: GraphArtifactSensitivity = .unspecified
+    ) {
+        self.schemaVersion = schemaVersion
+        self.id = id
+        self.contentDigest = contentDigest
+        self.mediaType = mediaType
+        self.logicalRole = logicalRole
+        self.producingRunID = producingRunID
+        self.producingNodeID = producingNodeID
+        self.producingAttemptID = producingAttemptID
+        self.createdAt = createdAt
+        self.storage = storage
+        self.sensitivity = sensitivity
+    }
+}
+
+public struct GraphCheckpointReference: Equatable, Codable, Sendable {
+    public let checkpointID: String
+    public let runID: String
+    public let streamVersion: UInt64
+    public let namespace: String
+
+    public init(
+        checkpointID: String,
+        runID: String,
+        streamVersion: UInt64,
+        namespace: String
+    ) {
+        self.checkpointID = checkpointID
+        self.runID = runID
+        self.streamVersion = streamVersion
+        self.namespace = namespace
+    }
+}
+
+public struct GraphRunCreatedPayload: Equatable, Codable, Sendable {
+    public let graphID: String
+    public let graphDefinitionVersion: String
+    public let graphDefinitionDigest: GraphContentDigest
+    public let nodeIDs: [String]
+    public let parentRunID: String?
+    public let parentCheckpoint: GraphCheckpointReference?
+    public let checkpointNamespace: String
+
+    public init(
+        graphID: String,
+        graphDefinitionVersion: String,
+        graphDefinitionDigest: GraphContentDigest,
+        nodeIDs: [String],
+        parentRunID: String? = nil,
+        parentCheckpoint: GraphCheckpointReference? = nil,
+        checkpointNamespace: String = "root"
+    ) {
+        self.graphID = graphID
+        self.graphDefinitionVersion = graphDefinitionVersion
+        self.graphDefinitionDigest = graphDefinitionDigest
+        self.nodeIDs = nodeIDs
+        self.parentRunID = parentRunID
+        self.parentCheckpoint = parentCheckpoint
+        self.checkpointNamespace = checkpointNamespace
+    }
+}
+
+public struct GraphNodeRegisteredPayload: Equatable, Codable, Sendable {
+    public let title: String
+    public let dependencyNodeIDs: [String]
+    public let executorID: String?
+    public let definitionVersion: String
+
+    public init(
+        title: String,
+        dependencyNodeIDs: [String] = [],
+        executorID: String? = nil,
+        definitionVersion: String = "1"
+    ) {
+        self.title = title
+        self.dependencyNodeIDs = dependencyNodeIDs
+        self.executorID = executorID
+        self.definitionVersion = definitionVersion
+    }
+}
+
+public struct GraphAttemptCreatedPayload: Equatable, Codable, Sendable {
+    public let ordinal: Int
+    public let executorID: String?
+
+    public init(ordinal: Int, executorID: String? = nil) {
+        self.ordinal = ordinal
+        self.executorID = executorID
+    }
+}
+
+public struct GraphAttemptStartingPayload: Equatable, Codable, Sendable {
+    public let reason: String?
+
+    public init(reason: String? = nil) {
+        self.reason = reason
+    }
+}
+
+public struct GraphProcessIdentityObservedPayload: Equatable, Codable, Sendable {
+    public let processIdentity: ProcessIdentity
+
+    public init(processIdentity: ProcessIdentity) {
+        self.processIdentity = processIdentity
+    }
+}
+
+public struct GraphHeartbeatObservedPayload: Equatable, Codable, Sendable {
+    public let processIdentity: ProcessIdentity
+    public let validUntil: Date
+
+    public init(
+        processIdentity: ProcessIdentity,
+        validUntil: Date
+    ) {
+        self.processIdentity = processIdentity
+        self.validUntil = validUntil
+    }
+}
+
+public struct GraphProcessExitObservedPayload: Equatable, Codable, Sendable {
+    public let processIdentity: ProcessIdentity
+    public let exitCode: Int32?
+    public let signal: Int32?
+    public let reason: String?
+
+    public init(
+        processIdentity: ProcessIdentity,
+        exitCode: Int32? = nil,
+        signal: Int32? = nil,
+        reason: String? = nil
+    ) {
+        self.processIdentity = processIdentity
+        self.exitCode = exitCode
+        self.signal = signal
+        self.reason = reason
+    }
+}
+
+public struct GraphAttemptTerminalPayload: Equatable, Codable, Sendable {
+    public let reason: String?
+    public let artifactIDs: [String]
+
+    public init(
+        reason: String? = nil,
+        artifactIDs: [String] = []
+    ) {
+        self.reason = reason
+        self.artifactIDs = artifactIDs
+    }
+}
+
+public struct GraphArtifactRecordedPayload: Equatable, Codable, Sendable {
+    public let artifact: GraphArtifactReference
+
+    public init(artifact: GraphArtifactReference) {
+        self.artifact = artifact
+    }
+}
+
+public enum GraphHumanInterruptResolution: String, Codable, Sendable {
+    case approved
+    case rejected
+    case modified
+    case delegated
+    case additionalEvidenceRequested
+}
+
+public struct GraphHumanInterruptRequestedPayload: Equatable, Codable, Sendable {
+    public let requestID: String
+    public let requestSchemaID: String
+    public let requestArtifactID: String?
+    public let expiresAt: Date?
+    public let requiredDecisionCount: Int
+
+    public init(
+        requestID: String,
+        requestSchemaID: String,
+        requestArtifactID: String? = nil,
+        expiresAt: Date? = nil,
+        requiredDecisionCount: Int = 1
+    ) {
+        self.requestID = requestID
+        self.requestSchemaID = requestSchemaID
+        self.requestArtifactID = requestArtifactID
+        self.expiresAt = expiresAt
+        self.requiredDecisionCount = requiredDecisionCount
+    }
+}
+
+public struct GraphHumanInterruptResolvedPayload: Equatable, Codable, Sendable {
+    public let requestID: String
+    public let resolution: GraphHumanInterruptResolution
+    public let decidedBy: String
+    public let responseArtifactID: String?
+
+    public init(
+        requestID: String,
+        resolution: GraphHumanInterruptResolution,
+        decidedBy: String,
+        responseArtifactID: String? = nil
+    ) {
+        self.requestID = requestID
+        self.resolution = resolution
+        self.decidedBy = decidedBy
+        self.responseArtifactID = responseArtifactID
+    }
+}
+
+public struct GraphRunTerminalPayload: Equatable, Codable, Sendable {
+    public let state: ReconciledExecutionState
+    public let reason: String?
+
+    public init(
+        state: ReconciledExecutionState,
+        reason: String? = nil
+    ) {
+        self.state = state
+        self.reason = reason
+    }
+}
+
+public enum GraphExecutionEventType: String, CaseIterable, Codable, Sendable {
+    case runCreated = "graph.run.created"
+    case nodeRegistered = "graph.node.registered"
+    case attemptCreated = "graph.attempt.created"
+    case attemptStarting = "graph.attempt.starting"
+    case processIdentityObserved = "graph.process.identity.observed"
+    case heartbeatObserved = "graph.executor.heartbeat.observed"
+    case processExitObserved = "graph.process.exit.observed"
+    case attemptCompleted = "graph.attempt.completed"
+    case attemptFailed = "graph.attempt.failed"
+    case attemptInterrupted = "graph.attempt.interrupted"
+    case attemptOrphaned = "graph.attempt.orphaned"
+    case attemptCancelled = "graph.attempt.cancelled"
+    case artifactRecorded = "graph.artifact.recorded"
+    case humanInterruptRequested = "graph.human_interrupt.requested"
+    case humanInterruptResolved = "graph.human_interrupt.resolved"
+    case runTerminalStateRecorded = "graph.run.terminal.recorded"
+}
+
+public enum GraphExecutionEventFactClass: String, Codable, Sendable {
+    case command
+    case observation
+    case declaration
+    case metadata
+}
+
+public enum GraphJSONValue: Equatable, Codable, Sendable {
+    case null
+    case bool(Bool)
+    case number(Double)
+    case string(String)
+    case array([GraphJSONValue])
+    case object([String: GraphJSONValue])
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([GraphJSONValue].self) {
+            self = .array(value)
+        } else {
+            self = .object(
+                try container.decode([String: GraphJSONValue].self)
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case .null:
+            try container.encodeNil()
+        case let .bool(value):
+            try container.encode(value)
+        case let .number(value):
+            try container.encode(value)
+        case let .string(value):
+            try container.encode(value)
+        case let .array(value):
+            try container.encode(value)
+        case let .object(value):
+            try container.encode(value)
+        }
+    }
+}
+
+public enum GraphExecutionEventPayload: Equatable, Sendable {
+    case runCreated(GraphRunCreatedPayload)
+    case nodeRegistered(GraphNodeRegisteredPayload)
+    case attemptCreated(GraphAttemptCreatedPayload)
+    case attemptStarting(GraphAttemptStartingPayload)
+    case processIdentityObserved(GraphProcessIdentityObservedPayload)
+    case heartbeatObserved(GraphHeartbeatObservedPayload)
+    case processExitObserved(GraphProcessExitObservedPayload)
+    case attemptCompleted(GraphAttemptTerminalPayload)
+    case attemptFailed(GraphAttemptTerminalPayload)
+    case attemptInterrupted(GraphAttemptTerminalPayload)
+    case attemptOrphaned(GraphAttemptTerminalPayload)
+    case attemptCancelled(GraphAttemptTerminalPayload)
+    case artifactRecorded(GraphArtifactRecordedPayload)
+    case humanInterruptRequested(GraphHumanInterruptRequestedPayload)
+    case humanInterruptResolved(GraphHumanInterruptResolvedPayload)
+    case runTerminalStateRecorded(GraphRunTerminalPayload)
+    case unknown(eventType: String, body: GraphJSONValue)
+
+    public var eventType: String {
+        switch self {
+        case .runCreated:
+            GraphExecutionEventType.runCreated.rawValue
+        case .nodeRegistered:
+            GraphExecutionEventType.nodeRegistered.rawValue
+        case .attemptCreated:
+            GraphExecutionEventType.attemptCreated.rawValue
+        case .attemptStarting:
+            GraphExecutionEventType.attemptStarting.rawValue
+        case .processIdentityObserved:
+            GraphExecutionEventType.processIdentityObserved.rawValue
+        case .heartbeatObserved:
+            GraphExecutionEventType.heartbeatObserved.rawValue
+        case .processExitObserved:
+            GraphExecutionEventType.processExitObserved.rawValue
+        case .attemptCompleted:
+            GraphExecutionEventType.attemptCompleted.rawValue
+        case .attemptFailed:
+            GraphExecutionEventType.attemptFailed.rawValue
+        case .attemptInterrupted:
+            GraphExecutionEventType.attemptInterrupted.rawValue
+        case .attemptOrphaned:
+            GraphExecutionEventType.attemptOrphaned.rawValue
+        case .attemptCancelled:
+            GraphExecutionEventType.attemptCancelled.rawValue
+        case .artifactRecorded:
+            GraphExecutionEventType.artifactRecorded.rawValue
+        case .humanInterruptRequested:
+            GraphExecutionEventType.humanInterruptRequested.rawValue
+        case .humanInterruptResolved:
+            GraphExecutionEventType.humanInterruptResolved.rawValue
+        case .runTerminalStateRecorded:
+            GraphExecutionEventType.runTerminalStateRecorded.rawValue
+        case let .unknown(eventType, _):
+            eventType
+        }
+    }
+
+    public var factClass: GraphExecutionEventFactClass {
+        switch self {
+        case .attemptStarting, .humanInterruptRequested:
+            .command
+        case .processIdentityObserved,
+             .heartbeatObserved,
+             .processExitObserved:
+            .observation
+        case .attemptCompleted,
+             .attemptFailed,
+             .attemptInterrupted,
+             .attemptOrphaned,
+             .attemptCancelled,
+             .humanInterruptResolved,
+             .runTerminalStateRecorded:
+            .declaration
+        case .runCreated,
+             .nodeRegistered,
+             .attemptCreated,
+             .artifactRecorded,
+             .unknown:
+            .metadata
+        }
+    }
+}
+
+public struct GraphExecutionEventEnvelope: Equatable, Identifiable, Sendable {
+    public let schemaVersion: Int
+    public let id: String
+    public let runID: String
+    public let nodeID: String?
+    public let attemptID: String?
+    public let streamSequence: UInt64
+    public let occurredAt: Date
+    public let recordedAt: Date
+    public let producer: GraphExecutionProducer
+    public let correlationID: String?
+    public let causationID: String?
+    public let telemetryContext: GraphExecutionTelemetryContext?
+    public let payloadVersion: Int
+    public let payload: GraphExecutionEventPayload
+    public let integrity: GraphExecutionIntegrityMetadata?
+
+    public init(
+        schemaVersion: Int = GraphExecutionSchema.eventEnvelopeVersion,
+        id: String,
+        runID: String,
+        nodeID: String? = nil,
+        attemptID: String? = nil,
+        streamSequence: UInt64,
+        occurredAt: Date,
+        recordedAt: Date,
+        producer: GraphExecutionProducer,
+        correlationID: String? = nil,
+        causationID: String? = nil,
+        telemetryContext: GraphExecutionTelemetryContext? = nil,
+        payloadVersion: Int = GraphExecutionSchema.eventPayloadVersion,
+        payload: GraphExecutionEventPayload,
+        integrity: GraphExecutionIntegrityMetadata? = nil
+    ) {
+        self.schemaVersion = schemaVersion
+        self.id = id
+        self.runID = runID
+        self.nodeID = nodeID
+        self.attemptID = attemptID
+        self.streamSequence = streamSequence
+        self.occurredAt = occurredAt
+        self.recordedAt = recordedAt
+        self.producer = producer
+        self.correlationID = correlationID
+        self.causationID = causationID
+        self.telemetryContext = telemetryContext
+        self.payloadVersion = payloadVersion
+        self.payload = payload
+        self.integrity = integrity
+    }
+
+    public var eventType: String {
+        payload.eventType
+    }
+
+    public var factClass: GraphExecutionEventFactClass {
+        payload.factClass
+    }
+}
+
+extension GraphExecutionEventEnvelope: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion
+        case id
+        case runID
+        case nodeID
+        case attemptID
+        case streamSequence
+        case occurredAt
+        case recordedAt
+        case eventType
+        case producer
+        case correlationID
+        case causationID
+        case telemetryContext
+        case payloadVersion
+        case payload
+        case integrity
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
+        id = try container.decode(String.self, forKey: .id)
+        runID = try container.decode(String.self, forKey: .runID)
+        nodeID = try container.decodeIfPresent(String.self, forKey: .nodeID)
+        attemptID = try container.decodeIfPresent(
+            String.self,
+            forKey: .attemptID
+        )
+        streamSequence = try container.decode(
+            UInt64.self,
+            forKey: .streamSequence
+        )
+        occurredAt = try container.decode(Date.self, forKey: .occurredAt)
+        recordedAt = try container.decode(Date.self, forKey: .recordedAt)
+        producer = try container.decode(
+            GraphExecutionProducer.self,
+            forKey: .producer
+        )
+        correlationID = try container.decodeIfPresent(
+            String.self,
+            forKey: .correlationID
+        )
+        causationID = try container.decodeIfPresent(
+            String.self,
+            forKey: .causationID
+        )
+        telemetryContext = try container.decodeIfPresent(
+            GraphExecutionTelemetryContext.self,
+            forKey: .telemetryContext
+        )
+        payloadVersion = try container.decode(
+            Int.self,
+            forKey: .payloadVersion
+        )
+        integrity = try container.decodeIfPresent(
+            GraphExecutionIntegrityMetadata.self,
+            forKey: .integrity
+        )
+
+        let eventType = try container.decode(
+            String.self,
+            forKey: .eventType
+        )
+        let payloadDecoder = try container.superDecoder(forKey: .payload)
+        payload = try Self.decodePayload(
+            eventType: eventType,
+            from: payloadDecoder
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(schemaVersion, forKey: .schemaVersion)
+        try container.encode(id, forKey: .id)
+        try container.encode(runID, forKey: .runID)
+        try container.encodeIfPresent(nodeID, forKey: .nodeID)
+        try container.encodeIfPresent(attemptID, forKey: .attemptID)
+        try container.encode(streamSequence, forKey: .streamSequence)
+        try container.encode(occurredAt, forKey: .occurredAt)
+        try container.encode(recordedAt, forKey: .recordedAt)
+        try container.encode(eventType, forKey: .eventType)
+        try container.encode(producer, forKey: .producer)
+        try container.encodeIfPresent(
+            correlationID,
+            forKey: .correlationID
+        )
+        try container.encodeIfPresent(causationID, forKey: .causationID)
+        try container.encodeIfPresent(
+            telemetryContext,
+            forKey: .telemetryContext
+        )
+        try container.encode(payloadVersion, forKey: .payloadVersion)
+        try container.encodeIfPresent(integrity, forKey: .integrity)
+
+        let payloadEncoder = container.superEncoder(forKey: .payload)
+        try Self.encodePayload(payload, to: payloadEncoder)
+    }
+
+    private static func decodePayload(
+        eventType: String,
+        from decoder: Decoder
+    ) throws -> GraphExecutionEventPayload {
+        switch GraphExecutionEventType(rawValue: eventType) {
+        case .runCreated:
+            return .runCreated(try GraphRunCreatedPayload(from: decoder))
+        case .nodeRegistered:
+            return .nodeRegistered(
+                try GraphNodeRegisteredPayload(from: decoder)
+            )
+        case .attemptCreated:
+            return .attemptCreated(
+                try GraphAttemptCreatedPayload(from: decoder)
+            )
+        case .attemptStarting:
+            return .attemptStarting(
+                try GraphAttemptStartingPayload(from: decoder)
+            )
+        case .processIdentityObserved:
+            return .processIdentityObserved(
+                try GraphProcessIdentityObservedPayload(from: decoder)
+            )
+        case .heartbeatObserved:
+            return .heartbeatObserved(
+                try GraphHeartbeatObservedPayload(from: decoder)
+            )
+        case .processExitObserved:
+            return .processExitObserved(
+                try GraphProcessExitObservedPayload(from: decoder)
+            )
+        case .attemptCompleted:
+            return .attemptCompleted(
+                try GraphAttemptTerminalPayload(from: decoder)
+            )
+        case .attemptFailed:
+            return .attemptFailed(
+                try GraphAttemptTerminalPayload(from: decoder)
+            )
+        case .attemptInterrupted:
+            return .attemptInterrupted(
+                try GraphAttemptTerminalPayload(from: decoder)
+            )
+        case .attemptOrphaned:
+            return .attemptOrphaned(
+                try GraphAttemptTerminalPayload(from: decoder)
+            )
+        case .attemptCancelled:
+            return .attemptCancelled(
+                try GraphAttemptTerminalPayload(from: decoder)
+            )
+        case .artifactRecorded:
+            return .artifactRecorded(
+                try GraphArtifactRecordedPayload(from: decoder)
+            )
+        case .humanInterruptRequested:
+            return .humanInterruptRequested(
+                try GraphHumanInterruptRequestedPayload(from: decoder)
+            )
+        case .humanInterruptResolved:
+            return .humanInterruptResolved(
+                try GraphHumanInterruptResolvedPayload(from: decoder)
+            )
+        case .runTerminalStateRecorded:
+            return .runTerminalStateRecorded(
+                try GraphRunTerminalPayload(from: decoder)
+            )
+        case nil:
+            return .unknown(
+                eventType: eventType,
+                body: try GraphJSONValue(from: decoder)
+            )
+        }
+    }
+
+    private static func encodePayload(
+        _ payload: GraphExecutionEventPayload,
+        to encoder: Encoder
+    ) throws {
+        switch payload {
+        case let .runCreated(value):
+            try value.encode(to: encoder)
+        case let .nodeRegistered(value):
+            try value.encode(to: encoder)
+        case let .attemptCreated(value):
+            try value.encode(to: encoder)
+        case let .attemptStarting(value):
+            try value.encode(to: encoder)
+        case let .processIdentityObserved(value):
+            try value.encode(to: encoder)
+        case let .heartbeatObserved(value):
+            try value.encode(to: encoder)
+        case let .processExitObserved(value):
+            try value.encode(to: encoder)
+        case let .attemptCompleted(value):
+            try value.encode(to: encoder)
+        case let .attemptFailed(value):
+            try value.encode(to: encoder)
+        case let .attemptInterrupted(value):
+            try value.encode(to: encoder)
+        case let .attemptOrphaned(value):
+            try value.encode(to: encoder)
+        case let .attemptCancelled(value):
+            try value.encode(to: encoder)
+        case let .artifactRecorded(value):
+            try value.encode(to: encoder)
+        case let .humanInterruptRequested(value):
+            try value.encode(to: encoder)
+        case let .humanInterruptResolved(value):
+            try value.encode(to: encoder)
+        case let .runTerminalStateRecorded(value):
+            try value.encode(to: encoder)
+        case let .unknown(_, body):
+            try body.encode(to: encoder)
+        }
+    }
+}

--- a/Sources/OpenIslandCore/GraphExecutionHistory.swift
+++ b/Sources/OpenIslandCore/GraphExecutionHistory.swift
@@ -365,9 +365,27 @@ public enum GraphExecutionEventType: String, CaseIterable, Codable, Sendable {
     case humanInterruptRequested = "graph.human_interrupt.requested"
     case humanInterruptResolved = "graph.human_interrupt.resolved"
     case runTerminalStateRecorded = "graph.run.terminal.recorded"
+    case schedulerEvaluationRecorded = "graph.scheduler.evaluation.recorded"
+    case nodeBecameRunnable = "graph.scheduler.node.runnable"
+    case nodeSchedulingDeferred = "graph.scheduler.node.deferred"
+    case executorClaimRequested = "graph.executor.claim.requested"
+    case executorClaimGranted = "graph.executor.claim.granted"
+    case executorClaimRejected = "graph.executor.claim.rejected"
+    case executorLeaseRenewed = "graph.executor.lease.renewed"
+    case executorLeaseExpired = "graph.executor.lease.expired"
+    case executorClaimReleased = "graph.executor.claim.released"
+    case retryScheduled = "graph.scheduler.retry.scheduled"
+    case retrySuppressed = "graph.scheduler.retry.suppressed"
+    case cancellationRequested = "graph.cancellation.requested"
+    case cancellationAcknowledged = "graph.cancellation.acknowledged"
+    case timeoutDeclared = "graph.scheduler.timeout.declared"
+    case dependencyFailurePropagated =
+        "graph.scheduler.dependency_failure.propagated"
+    case schedulerCycleCompleted = "graph.scheduler.cycle.completed"
 }
 
 public enum GraphExecutionEventFactClass: String, Codable, Sendable {
+    case decision
     case command
     case observation
     case declaration
@@ -439,6 +457,24 @@ public enum GraphExecutionEventPayload: Equatable, Sendable {
     case humanInterruptRequested(GraphHumanInterruptRequestedPayload)
     case humanInterruptResolved(GraphHumanInterruptResolvedPayload)
     case runTerminalStateRecorded(GraphRunTerminalPayload)
+    case schedulerEvaluationRecorded(GraphSchedulerEvaluationPayload)
+    case nodeBecameRunnable(GraphNodeSchedulingPayload)
+    case nodeSchedulingDeferred(GraphNodeSchedulingPayload)
+    case executorClaimRequested(GraphExecutorClaimPayload)
+    case executorClaimGranted(GraphExecutorClaimPayload)
+    case executorClaimRejected(GraphExecutorClaimRejectedPayload)
+    case executorLeaseRenewed(GraphExecutorClaimPayload)
+    case executorLeaseExpired(GraphExecutorLeaseEndedPayload)
+    case executorClaimReleased(GraphExecutorLeaseEndedPayload)
+    case retryScheduled(GraphRetryScheduledPayload)
+    case retrySuppressed(GraphRetrySuppressedPayload)
+    case cancellationRequested(GraphCancellationRequestedPayload)
+    case cancellationAcknowledged(GraphCancellationAcknowledgedPayload)
+    case timeoutDeclared(GraphTimeoutDeclaredPayload)
+    case dependencyFailurePropagated(
+        GraphDependencyFailurePropagatedPayload
+    )
+    case schedulerCycleCompleted(GraphSchedulerCycleCompletedPayload)
     case unknown(eventType: String, body: GraphJSONValue)
 
     public var eventType: String {
@@ -475,6 +511,38 @@ public enum GraphExecutionEventPayload: Equatable, Sendable {
             GraphExecutionEventType.humanInterruptResolved.rawValue
         case .runTerminalStateRecorded:
             GraphExecutionEventType.runTerminalStateRecorded.rawValue
+        case .schedulerEvaluationRecorded:
+            GraphExecutionEventType.schedulerEvaluationRecorded.rawValue
+        case .nodeBecameRunnable:
+            GraphExecutionEventType.nodeBecameRunnable.rawValue
+        case .nodeSchedulingDeferred:
+            GraphExecutionEventType.nodeSchedulingDeferred.rawValue
+        case .executorClaimRequested:
+            GraphExecutionEventType.executorClaimRequested.rawValue
+        case .executorClaimGranted:
+            GraphExecutionEventType.executorClaimGranted.rawValue
+        case .executorClaimRejected:
+            GraphExecutionEventType.executorClaimRejected.rawValue
+        case .executorLeaseRenewed:
+            GraphExecutionEventType.executorLeaseRenewed.rawValue
+        case .executorLeaseExpired:
+            GraphExecutionEventType.executorLeaseExpired.rawValue
+        case .executorClaimReleased:
+            GraphExecutionEventType.executorClaimReleased.rawValue
+        case .retryScheduled:
+            GraphExecutionEventType.retryScheduled.rawValue
+        case .retrySuppressed:
+            GraphExecutionEventType.retrySuppressed.rawValue
+        case .cancellationRequested:
+            GraphExecutionEventType.cancellationRequested.rawValue
+        case .cancellationAcknowledged:
+            GraphExecutionEventType.cancellationAcknowledged.rawValue
+        case .timeoutDeclared:
+            GraphExecutionEventType.timeoutDeclared.rawValue
+        case .dependencyFailurePropagated:
+            GraphExecutionEventType.dependencyFailurePropagated.rawValue
+        case .schedulerCycleCompleted:
+            GraphExecutionEventType.schedulerCycleCompleted.rawValue
         case let .unknown(eventType, _):
             eventType
         }
@@ -482,7 +550,10 @@ public enum GraphExecutionEventPayload: Equatable, Sendable {
 
     public var factClass: GraphExecutionEventFactClass {
         switch self {
-        case .attemptStarting, .humanInterruptRequested:
+        case .attemptStarting,
+             .humanInterruptRequested,
+             .executorClaimRequested,
+             .cancellationRequested:
             .command
         case .processIdentityObserved,
              .heartbeatObserved,
@@ -494,8 +565,23 @@ public enum GraphExecutionEventPayload: Equatable, Sendable {
              .attemptOrphaned,
              .attemptCancelled,
              .humanInterruptResolved,
-             .runTerminalStateRecorded:
+             .runTerminalStateRecorded,
+             .executorClaimGranted,
+             .executorClaimRejected,
+             .executorLeaseRenewed,
+             .executorLeaseExpired,
+             .executorClaimReleased,
+             .cancellationAcknowledged,
+             .schedulerCycleCompleted:
             .declaration
+        case .schedulerEvaluationRecorded,
+             .nodeBecameRunnable,
+             .nodeSchedulingDeferred,
+             .retryScheduled,
+             .retrySuppressed,
+             .timeoutDeclared,
+             .dependencyFailurePropagated:
+            .decision
         case .runCreated,
              .nodeRegistered,
              .attemptCreated,
@@ -733,6 +819,72 @@ extension GraphExecutionEventEnvelope: Codable {
             return .runTerminalStateRecorded(
                 try GraphRunTerminalPayload(from: decoder)
             )
+        case .schedulerEvaluationRecorded:
+            return .schedulerEvaluationRecorded(
+                try GraphSchedulerEvaluationPayload(from: decoder)
+            )
+        case .nodeBecameRunnable:
+            return .nodeBecameRunnable(
+                try GraphNodeSchedulingPayload(from: decoder)
+            )
+        case .nodeSchedulingDeferred:
+            return .nodeSchedulingDeferred(
+                try GraphNodeSchedulingPayload(from: decoder)
+            )
+        case .executorClaimRequested:
+            return .executorClaimRequested(
+                try GraphExecutorClaimPayload(from: decoder)
+            )
+        case .executorClaimGranted:
+            return .executorClaimGranted(
+                try GraphExecutorClaimPayload(from: decoder)
+            )
+        case .executorClaimRejected:
+            return .executorClaimRejected(
+                try GraphExecutorClaimRejectedPayload(from: decoder)
+            )
+        case .executorLeaseRenewed:
+            return .executorLeaseRenewed(
+                try GraphExecutorClaimPayload(from: decoder)
+            )
+        case .executorLeaseExpired:
+            return .executorLeaseExpired(
+                try GraphExecutorLeaseEndedPayload(from: decoder)
+            )
+        case .executorClaimReleased:
+            return .executorClaimReleased(
+                try GraphExecutorLeaseEndedPayload(from: decoder)
+            )
+        case .retryScheduled:
+            return .retryScheduled(
+                try GraphRetryScheduledPayload(from: decoder)
+            )
+        case .retrySuppressed:
+            return .retrySuppressed(
+                try GraphRetrySuppressedPayload(from: decoder)
+            )
+        case .cancellationRequested:
+            return .cancellationRequested(
+                try GraphCancellationRequestedPayload(from: decoder)
+            )
+        case .cancellationAcknowledged:
+            return .cancellationAcknowledged(
+                try GraphCancellationAcknowledgedPayload(from: decoder)
+            )
+        case .timeoutDeclared:
+            return .timeoutDeclared(
+                try GraphTimeoutDeclaredPayload(from: decoder)
+            )
+        case .dependencyFailurePropagated:
+            return .dependencyFailurePropagated(
+                try GraphDependencyFailurePropagatedPayload(
+                    from: decoder
+                )
+            )
+        case .schedulerCycleCompleted:
+            return .schedulerCycleCompleted(
+                try GraphSchedulerCycleCompletedPayload(from: decoder)
+            )
         case nil:
             return .unknown(
                 eventType: eventType,
@@ -777,6 +929,38 @@ extension GraphExecutionEventEnvelope: Codable {
         case let .humanInterruptResolved(value):
             try value.encode(to: encoder)
         case let .runTerminalStateRecorded(value):
+            try value.encode(to: encoder)
+        case let .schedulerEvaluationRecorded(value):
+            try value.encode(to: encoder)
+        case let .nodeBecameRunnable(value):
+            try value.encode(to: encoder)
+        case let .nodeSchedulingDeferred(value):
+            try value.encode(to: encoder)
+        case let .executorClaimRequested(value):
+            try value.encode(to: encoder)
+        case let .executorClaimGranted(value):
+            try value.encode(to: encoder)
+        case let .executorClaimRejected(value):
+            try value.encode(to: encoder)
+        case let .executorLeaseRenewed(value):
+            try value.encode(to: encoder)
+        case let .executorLeaseExpired(value):
+            try value.encode(to: encoder)
+        case let .executorClaimReleased(value):
+            try value.encode(to: encoder)
+        case let .retryScheduled(value):
+            try value.encode(to: encoder)
+        case let .retrySuppressed(value):
+            try value.encode(to: encoder)
+        case let .cancellationRequested(value):
+            try value.encode(to: encoder)
+        case let .cancellationAcknowledged(value):
+            try value.encode(to: encoder)
+        case let .timeoutDeclared(value):
+            try value.encode(to: encoder)
+        case let .dependencyFailurePropagated(value):
+            try value.encode(to: encoder)
+        case let .schedulerCycleCompleted(value):
             try value.encode(to: encoder)
         case let .unknown(_, body):
             try body.encode(to: encoder)

--- a/Sources/OpenIslandCore/GraphExecutionHistory.swift
+++ b/Sources/OpenIslandCore/GraphExecutionHistory.swift
@@ -110,6 +110,8 @@ public struct GraphArtifactReference: Equatable, Identifiable, Codable, Sendable
     public let producingRunID: String
     public let producingNodeID: String
     public let producingAttemptID: String
+    public let producingAttemptOrdinal: Int?
+    public let producingClaimID: String?
     public let createdAt: Date
     public let storage: GraphArtifactStorageLocator
     public let sensitivity: GraphArtifactSensitivity
@@ -123,6 +125,8 @@ public struct GraphArtifactReference: Equatable, Identifiable, Codable, Sendable
         producingRunID: String,
         producingNodeID: String,
         producingAttemptID: String,
+        producingAttemptOrdinal: Int? = nil,
+        producingClaimID: String? = nil,
         createdAt: Date,
         storage: GraphArtifactStorageLocator,
         sensitivity: GraphArtifactSensitivity = .unspecified
@@ -135,6 +139,8 @@ public struct GraphArtifactReference: Equatable, Identifiable, Codable, Sendable
         self.producingRunID = producingRunID
         self.producingNodeID = producingNodeID
         self.producingAttemptID = producingAttemptID
+        self.producingAttemptOrdinal = producingAttemptOrdinal
+        self.producingClaimID = producingClaimID
         self.createdAt = createdAt
         self.storage = storage
         self.sensitivity = sensitivity
@@ -168,6 +174,9 @@ public struct GraphRunCreatedPayload: Equatable, Codable, Sendable {
     public let parentRunID: String?
     public let parentCheckpoint: GraphCheckpointReference?
     public let checkpointNamespace: String
+    public let clientIdempotencyKey: String?
+    public let requestFingerprint: GraphContentDigest?
+    public let executableDefinition: GraphExecutableDefinition?
 
     public init(
         graphID: String,
@@ -176,7 +185,10 @@ public struct GraphRunCreatedPayload: Equatable, Codable, Sendable {
         nodeIDs: [String],
         parentRunID: String? = nil,
         parentCheckpoint: GraphCheckpointReference? = nil,
-        checkpointNamespace: String = "root"
+        checkpointNamespace: String = "root",
+        clientIdempotencyKey: String? = nil,
+        requestFingerprint: GraphContentDigest? = nil,
+        executableDefinition: GraphExecutableDefinition? = nil
     ) {
         self.graphID = graphID
         self.graphDefinitionVersion = graphDefinitionVersion
@@ -185,6 +197,41 @@ public struct GraphRunCreatedPayload: Equatable, Codable, Sendable {
         self.parentRunID = parentRunID
         self.parentCheckpoint = parentCheckpoint
         self.checkpointNamespace = checkpointNamespace
+        self.clientIdempotencyKey = clientIdempotencyKey
+        self.requestFingerprint = requestFingerprint
+        self.executableDefinition = executableDefinition
+    }
+}
+
+public struct GraphRunStartRequestedPayload: Equatable, Codable, Sendable {
+    public let requestID: String
+    public let clientIdempotencyKey: String
+    public let requestedBy: String
+
+    public init(
+        requestID: String,
+        clientIdempotencyKey: String,
+        requestedBy: String
+    ) {
+        self.requestID = requestID
+        self.clientIdempotencyKey = clientIdempotencyKey
+        self.requestedBy = requestedBy
+    }
+}
+
+public struct GraphRetryRequestedPayload: Equatable, Codable, Sendable {
+    public let requestID: String
+    public let clientIdempotencyKey: String
+    public let requestedBy: String
+
+    public init(
+        requestID: String,
+        clientIdempotencyKey: String,
+        requestedBy: String
+    ) {
+        self.requestID = requestID
+        self.clientIdempotencyKey = clientIdempotencyKey
+        self.requestedBy = requestedBy
     }
 }
 
@@ -350,6 +397,7 @@ public struct GraphRunTerminalPayload: Equatable, Codable, Sendable {
 
 public enum GraphExecutionEventType: String, CaseIterable, Codable, Sendable {
     case runCreated = "graph.run.created"
+    case runStartRequested = "graph.run.start.requested"
     case nodeRegistered = "graph.node.registered"
     case attemptCreated = "graph.attempt.created"
     case attemptStarting = "graph.attempt.starting"
@@ -375,6 +423,7 @@ public enum GraphExecutionEventType: String, CaseIterable, Codable, Sendable {
     case executorLeaseExpired = "graph.executor.lease.expired"
     case executorClaimReleased = "graph.executor.claim.released"
     case retryScheduled = "graph.scheduler.retry.scheduled"
+    case retryRequested = "graph.retry.requested"
     case retrySuppressed = "graph.scheduler.retry.suppressed"
     case cancellationRequested = "graph.cancellation.requested"
     case cancellationAcknowledged = "graph.cancellation.acknowledged"
@@ -442,6 +491,7 @@ public enum GraphJSONValue: Equatable, Codable, Sendable {
 
 public enum GraphExecutionEventPayload: Equatable, Sendable {
     case runCreated(GraphRunCreatedPayload)
+    case runStartRequested(GraphRunStartRequestedPayload)
     case nodeRegistered(GraphNodeRegisteredPayload)
     case attemptCreated(GraphAttemptCreatedPayload)
     case attemptStarting(GraphAttemptStartingPayload)
@@ -467,6 +517,7 @@ public enum GraphExecutionEventPayload: Equatable, Sendable {
     case executorLeaseExpired(GraphExecutorLeaseEndedPayload)
     case executorClaimReleased(GraphExecutorLeaseEndedPayload)
     case retryScheduled(GraphRetryScheduledPayload)
+    case retryRequested(GraphRetryRequestedPayload)
     case retrySuppressed(GraphRetrySuppressedPayload)
     case cancellationRequested(GraphCancellationRequestedPayload)
     case cancellationAcknowledged(GraphCancellationAcknowledgedPayload)
@@ -481,6 +532,8 @@ public enum GraphExecutionEventPayload: Equatable, Sendable {
         switch self {
         case .runCreated:
             GraphExecutionEventType.runCreated.rawValue
+        case .runStartRequested:
+            GraphExecutionEventType.runStartRequested.rawValue
         case .nodeRegistered:
             GraphExecutionEventType.nodeRegistered.rawValue
         case .attemptCreated:
@@ -531,6 +584,8 @@ public enum GraphExecutionEventPayload: Equatable, Sendable {
             GraphExecutionEventType.executorClaimReleased.rawValue
         case .retryScheduled:
             GraphExecutionEventType.retryScheduled.rawValue
+        case .retryRequested:
+            GraphExecutionEventType.retryRequested.rawValue
         case .retrySuppressed:
             GraphExecutionEventType.retrySuppressed.rawValue
         case .cancellationRequested:
@@ -551,6 +606,8 @@ public enum GraphExecutionEventPayload: Equatable, Sendable {
     public var factClass: GraphExecutionEventFactClass {
         switch self {
         case .attemptStarting,
+             .runStartRequested,
+             .retryRequested,
              .humanInterruptRequested,
              .executorClaimRequested,
              .cancellationRequested:
@@ -759,6 +816,10 @@ extension GraphExecutionEventEnvelope: Codable {
         switch GraphExecutionEventType(rawValue: eventType) {
         case .runCreated:
             return .runCreated(try GraphRunCreatedPayload(from: decoder))
+        case .runStartRequested:
+            return .runStartRequested(
+                try GraphRunStartRequestedPayload(from: decoder)
+            )
         case .nodeRegistered:
             return .nodeRegistered(
                 try GraphNodeRegisteredPayload(from: decoder)
@@ -859,6 +920,10 @@ extension GraphExecutionEventEnvelope: Codable {
             return .retryScheduled(
                 try GraphRetryScheduledPayload(from: decoder)
             )
+        case .retryRequested:
+            return .retryRequested(
+                try GraphRetryRequestedPayload(from: decoder)
+            )
         case .retrySuppressed:
             return .retrySuppressed(
                 try GraphRetrySuppressedPayload(from: decoder)
@@ -899,6 +964,8 @@ extension GraphExecutionEventEnvelope: Codable {
     ) throws {
         switch payload {
         case let .runCreated(value):
+            try value.encode(to: encoder)
+        case let .runStartRequested(value):
             try value.encode(to: encoder)
         case let .nodeRegistered(value):
             try value.encode(to: encoder)
@@ -949,6 +1016,8 @@ extension GraphExecutionEventEnvelope: Codable {
         case let .executorClaimReleased(value):
             try value.encode(to: encoder)
         case let .retryScheduled(value):
+            try value.encode(to: encoder)
+        case let .retryRequested(value):
             try value.encode(to: encoder)
         case let .retrySuppressed(value):
             try value.encode(to: encoder)

--- a/Sources/OpenIslandCore/GraphExecutionInspectionStore.swift
+++ b/Sources/OpenIslandCore/GraphExecutionInspectionStore.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+public struct GraphExecutionStreamDescriptor:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let runID: String
+    public let currentVersion: UInt64
+
+    public init(runID: String, currentVersion: UInt64) {
+        self.runID = runID
+        self.currentVersion = currentVersion
+    }
+}
+
+public struct GraphExecutionEventPage:
+    Equatable,
+    Sendable
+{
+    public let runID: String
+    public let afterVersion: UInt64
+    public let currentVersion: UInt64
+    public let events: [GraphExecutionEventEnvelope]
+    public let hasMore: Bool
+
+    public init(
+        runID: String,
+        afterVersion: UInt64,
+        currentVersion: UInt64,
+        events: [GraphExecutionEventEnvelope],
+        hasMore: Bool
+    ) {
+        self.runID = runID
+        self.afterVersion = afterVersion
+        self.currentVersion = currentVersion
+        self.events = events
+        self.hasMore = hasMore
+    }
+
+    public var nextAfterVersion: UInt64 {
+        events.last?.streamSequence ?? afterVersion
+    }
+}
+
+public protocol GraphExecutionReadStore: Sendable {
+    func listStreams() async throws -> [GraphExecutionStreamDescriptor]
+
+    func streamDescriptor(
+        runID: String
+    ) async throws -> GraphExecutionStreamDescriptor?
+
+    func readPage(
+        runID: String,
+        afterVersion: UInt64,
+        limit: Int
+    ) async throws -> GraphExecutionEventPage
+}
+
+public protocol GraphExecutionSnapshotReadStore: Sendable {
+    func loadLatest(
+        runID: String,
+        throughVersion: UInt64
+    ) async throws -> GraphExecutionSnapshot?
+}
+
+extension InMemoryGraphExecutionEventStore: GraphExecutionReadStore {
+    public func listStreams() -> [GraphExecutionStreamDescriptor] {
+        streams
+            .map { runID, events in
+                GraphExecutionStreamDescriptor(
+                    runID: runID,
+                    currentVersion: events.last?.streamSequence ?? 0
+                )
+            }
+            .sorted { $0.runID < $1.runID }
+    }
+
+    public func streamDescriptor(
+        runID: String
+    ) -> GraphExecutionStreamDescriptor? {
+        guard let events = streams[runID] else {
+            return nil
+        }
+
+        return GraphExecutionStreamDescriptor(
+            runID: runID,
+            currentVersion: events.last?.streamSequence ?? 0
+        )
+    }
+
+    public func readPage(
+        runID: String,
+        afterVersion: UInt64,
+        limit: Int
+    ) throws -> GraphExecutionEventPage {
+        let pageLimit = max(1, min(limit, 10_000))
+        let stream = streams[runID] ?? []
+        let currentVersion = stream.last?.streamSequence ?? 0
+        let events = Array(
+            stream
+                .lazy
+                .filter { $0.streamSequence > afterVersion }
+                .prefix(pageLimit)
+        )
+
+        if afterVersion < currentVersion {
+            guard let first = events.first,
+                  first.streamSequence == afterVersion + 1 else {
+                throw GraphExecutionPersistenceError.corruptRecord(
+                    "Run \(runID) has a gap after sequence \(afterVersion)."
+                )
+            }
+        }
+
+        let nextVersion = events.last?.streamSequence ?? afterVersion
+        return GraphExecutionEventPage(
+            runID: runID,
+            afterVersion: afterVersion,
+            currentVersion: currentVersion,
+            events: events,
+            hasMore: nextVersion < currentVersion
+        )
+    }
+}
+
+extension InMemoryGraphExecutionSnapshotStore:
+    GraphExecutionSnapshotReadStore
+{
+    public func loadLatest(
+        runID: String,
+        throughVersion: UInt64
+    ) -> GraphExecutionSnapshot? {
+        snapshots[runID]?
+            .filter { $0.streamVersion <= throughVersion }
+            .max {
+                if $0.streamVersion != $1.streamVersion {
+                    return $0.streamVersion < $1.streamVersion
+                }
+
+                return $0.createdAt < $1.createdAt
+            }
+    }
+}

--- a/Sources/OpenIslandCore/GraphExecutionReplay.swift
+++ b/Sources/OpenIslandCore/GraphExecutionReplay.swift
@@ -210,6 +210,11 @@ public struct GraphExecutionProjection: Equatable, Codable, Sendable {
     public var parentCheckpoint: GraphCheckpointReference?
     public var namedCheckpoints: [GraphCheckpointReference]
     public var scheduling: GraphSchedulingProjection
+    public var executableDefinition: GraphExecutableDefinition?
+    public var runStartRequestedAt: Date?
+    public var runStartRequestID: String?
+    public var retryRequestIDs: [String]
+    public var attemptLifecycles: [GraphAttemptLifecycleRecord]
 
     public init(
         runID: String,
@@ -230,7 +235,12 @@ public struct GraphExecutionProjection: Equatable, Codable, Sendable {
         parentCheckpoint: GraphCheckpointReference? = nil,
         namedCheckpoints: [GraphCheckpointReference] = [],
         scheduling: GraphSchedulingProjection =
-            GraphSchedulingProjection()
+            GraphSchedulingProjection(),
+        executableDefinition: GraphExecutableDefinition? = nil,
+        runStartRequestedAt: Date? = nil,
+        runStartRequestID: String? = nil,
+        retryRequestIDs: [String] = [],
+        attemptLifecycles: [GraphAttemptLifecycleRecord] = []
     ) {
         self.runID = runID
         self.streamVersion = streamVersion
@@ -250,6 +260,11 @@ public struct GraphExecutionProjection: Equatable, Codable, Sendable {
         self.parentCheckpoint = parentCheckpoint
         self.namedCheckpoints = namedCheckpoints
         self.scheduling = scheduling
+        self.executableDefinition = executableDefinition
+        self.runStartRequestedAt = runStartRequestedAt
+        self.runStartRequestID = runStartRequestID
+        self.retryRequestIDs = retryRequestIDs
+        self.attemptLifecycles = attemptLifecycles
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -271,6 +286,11 @@ public struct GraphExecutionProjection: Equatable, Codable, Sendable {
         case parentCheckpoint
         case namedCheckpoints
         case scheduling
+        case executableDefinition
+        case runStartRequestedAt
+        case runStartRequestID
+        case retryRequestIDs
+        case attemptLifecycles
     }
 
     public init(from decoder: any Decoder) throws {
@@ -335,6 +355,26 @@ public struct GraphExecutionProjection: Equatable, Codable, Sendable {
             GraphSchedulingProjection.self,
             forKey: .scheduling
         ) ?? GraphSchedulingProjection()
+        executableDefinition = try values.decodeIfPresent(
+            GraphExecutableDefinition.self,
+            forKey: .executableDefinition
+        )
+        runStartRequestedAt = try values.decodeIfPresent(
+            Date.self,
+            forKey: .runStartRequestedAt
+        )
+        runStartRequestID = try values.decodeIfPresent(
+            String.self,
+            forKey: .runStartRequestID
+        )
+        retryRequestIDs = try values.decodeIfPresent(
+            [String].self,
+            forKey: .retryRequestIDs
+        ) ?? []
+        attemptLifecycles = try values.decodeIfPresent(
+            [GraphAttemptLifecycleRecord].self,
+            forKey: .attemptLifecycles
+        ) ?? []
     }
 
     public func encode(to encoder: any Encoder) throws {
@@ -369,6 +409,23 @@ public struct GraphExecutionProjection: Equatable, Codable, Sendable {
         )
         try values.encode(namedCheckpoints, forKey: .namedCheckpoints)
         try values.encode(scheduling, forKey: .scheduling)
+        try values.encodeIfPresent(
+            executableDefinition,
+            forKey: .executableDefinition
+        )
+        try values.encodeIfPresent(
+            runStartRequestedAt,
+            forKey: .runStartRequestedAt
+        )
+        try values.encodeIfPresent(
+            runStartRequestID,
+            forKey: .runStartRequestID
+        )
+        try values.encode(retryRequestIDs, forKey: .retryRequestIDs)
+        try values.encode(
+            attemptLifecycles,
+            forKey: .attemptLifecycles
+        )
     }
 }
 
@@ -556,6 +613,29 @@ public enum GraphExecutionProjector {
                 payload.checkpointNamespace
             projection.parentRunID = payload.parentRunID
             projection.parentCheckpoint = payload.parentCheckpoint
+            projection.executableDefinition =
+                payload.executableDefinition
+
+        case let .runStartRequested(payload):
+            try requireRun(event: event, projection: projection)
+            if let existing = projection.runStartRequestID,
+               existing != payload.requestID {
+                throw GraphExecutionReplayError.terminalRunRegression(
+                    runID: event.runID
+                )
+            }
+            projection.runStartRequestID = payload.requestID
+            projection.runStartRequestedAt = event.occurredAt
+            projection.run?.state = .ready
+            projection.run?.startedAt = event.occurredAt
+            projection.run?.updatedAt = event.occurredAt
+            projection.executionEvents.append(
+                executionEvent(
+                    from: event,
+                    kind: .runStarted,
+                    reason: "start_requested"
+                )
+            )
 
         case let .nodeRegistered(payload):
             try requireRun(event: event, projection: projection)
@@ -619,6 +699,15 @@ public enum GraphExecutionProjector {
                     updatedAt: event.occurredAt
                 )
             )
+            projection.attemptLifecycles.append(
+                GraphAttemptLifecycleRecord(
+                    attemptID: attemptID,
+                    nodeID: nodeID,
+                    ordinal: payload.ordinal,
+                    phase: .created,
+                    updatedAt: event.occurredAt
+                )
+            )
 
         case let .attemptStarting(payload):
             let attemptIndex = try requireAttemptIndex(
@@ -636,6 +725,12 @@ public enum GraphExecutionProjector {
                 event.occurredAt
             projection.attempts[attemptIndex].statusReason =
                 payload.reason
+            updateLifecycle(
+                attemptID: projection.attempts[attemptIndex].id,
+                phase: .startRequested,
+                at: event.occurredAt,
+                projection: &projection
+            )
             updateNode(
                 for: projection.attempts[attemptIndex],
                 state: .running,
@@ -667,6 +762,12 @@ public enum GraphExecutionProjector {
                 attemptIndex: index,
                 projection: &projection
             )
+            updateLifecycle(
+                attemptID: projection.attempts[index].id,
+                phase: .started,
+                at: event.occurredAt,
+                projection: &projection
+            )
 
         case let .heartbeatObserved(payload):
             let index = try requireAttemptIndex(
@@ -685,6 +786,12 @@ public enum GraphExecutionProjector {
                     observedAt: event.occurredAt,
                     validUntil: payload.validUntil
                 )
+            )
+            updateLifecycle(
+                attemptID: projection.attempts[index].id,
+                phase: .running,
+                at: event.occurredAt,
+                projection: &projection
             )
 
         case let .processExitObserved(payload):
@@ -848,6 +955,16 @@ public enum GraphExecutionProjector {
                 )
             )
 
+        case let .retryRequested(payload):
+            try requireRun(event: event, projection: projection)
+            _ = try requireNodeID(event)
+            if projection.retryRequestIDs.contains(payload.requestID) {
+                throw GraphExecutionReplayError.eventIDCollision(
+                    eventID: payload.requestID
+                )
+            }
+            projection.retryRequestIDs.append(payload.requestID)
+
         case .schedulerEvaluationRecorded,
              .nodeBecameRunnable,
              .nodeSchedulingDeferred,
@@ -929,6 +1046,13 @@ public enum GraphExecutionProjector {
                     )
                 )
             }
+            updateLifecycle(
+                attemptID: event.attemptID,
+                phase: .claimed,
+                claim: claim,
+                at: event.occurredAt,
+                projection: &projection
+            )
             reason = payload.reason
 
         case let .executorClaimRejected(payload):
@@ -984,6 +1108,12 @@ public enum GraphExecutionProjector {
                 at: event.occurredAt,
                 projection: &projection
             )
+            updateLifecycle(
+                attemptID: event.attemptID,
+                phase: .claimReleased,
+                at: event.occurredAt,
+                projection: &projection
+            )
             reason = payload.reason
 
         case let .retryScheduled(payload):
@@ -1035,6 +1165,12 @@ public enum GraphExecutionProjector {
             } else {
                 projection.scheduling.cancellations.append(cancellation)
             }
+            updateLifecycle(
+                attemptID: event.attemptID,
+                phase: .cancellationRequested,
+                at: event.occurredAt,
+                projection: &projection
+            )
             reason = .cancellationPending
 
         case let .cancellationAcknowledged(payload):
@@ -1179,6 +1315,12 @@ public enum GraphExecutionProjector {
                 reason: payload.reason
             )
         )
+        updateLifecycle(
+            attemptID: projection.attempts[index].id,
+            phase: .terminal,
+            at: event.occurredAt,
+            projection: &projection
+        )
     }
 
     private static func requireRun(
@@ -1311,6 +1453,30 @@ public enum GraphExecutionProjector {
         )
     }
 
+    private static func updateLifecycle(
+        attemptID: String?,
+        phase: GraphAttemptLifecyclePhase,
+        claim: GraphExecutorClaim? = nil,
+        at timestamp: Date,
+        projection: inout GraphExecutionProjection
+    ) {
+        guard let attemptID,
+              let index = projection.attemptLifecycles.firstIndex(
+                where: { $0.attemptID == attemptID }
+              ) else {
+            return
+        }
+        projection.attemptLifecycles[index].phase = phase
+        projection.attemptLifecycles[index].updatedAt = timestamp
+        if let claim {
+            projection.attemptLifecycles[index].claimID = claim.id
+            projection.attemptLifecycles[index].leaseGeneration =
+                claim.leaseGeneration
+            projection.attemptLifecycles[index].executorID =
+                claim.executorID
+        }
+    }
+
     private static func runEventKind(
         for state: ReconciledExecutionState
     ) -> ExecutionEventKind {
@@ -1390,6 +1556,13 @@ public enum GraphExecutionProjector {
                 return $0.sequence < $1.sequence
             }
             return $0.id < $1.id
+        }
+        projection.retryRequestIDs.sort()
+        projection.attemptLifecycles.sort {
+            if $0.nodeID != $1.nodeID {
+                return $0.nodeID < $1.nodeID
+            }
+            return $0.ordinal < $1.ordinal
         }
         projection.scheduling.evaluations.sort {
             $0.evaluationID < $1.evaluationID

--- a/Sources/OpenIslandCore/GraphExecutionReplay.swift
+++ b/Sources/OpenIslandCore/GraphExecutionReplay.swift
@@ -1,0 +1,938 @@
+import Foundation
+
+public enum GraphReplayDiagnosticSeverity: String, Codable, Sendable {
+    case information
+    case warning
+}
+
+public enum GraphReplayDiagnosticCategory: String, Codable, Sendable {
+    case exactDuplicate
+    case unknownEvent
+    case snapshotBoundary
+}
+
+public struct GraphReplayDiagnostic: Equatable, Codable, Sendable {
+    public let severity: GraphReplayDiagnosticSeverity
+    public let category: GraphReplayDiagnosticCategory
+    public let message: String
+    public let eventID: String?
+    public let streamSequence: UInt64?
+
+    public init(
+        severity: GraphReplayDiagnosticSeverity,
+        category: GraphReplayDiagnosticCategory,
+        message: String,
+        eventID: String? = nil,
+        streamSequence: UInt64? = nil
+    ) {
+        self.severity = severity
+        self.category = category
+        self.message = message
+        self.eventID = eventID
+        self.streamSequence = streamSequence
+    }
+}
+
+public enum GraphExecutionReplayError: Error, Equatable, Sendable {
+    case eventIDCollision(eventID: String)
+    case sequenceGap(expected: UInt64, actual: UInt64)
+    case sequenceConflict(sequence: UInt64)
+    case unsupportedEnvelopeSchema(found: Int, supported: Int)
+    case unsupportedPayloadSchema(
+        eventType: String,
+        found: Int,
+        supported: Int
+    )
+    case runIDMismatch(expected: String, actual: String)
+    case duplicateRunCreation
+    case missingRun(eventID: String)
+    case missingNode(nodeID: String)
+    case duplicateNode(nodeID: String)
+    case missingAttempt(attemptID: String)
+    case duplicateAttempt(attemptID: String)
+    case attemptOrdinalRegression(
+        nodeID: String,
+        previous: Int,
+        proposed: Int
+    )
+    case processIdentityChanged(attemptID: String)
+    case terminalAttemptRegression(attemptID: String)
+    case invalidTerminalRunState(ReconciledExecutionState)
+    case terminalRunRegression(runID: String)
+    case artifactProvenanceMismatch(artifactID: String)
+    case artifactIDCollision(artifactID: String)
+    case interruptIDCollision(requestID: String)
+    case missingInterrupt(requestID: String)
+    case interruptAlreadyResolved(requestID: String)
+    case invalidSnapshot(String)
+}
+
+extension GraphExecutionReplayError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .eventIDCollision(eventID):
+            "Event ID \(eventID) has contradictory content."
+        case let .sequenceGap(expected, actual):
+            "Replay expected sequence \(expected), found \(actual)."
+        case let .sequenceConflict(sequence):
+            "Replay found contradictory events at sequence \(sequence)."
+        case let .unsupportedEnvelopeSchema(found, supported):
+            "Event envelope schema \(found) exceeds supported version \(supported)."
+        case let .unsupportedPayloadSchema(eventType, found, supported):
+            "Payload \(eventType) schema \(found) exceeds supported version \(supported)."
+        case let .runIDMismatch(expected, actual):
+            "Replay expected run \(expected), found \(actual)."
+        case .duplicateRunCreation:
+            "A run may only be created once."
+        case let .missingRun(eventID):
+            "Event \(eventID) requires a run-created event."
+        case let .missingNode(nodeID):
+            "Graph node \(nodeID) is not registered."
+        case let .duplicateNode(nodeID):
+            "Graph node \(nodeID) is already registered."
+        case let .missingAttempt(attemptID):
+            "Execution attempt \(attemptID) does not exist."
+        case let .duplicateAttempt(attemptID):
+            "Execution attempt \(attemptID) already exists."
+        case let .attemptOrdinalRegression(nodeID, previous, proposed):
+            "Node \(nodeID) attempt ordinal must exceed \(previous), found \(proposed)."
+        case let .processIdentityChanged(attemptID):
+            "Attempt \(attemptID) changed process identity without migration."
+        case let .terminalAttemptRegression(attemptID):
+            "Terminal attempt \(attemptID) cannot transition again."
+        case let .invalidTerminalRunState(state):
+            "State \(state.rawValue) is not an authoritative run terminal declaration."
+        case let .terminalRunRegression(runID):
+            "Terminal run \(runID) cannot transition again."
+        case let .artifactProvenanceMismatch(artifactID):
+            "Artifact \(artifactID) provenance does not match its event envelope."
+        case let .artifactIDCollision(artifactID):
+            "Artifact ID \(artifactID) was reused with different metadata."
+        case let .interruptIDCollision(requestID):
+            "Human interrupt \(requestID) was requested more than once."
+        case let .missingInterrupt(requestID):
+            "Human interrupt \(requestID) does not exist."
+        case let .interruptAlreadyResolved(requestID):
+            "Human interrupt \(requestID) is already resolved."
+        case let .invalidSnapshot(message):
+            "Invalid graph execution snapshot: \(message)"
+        }
+    }
+}
+
+public enum GraphHumanInterruptState: String, Codable, Sendable {
+    case pending
+    case resolved
+}
+
+public struct GraphHumanInterruptRecord: Equatable, Identifiable, Codable, Sendable {
+    public var id: String {
+        request.requestID
+    }
+
+    public let runID: String
+    public let nodeID: String?
+    public let attemptID: String?
+    public let requestedAt: Date
+    public let request: GraphHumanInterruptRequestedPayload
+    public var state: GraphHumanInterruptState
+    public var resolvedAt: Date?
+    public var resolution: GraphHumanInterruptResolvedPayload?
+
+    public init(
+        runID: String,
+        nodeID: String?,
+        attemptID: String?,
+        requestedAt: Date,
+        request: GraphHumanInterruptRequestedPayload,
+        state: GraphHumanInterruptState = .pending,
+        resolvedAt: Date? = nil,
+        resolution: GraphHumanInterruptResolvedPayload? = nil
+    ) {
+        self.runID = runID
+        self.nodeID = nodeID
+        self.attemptID = attemptID
+        self.requestedAt = requestedAt
+        self.request = request
+        self.state = state
+        self.resolvedAt = resolvedAt
+        self.resolution = resolution
+    }
+}
+
+public struct GraphExecutionProjection: Equatable, Codable, Sendable {
+    public let runID: String
+    public var streamVersion: UInt64
+    public var run: GraphRun?
+    public var nodes: [GraphNode]
+    public var attempts: [ExecutionAttempt]
+    public var processExits: [ProcessExit]
+    public var heartbeats: [ExecutorHeartbeat]
+    public var executionEvents: [ExecutionEvent]
+    public var artifacts: [GraphArtifactReference]
+    public var humanInterrupts: [GraphHumanInterruptRecord]
+    public var unknownEvents: [GraphExecutionEventEnvelope]
+    public var graphDefinitionVersion: String?
+    public var graphDefinitionDigest: GraphContentDigest?
+    public var checkpointNamespace: String
+    public var parentRunID: String?
+    public var parentCheckpoint: GraphCheckpointReference?
+    public var namedCheckpoints: [GraphCheckpointReference]
+
+    public init(
+        runID: String,
+        streamVersion: UInt64 = 0,
+        run: GraphRun? = nil,
+        nodes: [GraphNode] = [],
+        attempts: [ExecutionAttempt] = [],
+        processExits: [ProcessExit] = [],
+        heartbeats: [ExecutorHeartbeat] = [],
+        executionEvents: [ExecutionEvent] = [],
+        artifacts: [GraphArtifactReference] = [],
+        humanInterrupts: [GraphHumanInterruptRecord] = [],
+        unknownEvents: [GraphExecutionEventEnvelope] = [],
+        graphDefinitionVersion: String? = nil,
+        graphDefinitionDigest: GraphContentDigest? = nil,
+        checkpointNamespace: String = "root",
+        parentRunID: String? = nil,
+        parentCheckpoint: GraphCheckpointReference? = nil,
+        namedCheckpoints: [GraphCheckpointReference] = []
+    ) {
+        self.runID = runID
+        self.streamVersion = streamVersion
+        self.run = run
+        self.nodes = nodes
+        self.attempts = attempts
+        self.processExits = processExits
+        self.heartbeats = heartbeats
+        self.executionEvents = executionEvents
+        self.artifacts = artifacts
+        self.humanInterrupts = humanInterrupts
+        self.unknownEvents = unknownEvents
+        self.graphDefinitionVersion = graphDefinitionVersion
+        self.graphDefinitionDigest = graphDefinitionDigest
+        self.checkpointNamespace = checkpointNamespace
+        self.parentRunID = parentRunID
+        self.parentCheckpoint = parentCheckpoint
+        self.namedCheckpoints = namedCheckpoints
+    }
+}
+
+public struct GraphExecutionReplayResult: Equatable, Sendable {
+    public let projection: GraphExecutionProjection
+    public let diagnostics: [GraphReplayDiagnostic]
+    public let replayedEventCount: Int
+    public let duplicateEventCount: Int
+
+    public init(
+        projection: GraphExecutionProjection,
+        diagnostics: [GraphReplayDiagnostic],
+        replayedEventCount: Int,
+        duplicateEventCount: Int
+    ) {
+        self.projection = projection
+        self.diagnostics = diagnostics
+        self.replayedEventCount = replayedEventCount
+        self.duplicateEventCount = duplicateEventCount
+    }
+}
+
+public enum GraphExecutionProjector {
+    public static func replay(
+        runID: String,
+        events: [GraphExecutionEventEnvelope],
+        initialProjection: GraphExecutionProjection? = nil
+    ) throws -> GraphExecutionReplayResult {
+        var projection = try validatedInitialProjection(
+            runID: runID,
+            projection: initialProjection
+        )
+        var diagnostics: [GraphReplayDiagnostic] = []
+        var seenByID: [String: GraphExecutionEventEnvelope] = [:]
+        var seenBySequence: [UInt64: GraphExecutionEventEnvelope] = [:]
+        var duplicateCount = 0
+        var replayedCount = 0
+        let ordered = events.sorted(by: eventIsOrderedBefore)
+
+        for event in ordered {
+            guard event.runID == runID else {
+                throw GraphExecutionReplayError.runIDMismatch(
+                    expected: runID,
+                    actual: event.runID
+                )
+            }
+
+            if let existing = seenByID[event.id] {
+                guard existing == event else {
+                    throw GraphExecutionReplayError.eventIDCollision(
+                        eventID: event.id
+                    )
+                }
+
+                duplicateCount += 1
+                diagnostics.append(
+                    GraphReplayDiagnostic(
+                        severity: .information,
+                        category: .exactDuplicate,
+                        message: "Ignored exact duplicate event delivery.",
+                        eventID: event.id,
+                        streamSequence: event.streamSequence
+                    )
+                )
+                continue
+            }
+
+            if let existing = seenBySequence[event.streamSequence] {
+                if existing == event {
+                    duplicateCount += 1
+                    continue
+                }
+
+                throw GraphExecutionReplayError.sequenceConflict(
+                    sequence: event.streamSequence
+                )
+            }
+
+            let expectedSequence = projection.streamVersion + 1
+
+            guard event.streamSequence == expectedSequence else {
+                if event.streamSequence <= projection.streamVersion {
+                    throw GraphExecutionReplayError.sequenceConflict(
+                        sequence: event.streamSequence
+                    )
+                }
+
+                throw GraphExecutionReplayError.sequenceGap(
+                    expected: expectedSequence,
+                    actual: event.streamSequence
+                )
+            }
+
+            guard event.schemaVersion
+                    <= GraphExecutionSchema.eventEnvelopeVersion else {
+                throw GraphExecutionReplayError
+                    .unsupportedEnvelopeSchema(
+                        found: event.schemaVersion,
+                        supported: GraphExecutionSchema.eventEnvelopeVersion
+                    )
+            }
+
+            if event.payloadVersion
+                > GraphExecutionSchema.eventPayloadVersion {
+                guard case .unknown = event.payload else {
+                    throw GraphExecutionReplayError
+                        .unsupportedPayloadSchema(
+                            eventType: event.eventType,
+                            found: event.payloadVersion,
+                            supported: GraphExecutionSchema
+                                .eventPayloadVersion
+                        )
+                }
+            }
+
+            try apply(event, to: &projection)
+            projection.streamVersion = event.streamSequence
+            seenByID[event.id] = event
+            seenBySequence[event.streamSequence] = event
+            replayedCount += 1
+
+            if case .unknown = event.payload {
+                diagnostics.append(
+                    GraphReplayDiagnostic(
+                        severity: .warning,
+                        category: .unknownEvent,
+                        message: "Retained unknown event without applying semantics.",
+                        eventID: event.id,
+                        streamSequence: event.streamSequence
+                    )
+                )
+            }
+        }
+
+        normalizeProjection(&projection)
+
+        return GraphExecutionReplayResult(
+            projection: projection,
+            diagnostics: diagnostics,
+            replayedEventCount: replayedCount,
+            duplicateEventCount: duplicateCount
+        )
+    }
+
+    private static func validatedInitialProjection(
+        runID: String,
+        projection: GraphExecutionProjection?
+    ) throws -> GraphExecutionProjection {
+        guard let projection else {
+            return GraphExecutionProjection(runID: runID)
+        }
+
+        guard projection.runID == runID else {
+            throw GraphExecutionReplayError.invalidSnapshot(
+                "Projection run ID \(projection.runID) does not match \(runID)."
+            )
+        }
+
+        return projection
+    }
+
+    private static func apply(
+        _ event: GraphExecutionEventEnvelope,
+        to projection: inout GraphExecutionProjection
+    ) throws {
+        switch event.payload {
+        case let .runCreated(payload):
+            guard projection.run == nil else {
+                throw GraphExecutionReplayError.duplicateRunCreation
+            }
+
+            projection.run = GraphRun(
+                id: event.runID,
+                graphID: payload.graphID,
+                state: .pending,
+                nodeIDs: payload.nodeIDs,
+                createdAt: event.occurredAt,
+                updatedAt: event.occurredAt
+            )
+            projection.graphDefinitionVersion =
+                payload.graphDefinitionVersion
+            projection.graphDefinitionDigest =
+                payload.graphDefinitionDigest
+            projection.checkpointNamespace =
+                payload.checkpointNamespace
+            projection.parentRunID = payload.parentRunID
+            projection.parentCheckpoint = payload.parentCheckpoint
+
+        case let .nodeRegistered(payload):
+            try requireRun(event: event, projection: projection)
+            let nodeID = try requireNodeID(event)
+
+            guard !projection.nodes.contains(where: {
+                $0.id == nodeID
+            }) else {
+                throw GraphExecutionReplayError.duplicateNode(
+                    nodeID: nodeID
+                )
+            }
+
+            projection.nodes.append(
+                GraphNode(
+                    id: nodeID,
+                    graphRunID: event.runID,
+                    title: payload.title,
+                    dependencyNodeIDs: payload.dependencyNodeIDs,
+                    executorID: payload.executorID,
+                    state: .pending,
+                    updatedAt: event.occurredAt
+                )
+            )
+
+        case let .attemptCreated(payload):
+            try requireRun(event: event, projection: projection)
+            let nodeID = try requireNodeID(event)
+            let attemptID = try requireAttemptID(event)
+            try requireNode(nodeID, projection: projection)
+
+            guard !projection.attempts.contains(where: {
+                $0.id == attemptID
+            }) else {
+                throw GraphExecutionReplayError.duplicateAttempt(
+                    attemptID: attemptID
+                )
+            }
+
+            let previousOrdinal = projection.attempts
+                .filter { $0.nodeID == nodeID }
+                .map(\.ordinal)
+                .max() ?? 0
+
+            guard payload.ordinal == previousOrdinal + 1 else {
+                throw GraphExecutionReplayError.attemptOrdinalRegression(
+                    nodeID: nodeID,
+                    previous: previousOrdinal,
+                    proposed: payload.ordinal
+                )
+            }
+
+            projection.attempts.append(
+                ExecutionAttempt(
+                    id: attemptID,
+                    graphRunID: event.runID,
+                    nodeID: nodeID,
+                    ordinal: payload.ordinal,
+                    state: .pending,
+                    createdAt: event.occurredAt,
+                    updatedAt: event.occurredAt
+                )
+            )
+
+        case let .attemptStarting(payload):
+            let attemptIndex = try requireAttemptIndex(
+                event: event,
+                projection: projection
+            )
+            try requireNonterminalAttempt(
+                projection.attempts[attemptIndex]
+            )
+            projection.attempts[attemptIndex].state = .running
+            projection.attempts[attemptIndex].startedAt =
+                projection.attempts[attemptIndex].startedAt
+                    ?? event.occurredAt
+            projection.attempts[attemptIndex].updatedAt =
+                event.occurredAt
+            projection.attempts[attemptIndex].statusReason =
+                payload.reason
+            updateNode(
+                for: projection.attempts[attemptIndex],
+                state: .running,
+                at: event.occurredAt,
+                projection: &projection
+            )
+
+            if projection.run?.startedAt == nil {
+                projection.run?.startedAt = event.occurredAt
+            }
+
+            projection.run?.state = .running
+            projection.run?.updatedAt = event.occurredAt
+            projection.executionEvents.append(
+                executionEvent(
+                    from: event,
+                    kind: .attemptStarted,
+                    reason: payload.reason
+                )
+            )
+
+        case let .processIdentityObserved(payload):
+            let index = try requireAttemptIndex(
+                event: event,
+                projection: projection
+            )
+            try assignProcessIdentity(
+                payload.processIdentity,
+                attemptIndex: index,
+                projection: &projection
+            )
+
+        case let .heartbeatObserved(payload):
+            let index = try requireAttemptIndex(
+                event: event,
+                projection: projection
+            )
+            try assignProcessIdentity(
+                payload.processIdentity,
+                attemptIndex: index,
+                projection: &projection
+            )
+            projection.heartbeats.append(
+                ExecutorHeartbeat(
+                    attemptID: projection.attempts[index].id,
+                    processIdentity: payload.processIdentity,
+                    observedAt: event.occurredAt,
+                    validUntil: payload.validUntil
+                )
+            )
+
+        case let .processExitObserved(payload):
+            let index = try requireAttemptIndex(
+                event: event,
+                projection: projection
+            )
+            try assignProcessIdentity(
+                payload.processIdentity,
+                attemptIndex: index,
+                projection: &projection
+            )
+            projection.processExits.append(
+                ProcessExit(
+                    attemptID: projection.attempts[index].id,
+                    processIdentity: payload.processIdentity,
+                    observedAt: event.occurredAt,
+                    exitCode: payload.exitCode,
+                    signal: payload.signal,
+                    reason: payload.reason
+                )
+            )
+
+        case let .attemptCompleted(payload):
+            try applyTerminalAttempt(
+                event,
+                payload: payload,
+                state: .completed,
+                kind: .attemptCompleted,
+                projection: &projection
+            )
+        case let .attemptFailed(payload):
+            try applyTerminalAttempt(
+                event,
+                payload: payload,
+                state: .failed,
+                kind: .attemptFailed,
+                projection: &projection
+            )
+        case let .attemptInterrupted(payload):
+            try applyTerminalAttempt(
+                event,
+                payload: payload,
+                state: .interrupted,
+                kind: .attemptInterrupted,
+                projection: &projection
+            )
+        case let .attemptOrphaned(payload):
+            try applyTerminalAttempt(
+                event,
+                payload: payload,
+                state: .orphaned,
+                kind: .attemptOrphaned,
+                projection: &projection
+            )
+        case let .attemptCancelled(payload):
+            try applyTerminalAttempt(
+                event,
+                payload: payload,
+                state: .cancelled,
+                kind: .attemptCancelled,
+                projection: &projection
+            )
+
+        case let .artifactRecorded(payload):
+            let artifact = payload.artifact
+
+            guard artifact.producingRunID == event.runID,
+                  artifact.producingNodeID == event.nodeID,
+                  artifact.producingAttemptID == event.attemptID else {
+                throw GraphExecutionReplayError
+                    .artifactProvenanceMismatch(
+                        artifactID: artifact.id
+                    )
+            }
+
+            _ = try requireAttemptIndex(
+                event: event,
+                projection: projection
+            )
+
+            if let existing = projection.artifacts.first(where: {
+                $0.id == artifact.id
+            }) {
+                guard existing == artifact else {
+                    throw GraphExecutionReplayError
+                        .artifactIDCollision(artifactID: artifact.id)
+                }
+            } else {
+                projection.artifacts.append(artifact)
+            }
+
+        case let .humanInterruptRequested(payload):
+            try requireRun(event: event, projection: projection)
+
+            guard !projection.humanInterrupts.contains(where: {
+                $0.id == payload.requestID
+            }) else {
+                throw GraphExecutionReplayError.interruptIDCollision(
+                    requestID: payload.requestID
+                )
+            }
+
+            projection.humanInterrupts.append(
+                GraphHumanInterruptRecord(
+                    runID: event.runID,
+                    nodeID: event.nodeID,
+                    attemptID: event.attemptID,
+                    requestedAt: event.occurredAt,
+                    request: payload
+                )
+            )
+
+        case let .humanInterruptResolved(payload):
+            guard let index = projection.humanInterrupts.firstIndex(
+                where: { $0.id == payload.requestID }
+            ) else {
+                throw GraphExecutionReplayError.missingInterrupt(
+                    requestID: payload.requestID
+                )
+            }
+
+            guard projection.humanInterrupts[index].state == .pending else {
+                throw GraphExecutionReplayError.interruptAlreadyResolved(
+                    requestID: payload.requestID
+                )
+            }
+
+            projection.humanInterrupts[index].state = .resolved
+            projection.humanInterrupts[index].resolvedAt =
+                event.occurredAt
+            projection.humanInterrupts[index].resolution = payload
+
+        case let .runTerminalStateRecorded(payload):
+            try requireRun(event: event, projection: projection)
+
+            guard payload.state == .completed
+                    || payload.state == .failed
+                    || payload.state == .interrupted
+                    || payload.state == .orphaned
+                    || payload.state == .cancelled else {
+                throw GraphExecutionReplayError.invalidTerminalRunState(
+                    payload.state
+                )
+            }
+
+            if projection.run?.state.isTerminal == true {
+                throw GraphExecutionReplayError.terminalRunRegression(
+                    runID: event.runID
+                )
+            }
+
+            projection.run?.state = payload.state
+            projection.run?.updatedAt = event.occurredAt
+            projection.run?.finishedAt = event.occurredAt
+            projection.executionEvents.append(
+                executionEvent(
+                    from: event,
+                    kind: runEventKind(for: payload.state),
+                    reason: payload.reason
+                )
+            )
+
+        case .unknown:
+            projection.unknownEvents.append(event)
+        }
+    }
+
+    private static func applyTerminalAttempt(
+        _ event: GraphExecutionEventEnvelope,
+        payload: GraphAttemptTerminalPayload,
+        state: ReconciledExecutionState,
+        kind: ExecutionEventKind,
+        projection: inout GraphExecutionProjection
+    ) throws {
+        let index = try requireAttemptIndex(
+            event: event,
+            projection: projection
+        )
+        try requireNonterminalAttempt(projection.attempts[index])
+        projection.attempts[index].state = state
+        projection.attempts[index].updatedAt = event.occurredAt
+        projection.attempts[index].finishedAt = event.occurredAt
+        projection.attempts[index].statusReason = payload.reason
+        updateNode(
+            for: projection.attempts[index],
+            state: state,
+            at: event.occurredAt,
+            projection: &projection
+        )
+        projection.executionEvents.append(
+            executionEvent(
+                from: event,
+                kind: kind,
+                reason: payload.reason
+            )
+        )
+    }
+
+    private static func requireRun(
+        event: GraphExecutionEventEnvelope,
+        projection: GraphExecutionProjection
+    ) throws {
+        guard projection.run != nil else {
+            throw GraphExecutionReplayError.missingRun(
+                eventID: event.id
+            )
+        }
+    }
+
+    private static func requireNodeID(
+        _ event: GraphExecutionEventEnvelope
+    ) throws -> String {
+        guard let nodeID = event.nodeID else {
+            throw GraphExecutionReplayError.missingNode(
+                nodeID: "<missing>"
+            )
+        }
+
+        return nodeID
+    }
+
+    private static func requireAttemptID(
+        _ event: GraphExecutionEventEnvelope
+    ) throws -> String {
+        guard let attemptID = event.attemptID else {
+            throw GraphExecutionReplayError.missingAttempt(
+                attemptID: "<missing>"
+            )
+        }
+
+        return attemptID
+    }
+
+    private static func requireNode(
+        _ nodeID: String,
+        projection: GraphExecutionProjection
+    ) throws {
+        guard projection.nodes.contains(where: {
+            $0.id == nodeID
+        }) else {
+            throw GraphExecutionReplayError.missingNode(nodeID: nodeID)
+        }
+    }
+
+    private static func requireAttemptIndex(
+        event: GraphExecutionEventEnvelope,
+        projection: GraphExecutionProjection
+    ) throws -> Int {
+        let attemptID = try requireAttemptID(event)
+
+        guard let index = projection.attempts.firstIndex(where: {
+            $0.id == attemptID
+        }) else {
+            throw GraphExecutionReplayError.missingAttempt(
+                attemptID: attemptID
+            )
+        }
+
+        if let nodeID = event.nodeID,
+           projection.attempts[index].nodeID != nodeID {
+            throw GraphExecutionReplayError.missingAttempt(
+                attemptID: attemptID
+            )
+        }
+
+        return index
+    }
+
+    private static func requireNonterminalAttempt(
+        _ attempt: ExecutionAttempt
+    ) throws {
+        guard !attempt.state.isTerminal else {
+            throw GraphExecutionReplayError.terminalAttemptRegression(
+                attemptID: attempt.id
+            )
+        }
+    }
+
+    private static func assignProcessIdentity(
+        _ identity: ProcessIdentity,
+        attemptIndex: Int,
+        projection: inout GraphExecutionProjection
+    ) throws {
+        if let existing = projection.attempts[attemptIndex]
+            .processIdentity,
+           existing != identity {
+            throw GraphExecutionReplayError.processIdentityChanged(
+                attemptID: projection.attempts[attemptIndex].id
+            )
+        }
+
+        projection.attempts[attemptIndex].processIdentity = identity
+    }
+
+    private static func updateNode(
+        for attempt: ExecutionAttempt,
+        state: ReconciledExecutionState,
+        at timestamp: Date,
+        projection: inout GraphExecutionProjection
+    ) {
+        guard let index = projection.nodes.firstIndex(where: {
+            $0.id == attempt.nodeID
+        }) else {
+            return
+        }
+
+        projection.nodes[index].state = state
+        projection.nodes[index].activeAttemptID = attempt.id
+        projection.nodes[index].updatedAt = timestamp
+    }
+
+    private static func executionEvent(
+        from event: GraphExecutionEventEnvelope,
+        kind: ExecutionEventKind,
+        reason: String?
+    ) -> ExecutionEvent {
+        ExecutionEvent(
+            id: event.id,
+            graphRunID: event.runID,
+            nodeID: event.nodeID,
+            attemptID: event.attemptID,
+            sequence: event.streamSequence,
+            occurredAt: event.occurredAt,
+            kind: kind,
+            reason: reason
+        )
+    }
+
+    private static func runEventKind(
+        for state: ReconciledExecutionState
+    ) -> ExecutionEventKind {
+        switch state {
+        case .completed:
+            .runCompleted
+        case .failed:
+            .runFailed
+        case .interrupted, .orphaned:
+            .runInterrupted
+        case .cancelled:
+            .runCancelled
+        case .pending, .ready, .running, .blocked:
+            .runInterrupted
+        }
+    }
+
+    private static func eventIsOrderedBefore(
+        _ lhs: GraphExecutionEventEnvelope,
+        _ rhs: GraphExecutionEventEnvelope
+    ) -> Bool {
+        if lhs.streamSequence != rhs.streamSequence {
+            return lhs.streamSequence < rhs.streamSequence
+        }
+
+        return lhs.id < rhs.id
+    }
+
+    private static func normalizeProjection(
+        _ projection: inout GraphExecutionProjection
+    ) {
+        projection.nodes.sort { $0.id < $1.id }
+        projection.attempts.sort {
+            if $0.nodeID != $1.nodeID {
+                return $0.nodeID < $1.nodeID
+            }
+
+            if $0.ordinal != $1.ordinal {
+                return $0.ordinal < $1.ordinal
+            }
+
+            return $0.id < $1.id
+        }
+        projection.processExits.sort {
+            if $0.observedAt != $1.observedAt {
+                return $0.observedAt < $1.observedAt
+            }
+
+            return $0.attemptID < $1.attemptID
+        }
+        projection.heartbeats.sort {
+            if $0.observedAt != $1.observedAt {
+                return $0.observedAt < $1.observedAt
+            }
+
+            return $0.attemptID < $1.attemptID
+        }
+        projection.executionEvents.sort {
+            if $0.sequence != $1.sequence {
+                return $0.sequence < $1.sequence
+            }
+
+            return $0.id < $1.id
+        }
+        projection.artifacts.sort { $0.id < $1.id }
+        projection.humanInterrupts.sort { $0.id < $1.id }
+        projection.unknownEvents.sort(by: eventIsOrderedBefore)
+        projection.namedCheckpoints.sort {
+            if $0.streamVersion != $1.streamVersion {
+                return $0.streamVersion < $1.streamVersion
+            }
+
+            return $0.checkpointID < $1.checkpointID
+        }
+    }
+}

--- a/Sources/OpenIslandCore/GraphExecutionReplay.swift
+++ b/Sources/OpenIslandCore/GraphExecutionReplay.swift
@@ -251,6 +251,125 @@ public struct GraphExecutionProjection: Equatable, Codable, Sendable {
         self.namedCheckpoints = namedCheckpoints
         self.scheduling = scheduling
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case runID
+        case streamVersion
+        case run
+        case nodes
+        case attempts
+        case processExits
+        case heartbeats
+        case executionEvents
+        case artifacts
+        case humanInterrupts
+        case unknownEvents
+        case graphDefinitionVersion
+        case graphDefinitionDigest
+        case checkpointNamespace
+        case parentRunID
+        case parentCheckpoint
+        case namedCheckpoints
+        case scheduling
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        runID = try values.decode(String.self, forKey: .runID)
+        streamVersion = try values.decode(UInt64.self, forKey: .streamVersion)
+        run = try values.decodeIfPresent(GraphRun.self, forKey: .run)
+        nodes = try values.decode([GraphNode].self, forKey: .nodes)
+        attempts = try values.decode(
+            [ExecutionAttempt].self,
+            forKey: .attempts
+        )
+        processExits = try values.decode(
+            [ProcessExit].self,
+            forKey: .processExits
+        )
+        heartbeats = try values.decode(
+            [ExecutorHeartbeat].self,
+            forKey: .heartbeats
+        )
+        executionEvents = try values.decode(
+            [ExecutionEvent].self,
+            forKey: .executionEvents
+        )
+        artifacts = try values.decode(
+            [GraphArtifactReference].self,
+            forKey: .artifacts
+        )
+        humanInterrupts = try values.decode(
+            [GraphHumanInterruptRecord].self,
+            forKey: .humanInterrupts
+        )
+        unknownEvents = try values.decode(
+            [GraphExecutionEventEnvelope].self,
+            forKey: .unknownEvents
+        )
+        graphDefinitionVersion = try values.decodeIfPresent(
+            String.self,
+            forKey: .graphDefinitionVersion
+        )
+        graphDefinitionDigest = try values.decodeIfPresent(
+            GraphContentDigest.self,
+            forKey: .graphDefinitionDigest
+        )
+        checkpointNamespace = try values.decode(
+            String.self,
+            forKey: .checkpointNamespace
+        )
+        parentRunID = try values.decodeIfPresent(
+            String.self,
+            forKey: .parentRunID
+        )
+        parentCheckpoint = try values.decodeIfPresent(
+            GraphCheckpointReference.self,
+            forKey: .parentCheckpoint
+        )
+        namedCheckpoints = try values.decode(
+            [GraphCheckpointReference].self,
+            forKey: .namedCheckpoints
+        )
+        scheduling = try values.decodeIfPresent(
+            GraphSchedulingProjection.self,
+            forKey: .scheduling
+        ) ?? GraphSchedulingProjection()
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var values = encoder.container(keyedBy: CodingKeys.self)
+        try values.encode(runID, forKey: .runID)
+        try values.encode(streamVersion, forKey: .streamVersion)
+        try values.encodeIfPresent(run, forKey: .run)
+        try values.encode(nodes, forKey: .nodes)
+        try values.encode(attempts, forKey: .attempts)
+        try values.encode(processExits, forKey: .processExits)
+        try values.encode(heartbeats, forKey: .heartbeats)
+        try values.encode(executionEvents, forKey: .executionEvents)
+        try values.encode(artifacts, forKey: .artifacts)
+        try values.encode(humanInterrupts, forKey: .humanInterrupts)
+        try values.encode(unknownEvents, forKey: .unknownEvents)
+        try values.encodeIfPresent(
+            graphDefinitionVersion,
+            forKey: .graphDefinitionVersion
+        )
+        try values.encodeIfPresent(
+            graphDefinitionDigest,
+            forKey: .graphDefinitionDigest
+        )
+        try values.encode(
+            checkpointNamespace,
+            forKey: .checkpointNamespace
+        )
+        try values.encodeIfPresent(parentRunID, forKey: .parentRunID)
+        try values.encodeIfPresent(
+            parentCheckpoint,
+            forKey: .parentCheckpoint
+        )
+        try values.encode(namedCheckpoints, forKey: .namedCheckpoints)
+        try values.encode(scheduling, forKey: .scheduling)
+    }
 }
 
 public struct GraphExecutionReplayResult: Equatable, Sendable {

--- a/Sources/OpenIslandCore/GraphExecutionReplay.swift
+++ b/Sources/OpenIslandCore/GraphExecutionReplay.swift
@@ -64,6 +64,19 @@ public enum GraphExecutionReplayError: Error, Equatable, Sendable {
     case interruptIDCollision(requestID: String)
     case missingInterrupt(requestID: String)
     case interruptAlreadyResolved(requestID: String)
+    case claimIDCollision(claimID: String)
+    case duplicateActiveClaim(nodeID: String, attemptOrdinal: Int)
+    case missingClaim(claimID: String)
+    case claimGenerationMismatch(
+        claimID: String,
+        expected: UInt64,
+        actual: UInt64
+    )
+    case retryOrdinalConflict(nodeID: String, ordinal: Int)
+    case cancellationIDCollision(requestID: String)
+    case missingCancellation(requestID: String)
+    case cancellationAlreadyAcknowledged(requestID: String)
+    case timeoutIDCollision(timeoutID: String)
     case invalidSnapshot(String)
 }
 
@@ -114,6 +127,24 @@ extension GraphExecutionReplayError: LocalizedError {
             "Human interrupt \(requestID) does not exist."
         case let .interruptAlreadyResolved(requestID):
             "Human interrupt \(requestID) is already resolved."
+        case let .claimIDCollision(claimID):
+            "Executor claim ID \(claimID) has contradictory content."
+        case let .duplicateActiveClaim(nodeID, ordinal):
+            "Node \(nodeID) attempt \(ordinal) already has an active claim."
+        case let .missingClaim(claimID):
+            "Executor claim \(claimID) does not exist."
+        case let .claimGenerationMismatch(claimID, expected, actual):
+            "Executor claim \(claimID) expected generation \(expected), found \(actual)."
+        case let .retryOrdinalConflict(nodeID, ordinal):
+            "Node \(nodeID) has contradictory retry state for attempt \(ordinal)."
+        case let .cancellationIDCollision(requestID):
+            "Cancellation request ID \(requestID) has contradictory content."
+        case let .missingCancellation(requestID):
+            "Cancellation request \(requestID) does not exist."
+        case let .cancellationAlreadyAcknowledged(requestID):
+            "Cancellation request \(requestID) was already acknowledged."
+        case let .timeoutIDCollision(timeoutID):
+            "Timeout decision ID \(timeoutID) has contradictory content."
         case let .invalidSnapshot(message):
             "Invalid graph execution snapshot: \(message)"
         }
@@ -178,6 +209,7 @@ public struct GraphExecutionProjection: Equatable, Codable, Sendable {
     public var parentRunID: String?
     public var parentCheckpoint: GraphCheckpointReference?
     public var namedCheckpoints: [GraphCheckpointReference]
+    public var scheduling: GraphSchedulingProjection
 
     public init(
         runID: String,
@@ -196,7 +228,9 @@ public struct GraphExecutionProjection: Equatable, Codable, Sendable {
         checkpointNamespace: String = "root",
         parentRunID: String? = nil,
         parentCheckpoint: GraphCheckpointReference? = nil,
-        namedCheckpoints: [GraphCheckpointReference] = []
+        namedCheckpoints: [GraphCheckpointReference] = [],
+        scheduling: GraphSchedulingProjection =
+            GraphSchedulingProjection()
     ) {
         self.runID = runID
         self.streamVersion = streamVersion
@@ -215,6 +249,7 @@ public struct GraphExecutionProjection: Equatable, Codable, Sendable {
         self.parentRunID = parentRunID
         self.parentCheckpoint = parentCheckpoint
         self.namedCheckpoints = namedCheckpoints
+        self.scheduling = scheduling
     }
 }
 
@@ -694,9 +729,301 @@ public enum GraphExecutionProjector {
                 )
             )
 
+        case .schedulerEvaluationRecorded,
+             .nodeBecameRunnable,
+             .nodeSchedulingDeferred,
+             .executorClaimRequested,
+             .executorClaimGranted,
+             .executorClaimRejected,
+             .executorLeaseRenewed,
+             .executorLeaseExpired,
+             .executorClaimReleased,
+             .retryScheduled,
+             .retrySuppressed,
+             .cancellationRequested,
+             .cancellationAcknowledged,
+             .timeoutDeclared,
+             .dependencyFailurePropagated,
+             .schedulerCycleCompleted:
+            try applyScheduling(event, projection: &projection)
+
         case .unknown:
             projection.unknownEvents.append(event)
         }
+    }
+
+    private static func applyScheduling(
+        _ event: GraphExecutionEventEnvelope,
+        projection: inout GraphExecutionProjection
+    ) throws {
+        try requireRun(event: event, projection: projection)
+        var evaluationID: String?
+        var reason: GraphSchedulingReasonCode?
+
+        switch event.payload {
+        case let .schedulerEvaluationRecorded(payload):
+            evaluationID = payload.evaluationID
+
+        case let .nodeBecameRunnable(payload),
+             let .nodeSchedulingDeferred(payload):
+            _ = try requireNodeID(event)
+            evaluationID = payload.evaluationID
+            reason = payload.reason
+
+        case let .executorClaimRequested(payload):
+            try validateClaimEnvelope(payload.claim, event: event)
+            reason = payload.reason
+
+        case let .executorClaimGranted(payload):
+            try validateClaimEnvelope(payload.claim, event: event)
+            let claim = payload.claim
+
+            if let existing = projection.scheduling.claims.first(
+                where: { $0.claim.id == claim.id }
+            ) {
+                guard existing.claim == claim else {
+                    throw GraphExecutionReplayError.claimIDCollision(
+                        claimID: claim.id
+                    )
+                }
+            } else {
+                guard !projection.scheduling.claims.contains(where: {
+                    $0.claim.nodeID == claim.nodeID
+                        && $0.claim.attemptOrdinal == claim.attemptOrdinal
+                        && $0.status == .active
+                }) else {
+                    throw GraphExecutionReplayError.duplicateActiveClaim(
+                        nodeID: claim.nodeID,
+                        attemptOrdinal: claim.attemptOrdinal
+                    )
+                }
+                projection.scheduling.claims.append(
+                    GraphExecutorClaimRecord(
+                        claim: claim,
+                        statusChangedAt: event.occurredAt,
+                        reason: payload.reason
+                    )
+                )
+            }
+            reason = payload.reason
+
+        case let .executorClaimRejected(payload):
+            _ = try requireNodeID(event)
+            reason = payload.reason
+
+        case let .executorLeaseRenewed(payload):
+            let renewed = payload.claim
+            guard let index = projection.scheduling.claims.firstIndex(
+                where: { $0.claim.id == renewed.id }
+            ) else {
+                throw GraphExecutionReplayError.missingClaim(
+                    claimID: renewed.id
+                )
+            }
+            let current = projection.scheduling.claims[index].claim
+            guard projection.scheduling.claims[index].status == .active,
+                  renewed.runID == current.runID,
+                  renewed.nodeID == current.nodeID,
+                  renewed.attemptOrdinal == current.attemptOrdinal,
+                  renewed.executorID == current.executorID,
+                  renewed.executorCapabilityIdentity
+                    == current.executorCapabilityIdentity,
+                  renewed.hostID == current.hostID,
+                  renewed.grantedSequence == current.grantedSequence,
+                  renewed.leaseGeneration == current.leaseGeneration + 1
+            else {
+                throw GraphExecutionReplayError.claimGenerationMismatch(
+                    claimID: renewed.id,
+                    expected: current.leaseGeneration + 1,
+                    actual: renewed.leaseGeneration
+                )
+            }
+            projection.scheduling.claims[index].claim = renewed
+            projection.scheduling.claims[index].statusChangedAt =
+                event.occurredAt
+            projection.scheduling.claims[index].reason = payload.reason
+            reason = payload.reason
+
+        case let .executorLeaseExpired(payload):
+            try endClaim(
+                payload,
+                status: .expired,
+                at: event.occurredAt,
+                projection: &projection
+            )
+            reason = payload.reason
+
+        case let .executorClaimReleased(payload):
+            try endClaim(
+                payload,
+                status: .released,
+                at: event.occurredAt,
+                projection: &projection
+            )
+            reason = payload.reason
+
+        case let .retryScheduled(payload):
+            let retry = payload.retry
+            guard retry.nodeID == event.nodeID else {
+                throw GraphExecutionReplayError.missingNode(
+                    nodeID: retry.nodeID
+                )
+            }
+            if let existing = projection.scheduling.retries.first(
+                where: {
+                    $0.nodeID == retry.nodeID
+                        && $0.nextAttemptOrdinal
+                            == retry.nextAttemptOrdinal
+                }
+            ) {
+                guard existing == retry else {
+                    throw GraphExecutionReplayError.retryOrdinalConflict(
+                        nodeID: retry.nodeID,
+                        ordinal: retry.nextAttemptOrdinal
+                    )
+                }
+            } else {
+                projection.scheduling.retries.append(retry)
+            }
+            reason = retry.reason
+
+        case let .retrySuppressed(payload):
+            reason = payload.reason
+
+        case let .cancellationRequested(payload):
+            let cancellation = payload.cancellation
+            guard cancellation.runID == event.runID,
+                  cancellation.nodeID == event.nodeID,
+                  cancellation.attemptID == event.attemptID else {
+                throw GraphExecutionReplayError.cancellationIDCollision(
+                    requestID: cancellation.id
+                )
+            }
+            if let existing = projection.scheduling.cancellations.first(
+                where: { $0.id == cancellation.id }
+            ) {
+                guard existing == cancellation else {
+                    throw GraphExecutionReplayError
+                        .cancellationIDCollision(
+                            requestID: cancellation.id
+                        )
+                }
+            } else {
+                projection.scheduling.cancellations.append(cancellation)
+            }
+            reason = .cancellationPending
+
+        case let .cancellationAcknowledged(payload):
+            guard let index = projection.scheduling.cancellations
+                .firstIndex(where: { $0.id == payload.requestID }) else {
+                throw GraphExecutionReplayError.missingCancellation(
+                    requestID: payload.requestID
+                )
+            }
+            guard projection.scheduling.cancellations[index].state
+                    == .requested else {
+                throw GraphExecutionReplayError
+                    .cancellationAlreadyAcknowledged(
+                        requestID: payload.requestID
+                    )
+            }
+            guard projection.scheduling.cancellations[index].claimID
+                    == payload.claimID else {
+                throw GraphExecutionReplayError.claimIDCollision(
+                    claimID: payload.claimID ?? "unclaimed"
+                )
+            }
+            projection.scheduling.cancellations[index].state =
+                .acknowledged
+            projection.scheduling.cancellations[index].acknowledgedAt =
+                payload.acknowledgedAt
+            projection.scheduling.cancellations[index]
+                .acknowledgedByExecutorID = payload.executorID
+            reason = .cancellationAcknowledged
+
+        case let .timeoutDeclared(payload):
+            if let existing = projection.scheduling.timeouts.first(
+                where: { $0.id == payload.timeout.id }
+            ) {
+                guard existing == payload.timeout else {
+                    throw GraphExecutionReplayError.timeoutIDCollision(
+                        timeoutID: payload.timeout.id
+                    )
+                }
+            } else {
+                projection.scheduling.timeouts.append(payload.timeout)
+            }
+            reason = payload.timeout.reason
+
+        case let .dependencyFailurePropagated(payload):
+            evaluationID = payload.evaluationID
+            reason = payload.reason
+
+        case let .schedulerCycleCompleted(payload):
+            evaluationID = payload.evaluationID
+            if !projection.scheduling.completedEvaluationIDs.contains(
+                payload.evaluationID
+            ) {
+                projection.scheduling.completedEvaluationIDs.append(
+                    payload.evaluationID
+                )
+            }
+
+        default:
+            return
+        }
+
+        projection.scheduling.records.append(
+            GraphSchedulingRecord(
+                id: event.id,
+                sequence: event.streamSequence,
+                eventType: event.eventType,
+                factClass: event.factClass,
+                nodeID: event.nodeID,
+                attemptID: event.attemptID,
+                evaluationID: evaluationID,
+                reason: reason,
+                occurredAt: event.occurredAt
+            )
+        )
+    }
+
+    private static func validateClaimEnvelope(
+        _ claim: GraphExecutorClaim,
+        event: GraphExecutionEventEnvelope
+    ) throws {
+        guard claim.runID == event.runID,
+              claim.nodeID == event.nodeID else {
+            throw GraphExecutionReplayError.claimIDCollision(
+                claimID: claim.id
+            )
+        }
+    }
+
+    private static func endClaim(
+        _ payload: GraphExecutorLeaseEndedPayload,
+        status: GraphExecutorClaimStatus,
+        at occurredAt: Date,
+        projection: inout GraphExecutionProjection
+    ) throws {
+        guard let index = projection.scheduling.claims.firstIndex(
+            where: { $0.claim.id == payload.claimID }
+        ) else {
+            throw GraphExecutionReplayError.missingClaim(
+                claimID: payload.claimID
+            )
+        }
+        let claim = projection.scheduling.claims[index].claim
+        guard claim.leaseGeneration == payload.leaseGeneration else {
+            throw GraphExecutionReplayError.claimGenerationMismatch(
+                claimID: payload.claimID,
+                expected: claim.leaseGeneration,
+                actual: payload.leaseGeneration
+            )
+        }
+        projection.scheduling.claims[index].status = status
+        projection.scheduling.claims[index].statusChangedAt = occurredAt
+        projection.scheduling.claims[index].reason = payload.reason
     }
 
     private static func applyTerminalAttempt(
@@ -934,5 +1261,32 @@ public enum GraphExecutionProjector {
 
             return $0.checkpointID < $1.checkpointID
         }
+        projection.scheduling.records.sort {
+            if $0.sequence != $1.sequence {
+                return $0.sequence < $1.sequence
+            }
+            return $0.id < $1.id
+        }
+        projection.scheduling.claims.sort {
+            if $0.claim.nodeID != $1.claim.nodeID {
+                return $0.claim.nodeID < $1.claim.nodeID
+            }
+            if $0.claim.attemptOrdinal != $1.claim.attemptOrdinal {
+                return $0.claim.attemptOrdinal
+                    < $1.claim.attemptOrdinal
+            }
+            return $0.claim.id < $1.claim.id
+        }
+        projection.scheduling.retries.sort {
+            if $0.nodeID != $1.nodeID {
+                return $0.nodeID < $1.nodeID
+            }
+            return $0.nextAttemptOrdinal < $1.nextAttemptOrdinal
+        }
+        projection.scheduling.cancellations.sort { $0.id < $1.id }
+        projection.scheduling.timeouts.sort { $0.id < $1.id }
+        projection.scheduling.completedEvaluationIDs = Array(
+            Set(projection.scheduling.completedEvaluationIDs)
+        ).sorted()
     }
 }

--- a/Sources/OpenIslandCore/GraphExecutionReplay.swift
+++ b/Sources/OpenIslandCore/GraphExecutionReplay.swift
@@ -763,6 +763,11 @@ public enum GraphExecutionProjector {
         switch event.payload {
         case let .schedulerEvaluationRecorded(payload):
             evaluationID = payload.evaluationID
+            if !projection.scheduling.evaluations.contains(where: {
+                $0.evaluationID == payload.evaluationID
+            }) {
+                projection.scheduling.evaluations.append(payload)
+            }
 
         case let .nodeBecameRunnable(payload),
              let .nodeSchedulingDeferred(payload):
@@ -1266,6 +1271,9 @@ public enum GraphExecutionProjector {
                 return $0.sequence < $1.sequence
             }
             return $0.id < $1.id
+        }
+        projection.scheduling.evaluations.sort {
+            $0.evaluationID < $1.evaluationID
         }
         projection.scheduling.claims.sort {
             if $0.claim.nodeID != $1.claim.nodeID {

--- a/Sources/OpenIslandCore/GraphExecutionReplay.swift
+++ b/Sources/OpenIslandCore/GraphExecutionReplay.swift
@@ -215,6 +215,7 @@ public struct GraphExecutionProjection: Equatable, Codable, Sendable {
     public var runStartRequestID: String?
     public var retryRequestIDs: [String]
     public var attemptLifecycles: [GraphAttemptLifecycleRecord]
+    public var executorObservations: [GraphExecutorObservation]
 
     public init(
         runID: String,
@@ -240,7 +241,8 @@ public struct GraphExecutionProjection: Equatable, Codable, Sendable {
         runStartRequestedAt: Date? = nil,
         runStartRequestID: String? = nil,
         retryRequestIDs: [String] = [],
-        attemptLifecycles: [GraphAttemptLifecycleRecord] = []
+        attemptLifecycles: [GraphAttemptLifecycleRecord] = [],
+        executorObservations: [GraphExecutorObservation] = []
     ) {
         self.runID = runID
         self.streamVersion = streamVersion
@@ -265,6 +267,7 @@ public struct GraphExecutionProjection: Equatable, Codable, Sendable {
         self.runStartRequestID = runStartRequestID
         self.retryRequestIDs = retryRequestIDs
         self.attemptLifecycles = attemptLifecycles
+        self.executorObservations = executorObservations
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -291,6 +294,7 @@ public struct GraphExecutionProjection: Equatable, Codable, Sendable {
         case runStartRequestID
         case retryRequestIDs
         case attemptLifecycles
+        case executorObservations
     }
 
     public init(from decoder: any Decoder) throws {
@@ -375,6 +379,10 @@ public struct GraphExecutionProjection: Equatable, Codable, Sendable {
             [GraphAttemptLifecycleRecord].self,
             forKey: .attemptLifecycles
         ) ?? []
+        executorObservations = try values.decodeIfPresent(
+            [GraphExecutorObservation].self,
+            forKey: .executorObservations
+        ) ?? []
     }
 
     public func encode(to encoder: any Encoder) throws {
@@ -425,6 +433,10 @@ public struct GraphExecutionProjection: Equatable, Codable, Sendable {
         try values.encode(
             attemptLifecycles,
             forKey: .attemptLifecycles
+        )
+        try values.encode(
+            executorObservations,
+            forKey: .executorObservations
         )
     }
 }
@@ -717,10 +729,13 @@ public enum GraphExecutionProjector {
             try requireNonterminalAttempt(
                 projection.attempts[attemptIndex]
             )
-            projection.attempts[attemptIndex].state = .running
-            projection.attempts[attemptIndex].startedAt =
-                projection.attempts[attemptIndex].startedAt
-                    ?? event.occurredAt
+            if let identity = payload.identity {
+                try validateExecutorIdentity(
+                    identity,
+                    event: event,
+                    attempt: projection.attempts[attemptIndex]
+                )
+            }
             projection.attempts[attemptIndex].updatedAt =
                 event.occurredAt
             projection.attempts[attemptIndex].statusReason =
@@ -731,26 +746,14 @@ public enum GraphExecutionProjector {
                 at: event.occurredAt,
                 projection: &projection
             )
-            updateNode(
-                for: projection.attempts[attemptIndex],
-                state: .running,
-                at: event.occurredAt,
-                projection: &projection
-            )
-
-            if projection.run?.startedAt == nil {
-                projection.run?.startedAt = event.occurredAt
-            }
-
-            projection.run?.state = .running
-            projection.run?.updatedAt = event.occurredAt
-            projection.executionEvents.append(
-                executionEvent(
-                    from: event,
-                    kind: .attemptStarted,
-                    reason: payload.reason
+            if payload.identity == nil {
+                applyAttemptStarted(
+                    attemptIndex: attemptIndex,
+                    event: event,
+                    reason: payload.reason,
+                    projection: &projection
                 )
-            )
+            }
 
         case let .processIdentityObserved(payload):
             let index = try requireAttemptIndex(
@@ -814,6 +817,67 @@ public enum GraphExecutionProjector {
                     reason: payload.reason
                 )
             )
+
+        case let .executorObservationRecorded(payload):
+            let index = try requireAttemptIndex(
+                event: event,
+                projection: projection
+            )
+            try validateExecutorIdentity(
+                payload.observation.identity,
+                event: event,
+                attempt: projection.attempts[index]
+            )
+            if let existing = projection.executorObservations.first(
+                where: { $0.id == payload.observation.id }
+            ) {
+                guard existing == payload.observation else {
+                    throw GraphExecutionReplayError.eventIDCollision(
+                        eventID: payload.observation.id
+                    )
+                }
+            } else {
+                projection.executorObservations.append(
+                    payload.observation
+                )
+            }
+            if let processIdentity = payload.observation.processIdentity {
+                try assignProcessIdentity(
+                    processIdentity,
+                    attemptIndex: index,
+                    projection: &projection
+                )
+            }
+            switch payload.observation.status {
+            case .started:
+                applyAttemptStarted(
+                    attemptIndex: index,
+                    event: event,
+                    reason: nil,
+                    projection: &projection
+                )
+                updateLifecycle(
+                    attemptID: event.attemptID,
+                    phase: .started,
+                    at: event.occurredAt,
+                    projection: &projection
+                )
+            case .stillRunning:
+                applyAttemptStarted(
+                    attemptIndex: index,
+                    event: event,
+                    reason: nil,
+                    projection: &projection
+                )
+                updateLifecycle(
+                    attemptID: event.attemptID,
+                    phase: .running,
+                    at: event.occurredAt,
+                    projection: &projection
+                )
+            default:
+                break
+            }
 
         case let .attemptCompleted(payload):
             try applyTerminalAttempt(
@@ -1260,6 +1324,22 @@ public enum GraphExecutionProjector {
         }
     }
 
+    private static func validateExecutorIdentity(
+        _ identity: GraphExecutorInteractionIdentity,
+        event: GraphExecutionEventEnvelope,
+        attempt: ExecutionAttempt
+    ) throws {
+        guard identity.runID == event.runID,
+              identity.nodeID == event.nodeID,
+              identity.attemptID == event.attemptID,
+              identity.attemptID == attempt.id,
+              identity.attemptOrdinal == attempt.ordinal else {
+            throw GraphExecutionReplayError.missingAttempt(
+                attemptID: identity.attemptID
+            )
+        }
+    }
+
     private static func endClaim(
         _ payload: GraphExecutorLeaseEndedPayload,
         status: GraphExecutorClaimStatus,
@@ -1477,6 +1557,36 @@ public enum GraphExecutionProjector {
         }
     }
 
+    private static func applyAttemptStarted(
+        attemptIndex: Int,
+        event: GraphExecutionEventEnvelope,
+        reason: String?,
+        projection: inout GraphExecutionProjection
+    ) {
+        let wasRunning = projection.attempts[attemptIndex].state == .running
+        projection.attempts[attemptIndex].state = .running
+        projection.attempts[attemptIndex].startedAt =
+            projection.attempts[attemptIndex].startedAt ?? event.occurredAt
+        projection.attempts[attemptIndex].updatedAt = event.occurredAt
+        updateNode(
+            for: projection.attempts[attemptIndex],
+            state: .running,
+            at: event.occurredAt,
+            projection: &projection
+        )
+        projection.run?.state = .running
+        projection.run?.updatedAt = event.occurredAt
+        if !wasRunning {
+            projection.executionEvents.append(
+                executionEvent(
+                    from: event,
+                    kind: .attemptStarted,
+                    reason: reason
+                )
+            )
+        }
+    }
+
     private static func runEventKind(
         for state: ReconciledExecutionState
     ) -> ExecutionEventKind {
@@ -1563,6 +1673,12 @@ public enum GraphExecutionProjector {
                 return $0.nodeID < $1.nodeID
             }
             return $0.ordinal < $1.ordinal
+        }
+        projection.executorObservations.sort {
+            if $0.observedAt != $1.observedAt {
+                return $0.observedAt < $1.observedAt
+            }
+            return $0.id < $1.id
         }
         projection.scheduling.evaluations.sort {
             $0.evaluationID < $1.evaluationID

--- a/Sources/OpenIslandCore/GraphExecutionRepository.swift
+++ b/Sources/OpenIslandCore/GraphExecutionRepository.swift
@@ -48,7 +48,7 @@ public protocol GraphExecutionSnapshotStore: Sendable {
 public actor InMemoryGraphExecutionSnapshotStore:
     GraphExecutionSnapshotStore
 {
-    private var snapshots: [String: [GraphExecutionSnapshot]]
+    package var snapshots: [String: [GraphExecutionSnapshot]]
 
     public init(snapshots: [GraphExecutionSnapshot] = []) {
         self.snapshots = Dictionary(
@@ -329,6 +329,45 @@ public struct GraphExecutionRepositoryLoadResult:
     }
 }
 
+public enum GraphExecutionProjectionReconciler {
+    public static func reconcile(
+        projection: GraphExecutionProjection,
+        evidenceOutcome: GraphProcessEvidenceOutcome,
+        observedAt: Date
+    ) -> ExecutionReconciliationResult? {
+        guard let run = projection.run else {
+            return nil
+        }
+
+        var processExits = projection.processExits
+        var heartbeats = projection.heartbeats
+
+        switch evidenceOutcome {
+        case let .available(evidence),
+             let .stale(evidence, _):
+            processExits.append(contentsOf: evidence.processExits)
+            heartbeats.append(contentsOf: evidence.heartbeats)
+        case .unavailable,
+             .permissionDenied,
+             .adapterFailed,
+             .identityMismatch:
+            break
+        }
+
+        return GraphExecutionReconciler.reconcile(
+            ExecutionReconciliationInput(
+                run: run,
+                nodes: projection.nodes,
+                attempts: projection.attempts,
+                processExits: processExits,
+                heartbeats: heartbeats,
+                events: projection.executionEvents,
+                observedAt: observedAt
+            )
+        )
+    }
+}
+
 public protocol GraphExecutionRepository: Sendable {
     func load(
         runID: String,
@@ -483,7 +522,7 @@ public struct DefaultGraphExecutionRepository:
             )
         )
 
-        let reconciled = reconcile(
+        let reconciled = GraphExecutionProjectionReconciler.reconcile(
             projection: replay.projection,
             evidenceOutcome: evidenceOutcome,
             observedAt: observedAt
@@ -607,43 +646,6 @@ public struct DefaultGraphExecutionRepository:
             )
             return (nil, .corrupt)
         }
-    }
-
-    private func reconcile(
-        projection: GraphExecutionProjection,
-        evidenceOutcome: GraphProcessEvidenceOutcome,
-        observedAt: Date
-    ) -> ExecutionReconciliationResult? {
-        guard let run = projection.run else {
-            return nil
-        }
-
-        var processExits = projection.processExits
-        var heartbeats = projection.heartbeats
-
-        switch evidenceOutcome {
-        case let .available(evidence),
-             let .stale(evidence, _):
-            processExits.append(contentsOf: evidence.processExits)
-            heartbeats.append(contentsOf: evidence.heartbeats)
-        case .unavailable,
-             .permissionDenied,
-             .adapterFailed,
-             .identityMismatch:
-            break
-        }
-
-        return GraphExecutionReconciler.reconcile(
-            ExecutionReconciliationInput(
-                run: run,
-                nodes: projection.nodes,
-                attempts: projection.attempts,
-                processExits: processExits,
-                heartbeats: heartbeats,
-                events: projection.executionEvents,
-                observedAt: observedAt
-            )
-        )
     }
 
     private func makeSnapshot(

--- a/Sources/OpenIslandCore/GraphExecutionRepository.swift
+++ b/Sources/OpenIslandCore/GraphExecutionRepository.swift
@@ -1,0 +1,694 @@
+import Foundation
+
+public struct GraphExecutionSnapshot: Equatable, Codable, Sendable {
+    public let schemaVersion: Int
+    public let runID: String
+    public let streamVersion: UInt64
+    public let graphDefinitionVersion: String
+    public let graphDefinitionDigest: GraphContentDigest
+    public let projectedState: GraphExecutionProjection
+    public let createdAt: Date
+    public let createdBy: GraphExecutionProducer
+    public let integrity: GraphExecutionIntegrityMetadata?
+    public let checkpointNamespace: String
+    public let namedCheckpoints: [GraphCheckpointReference]
+
+    public init(
+        schemaVersion: Int = GraphExecutionSchema.snapshotVersion,
+        runID: String,
+        streamVersion: UInt64,
+        graphDefinitionVersion: String,
+        graphDefinitionDigest: GraphContentDigest,
+        projectedState: GraphExecutionProjection,
+        createdAt: Date,
+        createdBy: GraphExecutionProducer,
+        integrity: GraphExecutionIntegrityMetadata? = nil,
+        checkpointNamespace: String,
+        namedCheckpoints: [GraphCheckpointReference] = []
+    ) {
+        self.schemaVersion = schemaVersion
+        self.runID = runID
+        self.streamVersion = streamVersion
+        self.graphDefinitionVersion = graphDefinitionVersion
+        self.graphDefinitionDigest = graphDefinitionDigest
+        self.projectedState = projectedState
+        self.createdAt = createdAt
+        self.createdBy = createdBy
+        self.integrity = integrity
+        self.checkpointNamespace = checkpointNamespace
+        self.namedCheckpoints = namedCheckpoints
+    }
+}
+
+public protocol GraphExecutionSnapshotStore: Sendable {
+    func loadLatest(runID: String) async throws -> GraphExecutionSnapshot?
+    func save(_ snapshot: GraphExecutionSnapshot) async throws
+}
+
+public actor InMemoryGraphExecutionSnapshotStore:
+    GraphExecutionSnapshotStore
+{
+    private var snapshots: [String: [GraphExecutionSnapshot]]
+
+    public init(snapshots: [GraphExecutionSnapshot] = []) {
+        self.snapshots = Dictionary(
+            grouping: snapshots,
+            by: \.runID
+        )
+    }
+
+    public func loadLatest(
+        runID: String
+    ) -> GraphExecutionSnapshot? {
+        snapshots[runID]?.max {
+            if $0.streamVersion != $1.streamVersion {
+                return $0.streamVersion < $1.streamVersion
+            }
+
+            return $0.createdAt < $1.createdAt
+        }
+    }
+
+    public func save(
+        _ snapshot: GraphExecutionSnapshot
+    ) throws {
+        var runSnapshots = snapshots[snapshot.runID] ?? []
+
+        if let existing = runSnapshots.first(where: {
+            $0.streamVersion == snapshot.streamVersion
+        }) {
+            guard existing == snapshot else {
+                throw GraphExecutionPersistenceError.corruptRecord(
+                    "Snapshot \(snapshot.runID)@\(snapshot.streamVersion) already exists with different content."
+                )
+            }
+
+            return
+        }
+
+        runSnapshots.append(snapshot)
+        snapshots[snapshot.runID] = runSnapshots
+    }
+}
+
+public protocol GraphExecutionSnapshotPolicy: Sendable {
+    func shouldCreateSnapshot(
+        replayedEventCount: Int,
+        streamVersion: UInt64
+    ) -> Bool
+}
+
+public struct NeverGraphExecutionSnapshotPolicy:
+    GraphExecutionSnapshotPolicy
+{
+    public init() {}
+
+    public func shouldCreateSnapshot(
+        replayedEventCount: Int,
+        streamVersion: UInt64
+    ) -> Bool {
+        false
+    }
+}
+
+public struct EventCountGraphExecutionSnapshotPolicy:
+    GraphExecutionSnapshotPolicy
+{
+    public let minimumReplayedEventCount: Int
+
+    public init(minimumReplayedEventCount: Int) {
+        self.minimumReplayedEventCount = max(
+            1,
+            minimumReplayedEventCount
+        )
+    }
+
+    public func shouldCreateSnapshot(
+        replayedEventCount: Int,
+        streamVersion: UInt64
+    ) -> Bool {
+        replayedEventCount >= minimumReplayedEventCount
+            && streamVersion > 0
+    }
+}
+
+public struct GraphProcessEvidence: Equatable, Codable, Sendable {
+    public var processExits: [ProcessExit]
+    public var heartbeats: [ExecutorHeartbeat]
+
+    public init(
+        processExits: [ProcessExit] = [],
+        heartbeats: [ExecutorHeartbeat] = []
+    ) {
+        self.processExits = processExits
+        self.heartbeats = heartbeats
+    }
+}
+
+public enum GraphProcessEvidenceOutcome: Equatable, Codable, Sendable {
+    case available(GraphProcessEvidence)
+    case unavailable(reason: String)
+    case stale(GraphProcessEvidence, reason: String)
+    case permissionDenied(reason: String)
+    case adapterFailed(reason: String)
+    case identityMismatch(GraphProcessEvidence, reason: String)
+
+    public var status: String {
+        switch self {
+        case .available:
+            "available"
+        case .unavailable:
+            "unavailable"
+        case .stale:
+            "stale"
+        case .permissionDenied:
+            "permission_denied"
+        case .adapterFailed:
+            "adapter_failed"
+        case .identityMismatch:
+            "identity_mismatch"
+        }
+    }
+}
+
+public struct GraphProcessEvidenceRequest: Equatable, Sendable {
+    public let runID: String
+    public let attempts: [ExecutionAttempt]
+    public let observedAt: Date
+
+    public init(
+        runID: String,
+        attempts: [ExecutionAttempt],
+        observedAt: Date
+    ) {
+        self.runID = runID
+        self.attempts = attempts
+        self.observedAt = observedAt
+    }
+}
+
+public protocol ProcessEvidenceSource: Sendable {
+    func evidence(
+        for request: GraphProcessEvidenceRequest
+    ) async -> GraphProcessEvidenceOutcome
+}
+
+public struct UnavailableProcessEvidenceSource:
+    ProcessEvidenceSource
+{
+    public let reason: String
+
+    public init(reason: String = "No process evidence adapter configured.") {
+        self.reason = reason
+    }
+
+    public func evidence(
+        for request: GraphProcessEvidenceRequest
+    ) async -> GraphProcessEvidenceOutcome {
+        .unavailable(reason: reason)
+    }
+}
+
+public enum GraphTelemetryOperation: String, Codable, CaseIterable, Sendable {
+    case repositoryLoad = "openisland.graph.repository.load"
+    case eventAppend = "openisland.graph.event.append"
+    case eventReplay = "openisland.graph.event.replay"
+    case snapshotLoad = "openisland.graph.snapshot.load"
+    case reconciliation = "openisland.graph.reconciliation"
+    case processEvidenceQuery = "openisland.graph.process_evidence.query"
+}
+
+public enum GraphTelemetryPhase: String, Codable, Sendable {
+    case started
+    case completed
+    case failed
+}
+
+public enum GraphTelemetryAttribute {
+    public static let runID = "openisland.graph.run.id"
+    public static let nodeID = "openisland.graph.node.id"
+    public static let attemptID = "openisland.graph.attempt.id"
+    public static let executorID = "openisland.graph.executor.id"
+    public static let eventType = "openisland.graph.event.type"
+    public static let streamVersion = "openisland.graph.stream.version"
+    public static let replayCount = "openisland.graph.replay.count"
+    public static let reconciliationResult =
+        "openisland.graph.reconciliation.result"
+    public static let errorCategory = "error.type"
+}
+
+public struct GraphTelemetryRecord: Equatable, Codable, Sendable {
+    public let operation: GraphTelemetryOperation
+    public let phase: GraphTelemetryPhase
+    public let attributes: [String: String]
+
+    public init(
+        operation: GraphTelemetryOperation,
+        phase: GraphTelemetryPhase,
+        attributes: [String: String]
+    ) {
+        self.operation = operation
+        self.phase = phase
+        self.attributes = attributes
+    }
+}
+
+public protocol GraphExecutionTelemetrySink: Sendable {
+    func record(_ record: GraphTelemetryRecord) async
+}
+
+public struct NoopGraphExecutionTelemetrySink:
+    GraphExecutionTelemetrySink
+{
+    public init() {}
+
+    public func record(_ record: GraphTelemetryRecord) async {}
+}
+
+public enum GraphSnapshotDisposition: String, Codable, Sendable {
+    case missing
+    case current
+    case stale
+    case incompatible
+    case corrupt
+    case aheadOfStream
+    case created
+}
+
+public enum GraphRepositoryDiagnosticCategory: String, Codable, Sendable {
+    case snapshot
+    case replay
+    case evidence
+    case reconciliation
+}
+
+public struct GraphRepositoryDiagnostic: Equatable, Codable, Sendable {
+    public let category: GraphRepositoryDiagnosticCategory
+    public let message: String
+
+    public init(
+        category: GraphRepositoryDiagnosticCategory,
+        message: String
+    ) {
+        self.category = category
+        self.message = message
+    }
+}
+
+public struct GraphExecutionRepositoryLoadResult:
+    Equatable,
+    Sendable
+{
+    public let runID: String
+    public let streamVersion: UInt64
+    public let persistedProjection: GraphExecutionProjection
+    public let reconciledState: ExecutionReconciliationResult?
+    public let snapshotDisposition: GraphSnapshotDisposition
+    public let replayDiagnostics: [GraphReplayDiagnostic]
+    public let evidenceOutcome: GraphProcessEvidenceOutcome
+    public let diagnostics: [GraphRepositoryDiagnostic]
+
+    public init(
+        runID: String,
+        streamVersion: UInt64,
+        persistedProjection: GraphExecutionProjection,
+        reconciledState: ExecutionReconciliationResult?,
+        snapshotDisposition: GraphSnapshotDisposition,
+        replayDiagnostics: [GraphReplayDiagnostic],
+        evidenceOutcome: GraphProcessEvidenceOutcome,
+        diagnostics: [GraphRepositoryDiagnostic]
+    ) {
+        self.runID = runID
+        self.streamVersion = streamVersion
+        self.persistedProjection = persistedProjection
+        self.reconciledState = reconciledState
+        self.snapshotDisposition = snapshotDisposition
+        self.replayDiagnostics = replayDiagnostics
+        self.evidenceOutcome = evidenceOutcome
+        self.diagnostics = diagnostics
+    }
+}
+
+public protocol GraphExecutionRepository: Sendable {
+    func load(
+        runID: String,
+        observedAt: Date
+    ) async throws -> GraphExecutionRepositoryLoadResult
+}
+
+public struct DefaultGraphExecutionRepository:
+    GraphExecutionRepository,
+    Sendable
+{
+    private let eventStore: any GraphExecutionEventStore
+    private let snapshotStore: any GraphExecutionSnapshotStore
+    private let evidenceSource: any ProcessEvidenceSource
+    private let snapshotPolicy: any GraphExecutionSnapshotPolicy
+    private let snapshotProducer: GraphExecutionProducer
+    private let telemetry: any GraphExecutionTelemetrySink
+
+    public init(
+        eventStore: any GraphExecutionEventStore,
+        snapshotStore: any GraphExecutionSnapshotStore,
+        evidenceSource: any ProcessEvidenceSource,
+        snapshotPolicy: any GraphExecutionSnapshotPolicy =
+            NeverGraphExecutionSnapshotPolicy(),
+        snapshotProducer: GraphExecutionProducer =
+            GraphExecutionProducer(
+                id: "openisland.graph.repository",
+                kind: .application
+            ),
+        telemetry: any GraphExecutionTelemetrySink =
+            NoopGraphExecutionTelemetrySink()
+    ) {
+        self.eventStore = eventStore
+        self.snapshotStore = snapshotStore
+        self.evidenceSource = evidenceSource
+        self.snapshotPolicy = snapshotPolicy
+        self.snapshotProducer = snapshotProducer
+        self.telemetry = telemetry
+    }
+
+    public func load(
+        runID: String,
+        observedAt: Date
+    ) async throws -> GraphExecutionRepositoryLoadResult {
+        await telemetry.record(
+            telemetryRecord(
+                operation: .repositoryLoad,
+                phase: .started,
+                runID: runID
+            )
+        )
+
+        var diagnostics: [GraphRepositoryDiagnostic] = []
+        let snapshotLoad = await loadSnapshot(
+            runID: runID,
+            diagnostics: &diagnostics
+        )
+        var snapshot = snapshotLoad.snapshot
+        var disposition = snapshotLoad.disposition
+        var stream = try await eventStore.read(
+            runID: runID,
+            afterVersion: snapshot?.streamVersion ?? 0
+        )
+
+        if let loadedSnapshot = snapshot,
+           loadedSnapshot.streamVersion > stream.currentVersion {
+            diagnostics.append(
+                GraphRepositoryDiagnostic(
+                    category: .snapshot,
+                    message: "Snapshot is ahead of the event stream and was bypassed."
+                )
+            )
+            disposition = .aheadOfStream
+            stream = try await eventStore.read(
+                runID: runID,
+                afterVersion: 0
+            )
+            snapshot = nil
+        } else if snapshot != nil, !stream.events.isEmpty {
+            disposition = .stale
+            diagnostics.append(
+                GraphRepositoryDiagnostic(
+                    category: .snapshot,
+                    message: "Replayed events written after the snapshot boundary."
+                )
+            )
+        }
+
+        await telemetry.record(
+            telemetryRecord(
+                operation: .eventReplay,
+                phase: .started,
+                runID: runID,
+                streamVersion: stream.currentVersion
+            )
+        )
+        let replay = try GraphExecutionProjector.replay(
+            runID: runID,
+            events: stream.events,
+            initialProjection: snapshot?.projectedState
+        )
+        diagnostics.append(
+            GraphRepositoryDiagnostic(
+                category: .replay,
+                message: "Replayed \(replay.replayedEventCount) event(s) through stream version \(replay.projection.streamVersion)."
+            )
+        )
+        await telemetry.record(
+            GraphTelemetryRecord(
+                operation: .eventReplay,
+                phase: .completed,
+                attributes: [
+                    GraphTelemetryAttribute.runID: runID,
+                    GraphTelemetryAttribute.streamVersion:
+                        String(replay.projection.streamVersion),
+                    GraphTelemetryAttribute.replayCount:
+                        String(replay.replayedEventCount),
+                ]
+            )
+        )
+
+        let evidenceRequest = GraphProcessEvidenceRequest(
+            runID: runID,
+            attempts: replay.projection.attempts,
+            observedAt: observedAt
+        )
+        await telemetry.record(
+            telemetryRecord(
+                operation: .processEvidenceQuery,
+                phase: .started,
+                runID: runID
+            )
+        )
+        let evidenceOutcome = await evidenceSource.evidence(
+            for: evidenceRequest
+        )
+        diagnostics.append(
+            GraphRepositoryDiagnostic(
+                category: .evidence,
+                message: "Process evidence status: \(evidenceOutcome.status)."
+            )
+        )
+        await telemetry.record(
+            GraphTelemetryRecord(
+                operation: .processEvidenceQuery,
+                phase: .completed,
+                attributes: [
+                    GraphTelemetryAttribute.runID: runID,
+                    GraphTelemetryAttribute.reconciliationResult:
+                        evidenceOutcome.status,
+                ]
+            )
+        )
+
+        let reconciled = reconcile(
+            projection: replay.projection,
+            evidenceOutcome: evidenceOutcome,
+            observedAt: observedAt
+        )
+
+        if let reconciled {
+            diagnostics.append(
+                GraphRepositoryDiagnostic(
+                    category: .reconciliation,
+                    message: "Reconciled run to \(reconciled.run.state.rawValue)."
+                )
+            )
+            await telemetry.record(
+                GraphTelemetryRecord(
+                    operation: .reconciliation,
+                    phase: .completed,
+                    attributes: [
+                        GraphTelemetryAttribute.runID: runID,
+                        GraphTelemetryAttribute.reconciliationResult:
+                            reconciled.run.state.rawValue,
+                    ]
+                )
+            )
+        }
+
+        if snapshotPolicy.shouldCreateSnapshot(
+            replayedEventCount: replay.replayedEventCount,
+            streamVersion: replay.projection.streamVersion
+        ), let newSnapshot = makeSnapshot(
+            projection: replay.projection,
+            createdAt: observedAt
+        ) {
+            try await snapshotStore.save(newSnapshot)
+            disposition = .created
+            diagnostics.append(
+                GraphRepositoryDiagnostic(
+                    category: .snapshot,
+                    message: "Created snapshot at stream version \(newSnapshot.streamVersion)."
+                )
+            )
+        }
+
+        await telemetry.record(
+            telemetryRecord(
+                operation: .repositoryLoad,
+                phase: .completed,
+                runID: runID,
+                streamVersion: replay.projection.streamVersion
+            )
+        )
+
+        return GraphExecutionRepositoryLoadResult(
+            runID: runID,
+            streamVersion: replay.projection.streamVersion,
+            persistedProjection: replay.projection,
+            reconciledState: reconciled,
+            snapshotDisposition: disposition,
+            replayDiagnostics: replay.diagnostics,
+            evidenceOutcome: evidenceOutcome,
+            diagnostics: diagnostics
+        )
+    }
+
+    private func loadSnapshot(
+        runID: String,
+        diagnostics: inout [GraphRepositoryDiagnostic]
+    ) async -> (
+        snapshot: GraphExecutionSnapshot?,
+        disposition: GraphSnapshotDisposition
+    ) {
+        await telemetry.record(
+            telemetryRecord(
+                operation: .snapshotLoad,
+                phase: .started,
+                runID: runID
+            )
+        )
+
+        do {
+            guard let snapshot = try await snapshotStore.loadLatest(
+                runID: runID
+            ) else {
+                return (nil, .missing)
+            }
+
+            guard snapshot.schemaVersion
+                    == GraphExecutionSchema.snapshotVersion else {
+                diagnostics.append(
+                    GraphRepositoryDiagnostic(
+                        category: .snapshot,
+                        message: "Snapshot schema is incompatible and was bypassed."
+                    )
+                )
+                return (nil, .incompatible)
+            }
+
+            guard snapshot.runID == runID,
+                  snapshot.projectedState.runID == runID,
+                  snapshot.projectedState.streamVersion
+                    == snapshot.streamVersion,
+                  snapshot.projectedState.graphDefinitionVersion
+                    == snapshot.graphDefinitionVersion,
+                  snapshot.projectedState.graphDefinitionDigest
+                    == snapshot.graphDefinitionDigest else {
+                diagnostics.append(
+                    GraphRepositoryDiagnostic(
+                        category: .snapshot,
+                        message: "Snapshot metadata is internally inconsistent and was bypassed."
+                    )
+                )
+                return (nil, .corrupt)
+            }
+
+            return (snapshot, .current)
+        } catch {
+            diagnostics.append(
+                GraphRepositoryDiagnostic(
+                    category: .snapshot,
+                    message: "Snapshot load failed and full replay was used: \(error.localizedDescription)"
+                )
+            )
+            return (nil, .corrupt)
+        }
+    }
+
+    private func reconcile(
+        projection: GraphExecutionProjection,
+        evidenceOutcome: GraphProcessEvidenceOutcome,
+        observedAt: Date
+    ) -> ExecutionReconciliationResult? {
+        guard let run = projection.run else {
+            return nil
+        }
+
+        var processExits = projection.processExits
+        var heartbeats = projection.heartbeats
+
+        switch evidenceOutcome {
+        case let .available(evidence),
+             let .stale(evidence, _):
+            processExits.append(contentsOf: evidence.processExits)
+            heartbeats.append(contentsOf: evidence.heartbeats)
+        case .unavailable,
+             .permissionDenied,
+             .adapterFailed,
+             .identityMismatch:
+            break
+        }
+
+        return GraphExecutionReconciler.reconcile(
+            ExecutionReconciliationInput(
+                run: run,
+                nodes: projection.nodes,
+                attempts: projection.attempts,
+                processExits: processExits,
+                heartbeats: heartbeats,
+                events: projection.executionEvents,
+                observedAt: observedAt
+            )
+        )
+    }
+
+    private func makeSnapshot(
+        projection: GraphExecutionProjection,
+        createdAt: Date
+    ) -> GraphExecutionSnapshot? {
+        guard let graphDefinitionVersion =
+                projection.graphDefinitionVersion,
+              let graphDefinitionDigest =
+                projection.graphDefinitionDigest else {
+            return nil
+        }
+
+        return GraphExecutionSnapshot(
+            runID: projection.runID,
+            streamVersion: projection.streamVersion,
+            graphDefinitionVersion: graphDefinitionVersion,
+            graphDefinitionDigest: graphDefinitionDigest,
+            projectedState: projection,
+            createdAt: createdAt,
+            createdBy: snapshotProducer,
+            checkpointNamespace: projection.checkpointNamespace,
+            namedCheckpoints: projection.namedCheckpoints
+        )
+    }
+
+    private func telemetryRecord(
+        operation: GraphTelemetryOperation,
+        phase: GraphTelemetryPhase,
+        runID: String,
+        streamVersion: UInt64? = nil
+    ) -> GraphTelemetryRecord {
+        var attributes = [
+            GraphTelemetryAttribute.runID: runID,
+        ]
+
+        if let streamVersion {
+            attributes[GraphTelemetryAttribute.streamVersion] =
+                String(streamVersion)
+        }
+
+        return GraphTelemetryRecord(
+            operation: operation,
+            phase: phase,
+            attributes: attributes
+        )
+    }
+}

--- a/Sources/OpenIslandCore/GraphExecutionState.swift
+++ b/Sources/OpenIslandCore/GraphExecutionState.swift
@@ -307,6 +307,10 @@ public enum GraphExecutionReconciler {
                 reconciledNode.activeAttemptID = attempt.id
 
                 if attempt.state != .pending {
+                    if reconciledNode.state != attempt.state {
+                        reconciledNode.updatedAt = input.observedAt
+                    }
+
                     reconciledNode.state = attempt.state
                 }
             }
@@ -447,8 +451,28 @@ public enum GraphExecutionReconciler {
                     return $0.observedAt < $1.observedAt
                 }
 
-                return $0.processIdentity.launchID
-                    < $1.processIdentity.launchID
+                if $0.processIdentity != $1.processIdentity {
+                    return processIdentityIsOrderedBefore(
+                        $0.processIdentity,
+                        $1.processIdentity
+                    )
+                }
+
+                if $0.exitCode != $1.exitCode {
+                    return optionalIsOrderedBefore(
+                        $0.exitCode,
+                        $1.exitCode
+                    )
+                }
+
+                if $0.signal != $1.signal {
+                    return optionalIsOrderedBefore(
+                        $0.signal,
+                        $1.signal
+                    )
+                }
+
+                return optionalIsOrderedBefore($0.reason, $1.reason)
             }
     }
 
@@ -472,8 +496,14 @@ public enum GraphExecutionReconciler {
                     return $0.observedAt < $1.observedAt
                 }
 
-                return $0.processIdentity.launchID
-                    < $1.processIdentity.launchID
+                if $0.validUntil != $1.validUntil {
+                    return $0.validUntil < $1.validUntil
+                }
+
+                return processIdentityIsOrderedBefore(
+                    $0.processIdentity,
+                    $1.processIdentity
+                )
             }
     }
 
@@ -516,7 +546,26 @@ public enum GraphExecutionReconciler {
             return lhs.occurredAt < rhs.occurredAt
         }
 
-        return lhs.id < rhs.id
+        if lhs.id != rhs.id {
+            return lhs.id < rhs.id
+        }
+
+        if lhs.kind != rhs.kind {
+            return lhs.kind.rawValue < rhs.kind.rawValue
+        }
+
+        if lhs.nodeID != rhs.nodeID {
+            return optionalIsOrderedBefore(lhs.nodeID, rhs.nodeID)
+        }
+
+        if lhs.attemptID != rhs.attemptID {
+            return optionalIsOrderedBefore(
+                lhs.attemptID,
+                rhs.attemptID
+            )
+        }
+
+        return optionalIsOrderedBefore(lhs.reason, rhs.reason)
     }
 
     private static func latestAttempt(
@@ -636,6 +685,42 @@ public enum GraphExecutionReconciler {
         }
 
         return "Process exited without a terminal execution event."
+    }
+
+    private static func processIdentityIsOrderedBefore(
+        _ lhs: ProcessIdentity,
+        _ rhs: ProcessIdentity
+    ) -> Bool {
+        if lhs.hostID != rhs.hostID {
+            return lhs.hostID < rhs.hostID
+        }
+
+        if lhs.launchID != rhs.launchID {
+            return lhs.launchID < rhs.launchID
+        }
+
+        if lhs.processID != rhs.processID {
+            return optionalIsOrderedBefore(
+                lhs.processID,
+                rhs.processID
+            )
+        }
+
+        return optionalIsOrderedBefore(lhs.startedAt, rhs.startedAt)
+    }
+
+    private static func optionalIsOrderedBefore<Value: Comparable>(
+        _ lhs: Value?,
+        _ rhs: Value?
+    ) -> Bool {
+        switch (lhs, rhs) {
+        case (.none, .some):
+            return true
+        case (.some, .none), (.none, .none):
+            return false
+        case let (.some(lhs), .some(rhs)):
+            return lhs < rhs
+        }
     }
 }
 

--- a/Sources/OpenIslandCore/GraphExecutionState.swift
+++ b/Sources/OpenIslandCore/GraphExecutionState.swift
@@ -1,0 +1,682 @@
+import Foundation
+
+public enum ReconciledExecutionState: String, Codable, CaseIterable, Sendable {
+    case pending
+    case ready
+    case running
+    case completed
+    case failed
+    case interrupted
+    case orphaned
+    case blocked
+    case cancelled
+
+    public var isTerminal: Bool {
+        switch self {
+        case .completed, .failed, .interrupted, .orphaned, .blocked, .cancelled:
+            return true
+        case .pending, .ready, .running:
+            return false
+        }
+    }
+
+    public var preventsDependentExecution: Bool {
+        switch self {
+        case .failed, .interrupted, .orphaned, .blocked, .cancelled:
+            return true
+        case .pending, .ready, .running, .completed:
+            return false
+        }
+    }
+}
+
+public struct GraphRun: Equatable, Identifiable, Codable, Sendable {
+    public let id: String
+    public let graphID: String
+    public var state: ReconciledExecutionState
+    public var nodeIDs: [String]
+    public let createdAt: Date
+    public var updatedAt: Date
+    public var startedAt: Date?
+    public var finishedAt: Date?
+
+    public init(
+        id: String,
+        graphID: String,
+        state: ReconciledExecutionState = .pending,
+        nodeIDs: [String],
+        createdAt: Date,
+        updatedAt: Date,
+        startedAt: Date? = nil,
+        finishedAt: Date? = nil
+    ) {
+        self.id = id
+        self.graphID = graphID
+        self.state = state
+        self.nodeIDs = nodeIDs
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.startedAt = startedAt
+        self.finishedAt = finishedAt
+    }
+}
+
+public struct GraphNode: Equatable, Identifiable, Codable, Sendable {
+    public let id: String
+    public let graphRunID: String
+    public var title: String
+    public var dependencyNodeIDs: [String]
+    public var executorID: String?
+    public var state: ReconciledExecutionState
+    public var activeAttemptID: String?
+    public var updatedAt: Date
+
+    public init(
+        id: String,
+        graphRunID: String,
+        title: String,
+        dependencyNodeIDs: [String] = [],
+        executorID: String? = nil,
+        state: ReconciledExecutionState = .pending,
+        activeAttemptID: String? = nil,
+        updatedAt: Date
+    ) {
+        self.id = id
+        self.graphRunID = graphRunID
+        self.title = title
+        self.dependencyNodeIDs = dependencyNodeIDs
+        self.executorID = executorID
+        self.state = state
+        self.activeAttemptID = activeAttemptID
+        self.updatedAt = updatedAt
+    }
+}
+
+public struct ProcessIdentity: Equatable, Codable, Sendable {
+    public let hostID: String
+    public let launchID: String
+    public let processID: Int32?
+    public let startedAt: Date?
+
+    public init(
+        hostID: String,
+        launchID: String,
+        processID: Int32? = nil,
+        startedAt: Date? = nil
+    ) {
+        self.hostID = hostID
+        self.launchID = launchID
+        self.processID = processID
+        self.startedAt = startedAt
+    }
+}
+
+public struct ExecutionAttempt: Equatable, Identifiable, Codable, Sendable {
+    public let id: String
+    public let graphRunID: String
+    public let nodeID: String
+    public let ordinal: Int
+    public var state: ReconciledExecutionState
+    public var processIdentity: ProcessIdentity?
+    public let createdAt: Date
+    public var updatedAt: Date
+    public var startedAt: Date?
+    public var finishedAt: Date?
+    public var statusReason: String?
+
+    public init(
+        id: String,
+        graphRunID: String,
+        nodeID: String,
+        ordinal: Int,
+        state: ReconciledExecutionState = .pending,
+        processIdentity: ProcessIdentity? = nil,
+        createdAt: Date,
+        updatedAt: Date,
+        startedAt: Date? = nil,
+        finishedAt: Date? = nil,
+        statusReason: String? = nil
+    ) {
+        self.id = id
+        self.graphRunID = graphRunID
+        self.nodeID = nodeID
+        self.ordinal = ordinal
+        self.state = state
+        self.processIdentity = processIdentity
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.startedAt = startedAt
+        self.finishedAt = finishedAt
+        self.statusReason = statusReason
+    }
+}
+
+public struct ProcessExit: Equatable, Codable, Sendable {
+    public let attemptID: String
+    public let processIdentity: ProcessIdentity
+    public let observedAt: Date
+    public let exitCode: Int32?
+    public let signal: Int32?
+    public let reason: String?
+
+    public init(
+        attemptID: String,
+        processIdentity: ProcessIdentity,
+        observedAt: Date,
+        exitCode: Int32? = nil,
+        signal: Int32? = nil,
+        reason: String? = nil
+    ) {
+        self.attemptID = attemptID
+        self.processIdentity = processIdentity
+        self.observedAt = observedAt
+        self.exitCode = exitCode
+        self.signal = signal
+        self.reason = reason
+    }
+}
+
+public struct ExecutorHeartbeat: Equatable, Codable, Sendable {
+    public let attemptID: String
+    public let processIdentity: ProcessIdentity
+    public let observedAt: Date
+    public let validUntil: Date
+
+    public init(
+        attemptID: String,
+        processIdentity: ProcessIdentity,
+        observedAt: Date,
+        validUntil: Date
+    ) {
+        self.attemptID = attemptID
+        self.processIdentity = processIdentity
+        self.observedAt = observedAt
+        self.validUntil = validUntil
+    }
+}
+
+public enum ExecutionEventKind: String, Codable, CaseIterable, Sendable {
+    case runStarted
+    case runCompleted
+    case runFailed
+    case runInterrupted
+    case runCancelled
+    case attemptStarted
+    case attemptCompleted
+    case attemptFailed
+    case attemptInterrupted
+    case attemptCancelled
+}
+
+public struct ExecutionEvent: Equatable, Identifiable, Codable, Sendable {
+    public let id: String
+    public let graphRunID: String
+    public let nodeID: String?
+    public let attemptID: String?
+    public let sequence: UInt64
+    public let occurredAt: Date
+    public let kind: ExecutionEventKind
+    public let reason: String?
+
+    public init(
+        id: String,
+        graphRunID: String,
+        nodeID: String? = nil,
+        attemptID: String? = nil,
+        sequence: UInt64,
+        occurredAt: Date,
+        kind: ExecutionEventKind,
+        reason: String? = nil
+    ) {
+        self.id = id
+        self.graphRunID = graphRunID
+        self.nodeID = nodeID
+        self.attemptID = attemptID
+        self.sequence = sequence
+        self.occurredAt = occurredAt
+        self.kind = kind
+        self.reason = reason
+    }
+}
+
+public struct ExecutionReconciliationInput: Equatable, Codable, Sendable {
+    public var run: GraphRun
+    public var nodes: [GraphNode]
+    public var attempts: [ExecutionAttempt]
+    public var processExits: [ProcessExit]
+    public var heartbeats: [ExecutorHeartbeat]
+    public var events: [ExecutionEvent]
+    public let observedAt: Date
+
+    public init(
+        run: GraphRun,
+        nodes: [GraphNode],
+        attempts: [ExecutionAttempt],
+        processExits: [ProcessExit] = [],
+        heartbeats: [ExecutorHeartbeat] = [],
+        events: [ExecutionEvent] = [],
+        observedAt: Date
+    ) {
+        self.run = run
+        self.nodes = nodes
+        self.attempts = attempts
+        self.processExits = processExits
+        self.heartbeats = heartbeats
+        self.events = events
+        self.observedAt = observedAt
+    }
+}
+
+public struct ExecutionReconciliationResult: Equatable, Codable, Sendable {
+    public var run: GraphRun
+    public var nodes: [GraphNode]
+    public var attempts: [ExecutionAttempt]
+
+    public init(
+        run: GraphRun,
+        nodes: [GraphNode],
+        attempts: [ExecutionAttempt]
+    ) {
+        self.run = run
+        self.nodes = nodes
+        self.attempts = attempts
+    }
+}
+
+public enum GraphExecutionReconciler {
+    public static func reconcile(
+        _ input: ExecutionReconciliationInput
+    ) -> ExecutionReconciliationResult {
+        let reconciledAttempts = input.attempts.map {
+            reconcileAttempt($0, input: input)
+        }
+        let latestAttempts = Dictionary(
+            grouping: reconciledAttempts.filter {
+                $0.graphRunID == input.run.id
+            },
+            by: \.nodeID
+        ).compactMapValues(latestAttempt)
+        var reconciledNodes = input.nodes.map { node in
+            var reconciledNode = node
+
+            if let attempt = latestAttempts[node.id] {
+                if reconciledNode.activeAttemptID != attempt.id {
+                    reconciledNode.updatedAt = input.observedAt
+                }
+
+                reconciledNode.activeAttemptID = attempt.id
+
+                if attempt.state != .pending {
+                    reconciledNode.state = attempt.state
+                }
+            }
+
+            return reconciledNode
+        }
+
+        reconcileDependencyStates(
+            nodes: &reconciledNodes,
+            latestAttempts: latestAttempts,
+            observedAt: input.observedAt
+        )
+
+        var run = input.run
+        let state = reconcileRunState(
+            runID: run.id,
+            nodes: reconciledNodes,
+            events: input.events
+        )
+
+        if run.state != state {
+            run.state = state
+            run.updatedAt = input.observedAt
+            run.finishedAt = state.isTerminal ? input.observedAt : nil
+        }
+
+        return ExecutionReconciliationResult(
+            run: run,
+            nodes: reconciledNodes,
+            attempts: reconciledAttempts
+        )
+    }
+
+    private static func reconcileAttempt(
+        _ attempt: ExecutionAttempt,
+        input: ExecutionReconciliationInput
+    ) -> ExecutionAttempt {
+        var result = attempt
+        let attemptEvents = input.events.filter {
+            $0.graphRunID == attempt.graphRunID
+                && $0.attemptID == attempt.id
+        }
+
+        if let event = latestTerminalAttemptEvent(attemptEvents) {
+            apply(
+                state: event.kind.attemptTerminalState!,
+                at: event.occurredAt,
+                reason: event.reason,
+                to: &result
+            )
+            return result
+        }
+
+        if let exit = latestMatchingExit(for: attempt, exits: input.processExits) {
+            result.processIdentity = exit.processIdentity
+            apply(
+                state: .interrupted,
+                at: exit.observedAt,
+                reason: exit.reason ?? processExitReason(exit),
+                to: &result
+            )
+            return result
+        }
+
+        if let heartbeat = latestValidHeartbeat(
+            for: attempt,
+            heartbeats: input.heartbeats,
+            observedAt: input.observedAt
+        ) {
+            result.processIdentity = heartbeat.processIdentity
+            apply(
+                state: .running,
+                at: heartbeat.observedAt,
+                reason: nil,
+                to: &result
+            )
+            result.finishedAt = nil
+            return result
+        }
+
+        let hasStartedEvent = attemptEvents.contains {
+            $0.kind == .attemptStarted
+        }
+
+        if attempt.state == .running || hasStartedEvent {
+            let unsupportedState: ReconciledExecutionState =
+                attempt.processIdentity == nil ? .interrupted : .orphaned
+            let reason = unsupportedState == .orphaned
+                ? "No current executor evidence matches the recorded process."
+                : "The attempt was running without recoverable process identity."
+            apply(
+                state: unsupportedState,
+                at: input.observedAt,
+                reason: reason,
+                to: &result
+            )
+        }
+
+        return result
+    }
+
+    private static func apply(
+        state: ReconciledExecutionState,
+        at timestamp: Date,
+        reason: String?,
+        to attempt: inout ExecutionAttempt
+    ) {
+        if attempt.state != state {
+            attempt.state = state
+            attempt.updatedAt = timestamp
+        }
+
+        if state == .running {
+            attempt.startedAt = attempt.startedAt ?? timestamp
+        }
+
+        if state.isTerminal {
+            attempt.finishedAt = timestamp
+        }
+
+        attempt.statusReason = reason
+    }
+
+    private static func latestMatchingExit(
+        for attempt: ExecutionAttempt,
+        exits: [ProcessExit]
+    ) -> ProcessExit? {
+        exits
+            .filter {
+                $0.attemptID == attempt.id
+                    && evidenceMatches(
+                        recorded: attempt.processIdentity,
+                        observed: $0.processIdentity
+                    )
+            }
+            .max {
+                if $0.observedAt != $1.observedAt {
+                    return $0.observedAt < $1.observedAt
+                }
+
+                return $0.processIdentity.launchID
+                    < $1.processIdentity.launchID
+            }
+    }
+
+    private static func latestValidHeartbeat(
+        for attempt: ExecutionAttempt,
+        heartbeats: [ExecutorHeartbeat],
+        observedAt: Date
+    ) -> ExecutorHeartbeat? {
+        heartbeats
+            .filter {
+                $0.attemptID == attempt.id
+                    && $0.observedAt <= observedAt
+                    && observedAt <= $0.validUntil
+                    && evidenceMatches(
+                        recorded: attempt.processIdentity,
+                        observed: $0.processIdentity
+                    )
+            }
+            .max {
+                if $0.observedAt != $1.observedAt {
+                    return $0.observedAt < $1.observedAt
+                }
+
+                return $0.processIdentity.launchID
+                    < $1.processIdentity.launchID
+            }
+    }
+
+    private static func evidenceMatches(
+        recorded: ProcessIdentity?,
+        observed: ProcessIdentity
+    ) -> Bool {
+        recorded == nil || recorded == observed
+    }
+
+    private static func latestTerminalAttemptEvent(
+        _ events: [ExecutionEvent]
+    ) -> ExecutionEvent? {
+        events
+            .filter { $0.kind.attemptTerminalState != nil }
+            .max(by: eventIsOrderedBefore)
+    }
+
+    private static func latestTerminalRunEvent(
+        runID: String,
+        events: [ExecutionEvent]
+    ) -> ExecutionEvent? {
+        events
+            .filter {
+                $0.graphRunID == runID
+                    && $0.kind.runTerminalState != nil
+            }
+            .max(by: eventIsOrderedBefore)
+    }
+
+    private static func eventIsOrderedBefore(
+        _ lhs: ExecutionEvent,
+        _ rhs: ExecutionEvent
+    ) -> Bool {
+        if lhs.sequence != rhs.sequence {
+            return lhs.sequence < rhs.sequence
+        }
+
+        if lhs.occurredAt != rhs.occurredAt {
+            return lhs.occurredAt < rhs.occurredAt
+        }
+
+        return lhs.id < rhs.id
+    }
+
+    private static func latestAttempt(
+        _ attempts: [ExecutionAttempt]
+    ) -> ExecutionAttempt? {
+        attempts.max {
+            if $0.ordinal != $1.ordinal {
+                return $0.ordinal < $1.ordinal
+            }
+
+            if $0.createdAt != $1.createdAt {
+                return $0.createdAt < $1.createdAt
+            }
+
+            return $0.id < $1.id
+        }
+    }
+
+    private static func reconcileDependencyStates(
+        nodes: inout [GraphNode],
+        latestAttempts: [String: ExecutionAttempt],
+        observedAt: Date
+    ) {
+        let orderedIndices = nodes.indices.sorted {
+            nodes[$0].id < nodes[$1].id
+        }
+
+        for _ in 0..<nodes.count {
+            let previousStates = Dictionary(
+                uniqueKeysWithValues: nodes.map { ($0.id, $0.state) }
+            )
+            var changed = false
+
+            for index in orderedIndices {
+                let node = nodes[index]
+                let latestState = latestAttempts[node.id]?.state
+
+                guard latestState == nil
+                        || latestState == .pending
+                        || latestState == .ready
+                        || latestState == .blocked else {
+                    continue
+                }
+
+                let dependencyStates = node.dependencyNodeIDs.map {
+                    previousStates[$0]
+                }
+                let state: ReconciledExecutionState
+
+                if dependencyStates.contains(where: { $0 == nil })
+                    || dependencyStates.contains(where: {
+                        $0?.preventsDependentExecution == true
+                    }) {
+                    state = .blocked
+                } else if dependencyStates.allSatisfy({ $0 == .completed }) {
+                    state = .ready
+                } else {
+                    state = .pending
+                }
+
+                if nodes[index].state != state {
+                    nodes[index].state = state
+                    nodes[index].updatedAt = observedAt
+                    changed = true
+                }
+            }
+
+            if !changed {
+                break
+            }
+        }
+    }
+
+    private static func reconcileRunState(
+        runID: String,
+        nodes: [GraphNode],
+        events: [ExecutionEvent]
+    ) -> ReconciledExecutionState {
+        if let event = latestTerminalRunEvent(
+            runID: runID,
+            events: events
+        ) {
+            return event.kind.runTerminalState!
+        }
+
+        let states = nodes.map(\.state)
+
+        if !states.isEmpty && states.allSatisfy({ $0 == .completed }) {
+            return .completed
+        }
+
+        if states.contains(.running) {
+            return .running
+        }
+
+        for state in [
+            ReconciledExecutionState.failed,
+            .interrupted,
+            .orphaned,
+            .cancelled,
+            .blocked,
+            .ready,
+        ] where states.contains(state) {
+            return state
+        }
+
+        return .pending
+    }
+
+    private static func processExitReason(_ exit: ProcessExit) -> String {
+        if let signal = exit.signal {
+            return "Process exited after signal \(signal)."
+        }
+
+        if let exitCode = exit.exitCode {
+            return "Process exited with code \(exitCode) without a terminal execution event."
+        }
+
+        return "Process exited without a terminal execution event."
+    }
+}
+
+private extension ExecutionEventKind {
+    var attemptTerminalState: ReconciledExecutionState? {
+        switch self {
+        case .attemptCompleted:
+            return .completed
+        case .attemptFailed:
+            return .failed
+        case .attemptInterrupted:
+            return .interrupted
+        case .attemptCancelled:
+            return .cancelled
+        case .runStarted,
+             .runCompleted,
+             .runFailed,
+             .runInterrupted,
+             .runCancelled,
+             .attemptStarted:
+            return nil
+        }
+    }
+
+    var runTerminalState: ReconciledExecutionState? {
+        switch self {
+        case .runCompleted:
+            return .completed
+        case .runFailed:
+            return .failed
+        case .runInterrupted:
+            return .interrupted
+        case .runCancelled:
+            return .cancelled
+        case .runStarted,
+             .attemptStarted,
+             .attemptCompleted,
+             .attemptFailed,
+             .attemptInterrupted,
+             .attemptCancelled:
+            return nil
+        }
+    }
+}

--- a/Sources/OpenIslandCore/GraphExecutionState.swift
+++ b/Sources/OpenIslandCore/GraphExecutionState.swift
@@ -205,6 +205,7 @@ public enum ExecutionEventKind: String, Codable, CaseIterable, Sendable {
     case attemptCompleted
     case attemptFailed
     case attemptInterrupted
+    case attemptOrphaned
     case attemptCancelled
 }
 
@@ -733,6 +734,8 @@ private extension ExecutionEventKind {
             return .failed
         case .attemptInterrupted:
             return .interrupted
+        case .attemptOrphaned:
+            return .orphaned
         case .attemptCancelled:
             return .cancelled
         case .runStarted,
@@ -760,6 +763,7 @@ private extension ExecutionEventKind {
              .attemptCompleted,
              .attemptFailed,
              .attemptInterrupted,
+             .attemptOrphaned,
              .attemptCancelled:
             return nil
         }

--- a/Sources/OpenIslandCore/GraphExecutorAdapter.swift
+++ b/Sources/OpenIslandCore/GraphExecutorAdapter.swift
@@ -352,6 +352,7 @@ public protocol GraphExecutorAdapter: Sendable {
 
 public enum GraphExecutorAdapterError: Error, Equatable, Sendable {
     case unavailable
+    case unsupportedAdapter(String)
     case simulatedCrash(String)
     case invalidScript(String)
 }
@@ -361,6 +362,8 @@ extension GraphExecutorAdapterError: LocalizedError {
         switch self {
         case .unavailable:
             "Executor adapter is unavailable."
+        case let .unsupportedAdapter(kind):
+            "Executor adapter \(kind) is not configured."
         case let .simulatedCrash(boundary):
             "Executor adapter crashed at \(boundary)."
         case let .invalidScript(message):

--- a/Sources/OpenIslandCore/GraphExecutorAdapter.swift
+++ b/Sources/OpenIslandCore/GraphExecutorAdapter.swift
@@ -108,6 +108,7 @@ public struct GraphExecutorCommandContext:
     public let timeoutPolicy: GraphExecutionTimeoutPolicy
     public let correlation: GraphExecutorCorrelationMetadata
     public let priorObservationCount: Int
+    public let logicalTime: Date
 
     public init(
         identity: GraphExecutorInteractionIdentity,
@@ -119,7 +120,8 @@ public struct GraphExecutorCommandContext:
         cancellation: GraphCancellationRecord?,
         timeoutPolicy: GraphExecutionTimeoutPolicy,
         correlation: GraphExecutorCorrelationMetadata,
-        priorObservationCount: Int
+        priorObservationCount: Int,
+        logicalTime: Date
     ) {
         self.identity = identity
         self.capabilityRequirement = capabilityRequirement.sorted()
@@ -131,6 +133,7 @@ public struct GraphExecutorCommandContext:
         self.timeoutPolicy = timeoutPolicy
         self.correlation = correlation
         self.priorObservationCount = priorObservationCount
+        self.logicalTime = logicalTime
     }
 }
 

--- a/Sources/OpenIslandCore/GraphExecutorAdapter.swift
+++ b/Sources/OpenIslandCore/GraphExecutorAdapter.swift
@@ -1,0 +1,367 @@
+import Foundation
+
+public enum GraphExecutorOperation: String, Codable, CaseIterable, Sendable {
+    case prepare
+    case start
+    case observe
+    case requestCancellation = "request_cancellation"
+    case collectResult = "collect_result"
+    case cleanup
+    case recover
+}
+
+public enum GraphExecutorResponseStatus:
+    String,
+    Codable,
+    CaseIterable,
+    Sendable
+{
+    case accepted
+    case started
+    case stillRunning = "still_running"
+    case succeeded
+    case failed
+    case cancelled
+    case interrupted
+    case unavailable
+    case rejected
+    case identityMismatch = "identity_mismatch"
+    case staleClaim = "stale_claim"
+    case transientAdapterFailure = "transient_adapter_failure"
+
+    public var isTerminalObservation: Bool {
+        switch self {
+        case .succeeded, .failed, .cancelled, .interrupted:
+            true
+        case .accepted, .started, .stillRunning, .unavailable,
+             .rejected, .identityMismatch, .staleClaim,
+             .transientAdapterFailure:
+            false
+        }
+    }
+}
+
+public struct GraphExecutorInteractionIdentity:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let runID: String
+    public let nodeID: String
+    public let attemptID: String
+    public let attemptOrdinal: Int
+    public let claimID: String
+    public let leaseGeneration: UInt64
+    public let executorID: String
+
+    public init(
+        runID: String,
+        nodeID: String,
+        attemptID: String,
+        attemptOrdinal: Int,
+        claimID: String,
+        leaseGeneration: UInt64,
+        executorID: String
+    ) {
+        self.runID = runID
+        self.nodeID = nodeID
+        self.attemptID = attemptID
+        self.attemptOrdinal = attemptOrdinal
+        self.claimID = claimID
+        self.leaseGeneration = leaseGeneration
+        self.executorID = executorID
+    }
+}
+
+public struct GraphExecutorCorrelationMetadata:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let correlationID: String
+    public let causationID: String?
+    public let attributes: [String: String]
+
+    public init(
+        correlationID: String,
+        causationID: String? = nil,
+        attributes: [String: String] = [:]
+    ) {
+        self.correlationID = correlationID
+        self.causationID = causationID
+        self.attributes = attributes
+    }
+}
+
+public struct GraphExecutorCommandContext:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let identity: GraphExecutorInteractionIdentity
+    public let capabilityRequirement: [String]
+    public let specification: GraphImmutableExecutionSpecification
+    public let workspace: GraphExecutionWorkspaceContext
+    public let environmentAllowlist: [String]
+    public let inputArtifacts: [GraphArtifactReference]
+    public let cancellation: GraphCancellationRecord?
+    public let timeoutPolicy: GraphExecutionTimeoutPolicy
+    public let correlation: GraphExecutorCorrelationMetadata
+    public let priorObservationCount: Int
+
+    public init(
+        identity: GraphExecutorInteractionIdentity,
+        capabilityRequirement: [String],
+        specification: GraphImmutableExecutionSpecification,
+        workspace: GraphExecutionWorkspaceContext,
+        environmentAllowlist: [String],
+        inputArtifacts: [GraphArtifactReference],
+        cancellation: GraphCancellationRecord?,
+        timeoutPolicy: GraphExecutionTimeoutPolicy,
+        correlation: GraphExecutorCorrelationMetadata,
+        priorObservationCount: Int
+    ) {
+        self.identity = identity
+        self.capabilityRequirement = capabilityRequirement.sorted()
+        self.specification = specification
+        self.workspace = workspace
+        self.environmentAllowlist = environmentAllowlist.sorted()
+        self.inputArtifacts = inputArtifacts.sorted { $0.id < $1.id }
+        self.cancellation = cancellation
+        self.timeoutPolicy = timeoutPolicy
+        self.correlation = correlation
+        self.priorObservationCount = priorObservationCount
+    }
+}
+
+public struct GraphExecutorFailure: Equatable, Codable, Sendable {
+    public let category: String
+    public let retryable: Bool
+
+    public init(category: String, retryable: Bool) {
+        self.category = category
+        self.retryable = retryable
+    }
+}
+
+public struct GraphExecutorProducedArtifact:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let contentDigest: GraphContentDigest
+    public let mediaType: String
+    public let role: GraphArtifactRole
+    public let storage: GraphArtifactStorageLocator
+    public let sensitivity: GraphArtifactSensitivity
+
+    public init(
+        contentDigest: GraphContentDigest,
+        mediaType: String,
+        role: GraphArtifactRole,
+        storage: GraphArtifactStorageLocator,
+        sensitivity: GraphArtifactSensitivity = .internalUse
+    ) {
+        self.contentDigest = contentDigest
+        self.mediaType = mediaType
+        self.role = role
+        self.storage = storage
+        self.sensitivity = sensitivity
+    }
+}
+
+public struct GraphExecutorObservation: Equatable, Codable, Sendable {
+    public let schemaVersion: Int
+    public let id: String
+    public let operation: GraphExecutorOperation
+    public let identity: GraphExecutorInteractionIdentity
+    public let status: GraphExecutorResponseStatus
+    public let observedAt: Date
+    public let processIdentity: ProcessIdentity?
+    public let failure: GraphExecutorFailure?
+    public let artifacts: [GraphExecutorProducedArtifact]
+
+    public init(
+        schemaVersion: Int = GraphExecutionSchema.eventPayloadVersion,
+        id: String,
+        operation: GraphExecutorOperation,
+        identity: GraphExecutorInteractionIdentity,
+        status: GraphExecutorResponseStatus,
+        observedAt: Date,
+        processIdentity: ProcessIdentity? = nil,
+        failure: GraphExecutorFailure? = nil,
+        artifacts: [GraphExecutorProducedArtifact] = []
+    ) {
+        self.schemaVersion = schemaVersion
+        self.id = id
+        self.operation = operation
+        self.identity = identity
+        self.status = status
+        self.observedAt = observedAt
+        self.processIdentity = processIdentity
+        self.failure = failure
+        self.artifacts = artifacts.sorted {
+            if $0.role != $1.role {
+                return $0.role.rawValue < $1.role.rawValue
+            }
+            return $0.contentDigest.value < $1.contentDigest.value
+        }
+    }
+}
+
+public struct GraphExecutorPrepareRequest: Equatable, Sendable {
+    public let context: GraphExecutorCommandContext
+
+    public init(context: GraphExecutorCommandContext) {
+        self.context = context
+    }
+}
+
+public struct GraphExecutorPrepareResponse: Equatable, Sendable {
+    public let observation: GraphExecutorObservation
+
+    public init(observation: GraphExecutorObservation) {
+        self.observation = observation
+    }
+}
+
+public struct GraphExecutorStartRequest: Equatable, Sendable {
+    public let context: GraphExecutorCommandContext
+
+    public init(context: GraphExecutorCommandContext) {
+        self.context = context
+    }
+}
+
+public struct GraphExecutorStartResponse: Equatable, Sendable {
+    public let observation: GraphExecutorObservation
+
+    public init(observation: GraphExecutorObservation) {
+        self.observation = observation
+    }
+}
+
+public struct GraphExecutorObserveRequest: Equatable, Sendable {
+    public let context: GraphExecutorCommandContext
+
+    public init(context: GraphExecutorCommandContext) {
+        self.context = context
+    }
+}
+
+public struct GraphExecutorObserveResponse: Equatable, Sendable {
+    public let observation: GraphExecutorObservation
+
+    public init(observation: GraphExecutorObservation) {
+        self.observation = observation
+    }
+}
+
+public struct GraphExecutorCancellationRequest: Equatable, Sendable {
+    public let context: GraphExecutorCommandContext
+    public let cancellationRequestID: String
+
+    public init(
+        context: GraphExecutorCommandContext,
+        cancellationRequestID: String
+    ) {
+        self.context = context
+        self.cancellationRequestID = cancellationRequestID
+    }
+}
+
+public struct GraphExecutorCancellationResponse: Equatable, Sendable {
+    public let observation: GraphExecutorObservation
+
+    public init(observation: GraphExecutorObservation) {
+        self.observation = observation
+    }
+}
+
+public struct GraphExecutorCollectResultRequest: Equatable, Sendable {
+    public let context: GraphExecutorCommandContext
+
+    public init(context: GraphExecutorCommandContext) {
+        self.context = context
+    }
+}
+
+public struct GraphExecutorCollectResultResponse: Equatable, Sendable {
+    public let observation: GraphExecutorObservation
+
+    public init(observation: GraphExecutorObservation) {
+        self.observation = observation
+    }
+}
+
+public struct GraphExecutorCleanupRequest: Equatable, Sendable {
+    public let context: GraphExecutorCommandContext
+
+    public init(context: GraphExecutorCommandContext) {
+        self.context = context
+    }
+}
+
+public struct GraphExecutorCleanupResponse: Equatable, Sendable {
+    public let observation: GraphExecutorObservation
+
+    public init(observation: GraphExecutorObservation) {
+        self.observation = observation
+    }
+}
+
+public struct GraphExecutorRecoverRequest: Equatable, Sendable {
+    public let context: GraphExecutorCommandContext
+
+    public init(context: GraphExecutorCommandContext) {
+        self.context = context
+    }
+}
+
+public struct GraphExecutorRecoverResponse: Equatable, Sendable {
+    public let observation: GraphExecutorObservation
+
+    public init(observation: GraphExecutorObservation) {
+        self.observation = observation
+    }
+}
+
+public protocol GraphExecutorAdapter: Sendable {
+    var capabilities: GraphExecutorCapabilities { get }
+
+    func prepare(_ request: GraphExecutorPrepareRequest) async throws
+        -> GraphExecutorPrepareResponse
+    func start(_ request: GraphExecutorStartRequest) async throws
+        -> GraphExecutorStartResponse
+    func observe(_ request: GraphExecutorObserveRequest) async throws
+        -> GraphExecutorObserveResponse
+    func requestCancellation(
+        _ request: GraphExecutorCancellationRequest
+    ) async throws -> GraphExecutorCancellationResponse
+    func collectResult(
+        _ request: GraphExecutorCollectResultRequest
+    ) async throws -> GraphExecutorCollectResultResponse
+    func cleanup(_ request: GraphExecutorCleanupRequest) async throws
+        -> GraphExecutorCleanupResponse
+    func recover(_ request: GraphExecutorRecoverRequest) async throws
+        -> GraphExecutorRecoverResponse
+}
+
+public enum GraphExecutorAdapterError: Error, Equatable, Sendable {
+    case unavailable
+    case simulatedCrash(String)
+    case invalidScript(String)
+}
+
+extension GraphExecutorAdapterError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .unavailable:
+            "Executor adapter is unavailable."
+        case let .simulatedCrash(boundary):
+            "Executor adapter crashed at \(boundary)."
+        case let .invalidScript(message):
+            "Deterministic executor script is invalid: \(message)"
+        }
+    }
+}

--- a/Sources/OpenIslandCore/GraphExecutorRepository.swift
+++ b/Sources/OpenIslandCore/GraphExecutorRepository.swift
@@ -242,12 +242,32 @@ public struct DefaultGraphExecutorRepository:
             }
             return unchanged(loaded)
         }
-        let eventID = "executor-observation-\(observation.id)"
-        var events = [
+        var events: [GraphExecutionEventEnvelope] = []
+        if let processIdentity = observation.processIdentity,
+           loaded.projection.attempts.first(where: {
+               $0.id == observation.identity.attemptID
+           })?.processIdentity != processIdentity {
+            events.append(
+                envelope(
+                    id: "process-identity-\(processIdentity.launchID)",
+                    identity: observation.identity,
+                    sequence: loaded.version + 1,
+                    occurredAt: observation.observedAt,
+                    producer: command.producer,
+                    correlationID: command.correlationID,
+                    payload: .processIdentityObserved(
+                        GraphProcessIdentityObservedPayload(
+                            processIdentity: processIdentity
+                        )
+                    )
+                )
+            )
+        }
+        events.append(
             envelope(
-                id: eventID,
+                id: "executor-observation-\(observation.id)",
                 identity: observation.identity,
-                sequence: loaded.version + 1,
+                sequence: loaded.version + UInt64(events.count) + 1,
                 occurredAt: observation.observedAt,
                 producer: command.producer,
                 correlationID: command.correlationID,
@@ -256,8 +276,8 @@ public struct DefaultGraphExecutorRepository:
                         observation: observation
                     )
                 )
-            ),
-        ]
+            )
+        )
         for artifact in observation.artifacts {
             let reference = try artifactReference(
                 artifact,

--- a/Sources/OpenIslandCore/GraphExecutorRepository.swift
+++ b/Sources/OpenIslandCore/GraphExecutorRepository.swift
@@ -1,0 +1,716 @@
+import Foundation
+
+public enum GraphExecutorFencingReason:
+    String,
+    Codable,
+    CaseIterable,
+    Sendable
+{
+    case runMismatch = "run_mismatch"
+    case nodeMismatch = "node_mismatch"
+    case attemptMismatch = "attempt_mismatch"
+    case attemptOrdinalMismatch = "attempt_ordinal_mismatch"
+    case claimMismatch = "claim_mismatch"
+    case executorMismatch = "executor_mismatch"
+    case leaseGenerationMismatch = "lease_generation_mismatch"
+    case leaseExpired = "lease_expired"
+    case claimInactive = "claim_inactive"
+    case attemptTerminal = "attempt_terminal"
+    case completionBeforeStart = "completion_before_start"
+    case observationMissing = "observation_missing"
+    case observationConflict = "observation_conflict"
+    case terminalStatusMismatch = "terminal_status_mismatch"
+    case artifactProvenanceMismatch = "artifact_provenance_mismatch"
+    case cancellationOwnerMismatch = "cancellation_owner_mismatch"
+    case expectedVersionConflict = "expected_version_conflict"
+}
+
+public enum GraphExecutorRepositoryError: Error, Equatable, Sendable {
+    case rejected(GraphExecutorFencingReason, String)
+    case notFound(String)
+    case persistence(String)
+}
+
+extension GraphExecutorRepositoryError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .rejected(reason, message):
+            "Executor observation rejected [\(reason.rawValue)]: \(message)"
+        case let .notFound(runID):
+            "Graph run \(runID) was not found."
+        case let .persistence(message):
+            "Executor persistence failed: \(message)"
+        }
+    }
+}
+
+public struct GraphExecutorPersistenceResult: Equatable, Sendable {
+    public let appendResult: GraphExecutionAppendResult
+    public let projection: GraphExecutionProjection
+}
+
+public struct GraphExecutorStartCommand: Equatable, Sendable {
+    public let identity: GraphExecutorInteractionIdentity
+    public let expectedVersion: UInt64
+    public let logicalTime: Date
+    public let producer: GraphExecutionProducer
+    public let correlationID: String
+
+    public init(
+        identity: GraphExecutorInteractionIdentity,
+        expectedVersion: UInt64,
+        logicalTime: Date,
+        producer: GraphExecutionProducer,
+        correlationID: String
+    ) {
+        self.identity = identity
+        self.expectedVersion = expectedVersion
+        self.logicalTime = logicalTime
+        self.producer = producer
+        self.correlationID = correlationID
+    }
+}
+
+public struct GraphExecutorObservationCommand: Equatable, Sendable {
+    public let observation: GraphExecutorObservation
+    public let expectedVersion: UInt64
+    public let producer: GraphExecutionProducer
+    public let correlationID: String
+
+    public init(
+        observation: GraphExecutorObservation,
+        expectedVersion: UInt64,
+        producer: GraphExecutionProducer,
+        correlationID: String
+    ) {
+        self.observation = observation
+        self.expectedVersion = expectedVersion
+        self.producer = producer
+        self.correlationID = correlationID
+    }
+}
+
+public struct GraphExecutorTerminalDeclaration: Equatable, Sendable {
+    public let identity: GraphExecutorInteractionIdentity
+    public let observationID: String
+    public let state: ReconciledExecutionState
+    public let reason: String?
+    public let expectedVersion: UInt64
+    public let logicalTime: Date
+    public let producer: GraphExecutionProducer
+    public let correlationID: String
+
+    public init(
+        identity: GraphExecutorInteractionIdentity,
+        observationID: String,
+        state: ReconciledExecutionState,
+        reason: String? = nil,
+        expectedVersion: UInt64,
+        logicalTime: Date,
+        producer: GraphExecutionProducer,
+        correlationID: String
+    ) {
+        self.identity = identity
+        self.observationID = observationID
+        self.state = state
+        self.reason = reason
+        self.expectedVersion = expectedVersion
+        self.logicalTime = logicalTime
+        self.producer = producer
+        self.correlationID = correlationID
+    }
+}
+
+public struct GraphExecutorCancellationAcknowledgement:
+    Equatable,
+    Sendable
+{
+    public let identity: GraphExecutorInteractionIdentity
+    public let requestID: String
+    public let expectedVersion: UInt64
+    public let logicalTime: Date
+    public let producer: GraphExecutionProducer
+
+    public init(
+        identity: GraphExecutorInteractionIdentity,
+        requestID: String,
+        expectedVersion: UInt64,
+        logicalTime: Date,
+        producer: GraphExecutionProducer
+    ) {
+        self.identity = identity
+        self.requestID = requestID
+        self.expectedVersion = expectedVersion
+        self.logicalTime = logicalTime
+        self.producer = producer
+    }
+}
+
+public protocol GraphExecutorPersisting: Sendable {
+    func recordStartRequest(
+        _ command: GraphExecutorStartCommand
+    ) async throws -> GraphExecutorPersistenceResult
+
+    func recordObservation(
+        _ command: GraphExecutorObservationCommand
+    ) async throws -> GraphExecutorPersistenceResult
+
+    func declareTerminal(
+        _ declaration: GraphExecutorTerminalDeclaration
+    ) async throws -> GraphExecutorPersistenceResult
+
+    func acknowledgeCancellation(
+        _ acknowledgement: GraphExecutorCancellationAcknowledgement
+    ) async throws -> GraphExecutorPersistenceResult
+}
+
+public struct DefaultGraphExecutorRepository:
+    GraphExecutorPersisting,
+    Sendable
+{
+    private let eventStore: any GraphExecutionEventStore
+
+    public init(eventStore: any GraphExecutionEventStore) {
+        self.eventStore = eventStore
+    }
+
+    public func recordStartRequest(
+        _ command: GraphExecutorStartCommand
+    ) async throws -> GraphExecutorPersistenceResult {
+        let loaded = try await load(command.identity.runID)
+        try requireVersion(command.expectedVersion, loaded.version)
+        _ = try currentOwnership(
+            command.identity,
+            at: command.logicalTime,
+            projection: loaded.projection
+        )
+        let eventID = startEventID(command.identity)
+        if let existing = loaded.events.first(where: { $0.id == eventID }) {
+            guard case let .attemptStarting(payload) = existing.payload,
+                  payload.identity == command.identity else {
+                throw rejected(
+                    .observationConflict,
+                    "start request identity conflicts with durable history."
+                )
+            }
+            return unchanged(loaded)
+        }
+        guard let attempt = loaded.projection.attempts.first(where: {
+            $0.id == command.identity.attemptID
+        }), !attempt.state.isTerminal else {
+            throw rejected(
+                .attemptTerminal,
+                "terminal attempts cannot be started."
+            )
+        }
+        let event = envelope(
+            id: eventID,
+            identity: command.identity,
+            sequence: loaded.version + 1,
+            occurredAt: command.logicalTime,
+            producer: command.producer,
+            correlationID: command.correlationID,
+            payload: .attemptStarting(
+                GraphAttemptStartingPayload(
+                    reason: "executor_start_requested",
+                    identity: command.identity
+                )
+            )
+        )
+        return try await append([event], loaded: loaded)
+    }
+
+    public func recordObservation(
+        _ command: GraphExecutorObservationCommand
+    ) async throws -> GraphExecutorPersistenceResult {
+        let observation = command.observation
+        let loaded = try await load(observation.identity.runID)
+        try requireVersion(command.expectedVersion, loaded.version)
+        _ = try currentOwnership(
+            observation.identity,
+            at: observation.observedAt,
+            projection: loaded.projection
+        )
+        if let existing = loaded.projection.executorObservations.first(
+            where: { $0.id == observation.id }
+        ) {
+            guard existing == observation else {
+                throw rejected(
+                    .observationConflict,
+                    "observation ID was reused with different content."
+                )
+            }
+            return unchanged(loaded)
+        }
+        let eventID = "executor-observation-\(observation.id)"
+        var events = [
+            envelope(
+                id: eventID,
+                identity: observation.identity,
+                sequence: loaded.version + 1,
+                occurredAt: observation.observedAt,
+                producer: command.producer,
+                correlationID: command.correlationID,
+                payload: .executorObservationRecorded(
+                    GraphExecutorObservationPayload(
+                        observation: observation
+                    )
+                )
+            ),
+        ]
+        for artifact in observation.artifacts {
+            let reference = try artifactReference(
+                artifact,
+                observation: observation
+            )
+            events.append(
+                envelope(
+                    id: "artifact-event-\(reference.id)",
+                    identity: observation.identity,
+                    sequence: loaded.version
+                        + UInt64(events.count) + 1,
+                    occurredAt: observation.observedAt,
+                    producer: command.producer,
+                    correlationID: command.correlationID,
+                    payload: .artifactRecorded(
+                        GraphArtifactRecordedPayload(
+                            artifact: reference
+                        )
+                    )
+                )
+            )
+        }
+        return try await append(events, loaded: loaded)
+    }
+
+    public func declareTerminal(
+        _ declaration: GraphExecutorTerminalDeclaration
+    ) async throws -> GraphExecutorPersistenceResult {
+        let loaded = try await load(declaration.identity.runID)
+        let terminalID = terminalEventID(declaration.identity)
+        if let existing = loaded.events.first(where: {
+            $0.id == terminalID
+        }) {
+            guard terminalState(existing.payload) == declaration.state else {
+                throw rejected(
+                    .observationConflict,
+                    "terminal declaration conflicts with durable history."
+                )
+            }
+            return unchanged(loaded)
+        }
+        try requireVersion(declaration.expectedVersion, loaded.version)
+        guard [.completed, .failed, .interrupted, .orphaned, .cancelled]
+            .contains(declaration.state) else {
+            throw rejected(
+                .terminalStatusMismatch,
+                "requested state is not terminal."
+            )
+        }
+        let claim = try currentOwnership(
+            declaration.identity,
+            at: declaration.logicalTime,
+            projection: loaded.projection
+        )
+        guard let lifecycle = loaded.projection.attemptLifecycles.first(
+            where: { $0.attemptID == declaration.identity.attemptID }
+        ), [.startRequested, .started, .running, .cancellationRequested]
+            .contains(lifecycle.phase) else {
+            throw rejected(
+                .completionBeforeStart,
+                "terminal declaration requires a durable start request."
+            )
+        }
+        guard let observation = loaded.projection.executorObservations.first(
+            where: { $0.id == declaration.observationID }
+        ) else {
+            throw rejected(
+                .observationMissing,
+                "terminal declaration requires a durable observation."
+            )
+        }
+        guard observation.identity == declaration.identity else {
+            throw rejected(
+                .claimMismatch,
+                "terminal observation belongs to another execution identity."
+            )
+        }
+        guard Self.state(for: observation.status) == declaration.state else {
+            throw rejected(
+                .terminalStatusMismatch,
+                "observation status does not justify the declaration."
+            )
+        }
+        let artifactIDs = loaded.projection.artifacts.filter {
+            $0.producingAttemptID == declaration.identity.attemptID
+                && $0.producingClaimID == declaration.identity.claimID
+        }.map(\.id).sorted()
+        let attemptTerminalPayload = GraphAttemptTerminalPayload(
+            reason: declaration.reason ?? observation.failure?.category,
+            artifactIDs: artifactIDs
+        )
+        let terminalEvent = envelope(
+            id: terminalID,
+            identity: declaration.identity,
+            sequence: loaded.version + 1,
+            occurredAt: declaration.logicalTime,
+            producer: declaration.producer,
+            correlationID: declaration.correlationID,
+            payload: terminalPayload(
+                state: declaration.state,
+                payload: attemptTerminalPayload
+            )
+        )
+        let releaseEvent = envelope(
+            id: "claim-release-\(claim.id)-\(claim.leaseGeneration)",
+            identity: declaration.identity,
+            sequence: loaded.version + 2,
+            occurredAt: declaration.logicalTime,
+            producer: declaration.producer,
+            correlationID: declaration.correlationID,
+            payload: .executorClaimReleased(
+                GraphExecutorLeaseEndedPayload(
+                    claimID: claim.id,
+                    leaseGeneration: claim.leaseGeneration,
+                    reason: .claimReleased
+                )
+            )
+        )
+        return try await append(
+            [terminalEvent, releaseEvent],
+            loaded: loaded
+        )
+    }
+
+    public func acknowledgeCancellation(
+        _ acknowledgement: GraphExecutorCancellationAcknowledgement
+    ) async throws -> GraphExecutorPersistenceResult {
+        let loaded = try await load(acknowledgement.identity.runID)
+        try requireVersion(acknowledgement.expectedVersion, loaded.version)
+        _ = try currentOwnership(
+            acknowledgement.identity,
+            at: acknowledgement.logicalTime,
+            projection: loaded.projection
+        )
+        guard let cancellation = loaded.projection.scheduling
+            .cancellations.first(where: {
+                $0.id == acknowledgement.requestID
+            }), cancellation.claimID == acknowledgement.identity.claimID,
+            cancellation.attemptID == acknowledgement.identity.attemptID
+        else {
+            throw rejected(
+                .cancellationOwnerMismatch,
+                "cancellation does not belong to this execution identity."
+            )
+        }
+        if cancellation.state == .acknowledged {
+            guard cancellation.acknowledgedByExecutorID
+                    == acknowledgement.identity.executorID else {
+                throw rejected(
+                    .cancellationOwnerMismatch,
+                    "another executor acknowledged cancellation."
+                )
+            }
+            return unchanged(loaded)
+        }
+        let event = envelope(
+            id: "cancellation-ack-\(acknowledgement.requestID)",
+            identity: acknowledgement.identity,
+            sequence: loaded.version + 1,
+            occurredAt: acknowledgement.logicalTime,
+            producer: acknowledgement.producer,
+            correlationID: acknowledgement.requestID,
+            payload: .cancellationAcknowledged(
+                GraphCancellationAcknowledgedPayload(
+                    requestID: acknowledgement.requestID,
+                    claimID: acknowledgement.identity.claimID,
+                    executorID: acknowledgement.identity.executorID,
+                    acknowledgedAt: acknowledgement.logicalTime
+                )
+            )
+        )
+        return try await append([event], loaded: loaded)
+    }
+
+    private struct Loaded {
+        let version: UInt64
+        let events: [GraphExecutionEventEnvelope]
+        let projection: GraphExecutionProjection
+    }
+
+    private func load(_ runID: String) async throws -> Loaded {
+        do {
+            let stream = try await eventStore.read(
+                runID: runID,
+                afterVersion: 0
+            )
+            guard !stream.events.isEmpty else {
+                throw GraphExecutorRepositoryError.notFound(runID)
+            }
+            return Loaded(
+                version: stream.currentVersion,
+                events: stream.events,
+                projection: try GraphExecutionProjector.replay(
+                    runID: runID,
+                    events: stream.events
+                ).projection
+            )
+        } catch let error as GraphExecutorRepositoryError {
+            throw error
+        } catch {
+            throw GraphExecutorRepositoryError.persistence(
+                error.localizedDescription
+            )
+        }
+    }
+
+    private func currentOwnership(
+        _ identity: GraphExecutorInteractionIdentity,
+        at logicalTime: Date,
+        projection: GraphExecutionProjection
+    ) throws -> GraphExecutorClaim {
+        guard projection.runID == identity.runID else {
+            throw rejected(.runMismatch, "run identity does not match.")
+        }
+        guard let attempt = projection.attempts.first(where: {
+            $0.id == identity.attemptID
+        }) else {
+            throw rejected(.attemptMismatch, "attempt does not exist.")
+        }
+        guard attempt.nodeID == identity.nodeID else {
+            throw rejected(.nodeMismatch, "node identity does not match.")
+        }
+        guard attempt.ordinal == identity.attemptOrdinal else {
+            throw rejected(
+                .attemptOrdinalMismatch,
+                "attempt ordinal does not match."
+            )
+        }
+        guard let record = projection.scheduling.claims.first(where: {
+            $0.claim.id == identity.claimID
+        }) else {
+            throw rejected(.claimMismatch, "claim does not exist.")
+        }
+        let claim = record.claim
+        guard claim.nodeID == identity.nodeID,
+              claim.attemptOrdinal == identity.attemptOrdinal else {
+            throw rejected(.claimMismatch, "claim target does not match.")
+        }
+        guard claim.executorID == identity.executorID else {
+            throw rejected(
+                .executorMismatch,
+                "executor is not the claim owner."
+            )
+        }
+        guard claim.leaseGeneration == identity.leaseGeneration else {
+            throw rejected(
+                .leaseGenerationMismatch,
+                "lease fencing token is stale."
+            )
+        }
+        guard record.status == .active else {
+            throw rejected(.claimInactive, "claim is not active.")
+        }
+        guard claim.isValid(at: logicalTime) else {
+            throw rejected(.leaseExpired, "claim lease has expired.")
+        }
+        return claim
+    }
+
+    private func artifactReference(
+        _ artifact: GraphExecutorProducedArtifact,
+        observation: GraphExecutorObservation
+    ) throws -> GraphArtifactReference {
+        guard !artifact.contentDigest.value.isEmpty,
+              artifact.storage.scheme != "inline" else {
+            throw rejected(
+                .artifactProvenanceMismatch,
+                "artifacts must be content-addressed references."
+            )
+        }
+        let identity = observation.identity
+        let material = [
+            identity.runID,
+            identity.nodeID,
+            identity.attemptID,
+            identity.claimID,
+            artifact.role.rawValue,
+            artifact.contentDigest.value,
+        ].joined(separator: "|")
+        let id = "artifact-\(DefaultGraphMutationService.stableID(material))"
+        return GraphArtifactReference(
+            id: id,
+            contentDigest: artifact.contentDigest,
+            mediaType: artifact.mediaType,
+            logicalRole: artifact.role.rawValue,
+            producingRunID: identity.runID,
+            producingNodeID: identity.nodeID,
+            producingAttemptID: identity.attemptID,
+            producingAttemptOrdinal: identity.attemptOrdinal,
+            producingClaimID: identity.claimID,
+            createdAt: observation.observedAt,
+            storage: artifact.storage,
+            sensitivity: artifact.sensitivity
+        )
+    }
+
+    private func append(
+        _ events: [GraphExecutionEventEnvelope],
+        loaded: Loaded
+    ) async throws -> GraphExecutorPersistenceResult {
+        do {
+            let result = try await eventStore.append(
+                events,
+                to: loaded.projection.runID,
+                expectedVersion: loaded.version
+            )
+            return GraphExecutorPersistenceResult(
+                appendResult: result,
+                projection: try GraphExecutionProjector.replay(
+                    runID: loaded.projection.runID,
+                    events: loaded.events + events
+                ).projection
+            )
+        } catch let error as GraphExecutionPersistenceError {
+            if case let .expectedVersionConflict(_, expected, actual) = error {
+                throw rejected(
+                    .expectedVersionConflict,
+                    "expected \(expected), found \(actual)."
+                )
+            }
+            throw GraphExecutorRepositoryError.persistence(
+                error.localizedDescription
+            )
+        } catch let error as GraphExecutorRepositoryError {
+            throw error
+        } catch {
+            throw GraphExecutorRepositoryError.persistence(
+                error.localizedDescription
+            )
+        }
+    }
+
+    private func unchanged(
+        _ loaded: Loaded
+    ) -> GraphExecutorPersistenceResult {
+        GraphExecutorPersistenceResult(
+            appendResult: GraphExecutionAppendResult(
+                previousVersion: loaded.version,
+                newVersion: loaded.version,
+                appendedCount: 0,
+                deduplicatedCount: 1
+            ),
+            projection: loaded.projection
+        )
+    }
+
+    private func requireVersion(
+        _ expected: UInt64,
+        _ actual: UInt64
+    ) throws {
+        guard expected == actual else {
+            throw rejected(
+                .expectedVersionConflict,
+                "expected \(expected), found \(actual)."
+            )
+        }
+    }
+
+    private func envelope(
+        id: String,
+        identity: GraphExecutorInteractionIdentity,
+        sequence: UInt64,
+        occurredAt: Date,
+        producer: GraphExecutionProducer,
+        correlationID: String,
+        payload: GraphExecutionEventPayload
+    ) -> GraphExecutionEventEnvelope {
+        GraphExecutionEventEnvelope(
+            id: id,
+            runID: identity.runID,
+            nodeID: identity.nodeID,
+            attemptID: identity.attemptID,
+            streamSequence: sequence,
+            occurredAt: occurredAt,
+            recordedAt: occurredAt,
+            producer: producer,
+            correlationID: correlationID,
+            payload: payload
+        )
+    }
+
+    private func startEventID(
+        _ identity: GraphExecutorInteractionIdentity
+    ) -> String {
+        "attempt-start-request-\(identity.claimID)-\(identity.leaseGeneration)"
+    }
+
+    private func terminalEventID(
+        _ identity: GraphExecutorInteractionIdentity
+    ) -> String {
+        "attempt-terminal-\(identity.claimID)-\(identity.leaseGeneration)"
+    }
+
+    private func terminalPayload(
+        state: ReconciledExecutionState,
+        payload: GraphAttemptTerminalPayload
+    ) -> GraphExecutionEventPayload {
+        switch state {
+        case .completed:
+            .attemptCompleted(payload)
+        case .failed:
+            .attemptFailed(payload)
+        case .interrupted:
+            .attemptInterrupted(payload)
+        case .orphaned:
+            .attemptOrphaned(payload)
+        case .cancelled:
+            .attemptCancelled(payload)
+        case .pending, .ready, .running, .blocked:
+            .attemptFailed(payload)
+        }
+    }
+
+    private func terminalState(
+        _ payload: GraphExecutionEventPayload
+    ) -> ReconciledExecutionState? {
+        switch payload {
+        case .attemptCompleted:
+            .completed
+        case .attemptFailed:
+            .failed
+        case .attemptInterrupted:
+            .interrupted
+        case .attemptOrphaned:
+            .orphaned
+        case .attemptCancelled:
+            .cancelled
+        default:
+            nil
+        }
+    }
+
+    private static func state(
+        for status: GraphExecutorResponseStatus
+    ) -> ReconciledExecutionState? {
+        switch status {
+        case .succeeded:
+            .completed
+        case .failed:
+            .failed
+        case .cancelled:
+            .cancelled
+        case .interrupted:
+            .interrupted
+        default:
+            nil
+        }
+    }
+
+    private func rejected(
+        _ reason: GraphExecutorFencingReason,
+        _ message: String
+    ) -> GraphExecutorRepositoryError {
+        .rejected(reason, message)
+    }
+}

--- a/Sources/OpenIslandCore/GraphExecutorRepository.swift
+++ b/Sources/OpenIslandCore/GraphExecutorRepository.swift
@@ -532,7 +532,14 @@ public struct DefaultGraphExecutorRepository:
             throw rejected(.claimInactive, "claim is not active.")
         }
         guard claim.isValid(at: logicalTime) else {
-            throw rejected(.leaseExpired, "claim lease has expired.")
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            throw rejected(
+                .leaseExpired,
+                "claim lease is invalid at \(formatter.string(from: logicalTime)); "
+                    + "valid interval is [\(formatter.string(from: claim.leaseStart)), "
+                    + "\(formatter.string(from: claim.leaseExpiry)))."
+            )
         }
         return claim
     }

--- a/Sources/OpenIslandCore/GraphLocalProcessRuntime.swift
+++ b/Sources/OpenIslandCore/GraphLocalProcessRuntime.swift
@@ -160,6 +160,91 @@ public protocol GraphProcessInspecting: Sendable {
     ) -> GraphProcessRecoveryClassification
 }
 
+public struct GraphLocalProcessEvidenceSource:
+    ProcessEvidenceSource,
+    Sendable
+{
+    private let launchStore: GraphLocalProcessLaunchStore
+    private let inspector: any GraphProcessInspecting
+
+    public init(
+        launchStore: GraphLocalProcessLaunchStore,
+        inspector: any GraphProcessInspecting = DarwinGraphProcessInspector()
+    ) {
+        self.launchStore = launchStore
+        self.inspector = inspector
+    }
+
+    public func evidence(
+        for request: GraphProcessEvidenceRequest
+    ) async -> GraphProcessEvidenceOutcome {
+        do {
+            let records = try await launchStore.records().filter {
+                $0.identity.runID == request.runID
+            }
+            var evidence = GraphProcessEvidence()
+            var mismatch = false
+            for attempt in request.attempts {
+                guard let record = records
+                    .filter({ $0.identity.attemptID == attempt.id })
+                    .max(by: {
+                        $0.identity.leaseGeneration
+                            < $1.identity.leaseGeneration
+                    }) else { continue }
+                if let exit = record.exit {
+                    evidence.processExits.append(
+                        ProcessExit(
+                            attemptID: attempt.id,
+                            processIdentity: record.identity.process,
+                            observedAt: exit.observedAt,
+                            exitCode: exit.terminationReason == "exit"
+                                ? exit.terminationStatus : nil,
+                            signal: exit.terminationReason == "uncaught_signal"
+                                ? exit.terminationStatus : nil,
+                            reason: exit.terminationReason
+                        )
+                    )
+                    continue
+                }
+                switch inspector.classify(record.identity) {
+                case .matchingRunning:
+                    evidence.heartbeats.append(
+                        ExecutorHeartbeat(
+                            attemptID: attempt.id,
+                            processIdentity: record.identity.process,
+                            observedAt: request.observedAt,
+                            validUntil: request.observedAt
+                                .addingTimeInterval(5)
+                        )
+                    )
+                case .matchingExited:
+                    evidence.processExits.append(
+                        ProcessExit(
+                            attemptID: attempt.id,
+                            processIdentity: record.identity.process,
+                            observedAt: request.observedAt,
+                            reason: "process_exit_not_yet_persisted"
+                        )
+                    )
+                case .identityMismatch:
+                    mismatch = true
+                case .unavailableToInspect, .orphaned, .indeterminate:
+                    break
+                }
+            }
+            if mismatch {
+                return .identityMismatch(
+                    evidence,
+                    reason: "A durable local process identity no longer matches."
+                )
+            }
+            return .available(evidence)
+        } catch {
+            return .adapterFailed(reason: error.localizedDescription)
+        }
+    }
+}
+
 public struct DarwinGraphProcessInspector: GraphProcessInspecting, Sendable {
     public init() {}
 

--- a/Sources/OpenIslandCore/GraphLocalProcessRuntime.swift
+++ b/Sources/OpenIslandCore/GraphLocalProcessRuntime.swift
@@ -1,0 +1,538 @@
+import CryptoKit
+import Darwin
+import Foundation
+
+public struct GraphProcessBirthIdentity: Equatable, Codable, Sendable {
+    public let seconds: Int64
+    public let microseconds: Int32
+
+    public init(seconds: Int64, microseconds: Int32) {
+        self.seconds = seconds
+        self.microseconds = microseconds
+    }
+
+    public var token: String { "\(seconds):\(microseconds)" }
+}
+
+public struct GraphDurableProcessIdentity: Equatable, Codable, Sendable {
+    public let process: ProcessIdentity
+    public let birthIdentity: GraphProcessBirthIdentity?
+    public let executablePath: String
+    public let executableIdentity: String
+    public let invocationDigest: String
+    public let workspaceIdentity: String
+    public let runID: String
+    public let nodeID: String
+    public let attemptID: String
+    public let attemptOrdinal: Int
+    public let claimID: String
+    public var leaseGeneration: UInt64
+    public let executorID: String
+    public let executorInstanceID: String
+    public let processGroupID: Int32?
+    public let launchRecordID: String
+
+    public init(
+        process: ProcessIdentity,
+        birthIdentity: GraphProcessBirthIdentity?,
+        executablePath: String,
+        executableIdentity: String,
+        invocationDigest: String,
+        workspaceIdentity: String,
+        runID: String,
+        nodeID: String,
+        attemptID: String,
+        attemptOrdinal: Int,
+        claimID: String,
+        leaseGeneration: UInt64,
+        executorID: String,
+        executorInstanceID: String,
+        processGroupID: Int32?,
+        launchRecordID: String
+    ) {
+        self.process = process
+        self.birthIdentity = birthIdentity
+        self.executablePath = executablePath
+        self.executableIdentity = executableIdentity
+        self.invocationDigest = invocationDigest
+        self.workspaceIdentity = workspaceIdentity
+        self.runID = runID
+        self.nodeID = nodeID
+        self.attemptID = attemptID
+        self.attemptOrdinal = attemptOrdinal
+        self.claimID = claimID
+        self.leaseGeneration = leaseGeneration
+        self.executorID = executorID
+        self.executorInstanceID = executorInstanceID
+        self.processGroupID = processGroupID
+        self.launchRecordID = launchRecordID
+    }
+}
+
+public enum GraphLocalProcessLifecycle: String, Codable, Sendable {
+    case prepared
+    case running
+    case exited
+    case cleaned
+}
+
+public struct GraphLocalProcessExitRecord: Equatable, Codable, Sendable {
+    public let terminationStatus: Int32
+    public let terminationReason: String
+    public let observedAt: Date
+
+    public init(
+        terminationStatus: Int32,
+        terminationReason: String,
+        observedAt: Date
+    ) {
+        self.terminationStatus = terminationStatus
+        self.terminationReason = terminationReason
+        self.observedAt = observedAt
+    }
+}
+
+public struct GraphLocalProcessLaunchRecord: Equatable, Codable, Sendable {
+    public let schemaVersion: Int
+    public let id: String
+    public var lifecycle: GraphLocalProcessLifecycle
+    public var identity: GraphDurableProcessIdentity
+    public let preparedAt: Date
+    public var acceptedAt: Date?
+    public var exit: GraphLocalProcessExitRecord?
+    public var cancellationRequestedAt: Date?
+    public var cancellationEscalatedAt: Date?
+    public var cleanedAt: Date?
+    public let stdoutLogPath: String
+    public let stderrLogPath: String
+    public let logIndexPath: String
+    public let redactionLabels: [String]
+
+    public init(
+        schemaVersion: Int = 1,
+        id: String,
+        lifecycle: GraphLocalProcessLifecycle,
+        identity: GraphDurableProcessIdentity,
+        preparedAt: Date,
+        acceptedAt: Date? = nil,
+        exit: GraphLocalProcessExitRecord? = nil,
+        cancellationRequestedAt: Date? = nil,
+        cancellationEscalatedAt: Date? = nil,
+        cleanedAt: Date? = nil,
+        stdoutLogPath: String,
+        stderrLogPath: String,
+        logIndexPath: String,
+        redactionLabels: [String] = []
+    ) {
+        self.schemaVersion = schemaVersion
+        self.id = id
+        self.lifecycle = lifecycle
+        self.identity = identity
+        self.preparedAt = preparedAt
+        self.acceptedAt = acceptedAt
+        self.exit = exit
+        self.cancellationRequestedAt = cancellationRequestedAt
+        self.cancellationEscalatedAt = cancellationEscalatedAt
+        self.cleanedAt = cleanedAt
+        self.stdoutLogPath = stdoutLogPath
+        self.stderrLogPath = stderrLogPath
+        self.logIndexPath = logIndexPath
+        self.redactionLabels = redactionLabels.sorted()
+    }
+}
+
+public enum GraphProcessRecoveryClassification:
+    String,
+    Codable,
+    Sendable
+{
+    case matchingRunning = "matching_running"
+    case matchingExited = "matching_exited"
+    case identityMismatch = "identity_mismatch"
+    case unavailableToInspect = "unavailable_to_inspect"
+    case orphaned
+    case indeterminate
+}
+
+public protocol GraphProcessInspecting: Sendable {
+    func classify(
+        _ identity: GraphDurableProcessIdentity
+    ) -> GraphProcessRecoveryClassification
+}
+
+public struct DarwinGraphProcessInspector: GraphProcessInspecting, Sendable {
+    public init() {}
+
+    public func classify(
+        _ identity: GraphDurableProcessIdentity
+    ) -> GraphProcessRecoveryClassification {
+        guard let pid = identity.process.processID, pid > 0 else {
+            return .orphaned
+        }
+        errno = 0
+        guard kill(pid, 0) == 0 else {
+            if errno == ESRCH { return .matchingExited }
+            if errno == EPERM { return .unavailableToInspect }
+            return .indeterminate
+        }
+        guard let actual = Self.snapshot(pid: pid) else {
+            return .unavailableToInspect
+        }
+        guard actual.birthIdentity == identity.birthIdentity,
+              URL(fileURLWithPath: actual.executablePath).standardizedFileURL.path
+                == URL(fileURLWithPath: identity.executablePath)
+                    .standardizedFileURL.path else {
+            return .identityMismatch
+        }
+        return .matchingRunning
+    }
+
+    public static func snapshot(
+        pid: Int32
+    ) -> (birthIdentity: GraphProcessBirthIdentity, executablePath: String)? {
+        var info = proc_bsdinfo()
+        let bytes = proc_pidinfo(
+            pid,
+            PROC_PIDTBSDINFO,
+            0,
+            &info,
+            Int32(MemoryLayout<proc_bsdinfo>.size)
+        )
+        guard bytes == MemoryLayout<proc_bsdinfo>.size else { return nil }
+        var pathBuffer = [CChar](repeating: 0, count: 4 * Int(MAXPATHLEN))
+        let pathLength = proc_pidpath(
+            pid,
+            &pathBuffer,
+            UInt32(pathBuffer.count)
+        )
+        guard pathLength > 0 else { return nil }
+        return (
+            GraphProcessBirthIdentity(
+                seconds: Int64(info.pbi_start_tvsec),
+                microseconds: Int32(info.pbi_start_tvusec)
+            ),
+            String(cString: pathBuffer)
+        )
+    }
+}
+
+public actor GraphLocalProcessLaunchStore {
+    public let rootURL: URL
+
+    public init(rootURL: URL) throws {
+        self.rootURL = rootURL.standardizedFileURL
+        try FileManager.default.createDirectory(
+            at: self.rootURL,
+            withIntermediateDirectories: true
+        )
+    }
+
+    public static func defaultRootURL() throws -> URL {
+        let support = try FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        return support
+            .appendingPathComponent("OpenIsland", isDirectory: true)
+            .appendingPathComponent("local-process-runtime", isDirectory: true)
+    }
+
+    public func record(id: String) throws -> GraphLocalProcessLaunchRecord? {
+        let url = recordURL(id: id)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return nil
+        }
+        return try JSONDecoder.graphProcess.decode(
+            GraphLocalProcessLaunchRecord.self,
+            from: Data(contentsOf: url)
+        )
+    }
+
+    public func save(_ record: GraphLocalProcessLaunchRecord) throws {
+        let data = try JSONEncoder.graphProcess.encode(record)
+        let url = recordURL(id: record.id)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: url, options: .atomic)
+    }
+
+    public func update(
+        id: String,
+        _ transform: (inout GraphLocalProcessLaunchRecord) throws -> Void
+    ) throws -> GraphLocalProcessLaunchRecord {
+        guard var record = try record(id: id) else {
+            throw GraphLocalProcessRuntimeError.launchRecordMissing(id)
+        }
+        try transform(&record)
+        try save(record)
+        return record
+    }
+
+    public func logDirectory(id: String) throws -> URL {
+        let url = rootURL
+            .appendingPathComponent("logs", isDirectory: true)
+            .appendingPathComponent(Self.safeName(id), isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: url,
+            withIntermediateDirectories: true
+        )
+        return url
+    }
+
+    private func recordURL(id: String) -> URL {
+        rootURL
+            .appendingPathComponent("launch-records", isDirectory: true)
+            .appendingPathComponent(Self.safeName(id))
+            .appendingPathExtension("json")
+    }
+
+    private static func safeName(_ id: String) -> String {
+        SHA256.hash(data: Data(id.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+}
+
+public enum GraphProcessLogChannel: String, Codable, CaseIterable, Sendable {
+    case stdout
+    case stderr
+}
+
+public struct GraphProcessLogEntry: Equatable, Codable, Sendable, Identifiable {
+    public var id: UInt64 { sequence }
+    public let sequence: UInt64
+    public let channel: GraphProcessLogChannel
+    public let data: Data
+    public let byteOffset: UInt64
+    public let droppedByteCount: Int
+    public let redacted: Bool
+
+    public init(
+        sequence: UInt64,
+        channel: GraphProcessLogChannel,
+        data: Data,
+        byteOffset: UInt64,
+        droppedByteCount: Int = 0,
+        redacted: Bool = false
+    ) {
+        self.sequence = sequence
+        self.channel = channel
+        self.data = data
+        self.byteOffset = byteOffset
+        self.droppedByteCount = droppedByteCount
+        self.redacted = redacted
+    }
+
+    public var text: String { String(decoding: data, as: UTF8.self) }
+    public var usedUTF8Fallback: Bool { String(data: data, encoding: .utf8) == nil }
+    public var isTruncated: Bool { droppedByteCount > 0 }
+}
+
+public struct GraphProcessLogPage: Equatable, Sendable {
+    public let entries: [GraphProcessLogEntry]
+    public let nextSequence: UInt64
+    public let truncatedChannels: [GraphProcessLogChannel]
+    public let redactionLabels: [String]
+}
+
+public final class GraphProcessLogStore: @unchecked Sendable {
+    private struct State {
+        var nextSequence: UInt64 = 1
+        var bytesByChannel: [GraphProcessLogChannel: Int] = [:]
+        var truncatedChannels: Set<GraphProcessLogChannel> = []
+    }
+
+    private let lock = NSCondition()
+    private var states: [String: State] = [:]
+
+    public init() {}
+
+    public func append(
+        launchID: String,
+        channel: GraphProcessLogChannel,
+        data: Data,
+        indexURL: URL,
+        streamURL: URL,
+        maximumBytes: Int,
+        redactionValues: [String]
+    ) throws {
+        guard !data.isEmpty else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        var state = try states[launchID] ?? loadState(indexURL: indexURL)
+        guard !state.truncatedChannels.contains(channel) else { return }
+        let current = state.bytesByChannel[channel, default: 0]
+        let remaining = max(0, maximumBytes - current)
+        let accepted = data.prefix(remaining)
+        let dropped = data.count - accepted.count
+        var payload = Data(accepted)
+        var redacted = false
+        if !redactionValues.isEmpty,
+           var text = String(data: payload, encoding: .utf8) {
+            for value in redactionValues where text.contains(value) {
+                text = text.replacingOccurrences(of: value, with: "[REDACTED]")
+                redacted = true
+            }
+            payload = Data(text.utf8)
+        }
+        let entry = GraphProcessLogEntry(
+            sequence: state.nextSequence,
+            channel: channel,
+            data: payload,
+            byteOffset: UInt64(current),
+            droppedByteCount: dropped,
+            redacted: redacted
+        )
+        try Self.appendLine(entry, to: indexURL)
+        try Self.appendBytes(payload, to: streamURL)
+        state.nextSequence += 1
+        state.bytesByChannel[channel] = current + accepted.count
+        if dropped > 0 { state.truncatedChannels.insert(channel) }
+        states[launchID] = state
+        lock.broadcast()
+    }
+
+    public func read(
+        indexURL: URL,
+        channel: GraphProcessLogChannel? = nil,
+        afterSequence: UInt64 = 0,
+        limit: Int = 500,
+        redactionLabels: [String] = []
+    ) throws -> GraphProcessLogPage {
+        lock.lock()
+        defer { lock.unlock() }
+        let entries = try Self.readEntries(indexURL: indexURL)
+        let matching = entries.filter {
+            $0.sequence > afterSequence
+                && (channel == nil || $0.channel == channel)
+        }
+        let page = Array(matching.prefix(max(1, min(limit, 5_000))))
+        return GraphProcessLogPage(
+            entries: page,
+            nextSequence: page.last?.sequence ?? afterSequence,
+            truncatedChannels: GraphProcessLogChannel.allCases.filter {
+                candidate in entries.contains {
+                    $0.channel == candidate && $0.isTruncated
+                }
+            },
+            redactionLabels: redactionLabels.sorted()
+        )
+    }
+
+    public func waitForText(
+        indexURL: URL,
+        containing text: String,
+        timeout: TimeInterval
+    ) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        let deadline = Date().addingTimeInterval(max(0.1, timeout))
+        while true {
+            if let entries = try? Self.readEntries(indexURL: indexURL),
+               entries.contains(where: { $0.text.contains(text) }) {
+                return true
+            }
+            guard lock.wait(until: deadline) else { return false }
+        }
+    }
+
+    private func loadState(indexURL: URL) throws -> State {
+        let entries = try Self.readEntries(indexURL: indexURL)
+        var state = State()
+        state.nextSequence = (entries.last?.sequence ?? 0) + 1
+        for entry in entries {
+            state.bytesByChannel[entry.channel] = max(
+                state.bytesByChannel[entry.channel, default: 0],
+                Int(entry.byteOffset) + entry.data.count
+            )
+            if entry.isTruncated {
+                state.truncatedChannels.insert(entry.channel)
+            }
+        }
+        return state
+    }
+
+    private static func readEntries(indexURL: URL) throws
+        -> [GraphProcessLogEntry]
+    {
+        guard FileManager.default.fileExists(atPath: indexURL.path) else {
+            return []
+        }
+        return try Data(contentsOf: indexURL)
+            .split(separator: UInt8(ascii: "\n"))
+            .map { try JSONDecoder.graphProcess.decode(
+                GraphProcessLogEntry.self,
+                from: Data($0)
+            ) }
+            .sorted { $0.sequence < $1.sequence }
+    }
+
+    private static func appendLine<T: Encodable>(_ value: T, to url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        var data = try JSONEncoder.graphProcess.encode(value)
+        data.append(UInt8(ascii: "\n"))
+        try appendBytes(data, to: url)
+    }
+
+    private static func appendBytes(_ data: Data, to url: URL) throws {
+        if !FileManager.default.fileExists(atPath: url.path) {
+            _ = FileManager.default.createFile(atPath: url.path, contents: nil)
+        }
+        let handle = try FileHandle(forWritingTo: url)
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        try handle.write(contentsOf: data)
+    }
+}
+
+public enum GraphLocalProcessRuntimeError: Error, Equatable, Sendable {
+    case launchRecordMissing(String)
+    case launchRecordConflict(String)
+    case staleLeaseGeneration(expectedAtLeast: UInt64, actual: UInt64)
+    case identityMismatch(String)
+    case artifactMissing(String)
+    case artifactTooLarge(String, Int)
+}
+
+extension GraphLocalProcessRuntimeError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .launchRecordMissing(id):
+            "Local process launch record is missing: \(id)."
+        case let .launchRecordConflict(id):
+            "Local process launch record conflicts with the command: \(id)."
+        case let .staleLeaseGeneration(expected, actual):
+            "Stale lease generation \(actual); expected at least \(expected)."
+        case let .identityMismatch(id):
+            "Local process identity no longer matches launch record \(id)."
+        case let .artifactMissing(path):
+            "Declared artifact is missing: \(path)."
+        case let .artifactTooLarge(path, limit):
+            "Declared artifact \(path) exceeds \(limit) bytes."
+        }
+    }
+}
+
+extension JSONEncoder {
+    fileprivate static var graphProcess: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+}
+
+extension JSONDecoder {
+    fileprivate static var graphProcess: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}

--- a/Sources/OpenIslandCore/GraphLocalProcessRuntime.swift
+++ b/Sources/OpenIslandCore/GraphLocalProcessRuntime.swift
@@ -178,7 +178,10 @@ public struct DarwinGraphProcessInspector: GraphProcessInspecting, Sendable {
         guard let actual = Self.snapshot(pid: pid) else {
             return .unavailableToInspect
         }
-        guard actual.birthIdentity == identity.birthIdentity,
+        guard let expectedBirth = identity.birthIdentity else {
+            return .indeterminate
+        }
+        guard actual.birthIdentity == expectedBirth,
               URL(fileURLWithPath: actual.executablePath).standardizedFileURL.path
                 == URL(fileURLWithPath: identity.executablePath)
                     .standardizedFileURL.path else {
@@ -211,7 +214,10 @@ public struct DarwinGraphProcessInspector: GraphProcessInspecting, Sendable {
                 seconds: Int64(info.pbi_start_tvsec),
                 microseconds: Int32(info.pbi_start_tvusec)
             ),
-            String(cString: pathBuffer)
+            String(
+                decoding: pathBuffer.prefix { $0 != 0 }.map(UInt8.init),
+                as: UTF8.self
+            )
         )
     }
 }
@@ -258,6 +264,31 @@ public actor GraphLocalProcessLaunchStore {
             withIntermediateDirectories: true
         )
         try data.write(to: url, options: .atomic)
+    }
+
+    public func records() throws -> [GraphLocalProcessLaunchRecord] {
+        let directory = rootURL
+            .appendingPathComponent("launch-records", isDirectory: true)
+        guard FileManager.default.fileExists(atPath: directory.path) else {
+            return []
+        }
+        return try FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ).filter { $0.pathExtension == "json" }
+            .map {
+                try JSONDecoder.graphProcess.decode(
+                    GraphLocalProcessLaunchRecord.self,
+                    from: Data(contentsOf: $0)
+                )
+            }
+            .sorted {
+                if $0.preparedAt != $1.preparedAt {
+                    return $0.preparedAt < $1.preparedAt
+                }
+                return $0.id < $1.id
+            }
     }
 
     public func update(

--- a/Sources/OpenIslandCore/GraphLocalProcessSpecification.swift
+++ b/Sources/OpenIslandCore/GraphLocalProcessSpecification.swift
@@ -32,24 +32,36 @@ public struct GraphLocalProcessArtifactDeclaration:
     Codable,
     Sendable
 {
+    public let identifier: String?
     public let relativePath: String
     public let mediaType: String
     public let role: GraphArtifactRole
     public let sensitivity: GraphArtifactSensitivity
     public let maximumBytes: Int
+    public let isRequired: Bool?
+    public let downstreamVisibility: GraphArtifactDownstreamVisibility?
+
+    public var stableID: String { identifier ?? "output-\(role.rawValue)" }
+    public var required: Bool { isRequired ?? true }
 
     public init(
+        identifier: String? = nil,
         relativePath: String,
         mediaType: String,
         role: GraphArtifactRole,
         sensitivity: GraphArtifactSensitivity = .internalUse,
-        maximumBytes: Int = 64 * 1_024 * 1_024
+        maximumBytes: Int = 64 * 1_024 * 1_024,
+        isRequired: Bool = true,
+        downstreamVisibility: GraphArtifactDownstreamVisibility = .graph
     ) {
+        self.identifier = identifier
         self.relativePath = relativePath
         self.mediaType = mediaType
         self.role = role
         self.sensitivity = sensitivity
         self.maximumBytes = max(1, maximumBytes)
+        self.isRequired = isRequired
+        self.downstreamVisibility = downstreamVisibility
     }
 }
 

--- a/Sources/OpenIslandCore/GraphLocalProcessSpecification.swift
+++ b/Sources/OpenIslandCore/GraphLocalProcessSpecification.swift
@@ -1,0 +1,385 @@
+import Foundation
+
+public enum GraphLocalProcessEnvironmentInheritance:
+    String,
+    Codable,
+    Sendable
+{
+    case none
+    case allowlisted
+}
+
+public enum GraphLocalProcessStdinPolicy: String, Codable, Sendable {
+    case closed
+    case nullDevice = "null_device"
+}
+
+public struct GraphLocalProcessLogPolicy: Equatable, Codable, Sendable {
+    public let maximumBytesPerStream: Int
+    public let sensitiveEnvironmentKeys: [String]
+
+    public init(
+        maximumBytesPerStream: Int = 8 * 1_024 * 1_024,
+        sensitiveEnvironmentKeys: [String] = []
+    ) {
+        self.maximumBytesPerStream = max(1_024, maximumBytesPerStream)
+        self.sensitiveEnvironmentKeys = sensitiveEnvironmentKeys.sorted()
+    }
+}
+
+public struct GraphLocalProcessArtifactDeclaration:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let relativePath: String
+    public let mediaType: String
+    public let role: GraphArtifactRole
+    public let sensitivity: GraphArtifactSensitivity
+    public let maximumBytes: Int
+
+    public init(
+        relativePath: String,
+        mediaType: String,
+        role: GraphArtifactRole,
+        sensitivity: GraphArtifactSensitivity = .internalUse,
+        maximumBytes: Int = 64 * 1_024 * 1_024
+    ) {
+        self.relativePath = relativePath
+        self.mediaType = mediaType
+        self.role = role
+        self.sensitivity = sensitivity
+        self.maximumBytes = max(1, maximumBytes)
+    }
+}
+
+public struct GraphLocalProcessSpecification:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public static let adapterKind = "local_process"
+    public static let operation = "execute"
+
+    public let executable: String
+    public let arguments: [String]
+    public let workingDirectory: String
+    public let environment: [String: String]
+    public let inheritedEnvironment: GraphLocalProcessEnvironmentInheritance
+    public let stdin: GraphLocalProcessStdinPolicy
+    public let outputArtifacts: [GraphLocalProcessArtifactDeclaration]
+    public let retryableExitCodes: [Int32]
+    public let logPolicy: GraphLocalProcessLogPolicy
+
+    public init(
+        executable: String,
+        arguments: [String] = [],
+        workingDirectory: String = ".",
+        environment: [String: String] = [:],
+        inheritedEnvironment: GraphLocalProcessEnvironmentInheritance = .none,
+        stdin: GraphLocalProcessStdinPolicy = .nullDevice,
+        outputArtifacts: [GraphLocalProcessArtifactDeclaration] = [],
+        retryableExitCodes: [Int32] = [],
+        logPolicy: GraphLocalProcessLogPolicy = GraphLocalProcessLogPolicy()
+    ) {
+        self.executable = executable
+        self.arguments = arguments
+        self.workingDirectory = workingDirectory
+        self.environment = environment
+        self.inheritedEnvironment = inheritedEnvironment
+        self.stdin = stdin
+        self.outputArtifacts = outputArtifacts.sorted {
+            if $0.role != $1.role {
+                return $0.role.rawValue < $1.role.rawValue
+            }
+            return $0.relativePath < $1.relativePath
+        }
+        self.retryableExitCodes = retryableExitCodes.sorted()
+        self.logPolicy = logPolicy
+    }
+
+    public init(
+        immutableSpecification: GraphImmutableExecutionSpecification
+    ) throws {
+        guard immutableSpecification.adapterKind == Self.adapterKind,
+              immutableSpecification.operation == Self.operation else {
+            throw GraphLocalProcessSpecificationError.unsupportedAdapter(
+                immutableSpecification.adapterKind,
+                immutableSpecification.operation
+            )
+        }
+        let data = try JSONEncoder().encode(
+            immutableSpecification.parameters
+        )
+        self = try JSONDecoder().decode(Self.self, from: data)
+    }
+
+    public func immutableSpecification() throws
+        -> GraphImmutableExecutionSpecification
+    {
+        let data = try JSONEncoder().encode(self)
+        let parameters = try JSONDecoder().decode(
+            [String: GraphJSONValue].self,
+            from: data
+        )
+        return GraphImmutableExecutionSpecification(
+            adapterKind: Self.adapterKind,
+            operation: Self.operation,
+            parameters: parameters
+        )
+    }
+}
+
+public enum GraphLocalProcessSpecificationError:
+    Error,
+    Equatable,
+    Sendable
+{
+    case unsupportedAdapter(String, String)
+    case executableMustBeAbsolute(String)
+    case executableUnavailable(String)
+    case shellExecutionRequiresSeparatePolicy(String)
+    case workspaceRootRequired
+    case workspaceUnavailable(String)
+    case workingDirectoryEscapesWorkspace(String)
+    case workingDirectoryUnavailable(String)
+    case environmentNotAllowed(String)
+    case sensitiveEnvironmentValue(String)
+    case duplicateArtifactRole(String)
+    case artifactPathInvalid(String)
+    case artifactPathNotWritable(String)
+    case inputArtifactUnavailable(String)
+    case unknownArgumentToken(String)
+}
+
+extension GraphLocalProcessSpecificationError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .unsupportedAdapter(adapter, operation):
+            "Unsupported process adapter \(adapter)/\(operation)."
+        case let .executableMustBeAbsolute(path):
+            "Executable path must be absolute: \(path)."
+        case let .executableUnavailable(path):
+            "Executable is unavailable or not executable: \(path)."
+        case let .shellExecutionRequiresSeparatePolicy(path):
+            "Shell execution requires a separately classified adapter: \(path)."
+        case .workspaceRootRequired:
+            "Local process execution requires a workspace root."
+        case let .workspaceUnavailable(path):
+            "Workspace is unavailable: \(path)."
+        case let .workingDirectoryEscapesWorkspace(path):
+            "Working directory escapes the workspace: \(path)."
+        case let .workingDirectoryUnavailable(path):
+            "Working directory is unavailable: \(path)."
+        case let .environmentNotAllowed(key):
+            "Environment key is not allowlisted: \(key)."
+        case let .sensitiveEnvironmentValue(key):
+            "Sensitive environment key \(key) must be inherited, not embedded."
+        case let .duplicateArtifactRole(role):
+            "Output artifact role is declared more than once: \(role)."
+        case let .artifactPathInvalid(path):
+            "Artifact path is invalid or escapes the workspace: \(path)."
+        case let .artifactPathNotWritable(path):
+            "Artifact path is outside declared writable locations: \(path)."
+        case let .inputArtifactUnavailable(role):
+            "Input artifact is unavailable for role \(role)."
+        case let .unknownArgumentToken(token):
+            "Unknown structured argument token: \(token)."
+        }
+    }
+}
+
+public struct GraphResolvedLocalProcessSpecification: Sendable {
+    public let specification: GraphLocalProcessSpecification
+    public let executableURL: URL
+    public let arguments: [String]
+    public let workspaceURL: URL
+    public let workingDirectoryURL: URL
+    public let environment: [String: String]
+    public let artifactURLs: [GraphArtifactRole: URL]
+    public let redactionValues: [String]
+}
+
+public enum GraphLocalProcessSpecificationResolver {
+    public static func resolve(
+        _ specification: GraphLocalProcessSpecification,
+        context: GraphExecutorCommandContext,
+        processEnvironment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default
+    ) throws -> GraphResolvedLocalProcessSpecification {
+        let executableURL = URL(fileURLWithPath: specification.executable)
+            .standardizedFileURL
+        guard executableURL.path.hasPrefix("/") else {
+            throw GraphLocalProcessSpecificationError
+                .executableMustBeAbsolute(specification.executable)
+        }
+        let shells = ["/bin/sh", "/bin/bash", "/bin/zsh", "/usr/bin/env"]
+        guard !shells.contains(executableURL.path) else {
+            throw GraphLocalProcessSpecificationError
+                .shellExecutionRequiresSeparatePolicy(executableURL.path)
+        }
+        guard fileManager.isExecutableFile(atPath: executableURL.path) else {
+            throw GraphLocalProcessSpecificationError
+                .executableUnavailable(executableURL.path)
+        }
+        guard let root = context.workspace.root, !root.isEmpty else {
+            throw GraphLocalProcessSpecificationError.workspaceRootRequired
+        }
+        let workspaceURL = URL(fileURLWithPath: root, isDirectory: true)
+            .standardizedFileURL
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(
+            atPath: workspaceURL.path,
+            isDirectory: &isDirectory
+        ), isDirectory.boolValue else {
+            throw GraphLocalProcessSpecificationError
+                .workspaceUnavailable(workspaceURL.path)
+        }
+        let workingDirectoryURL = workspaceURL
+            .appendingPathComponent(specification.workingDirectory, isDirectory: true)
+            .standardizedFileURL
+        guard contains(workingDirectoryURL, in: workspaceURL) else {
+            throw GraphLocalProcessSpecificationError
+                .workingDirectoryEscapesWorkspace(specification.workingDirectory)
+        }
+        guard fileManager.fileExists(
+            atPath: workingDirectoryURL.path,
+            isDirectory: &isDirectory
+        ), isDirectory.boolValue else {
+            throw GraphLocalProcessSpecificationError
+                .workingDirectoryUnavailable(workingDirectoryURL.path)
+        }
+
+        let allowed = Set(context.environmentAllowlist)
+        for key in specification.environment.keys where !allowed.contains(key) {
+            throw GraphLocalProcessSpecificationError.environmentNotAllowed(key)
+        }
+        for key in specification.logPolicy.sensitiveEnvironmentKeys
+            where specification.environment[key] != nil {
+            throw GraphLocalProcessSpecificationError
+                .sensitiveEnvironmentValue(key)
+        }
+        var environment = specification.environment
+        if specification.inheritedEnvironment == .allowlisted {
+            for key in allowed where environment[key] == nil {
+                environment[key] = processEnvironment[key]
+            }
+        }
+
+        let groupedRoles = Dictionary(
+            grouping: specification.outputArtifacts,
+            by: \.role
+        )
+        if let duplicate = groupedRoles.first(where: { $0.value.count > 1 }) {
+            throw GraphLocalProcessSpecificationError
+                .duplicateArtifactRole(duplicate.key.rawValue)
+        }
+        var artifactURLs: [GraphArtifactRole: URL] = [:]
+        for declaration in specification.outputArtifacts {
+            guard !declaration.relativePath.isEmpty,
+                  !declaration.relativePath.hasPrefix("/") else {
+                throw GraphLocalProcessSpecificationError
+                    .artifactPathInvalid(declaration.relativePath)
+            }
+            let output = workspaceURL
+                .appendingPathComponent(declaration.relativePath)
+                .standardizedFileURL
+            guard contains(output, in: workspaceURL) else {
+                throw GraphLocalProcessSpecificationError
+                    .artifactPathInvalid(declaration.relativePath)
+            }
+            let writable = context.workspace.writableRelativePaths.contains {
+                writablePath in
+                let writableURL = workspaceURL
+                    .appendingPathComponent(writablePath, isDirectory: true)
+                    .standardizedFileURL
+                return contains(output, in: writableURL)
+                    || output == writableURL
+            }
+            guard writable else {
+                throw GraphLocalProcessSpecificationError
+                    .artifactPathNotWritable(declaration.relativePath)
+            }
+            artifactURLs[declaration.role] = output
+        }
+
+        let arguments = try specification.arguments.map { argument in
+            try resolveArgument(
+                argument,
+                context: context,
+                workspaceURL: workspaceURL,
+                artifactURLs: artifactURLs
+            )
+        }
+        let redactions = specification.logPolicy.sensitiveEnvironmentKeys
+            .compactMap { environment[$0] }
+            .filter { !$0.isEmpty }
+        return GraphResolvedLocalProcessSpecification(
+            specification: specification,
+            executableURL: executableURL,
+            arguments: arguments,
+            workspaceURL: workspaceURL,
+            workingDirectoryURL: workingDirectoryURL,
+            environment: environment,
+            artifactURLs: artifactURLs,
+            redactionValues: redactions
+        )
+    }
+
+    private static func resolveArgument(
+        _ argument: String,
+        context: GraphExecutorCommandContext,
+        workspaceURL: URL,
+        artifactURLs: [GraphArtifactRole: URL]
+    ) throws -> String {
+        guard argument.hasPrefix("${"), argument.hasSuffix("}") else {
+            return argument
+        }
+        if argument == "${workspace}" {
+            return workspaceURL.path
+        }
+        if argument.hasPrefix("${artifact:") {
+            let roleValue = String(argument.dropFirst(11).dropLast())
+            guard let role = GraphArtifactRole(rawValue: roleValue),
+                  let url = artifactURLs[role] else {
+                throw GraphLocalProcessSpecificationError
+                    .unknownArgumentToken(argument)
+            }
+            return url.path
+        }
+        if argument.hasPrefix("${input:") {
+            let role = String(argument.dropFirst(8).dropLast())
+            guard let artifact = context.inputArtifacts.first(where: {
+                $0.logicalRole == role && $0.storage.scheme == "file"
+            }) else {
+                throw GraphLocalProcessSpecificationError
+                    .inputArtifactUnavailable(role)
+            }
+            return artifact.storage.opaqueReference
+        }
+        throw GraphLocalProcessSpecificationError.unknownArgumentToken(argument)
+    }
+
+    private static func contains(_ child: URL, in parent: URL) -> Bool {
+        let childPath = child.standardizedFileURL.path
+        let parentPath = parent.standardizedFileURL.path
+        return childPath == parentPath
+            || childPath.hasPrefix(parentPath.hasSuffix("/")
+                ? parentPath : parentPath + "/")
+    }
+}
+
+public struct LocalProcessExecutionConfirmationPolicy:
+    GraphExecutionConfirmationPolicy,
+    Sendable
+{
+    public init() {}
+
+    public func permits(
+        operation: GraphExecutorOperation,
+        context: GraphExecutorCommandContext
+    ) -> Bool {
+        context.specification.adapterKind
+            == GraphLocalProcessSpecification.adapterKind
+    }
+}

--- a/Sources/OpenIslandCore/GraphMutationService.swift
+++ b/Sources/OpenIslandCore/GraphMutationService.swift
@@ -396,7 +396,7 @@ public struct DefaultGraphMutationService: GraphMutating, Sendable {
                 "retry requires a failed, interrupted, or orphaned attempt."
             )
         }
-        let policy = definition.schedulerPolicy.retryPolicy
+        let policy = definition.schedulerPolicy.retryPolicy(for: request.nodeID)
         let category = latest.statusReason ?? "execution_failure"
         guard latest.ordinal < policy.maximumAttempts,
               !policy.nonRetryableFailureCategories.contains(category),

--- a/Sources/OpenIslandCore/GraphMutationService.swift
+++ b/Sources/OpenIslandCore/GraphMutationService.swift
@@ -1,0 +1,767 @@
+import CryptoKit
+import Foundation
+
+public enum GraphMutationStatus: String, Codable, Sendable {
+    case proposed
+    case applied
+    case deduplicated
+}
+
+public struct GraphMutationReport: Equatable, Codable, Sendable {
+    public let schemaVersion: Int
+    public let operation: String
+    public let status: GraphMutationStatus
+    public let runID: String
+    public let nodeIDs: [String]
+    public let previousVersion: UInt64
+    public let streamVersion: UInt64
+    public let eventTypes: [String]
+    public let executorInvocationCount: Int
+
+    public init(
+        schemaVersion: Int = GraphCLIOutputSchema.currentVersion,
+        operation: String,
+        status: GraphMutationStatus,
+        runID: String,
+        nodeIDs: [String] = [],
+        previousVersion: UInt64,
+        streamVersion: UInt64,
+        eventTypes: [String],
+        executorInvocationCount: Int = 0
+    ) {
+        self.schemaVersion = schemaVersion
+        self.operation = operation
+        self.status = status
+        self.runID = runID
+        self.nodeIDs = nodeIDs.sorted()
+        self.previousVersion = previousVersion
+        self.streamVersion = streamVersion
+        self.eventTypes = eventTypes
+        self.executorInvocationCount = executorInvocationCount
+    }
+}
+
+public enum GraphMutationError: Error, Equatable, Sendable {
+    case invalidRequest(String)
+    case notFound(String)
+    case optimisticConflict(expected: UInt64, actual: UInt64)
+    case idempotencyConflict(String)
+    case policyDenied(String)
+    case persistence(String)
+}
+
+extension GraphMutationError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .invalidRequest(message):
+            "Invalid graph mutation: \(message)"
+        case let .notFound(runID):
+            "Graph run \(runID) was not found."
+        case let .optimisticConflict(expected, actual):
+            "Expected stream version \(expected), found \(actual)."
+        case let .idempotencyConflict(key):
+            "Idempotency key \(key) was reused for conflicting content."
+        case let .policyDenied(message):
+            "Graph mutation denied by policy: \(message)"
+        case let .persistence(message):
+            "Graph mutation persistence failed: \(message)"
+        }
+    }
+}
+
+public struct GraphCreateRequest: Equatable, Sendable {
+    public let runID: String
+    public let definition: GraphExecutableDefinition
+    public let idempotencyKey: String
+    public let expectedVersion: UInt64?
+    public let dryRun: Bool
+    public let occurredAt: Date
+    public let producer: GraphExecutionProducer
+
+    public init(
+        runID: String,
+        definition: GraphExecutableDefinition,
+        idempotencyKey: String,
+        expectedVersion: UInt64? = nil,
+        dryRun: Bool = false,
+        occurredAt: Date,
+        producer: GraphExecutionProducer
+    ) {
+        self.runID = runID
+        self.definition = definition
+        self.idempotencyKey = idempotencyKey
+        self.expectedVersion = expectedVersion
+        self.dryRun = dryRun
+        self.occurredAt = occurredAt
+        self.producer = producer
+    }
+}
+
+public struct GraphStartRequest: Equatable, Sendable {
+    public let runID: String
+    public let idempotencyKey: String
+    public let expectedVersion: UInt64?
+    public let requestedBy: String
+    public let dryRun: Bool
+    public let occurredAt: Date
+    public let producer: GraphExecutionProducer
+
+    public init(
+        runID: String,
+        idempotencyKey: String,
+        expectedVersion: UInt64? = nil,
+        requestedBy: String,
+        dryRun: Bool = false,
+        occurredAt: Date,
+        producer: GraphExecutionProducer
+    ) {
+        self.runID = runID
+        self.idempotencyKey = idempotencyKey
+        self.expectedVersion = expectedVersion
+        self.requestedBy = requestedBy
+        self.dryRun = dryRun
+        self.occurredAt = occurredAt
+        self.producer = producer
+    }
+}
+
+public struct GraphRetryMutationRequest: Equatable, Sendable {
+    public let runID: String
+    public let nodeID: String
+    public let idempotencyKey: String
+    public let expectedVersion: UInt64?
+    public let requestedBy: String
+    public let dryRun: Bool
+    public let occurredAt: Date
+    public let producer: GraphExecutionProducer
+
+    public init(
+        runID: String,
+        nodeID: String,
+        idempotencyKey: String,
+        expectedVersion: UInt64? = nil,
+        requestedBy: String,
+        dryRun: Bool = false,
+        occurredAt: Date,
+        producer: GraphExecutionProducer
+    ) {
+        self.runID = runID
+        self.nodeID = nodeID
+        self.idempotencyKey = idempotencyKey
+        self.expectedVersion = expectedVersion
+        self.requestedBy = requestedBy
+        self.dryRun = dryRun
+        self.occurredAt = occurredAt
+        self.producer = producer
+    }
+}
+
+public struct GraphCancelMutationRequest: Equatable, Sendable {
+    public let runID: String
+    public let nodeID: String?
+    public let idempotencyKey: String
+    public let expectedVersion: UInt64?
+    public let requestedBy: String
+    public let reason: String?
+    public let dryRun: Bool
+    public let occurredAt: Date
+    public let producer: GraphExecutionProducer
+
+    public init(
+        runID: String,
+        nodeID: String? = nil,
+        idempotencyKey: String,
+        expectedVersion: UInt64? = nil,
+        requestedBy: String,
+        reason: String? = nil,
+        dryRun: Bool = false,
+        occurredAt: Date,
+        producer: GraphExecutionProducer
+    ) {
+        self.runID = runID
+        self.nodeID = nodeID
+        self.idempotencyKey = idempotencyKey
+        self.expectedVersion = expectedVersion
+        self.requestedBy = requestedBy
+        self.reason = reason
+        self.dryRun = dryRun
+        self.occurredAt = occurredAt
+        self.producer = producer
+    }
+}
+
+public protocol GraphMutating: Sendable {
+    func create(_ request: GraphCreateRequest) async throws
+        -> GraphMutationReport
+    func start(_ request: GraphStartRequest) async throws
+        -> GraphMutationReport
+    func retry(_ request: GraphRetryMutationRequest) async throws
+        -> GraphMutationReport
+    func cancel(_ request: GraphCancelMutationRequest) async throws
+        -> GraphMutationReport
+}
+
+public struct DefaultGraphMutationService: GraphMutating, Sendable {
+    private let eventStore: any GraphExecutionEventStore
+    private let readStore: any GraphExecutionReadStore
+
+    public init(
+        eventStore: any GraphExecutionEventStore,
+        readStore: any GraphExecutionReadStore
+    ) {
+        self.eventStore = eventStore
+        self.readStore = readStore
+    }
+
+    public func create(
+        _ request: GraphCreateRequest
+    ) async throws -> GraphMutationReport {
+        guard !request.runID.isEmpty, !request.idempotencyKey.isEmpty else {
+            throw GraphMutationError.invalidRequest(
+                "run ID and idempotency key are required."
+            )
+        }
+        try request.definition.validate()
+        let fingerprint = try Self.fingerprint(request.definition)
+
+        if let existing = try await findCreate(
+            idempotencyKey: request.idempotencyKey
+        ) {
+            guard existing.runID == request.runID,
+                  existing.fingerprint == fingerprint else {
+                throw GraphMutationError.idempotencyConflict(
+                    request.idempotencyKey
+                )
+            }
+            return GraphMutationReport(
+                operation: "graph.create",
+                status: .deduplicated,
+                runID: request.runID,
+                nodeIDs: request.definition.scheduling.nodes.map(\.id),
+                previousVersion: existing.streamVersion,
+                streamVersion: existing.streamVersion,
+                eventTypes: []
+            )
+        }
+
+        let current = try await readStore.streamDescriptor(
+            runID: request.runID
+        )?.currentVersion ?? 0
+        let expected = request.expectedVersion ?? 0
+        guard current == expected else {
+            throw GraphMutationError.optimisticConflict(
+                expected: expected,
+                actual: current
+            )
+        }
+        guard current == 0 else {
+            throw GraphMutationError.invalidRequest(
+                "run ID already exists."
+            )
+        }
+        let events = createEvents(request, fingerprint: fingerprint)
+        if request.dryRun {
+            return report(
+                operation: "graph.create",
+                status: .proposed,
+                runID: request.runID,
+                nodeIDs: request.definition.scheduling.nodes.map(\.id),
+                previousVersion: current,
+                streamVersion: current,
+                events: events
+            )
+        }
+        let append = try await append(
+            events,
+            runID: request.runID,
+            expectedVersion: expected
+        )
+        return report(
+            operation: "graph.create",
+            status: .applied,
+            runID: request.runID,
+            nodeIDs: request.definition.scheduling.nodes.map(\.id),
+            previousVersion: append.previousVersion,
+            streamVersion: append.newVersion,
+            events: events
+        )
+    }
+
+    public func start(
+        _ request: GraphStartRequest
+    ) async throws -> GraphMutationReport {
+        let loaded = try await load(request.runID)
+        if let requestID = loaded.projection.runStartRequestID {
+            let expectedID = Self.stableID(
+                "start|\(request.idempotencyKey)"
+            )
+            guard requestID == expectedID else {
+                return GraphMutationReport(
+                    operation: "graph.start",
+                    status: .deduplicated,
+                    runID: request.runID,
+                    previousVersion: loaded.version,
+                    streamVersion: loaded.version,
+                    eventTypes: []
+                )
+            }
+            return GraphMutationReport(
+                operation: "graph.start",
+                status: .deduplicated,
+                runID: request.runID,
+                previousVersion: loaded.version,
+                streamVersion: loaded.version,
+                eventTypes: []
+            )
+        }
+        try requireExpected(request.expectedVersion, actual: loaded.version)
+        guard loaded.projection.run?.state.isTerminal != true else {
+            throw GraphMutationError.policyDenied(
+                "terminal runs cannot be started."
+            )
+        }
+        let requestID = Self.stableID("start|\(request.idempotencyKey)")
+        let event = GraphExecutionEventEnvelope(
+            id: "start-\(requestID)",
+            runID: request.runID,
+            streamSequence: loaded.version + 1,
+            occurredAt: request.occurredAt,
+            recordedAt: request.occurredAt,
+            producer: request.producer,
+            correlationID: requestID,
+            payload: .runStartRequested(
+                GraphRunStartRequestedPayload(
+                    requestID: requestID,
+                    clientIdempotencyKey: request.idempotencyKey,
+                    requestedBy: request.requestedBy
+                )
+            )
+        )
+        if request.dryRun {
+            return report(
+                operation: "graph.start",
+                status: .proposed,
+                runID: request.runID,
+                previousVersion: loaded.version,
+                streamVersion: loaded.version,
+                events: [event]
+            )
+        }
+        let append = try await append(
+            [event],
+            runID: request.runID,
+            expectedVersion: loaded.version
+        )
+        return report(
+            operation: "graph.start",
+            status: .applied,
+            runID: request.runID,
+            previousVersion: append.previousVersion,
+            streamVersion: append.newVersion,
+            events: [event]
+        )
+    }
+
+    public func retry(
+        _ request: GraphRetryMutationRequest
+    ) async throws -> GraphMutationReport {
+        let loaded = try await load(request.runID)
+        try requireExpected(request.expectedVersion, actual: loaded.version)
+        let requestID = Self.stableID("retry|\(request.idempotencyKey)")
+        if loaded.projection.retryRequestIDs.contains(requestID) {
+            return GraphMutationReport(
+                operation: "graph.retry",
+                status: .deduplicated,
+                runID: request.runID,
+                nodeIDs: [request.nodeID],
+                previousVersion: loaded.version,
+                streamVersion: loaded.version,
+                eventTypes: []
+            )
+        }
+        guard let definition = loaded.projection.executableDefinition,
+              definition.scheduling.nodes.contains(where: {
+                $0.id == request.nodeID
+              }) else {
+            throw GraphMutationError.invalidRequest(
+                "node \(request.nodeID) is not executable."
+            )
+        }
+        guard let latest = loaded.projection.attempts
+            .filter({ $0.nodeID == request.nodeID })
+            .max(by: { $0.ordinal < $1.ordinal }),
+            [.failed, .interrupted, .orphaned].contains(latest.state)
+        else {
+            throw GraphMutationError.policyDenied(
+                "retry requires a failed, interrupted, or orphaned attempt."
+            )
+        }
+        let policy = definition.schedulerPolicy.retryPolicy
+        let category = latest.statusReason ?? "execution_failure"
+        guard latest.ordinal < policy.maximumAttempts,
+              !policy.nonRetryableFailureCategories.contains(category),
+              policy.retryableFailureCategories.isEmpty
+                || policy.retryableFailureCategories.contains(category)
+        else {
+            throw GraphMutationError.policyDenied(
+                "retry policy does not permit category \(category)."
+            )
+        }
+        let event = GraphExecutionEventEnvelope(
+            id: "retry-request-\(requestID)",
+            runID: request.runID,
+            nodeID: request.nodeID,
+            attemptID: latest.id,
+            streamSequence: loaded.version + 1,
+            occurredAt: request.occurredAt,
+            recordedAt: request.occurredAt,
+            producer: request.producer,
+            correlationID: requestID,
+            payload: .retryRequested(
+                GraphRetryRequestedPayload(
+                    requestID: requestID,
+                    clientIdempotencyKey: request.idempotencyKey,
+                    requestedBy: request.requestedBy
+                )
+            )
+        )
+        if request.dryRun {
+            return report(
+                operation: "graph.retry",
+                status: .proposed,
+                runID: request.runID,
+                nodeIDs: [request.nodeID],
+                previousVersion: loaded.version,
+                streamVersion: loaded.version,
+                events: [event]
+            )
+        }
+        let append = try await append(
+            [event],
+            runID: request.runID,
+            expectedVersion: loaded.version
+        )
+        return report(
+            operation: "graph.retry",
+            status: .applied,
+            runID: request.runID,
+            nodeIDs: [request.nodeID],
+            previousVersion: append.previousVersion,
+            streamVersion: append.newVersion,
+            events: [event]
+        )
+    }
+
+    public func cancel(
+        _ request: GraphCancelMutationRequest
+    ) async throws -> GraphMutationReport {
+        let loaded = try await load(request.runID)
+        try requireExpected(request.expectedVersion, actual: loaded.version)
+        guard loaded.projection.run?.state.isTerminal != true else {
+            throw GraphMutationError.policyDenied(
+                "terminal runs cannot be cancelled."
+            )
+        }
+        let candidates = loaded.projection.nodes.filter { node in
+            request.nodeID == nil || request.nodeID == node.id
+        }
+        guard !candidates.isEmpty else {
+            throw GraphMutationError.invalidRequest(
+                "cancellation node was not found."
+            )
+        }
+        let latestByNode = Dictionary(
+            grouping: loaded.projection.attempts,
+            by: \.nodeID
+        ).mapValues { attempts in
+            attempts.max { $0.ordinal < $1.ordinal }!
+        }
+        let activeClaimByNode = Dictionary(
+            uniqueKeysWithValues: loaded.projection.scheduling.claims
+                .filter { $0.status == .active }
+                .map { ($0.claim.nodeID, $0.claim) }
+        )
+        var events: [GraphExecutionEventEnvelope] = []
+        for node in candidates.sorted(by: { $0.id < $1.id }) {
+            let attempt = latestByNode[node.id]
+            if attempt?.state.isTerminal == true {
+                continue
+            }
+            let requestID = Self.stableID(
+                "cancel|\(request.idempotencyKey)|\(node.id)"
+            )
+            if loaded.projection.scheduling.cancellations.contains(
+                where: { $0.id == requestID }
+            ) {
+                continue
+            }
+            let claim = activeClaimByNode[node.id]
+            let cancellation = GraphCancellationRecord(
+                requestID: requestID,
+                runID: request.runID,
+                nodeID: node.id,
+                attemptID: attempt?.id,
+                claimID: claim?.id,
+                requestedBy: request.requestedBy,
+                requestedAt: request.occurredAt,
+                reason: request.reason
+            )
+            events.append(
+                GraphExecutionEventEnvelope(
+                    id: "cancellation-request-\(requestID)",
+                    runID: request.runID,
+                    nodeID: node.id,
+                    attemptID: attempt?.id,
+                    streamSequence: loaded.version
+                        + UInt64(events.count) + 1,
+                    occurredAt: request.occurredAt,
+                    recordedAt: request.occurredAt,
+                    producer: request.producer,
+                    correlationID: requestID,
+                    payload: .cancellationRequested(
+                        GraphCancellationRequestedPayload(
+                            cancellation: cancellation
+                        )
+                    )
+                )
+            )
+        }
+        if events.isEmpty {
+            return GraphMutationReport(
+                operation: "graph.cancel",
+                status: .deduplicated,
+                runID: request.runID,
+                nodeIDs: candidates.map(\.id),
+                previousVersion: loaded.version,
+                streamVersion: loaded.version,
+                eventTypes: []
+            )
+        }
+        if request.dryRun {
+            return report(
+                operation: "graph.cancel",
+                status: .proposed,
+                runID: request.runID,
+                nodeIDs: candidates.map(\.id),
+                previousVersion: loaded.version,
+                streamVersion: loaded.version,
+                events: events
+            )
+        }
+        let append = try await append(
+            events,
+            runID: request.runID,
+            expectedVersion: loaded.version
+        )
+        return report(
+            operation: "graph.cancel",
+            status: .applied,
+            runID: request.runID,
+            nodeIDs: candidates.map(\.id),
+            previousVersion: append.previousVersion,
+            streamVersion: append.newVersion,
+            events: events
+        )
+    }
+
+    private struct Loaded {
+        let version: UInt64
+        let projection: GraphExecutionProjection
+    }
+
+    private struct ExistingCreate {
+        let runID: String
+        let fingerprint: GraphContentDigest?
+        let streamVersion: UInt64
+    }
+
+    private func load(_ runID: String) async throws -> Loaded {
+        let stream: GraphExecutionEventStream
+        do {
+            stream = try await eventStore.read(
+                runID: runID,
+                afterVersion: 0
+            )
+        } catch {
+            throw GraphMutationError.persistence(error.localizedDescription)
+        }
+        guard !stream.events.isEmpty else {
+            throw GraphMutationError.notFound(runID)
+        }
+        do {
+            return Loaded(
+                version: stream.currentVersion,
+                projection: try GraphExecutionProjector.replay(
+                    runID: runID,
+                    events: stream.events
+                ).projection
+            )
+        } catch {
+            throw GraphMutationError.persistence(error.localizedDescription)
+        }
+    }
+
+    private func findCreate(
+        idempotencyKey: String
+    ) async throws -> ExistingCreate? {
+        do {
+            for descriptor in try await readStore.listStreams() {
+                let page = try await readStore.readPage(
+                    runID: descriptor.runID,
+                    afterVersion: 0,
+                    limit: 1
+                )
+                guard let event = page.events.first,
+                      case let .runCreated(payload) = event.payload,
+                      payload.clientIdempotencyKey == idempotencyKey else {
+                    continue
+                }
+                return ExistingCreate(
+                    runID: descriptor.runID,
+                    fingerprint: payload.requestFingerprint,
+                    streamVersion: descriptor.currentVersion
+                )
+            }
+            return nil
+        } catch {
+            throw GraphMutationError.persistence(error.localizedDescription)
+        }
+    }
+
+    private func createEvents(
+        _ request: GraphCreateRequest,
+        fingerprint: GraphContentDigest
+    ) -> [GraphExecutionEventEnvelope] {
+        let scheduling = request.definition.scheduling
+        var events = [
+            GraphExecutionEventEnvelope(
+                id: "create-\(Self.stableID(request.idempotencyKey))",
+                runID: request.runID,
+                streamSequence: 1,
+                occurredAt: request.occurredAt,
+                recordedAt: request.occurredAt,
+                producer: request.producer,
+                correlationID: request.idempotencyKey,
+                payload: .runCreated(
+                    GraphRunCreatedPayload(
+                        graphID: scheduling.graphID,
+                        graphDefinitionVersion: scheduling.version,
+                        graphDefinitionDigest: scheduling.digest,
+                        nodeIDs: scheduling.nodes.map(\.id),
+                        clientIdempotencyKey: request.idempotencyKey,
+                        requestFingerprint: fingerprint,
+                        executableDefinition: request.definition
+                    )
+                )
+            ),
+        ]
+        for node in scheduling.nodes {
+            events.append(
+                GraphExecutionEventEnvelope(
+                    id: "create-node-\(Self.stableID("\(request.runID)|\(node.id)"))",
+                    runID: request.runID,
+                    nodeID: node.id,
+                    streamSequence: UInt64(events.count + 1),
+                    occurredAt: request.occurredAt,
+                    recordedAt: request.occurredAt,
+                    producer: request.producer,
+                    correlationID: request.idempotencyKey,
+                    payload: .nodeRegistered(
+                        GraphNodeRegisteredPayload(
+                            title: node.title,
+                            dependencyNodeIDs: node.dependencyNodeIDs,
+                            definitionVersion: scheduling.version
+                        )
+                    )
+                )
+            )
+        }
+        return events
+    }
+
+    private func requireExpected(
+        _ expected: UInt64?,
+        actual: UInt64
+    ) throws {
+        guard expected == nil || expected == actual else {
+            throw GraphMutationError.optimisticConflict(
+                expected: expected!,
+                actual: actual
+            )
+        }
+    }
+
+    private func append(
+        _ events: [GraphExecutionEventEnvelope],
+        runID: String,
+        expectedVersion: UInt64
+    ) async throws -> GraphExecutionAppendResult {
+        do {
+            return try await eventStore.append(
+                events,
+                to: runID,
+                expectedVersion: expectedVersion
+            )
+        } catch let error as GraphExecutionPersistenceError {
+            switch error {
+            case let .expectedVersionConflict(_, expected, actual):
+                throw GraphMutationError.optimisticConflict(
+                    expected: expected,
+                    actual: actual
+                )
+            case .eventIDCollision:
+                throw GraphMutationError.idempotencyConflict(
+                    events.first?.correlationID ?? "unknown"
+                )
+            default:
+                throw GraphMutationError.persistence(
+                    error.localizedDescription
+                )
+            }
+        } catch {
+            throw GraphMutationError.persistence(error.localizedDescription)
+        }
+    }
+
+    private func report(
+        operation: String,
+        status: GraphMutationStatus,
+        runID: String,
+        nodeIDs: [String] = [],
+        previousVersion: UInt64,
+        streamVersion: UInt64,
+        events: [GraphExecutionEventEnvelope]
+    ) -> GraphMutationReport {
+        GraphMutationReport(
+            operation: operation,
+            status: status,
+            runID: runID,
+            nodeIDs: nodeIDs,
+            previousVersion: previousVersion,
+            streamVersion: streamVersion,
+            eventTypes: events.map(\.eventType)
+        )
+    }
+
+    private static func fingerprint(
+        _ definition: GraphExecutableDefinition
+    ) throws -> GraphContentDigest {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(definition)
+        return GraphContentDigest(
+            algorithm: "sha256",
+            value: SHA256.hash(data: data)
+                .map { String(format: "%02x", $0) }
+                .joined()
+        )
+    }
+
+    package static func stableID(_ value: String) -> String {
+        SHA256.hash(data: Data(value.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+            .prefix(24)
+            .description
+    }
+}

--- a/Sources/OpenIslandCore/GraphOrchestrationService.swift
+++ b/Sources/OpenIslandCore/GraphOrchestrationService.swift
@@ -746,15 +746,20 @@ public struct DefaultGraphOrchestrationService:
                 )
                 persisted += persistedPrepare.appendResult.appendedCount
                 current = try await load(context.identity.runID)
-                let refreshed = try executionContext(
-                    claim: currentClaim(context.identity, current.projection),
-                    definition: definition,
-                    projection: current.projection,
-                    logicalTime: context.logicalTime
-                )
-                operation = .start
-                observation = try await invokeStart(refreshed)
-                invocations += 1
+                if prepared.status.isTerminalObservation {
+                    operation = .prepare
+                    observation = prepared
+                } else {
+                    let refreshed = try executionContext(
+                        claim: currentClaim(context.identity, current.projection),
+                        definition: definition,
+                        projection: current.projection,
+                        logicalTime: context.logicalTime
+                    )
+                    operation = .start
+                    observation = try await invokeStart(refreshed)
+                    invocations += 1
+                }
             } else if lifecycle?.phase == .startRequested {
                 operation = .recover
                 observation = try await invokeRecover(context)

--- a/Sources/OpenIslandCore/GraphOrchestrationService.swift
+++ b/Sources/OpenIslandCore/GraphOrchestrationService.swift
@@ -1,0 +1,1400 @@
+import Foundation
+
+public enum GraphOrchestrationCycleStatus:
+    String,
+    Codable,
+    Sendable
+{
+    case proposed
+    case progressed
+    case terminal
+    case waitingForCancellation = "waiting_for_cancellation"
+    case stalled
+    case adapterUnavailable = "adapter_unavailable"
+    case cycleLimitReached = "cycle_limit_reached"
+}
+
+public struct GraphOrchestrationCycleReport:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let schemaVersion: Int
+    public let runID: String
+    public let status: GraphOrchestrationCycleStatus
+    public let logicalTime: Date
+    public let previousVersion: UInt64
+    public let streamVersion: UInt64
+    public let schedulerEvaluationID: String?
+    public let claimedNodeID: String?
+    public let claimID: String?
+    public let executorOperation: GraphExecutorOperation?
+    public let executorStatus: GraphExecutorResponseStatus?
+    public let proposedEventTypes: [String]
+    public let persistedEventCount: Int
+    public let executorInvocationCount: Int
+    public let runState: ReconciledExecutionState
+    public let policyDenials: [GraphSchedulingReasonCode]
+
+    public init(
+        schemaVersion: Int = GraphCLIOutputSchema.currentVersion,
+        runID: String,
+        status: GraphOrchestrationCycleStatus,
+        logicalTime: Date,
+        previousVersion: UInt64,
+        streamVersion: UInt64,
+        schedulerEvaluationID: String? = nil,
+        claimedNodeID: String? = nil,
+        claimID: String? = nil,
+        executorOperation: GraphExecutorOperation? = nil,
+        executorStatus: GraphExecutorResponseStatus? = nil,
+        proposedEventTypes: [String] = [],
+        persistedEventCount: Int = 0,
+        executorInvocationCount: Int = 0,
+        runState: ReconciledExecutionState,
+        policyDenials: [GraphSchedulingReasonCode] = []
+    ) {
+        self.schemaVersion = schemaVersion
+        self.runID = runID
+        self.status = status
+        self.logicalTime = logicalTime
+        self.previousVersion = previousVersion
+        self.streamVersion = streamVersion
+        self.schedulerEvaluationID = schedulerEvaluationID
+        self.claimedNodeID = claimedNodeID
+        self.claimID = claimID
+        self.executorOperation = executorOperation
+        self.executorStatus = executorStatus
+        self.proposedEventTypes = proposedEventTypes
+        self.persistedEventCount = persistedEventCount
+        self.executorInvocationCount = executorInvocationCount
+        self.runState = runState
+        self.policyDenials = policyDenials.sorted {
+            $0.rawValue < $1.rawValue
+        }
+    }
+
+    public var madeProgress: Bool {
+        persistedEventCount > 0 || executorInvocationCount > 0
+    }
+}
+
+public struct GraphOrchestrationRunReport:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let schemaVersion: Int
+    public let runID: String
+    public let status: GraphOrchestrationCycleStatus
+    public let cycles: [GraphOrchestrationCycleReport]
+    public let finalVersion: UInt64
+    public let finalState: ReconciledExecutionState
+
+    public init(
+        schemaVersion: Int = GraphCLIOutputSchema.currentVersion,
+        runID: String,
+        status: GraphOrchestrationCycleStatus,
+        cycles: [GraphOrchestrationCycleReport],
+        finalVersion: UInt64,
+        finalState: ReconciledExecutionState
+    ) {
+        self.schemaVersion = schemaVersion
+        self.runID = runID
+        self.status = status
+        self.cycles = cycles
+        self.finalVersion = finalVersion
+        self.finalState = finalState
+    }
+}
+
+public struct GraphOrchestrationStepRequest: Equatable, Sendable {
+    public let runID: String
+    public let logicalTime: Date
+    public let expectedVersion: UInt64?
+    public let dryRun: Bool
+
+    public init(
+        runID: String,
+        logicalTime: Date,
+        expectedVersion: UInt64? = nil,
+        dryRun: Bool = false
+    ) {
+        self.runID = runID
+        self.logicalTime = logicalTime
+        self.expectedVersion = expectedVersion
+        self.dryRun = dryRun
+    }
+}
+
+public struct GraphOrchestrationRunRequest: Equatable, Sendable {
+    public let runID: String
+    public let cycleLimit: Int
+    public let expectedVersion: UInt64?
+    public let dryRun: Bool
+    public let logicalTime: Date?
+
+    public init(
+        runID: String,
+        cycleLimit: Int,
+        expectedVersion: UInt64? = nil,
+        dryRun: Bool = false,
+        logicalTime: Date? = nil
+    ) {
+        self.runID = runID
+        self.cycleLimit = max(1, cycleLimit)
+        self.expectedVersion = expectedVersion
+        self.dryRun = dryRun
+        self.logicalTime = logicalTime
+    }
+}
+
+public enum GraphOrchestrationError: Error, Equatable, Sendable {
+    case notFound(String)
+    case invalidDefinition(String)
+    case optimisticConflict(expected: UInt64, actual: UInt64)
+    case staleExecutor(GraphExecutorFencingReason)
+    case adapterUnavailable(String)
+    case persistence(String)
+}
+
+extension GraphOrchestrationError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .notFound(runID):
+            "Graph run \(runID) was not found."
+        case let .invalidDefinition(message):
+            "Graph execution definition is invalid: \(message)"
+        case let .optimisticConflict(expected, actual):
+            "Expected stream version \(expected), found \(actual)."
+        case let .staleExecutor(reason):
+            "Executor fencing rejected the operation: \(reason.rawValue)."
+        case let .adapterUnavailable(message):
+            "Executor adapter is unavailable: \(message)"
+        case let .persistence(message):
+            "Graph orchestration persistence failed: \(message)"
+        }
+    }
+}
+
+public protocol GraphOrchestrationClock: Sendable {
+    func now() -> Date
+}
+
+public struct SystemGraphOrchestrationClock:
+    GraphOrchestrationClock,
+    Sendable
+{
+    public init() {}
+    public func now() -> Date { Date() }
+}
+
+public protocol GraphExecutionConfirmationPolicy: Sendable {
+    func permits(
+        operation: GraphExecutorOperation,
+        context: GraphExecutorCommandContext
+    ) -> Bool
+}
+
+public struct DeterministicExecutionConfirmationPolicy:
+    GraphExecutionConfirmationPolicy,
+    Sendable
+{
+    public init() {}
+
+    public func permits(
+        operation: GraphExecutorOperation,
+        context: GraphExecutorCommandContext
+    ) -> Bool {
+        context.specification.adapterKind == "deterministic"
+    }
+}
+
+public protocol GraphOrchestrating: Sendable {
+    func step(_ request: GraphOrchestrationStepRequest) async throws
+        -> GraphOrchestrationCycleReport
+    func run(_ request: GraphOrchestrationRunRequest) async throws
+        -> GraphOrchestrationRunReport
+}
+
+public enum GraphArtifactInputResolver {
+    public static func resolve(
+        nodeID: String,
+        definition: GraphExecutableDefinition,
+        projection: GraphExecutionProjection
+    ) throws -> [GraphArtifactReference] {
+        guard let execution = definition.execution(for: nodeID),
+              let node = definition.scheduling.nodes.first(where: {
+                $0.id == nodeID
+              }) else {
+            throw GraphOrchestrationError.invalidDefinition(
+                "node \(nodeID) is missing."
+            )
+        }
+        let ancestorIDs = ancestors(
+            of: node,
+            nodes: definition.scheduling.nodes
+        )
+        let roles = Set(execution.inputArtifactRoles.map(\.rawValue))
+        return try projection.artifacts.filter { artifact in
+            guard ancestorIDs.contains(artifact.producingNodeID),
+                  roles.contains(artifact.logicalRole) else {
+                return false
+            }
+            guard artifact.producingRunID == projection.runID,
+                  let ordinal = artifact.producingAttemptOrdinal,
+                  let claimID = artifact.producingClaimID,
+                  projection.attempts.contains(where: {
+                    $0.id == artifact.producingAttemptID
+                        && $0.nodeID == artifact.producingNodeID
+                        && $0.ordinal == ordinal
+                        && $0.state == .completed
+                  }),
+                  projection.scheduling.claims.contains(where: {
+                    $0.claim.id == claimID
+                        && $0.claim.nodeID == artifact.producingNodeID
+                        && $0.claim.attemptOrdinal == ordinal
+                  }) else {
+                throw GraphOrchestrationError.invalidDefinition(
+                    "artifact \(artifact.id) has invalid provenance."
+                )
+            }
+            return true
+        }.sorted { $0.id < $1.id }
+    }
+
+    private static func ancestors(
+        of node: GraphSchedulingDefinitionNode,
+        nodes: [GraphSchedulingDefinitionNode]
+    ) -> Set<String> {
+        let byID = Dictionary(uniqueKeysWithValues: nodes.map { ($0.id, $0) })
+        var result = Set<String>()
+        var pending = node.dependencyNodeIDs
+        while let next = pending.popLast() {
+            guard result.insert(next).inserted else { continue }
+            pending.append(contentsOf: byID[next]?.dependencyNodeIDs ?? [])
+        }
+        return result
+    }
+}
+
+public struct DefaultGraphOrchestrationService:
+    GraphOrchestrating,
+    Sendable
+{
+    private let eventStore: any GraphExecutionEventStore
+    private let schedulingRepository: any GraphSchedulingRepository
+    private let executorRepository: any GraphExecutorPersisting
+    private let executor: any GraphExecutorAdapter
+    private let confirmationPolicy: any GraphExecutionConfirmationPolicy
+    private let clock: any GraphOrchestrationClock
+    private let producer: GraphExecutionProducer
+
+    public init(
+        eventStore: any GraphExecutionEventStore,
+        schedulingRepository: any GraphSchedulingRepository,
+        executorRepository: any GraphExecutorPersisting,
+        executor: any GraphExecutorAdapter,
+        confirmationPolicy: any GraphExecutionConfirmationPolicy =
+            DeterministicExecutionConfirmationPolicy(),
+        clock: any GraphOrchestrationClock =
+            SystemGraphOrchestrationClock(),
+        producer: GraphExecutionProducer = GraphExecutionProducer(
+            id: "openisland.orchestrator",
+            kind: .application
+        )
+    ) {
+        self.eventStore = eventStore
+        self.schedulingRepository = schedulingRepository
+        self.executorRepository = executorRepository
+        self.executor = executor
+        self.confirmationPolicy = confirmationPolicy
+        self.clock = clock
+        self.producer = producer
+    }
+
+    public func step(
+        _ request: GraphOrchestrationStepRequest
+    ) async throws -> GraphOrchestrationCycleReport {
+        let initial = try await load(request.runID)
+        if let expected = request.expectedVersion,
+           expected != initial.version {
+            throw GraphOrchestrationError.optimisticConflict(
+                expected: expected,
+                actual: initial.version
+            )
+        }
+        guard let definition = initial.projection.executableDefinition else {
+            throw GraphOrchestrationError.invalidDefinition(
+                "run has no durable executable definition."
+            )
+        }
+        try definition.validate()
+        if initial.projection.run?.state.isTerminal == true {
+            return report(
+                loaded: initial,
+                initialVersion: initial.version,
+                status: .terminal,
+                logicalTime: request.logicalTime
+            )
+        }
+        guard initial.projection.runStartRequestedAt != nil else {
+            return report(
+                loaded: initial,
+                initialVersion: initial.version,
+                status: .stalled,
+                logicalTime: request.logicalTime,
+                denials: [.runNotStarted]
+            )
+        }
+        if request.dryRun {
+            return try dryRunReport(
+                loaded: initial,
+                definition: definition,
+                logicalTime: request.logicalTime
+            )
+        }
+
+        if let cancellation = pendingUnclaimedCancellation(
+            initial.projection
+        ) {
+            let result = try await schedulingRepository
+                .declareCancellationTerminal(
+                    GraphCancellationTerminalRequest(
+                        runID: request.runID,
+                        requestID: cancellation.id,
+                        expectedVersion: initial.version,
+                        logicalTime: request.logicalTime,
+                        reason: cancellation.reason,
+                        producer: producer,
+                        recordedAt: request.logicalTime
+                    )
+                )
+            let loaded = try await load(request.runID)
+            let terminal = try await recordRunTerminalIfJustified(
+                loaded: loaded,
+                definition: definition,
+                logicalTime: request.logicalTime
+            )
+            return report(
+                loaded: terminal,
+                initialVersion: initial.version,
+                status: terminal.projection.run?.state.isTerminal == true
+                    ? .terminal : .progressed,
+                logicalTime: request.logicalTime,
+                persistedCount: result.appendResult.appendedCount
+                    + Int(terminal.version - loaded.version)
+            )
+        }
+
+        var current = initial
+        let evaluation = try await schedulingRepository.evaluateAndAppend(
+            GraphSchedulerEvaluationRequest(
+                runID: request.runID,
+                expectedVersion: current.version,
+                definition: definition.scheduling,
+                policy: definition.schedulerPolicy,
+                logicalTime: request.logicalTime,
+                availableExecutors: [executor.capabilities],
+                failureCategoriesByAttemptID: failureCategories(
+                    current.projection
+                ),
+                producer: producer,
+                recordedAt: request.logicalTime
+            )
+        )
+        current = try await load(request.runID)
+        let evaluationID = current.projection.scheduling.records.last(where: {
+            $0.eventType == GraphExecutionEventType
+                .schedulerCycleCompleted.rawValue
+        })?.evaluationID
+        var persisted = evaluation.appendResult.appendedCount
+
+        if let terminal = try await terminalAfterScheduling(
+            current,
+            definition: definition,
+            logicalTime: request.logicalTime
+        ) {
+            return report(
+                loaded: terminal,
+                initialVersion: initial.version,
+                status: .terminal,
+                logicalTime: request.logicalTime,
+                evaluationID: evaluationID,
+                persistedCount: persisted
+                    + Int(terminal.version - current.version)
+            )
+        }
+
+        var claim = current.projection.scheduling.activeClaim(
+            nodeID: current.projection.scheduling.claims
+                .filter { $0.status == .active }
+                .map(\.claim.nodeID)
+                .sorted().first ?? "",
+            at: request.logicalTime
+        )
+        if claim == nil,
+           let nodeID = claimableNode(
+            projection: current.projection,
+            evaluationID: evaluationID
+           ), let evaluationID {
+            let claimMaterial = [
+                evaluationID,
+                nodeID,
+                executor.capabilities.executorID,
+            ].joined(separator: "|")
+            let claimDigest = DefaultGraphMutationService.stableID(
+                claimMaterial
+            )
+            let claimID = "claim-\(claimDigest)"
+            let claimed = try await schedulingRepository.attemptClaim(
+                GraphExecutorClaimRequest(
+                    runID: request.runID,
+                    nodeID: nodeID,
+                    claimID: claimID,
+                    executor: executor.capabilities,
+                    evaluationID: evaluationID,
+                    expectedVersion: current.version,
+                    logicalTime: request.logicalTime,
+                    leaseDurationSeconds: definition.schedulerPolicy
+                        .defaultLeaseDurationSeconds,
+                    producer: producer,
+                    recordedAt: request.logicalTime
+                )
+            )
+            persisted += claimed.appendResult.appendedCount
+            claim = claimed.claim
+            current = try await load(request.runID)
+        }
+
+        guard let claim else {
+            return report(
+                loaded: current,
+                initialVersion: initial.version,
+                status: persisted > 0 ? .progressed : .stalled,
+                logicalTime: request.logicalTime,
+                evaluationID: evaluationID,
+                persistedCount: persisted,
+                denials: schedulingDenials(current.projection)
+            )
+        }
+        let execution = try executionContext(
+            claim: claim,
+            definition: definition,
+            projection: current.projection,
+            logicalTime: request.logicalTime
+        )
+
+        if let timeout = timeoutKind(
+            context: execution,
+            projection: current.projection
+        ) {
+            return try await timeOutExecution(
+                kind: timeout,
+                context: execution,
+                initial: initial,
+                current: current,
+                definition: definition,
+                evaluationID: evaluationID,
+                persisted: persisted
+            )
+        }
+
+        if let cancellation = current.projection.scheduling
+            .pendingCancellation(nodeID: claim.nodeID),
+           cancellation.state == .requested {
+            return try await cancelClaimedExecution(
+                cancellation: cancellation,
+                context: execution,
+                initial: initial,
+                current: current,
+                definition: definition,
+                evaluationID: evaluationID,
+                persisted: persisted
+            )
+        }
+
+        return try await executeOneOperation(
+            context: execution,
+            initial: initial,
+            current: current,
+            definition: definition,
+            evaluationID: evaluationID,
+            persisted: persisted
+        )
+    }
+
+    public func run(
+        _ request: GraphOrchestrationRunRequest
+    ) async throws -> GraphOrchestrationRunReport {
+        var cycles: [GraphOrchestrationCycleReport] = []
+        var expected = request.expectedVersion
+        for _ in 0..<request.cycleLimit {
+            let cycle = try await step(
+                GraphOrchestrationStepRequest(
+                    runID: request.runID,
+                    logicalTime: request.logicalTime ?? clock.now(),
+                    expectedVersion: expected,
+                    dryRun: request.dryRun
+                )
+            )
+            cycles.append(cycle)
+            expected = nil
+            if cycle.status == .terminal
+                || cycle.status == .waitingForCancellation
+                || cycle.status == .adapterUnavailable
+                || !cycle.madeProgress
+                || request.dryRun {
+                return GraphOrchestrationRunReport(
+                    runID: request.runID,
+                    status: cycle.status,
+                    cycles: cycles,
+                    finalVersion: cycle.streamVersion,
+                    finalState: cycle.runState
+                )
+            }
+        }
+        let last = cycles.last!
+        return GraphOrchestrationRunReport(
+            runID: request.runID,
+            status: .cycleLimitReached,
+            cycles: cycles,
+            finalVersion: last.streamVersion,
+            finalState: last.runState
+        )
+    }
+
+    private struct Loaded {
+        let version: UInt64
+        let events: [GraphExecutionEventEnvelope]
+        let projection: GraphExecutionProjection
+    }
+
+    private func load(_ runID: String) async throws -> Loaded {
+        do {
+            let stream = try await eventStore.read(
+                runID: runID,
+                afterVersion: 0
+            )
+            guard !stream.events.isEmpty else {
+                throw GraphOrchestrationError.notFound(runID)
+            }
+            return Loaded(
+                version: stream.currentVersion,
+                events: stream.events,
+                projection: try GraphExecutionProjector.replay(
+                    runID: runID,
+                    events: stream.events
+                ).projection
+            )
+        } catch let error as GraphOrchestrationError {
+            throw error
+        } catch {
+            throw GraphOrchestrationError.persistence(
+                error.localizedDescription
+            )
+        }
+    }
+
+    private func dryRunReport(
+        loaded: Loaded,
+        definition: GraphExecutableDefinition,
+        logicalTime: Date
+    ) throws -> GraphOrchestrationCycleReport {
+        guard let reconciled = GraphExecutionProjectionReconciler.reconcile(
+                projection: loaded.projection,
+                evidenceOutcome: .available(GraphProcessEvidence()),
+                observedAt: logicalTime
+        ) else {
+            throw GraphOrchestrationError.invalidDefinition(
+                "run projection cannot be reconciled."
+            )
+        }
+        let decision = GraphScheduler.evaluate(
+            GraphSchedulingInput(
+                definition: definition.scheduling,
+                projectedState: loaded.projection,
+                reconciledState: reconciled,
+                policy: definition.schedulerPolicy,
+                logicalTime: logicalTime,
+                availableExecutors: [executor.capabilities],
+                failureCategoriesByAttemptID: failureCategories(
+                    loaded.projection
+                )
+            )
+        )
+        let nodeID = decision.phasesByNodeID.keys.sorted().first {
+            decision.phasesByNodeID[$0] == .claimable
+        }
+        var eventTypes = decision.proposedEvents.map {
+            $0.payload.eventType
+        }
+        if nodeID != nil {
+            eventTypes += [
+                GraphExecutionEventType.executorClaimRequested.rawValue,
+                GraphExecutionEventType.executorClaimGranted.rawValue,
+                GraphExecutionEventType.attemptStarting.rawValue,
+                GraphExecutionEventType.executorObservationRecorded.rawValue,
+            ]
+        }
+        return GraphOrchestrationCycleReport(
+            runID: loaded.projection.runID,
+            status: .proposed,
+            logicalTime: logicalTime,
+            previousVersion: loaded.version,
+            streamVersion: loaded.version,
+            schedulerEvaluationID: decision.evaluationID,
+            claimedNodeID: nodeID,
+            executorOperation: nodeID == nil ? nil : .prepare,
+            proposedEventTypes: eventTypes,
+            runState: loaded.projection.run?.state ?? .pending,
+            policyDenials: Array(decision.reasonsByNodeID.values)
+                .filter { $0 != .dependenciesSatisfied }
+        )
+    }
+
+    private func executeOneOperation(
+        context: GraphExecutorCommandContext,
+        initial: Loaded,
+        current: Loaded,
+        definition: GraphExecutableDefinition,
+        evaluationID: String?,
+        persisted: Int
+    ) async throws -> GraphOrchestrationCycleReport {
+        var current = current
+        var persisted = persisted
+        let lifecycle = current.projection.attemptLifecycles.first {
+            $0.attemptID == context.identity.attemptID
+        }
+        let operation: GraphExecutorOperation
+        let observation: GraphExecutorObservation
+        var invocations = 0
+
+        do {
+            if lifecycle?.phase == .claimed || lifecycle?.phase == .created {
+                let started = try await executorRepository.recordStartRequest(
+                    GraphExecutorStartCommand(
+                        identity: context.identity,
+                        expectedVersion: current.version,
+                        logicalTime: context.logicalTime,
+                        producer: producer,
+                        correlationID: context.correlation.correlationID
+                    )
+                )
+                persisted += started.appendResult.appendedCount
+                current = try await load(context.identity.runID)
+                let prepared = try await invokePrepare(context)
+                invocations += 1
+                let persistedPrepare = try await persistObservation(
+                    prepared,
+                    current: current,
+                    correlationID: context.correlation.correlationID
+                )
+                persisted += persistedPrepare.appendResult.appendedCount
+                current = try await load(context.identity.runID)
+                let refreshed = try executionContext(
+                    claim: currentClaim(context.identity, current.projection),
+                    definition: definition,
+                    projection: current.projection,
+                    logicalTime: context.logicalTime
+                )
+                operation = .start
+                observation = try await invokeStart(refreshed)
+                invocations += 1
+            } else if lifecycle?.phase == .startRequested {
+                operation = .recover
+                observation = try await invokeRecover(context)
+                invocations += 1
+            } else {
+                operation = .observe
+                observation = try await invokeObserve(context)
+                invocations += 1
+            }
+        } catch is GraphExecutorAdapterError {
+            let loaded = try await load(context.identity.runID)
+            return report(
+                loaded: loaded,
+                initialVersion: initial.version,
+                status: .adapterUnavailable,
+                logicalTime: context.logicalTime,
+                evaluationID: evaluationID,
+                claim: currentClaim(context.identity, loaded.projection),
+                persistedCount: persisted,
+                executorOperation: lifecycle?.phase == .startRequested
+                    ? .recover : .start,
+                executorInvocations: invocations + 1,
+                denials: [],
+                adapterStatus: .transientAdapterFailure
+            )
+        }
+        let observationResult = try await persistObservation(
+            observation,
+            current: current,
+            correlationID: context.correlation.correlationID
+        )
+        persisted += observationResult.appendResult.appendedCount
+        current = try await load(context.identity.runID)
+
+        if observation.status.isTerminalObservation {
+            return try await finishTerminalObservation(
+                observation,
+                operation: operation,
+                context: context,
+                initial: initial,
+                current: current,
+                definition: definition,
+                evaluationID: evaluationID,
+                persisted: persisted,
+                invocations: invocations
+            )
+        }
+        return report(
+            loaded: current,
+            initialVersion: initial.version,
+            status: .progressed,
+            logicalTime: context.logicalTime,
+            evaluationID: evaluationID,
+            claim: currentClaim(context.identity, current.projection),
+            persistedCount: persisted,
+            executorOperation: operation,
+            executorInvocations: invocations,
+            adapterStatus: observation.status
+        )
+    }
+
+    private func finishTerminalObservation(
+        _ initialObservation: GraphExecutorObservation,
+        operation: GraphExecutorOperation,
+        context: GraphExecutorCommandContext,
+        initial: Loaded,
+        current: Loaded,
+        definition: GraphExecutableDefinition,
+        evaluationID: String?,
+        persisted: Int,
+        invocations: Int
+    ) async throws -> GraphOrchestrationCycleReport {
+        var current = current
+        var persisted = persisted
+        var invocations = invocations
+        var terminalObservation = initialObservation
+        if initialObservation.status == .succeeded,
+           operation != .collectResult {
+            let refreshed = try refreshedContext(context, loaded: current)
+            terminalObservation = try await invokeCollect(refreshed)
+            invocations += 1
+            let result = try await persistObservation(
+                terminalObservation,
+                current: current,
+                correlationID: context.correlation.correlationID
+            )
+            persisted += result.appendResult.appendedCount
+            current = try await load(context.identity.runID)
+        }
+        let refreshed = try refreshedContext(context, loaded: current)
+        let cleanup = try await invokeCleanup(refreshed)
+        invocations += 1
+        let cleanupResult = try await persistObservation(
+            cleanup,
+            current: current,
+            correlationID: context.correlation.correlationID
+        )
+        persisted += cleanupResult.appendResult.appendedCount
+        current = try await load(context.identity.runID)
+        let state = terminalState(terminalObservation.status)
+        let terminal = try await executorRepository.declareTerminal(
+            GraphExecutorTerminalDeclaration(
+                identity: context.identity,
+                observationID: terminalObservation.id,
+                state: state,
+                reason: terminalObservation.failure?.category,
+                expectedVersion: current.version,
+                logicalTime: context.logicalTime,
+                producer: producer,
+                correlationID: context.correlation.correlationID
+            )
+        )
+        persisted += terminal.appendResult.appendedCount
+        current = try await load(context.identity.runID)
+        let aggregate = try await recordRunTerminalIfJustified(
+            loaded: current,
+            definition: definition,
+            logicalTime: context.logicalTime
+        )
+        persisted += Int(aggregate.version - current.version)
+        return report(
+            loaded: aggregate,
+            initialVersion: initial.version,
+            status: aggregate.projection.run?.state.isTerminal == true
+                ? .terminal : .progressed,
+            logicalTime: context.logicalTime,
+            evaluationID: evaluationID,
+            claim: nil,
+            persistedCount: persisted,
+            executorOperation: operation,
+            executorInvocations: invocations,
+            adapterStatus: terminalObservation.status
+        )
+    }
+
+    private func cancelClaimedExecution(
+        cancellation: GraphCancellationRecord,
+        context: GraphExecutorCommandContext,
+        initial: Loaded,
+        current: Loaded,
+        definition: GraphExecutableDefinition,
+        evaluationID: String?,
+        persisted: Int
+    ) async throws -> GraphOrchestrationCycleReport {
+        var current = current
+        var persisted = persisted
+        let observation = try await invokeCancellation(
+            context,
+            requestID: cancellation.id
+        )
+        let result = try await persistObservation(
+            observation,
+            current: current,
+            correlationID: cancellation.id
+        )
+        persisted += result.appendResult.appendedCount
+        current = try await load(context.identity.runID)
+        guard observation.status == .cancelled else {
+            return report(
+                loaded: current,
+                initialVersion: initial.version,
+                status: .waitingForCancellation,
+                logicalTime: context.logicalTime,
+                evaluationID: evaluationID,
+                claim: currentClaim(context.identity, current.projection),
+                persistedCount: persisted,
+                executorOperation: .requestCancellation,
+                executorInvocations: 1,
+                adapterStatus: observation.status
+            )
+        }
+        let acknowledged = try await executorRepository
+            .acknowledgeCancellation(
+                GraphExecutorCancellationAcknowledgement(
+                    identity: context.identity,
+                    requestID: cancellation.id,
+                    expectedVersion: current.version,
+                    logicalTime: context.logicalTime,
+                    producer: producer
+                )
+            )
+        persisted += acknowledged.appendResult.appendedCount
+        current = try await load(context.identity.runID)
+        return try await finishTerminalObservation(
+            observation,
+            operation: .requestCancellation,
+            context: context,
+            initial: initial,
+            current: current,
+            definition: definition,
+            evaluationID: evaluationID,
+            persisted: persisted,
+            invocations: 1
+        )
+    }
+
+    private func timeOutExecution(
+        kind: GraphTimeoutKind,
+        context: GraphExecutorCommandContext,
+        initial: Loaded,
+        current: Loaded,
+        definition: GraphExecutableDefinition,
+        evaluationID: String?,
+        persisted: Int
+    ) async throws -> GraphOrchestrationCycleReport {
+        let deadline = timeoutDeadline(
+            kind: kind,
+            context: context,
+            projection: current.projection
+        )
+        let timeoutID = DefaultGraphMutationService.stableID(
+            "\(context.identity.claimID)|\(kind.rawValue)|\(deadline.timeIntervalSince1970)"
+        )
+        let timeout = try await schedulingRepository.recordTimeout(
+            GraphTimeoutCommandRequest(
+                decision: GraphTimeoutDecision(
+                    timeoutID: timeoutID,
+                    runID: context.identity.runID,
+                    nodeID: context.identity.nodeID,
+                    attemptID: context.identity.attemptID,
+                    claimID: context.identity.claimID,
+                    kind: kind,
+                    deadline: deadline,
+                    declaredAt: context.logicalTime
+                ),
+                expectedVersion: current.version,
+                producer: producer,
+                recordedAt: context.logicalTime
+            )
+        )
+        var persisted = persisted + timeout.appendResult.appendedCount
+        var loaded = try await load(context.identity.runID)
+        let observation = GraphExecutorObservation(
+            id: "timeout-observation-\(timeoutID)",
+            operation: .observe,
+            identity: context.identity,
+            status: .interrupted,
+            observedAt: context.logicalTime,
+            failure: GraphExecutorFailure(
+                category: "timeout",
+                retryable: true
+            )
+        )
+        let observed = try await persistObservation(
+            observation,
+            current: loaded,
+            correlationID: timeoutID
+        )
+        persisted += observed.appendResult.appendedCount
+        loaded = try await load(context.identity.runID)
+        return try await finishTerminalObservation(
+            observation,
+            operation: .observe,
+            context: context,
+            initial: initial,
+            current: loaded,
+            definition: definition,
+            evaluationID: evaluationID,
+            persisted: persisted,
+            invocations: 0
+        )
+    }
+
+    private func persistObservation(
+        _ observation: GraphExecutorObservation,
+        current: Loaded,
+        correlationID: String
+    ) async throws -> GraphExecutorPersistenceResult {
+        do {
+            return try await executorRepository.recordObservation(
+                GraphExecutorObservationCommand(
+                    observation: observation,
+                    expectedVersion: current.version,
+                    producer: producer,
+                    correlationID: correlationID
+                )
+            )
+        } catch let error as GraphExecutorRepositoryError {
+            if case let .rejected(reason, _) = error {
+                throw GraphOrchestrationError.staleExecutor(reason)
+            }
+            throw GraphOrchestrationError.persistence(
+                error.localizedDescription
+            )
+        }
+    }
+
+    private func executionContext(
+        claim: GraphExecutorClaim,
+        definition: GraphExecutableDefinition,
+        projection: GraphExecutionProjection,
+        logicalTime: Date
+    ) throws -> GraphExecutorCommandContext {
+        guard let attempt = projection.attempts.first(where: {
+            $0.nodeID == claim.nodeID
+                && $0.ordinal == claim.attemptOrdinal
+        }), let execution = definition.execution(for: claim.nodeID) else {
+            throw GraphOrchestrationError.invalidDefinition(
+                "claim target has no attempt or execution specification."
+            )
+        }
+        let identity = GraphExecutorInteractionIdentity(
+            runID: claim.runID,
+            nodeID: claim.nodeID,
+            attemptID: attempt.id,
+            attemptOrdinal: attempt.ordinal,
+            claimID: claim.id,
+            leaseGeneration: claim.leaseGeneration,
+            executorID: claim.executorID
+        )
+        let observations = projection.executorObservations.filter {
+            $0.identity == identity
+        }
+        return GraphExecutorCommandContext(
+            identity: identity,
+            capabilityRequirement: execution.capabilityRequirement,
+            specification: execution.specification,
+            workspace: execution.workspace,
+            environmentAllowlist: execution.environmentAllowlist,
+            inputArtifacts: try GraphArtifactInputResolver.resolve(
+                nodeID: claim.nodeID,
+                definition: definition,
+                projection: projection
+            ),
+            cancellation: projection.scheduling.pendingCancellation(
+                nodeID: claim.nodeID
+            ),
+            timeoutPolicy: execution.timeoutPolicy,
+            correlation: GraphExecutorCorrelationMetadata(
+                correlationID: claim.id
+            ),
+            priorObservationCount: observations.filter {
+                $0.operation == .observe
+            }.count,
+            logicalTime: logicalTime
+        )
+    }
+
+    private func refreshedContext(
+        _ context: GraphExecutorCommandContext,
+        loaded: Loaded
+    ) throws -> GraphExecutorCommandContext {
+        guard let definition = loaded.projection.executableDefinition else {
+            throw GraphOrchestrationError.invalidDefinition(
+                "executable definition disappeared."
+            )
+        }
+        return try executionContext(
+            claim: currentClaim(context.identity, loaded.projection),
+            definition: definition,
+            projection: loaded.projection,
+            logicalTime: context.logicalTime
+        )
+    }
+
+    private func invokePrepare(
+        _ context: GraphExecutorCommandContext
+    ) async throws -> GraphExecutorObservation {
+        try requireConfirmation(.prepare, context)
+        return try await executor.prepare(
+            GraphExecutorPrepareRequest(context: context)
+        ).observation
+    }
+
+    private func invokeStart(
+        _ context: GraphExecutorCommandContext
+    ) async throws -> GraphExecutorObservation {
+        try requireConfirmation(.start, context)
+        return try await executor.start(
+            GraphExecutorStartRequest(context: context)
+        ).observation
+    }
+
+    private func invokeObserve(
+        _ context: GraphExecutorCommandContext
+    ) async throws -> GraphExecutorObservation {
+        try requireConfirmation(.observe, context)
+        return try await executor.observe(
+            GraphExecutorObserveRequest(context: context)
+        ).observation
+    }
+
+    private func invokeRecover(
+        _ context: GraphExecutorCommandContext
+    ) async throws -> GraphExecutorObservation {
+        try requireConfirmation(.recover, context)
+        return try await executor.recover(
+            GraphExecutorRecoverRequest(context: context)
+        ).observation
+    }
+
+    private func invokeCollect(
+        _ context: GraphExecutorCommandContext
+    ) async throws -> GraphExecutorObservation {
+        try requireConfirmation(.collectResult, context)
+        return try await executor.collectResult(
+            GraphExecutorCollectResultRequest(context: context)
+        ).observation
+    }
+
+    private func invokeCleanup(
+        _ context: GraphExecutorCommandContext
+    ) async throws -> GraphExecutorObservation {
+        try requireConfirmation(.cleanup, context)
+        return try await executor.cleanup(
+            GraphExecutorCleanupRequest(context: context)
+        ).observation
+    }
+
+    private func invokeCancellation(
+        _ context: GraphExecutorCommandContext,
+        requestID: String
+    ) async throws -> GraphExecutorObservation {
+        try requireConfirmation(.requestCancellation, context)
+        return try await executor.requestCancellation(
+            GraphExecutorCancellationRequest(
+                context: context,
+                cancellationRequestID: requestID
+            )
+        ).observation
+    }
+
+    private func requireConfirmation(
+        _ operation: GraphExecutorOperation,
+        _ context: GraphExecutorCommandContext
+    ) throws {
+        guard confirmationPolicy.permits(
+            operation: operation,
+            context: context
+        ) else {
+            throw GraphOrchestrationError.adapterUnavailable(
+                "execution confirmation policy denied \(operation.rawValue)."
+            )
+        }
+    }
+
+    private func claimableNode(
+        projection: GraphExecutionProjection,
+        evaluationID: String?
+    ) -> String? {
+        projection.scheduling.records.filter {
+            $0.evaluationID == evaluationID
+                && $0.eventType == GraphExecutionEventType
+                    .nodeBecameRunnable.rawValue
+                && $0.reason == .dependenciesSatisfied
+        }.compactMap(\.nodeID).sorted().first
+    }
+
+    private func currentClaim(
+        _ identity: GraphExecutorInteractionIdentity,
+        _ projection: GraphExecutionProjection
+    ) -> GraphExecutorClaim {
+        projection.scheduling.claims.first {
+            $0.claim.id == identity.claimID
+                && $0.claim.leaseGeneration == identity.leaseGeneration
+        }!.claim
+    }
+
+    private func pendingUnclaimedCancellation(
+        _ projection: GraphExecutionProjection
+    ) -> GraphCancellationRecord? {
+        projection.scheduling.cancellations.filter {
+            $0.state == .requested && $0.claimID == nil
+        }.sorted { $0.id < $1.id }.first
+    }
+
+    private func timeoutKind(
+        context: GraphExecutorCommandContext,
+        projection: GraphExecutionProjection
+    ) -> GraphTimeoutKind? {
+        guard let attempt = projection.attempts.first(where: {
+            $0.id == context.identity.attemptID
+        }), let startedAt = attempt.startedAt else {
+            return nil
+        }
+        if let cancellation = context.cancellation,
+           context.logicalTime >= cancellation.requestedAt
+            .addingTimeInterval(
+                TimeInterval(
+                    context.timeoutPolicy
+                        .cancellationAcknowledgementSeconds
+                )
+            ) {
+            return .cancellationAcknowledgement
+        }
+        if context.logicalTime >= startedAt.addingTimeInterval(
+            TimeInterval(context.timeoutPolicy.executionSeconds)
+        ) {
+            return .attemptExecution
+        }
+        return nil
+    }
+
+    private func timeoutDeadline(
+        kind: GraphTimeoutKind,
+        context: GraphExecutorCommandContext,
+        projection: GraphExecutionProjection
+    ) -> Date {
+        if kind == .cancellationAcknowledgement,
+           let cancellation = context.cancellation {
+            return cancellation.requestedAt.addingTimeInterval(
+                TimeInterval(
+                    context.timeoutPolicy
+                        .cancellationAcknowledgementSeconds
+                )
+            )
+        }
+        let startedAt = projection.attempts.first {
+            $0.id == context.identity.attemptID
+        }?.startedAt ?? context.logicalTime
+        return startedAt.addingTimeInterval(
+            TimeInterval(context.timeoutPolicy.executionSeconds)
+        )
+    }
+
+    private func failureCategories(
+        _ projection: GraphExecutionProjection
+    ) -> [String: String] {
+        Dictionary(uniqueKeysWithValues: projection.attempts.compactMap {
+            guard let reason = $0.statusReason else { return nil }
+            return ($0.id, reason)
+        })
+    }
+
+    private func schedulingDenials(
+        _ projection: GraphExecutionProjection
+    ) -> [GraphSchedulingReasonCode] {
+        guard let evaluationID = projection.scheduling.records.last(where: {
+            $0.eventType == GraphExecutionEventType
+                .schedulerCycleCompleted.rawValue
+        })?.evaluationID else {
+            return []
+        }
+        return projection.scheduling.records.filter {
+            $0.evaluationID == evaluationID
+        }.compactMap(\.reason).filter {
+            $0 != .dependenciesSatisfied
+        }
+    }
+
+    private func terminalAfterScheduling(
+        _ loaded: Loaded,
+        definition: GraphExecutableDefinition,
+        logicalTime: Date
+    ) async throws -> Loaded? {
+        let result = try await recordRunTerminalIfJustified(
+            loaded: loaded,
+            definition: definition,
+            logicalTime: logicalTime
+        )
+        return result.version == loaded.version ? nil : result
+    }
+
+    private func recordRunTerminalIfJustified(
+        loaded: Loaded,
+        definition: GraphExecutableDefinition,
+        logicalTime: Date
+    ) async throws -> Loaded {
+        guard loaded.projection.run?.state.isTerminal != true,
+              let state = aggregateTerminalState(
+                projection: loaded.projection,
+                definition: definition
+              ) else {
+            return loaded
+        }
+        let terminalMaterial = [
+            loaded.projection.runID,
+            state.rawValue,
+        ].joined(separator: "|")
+        let terminalDigest = DefaultGraphMutationService.stableID(
+            terminalMaterial
+        )
+        let event = GraphExecutionEventEnvelope(
+            id: "run-terminal-\(terminalDigest)",
+            runID: loaded.projection.runID,
+            streamSequence: loaded.version + 1,
+            occurredAt: logicalTime,
+            recordedAt: logicalTime,
+            producer: producer,
+            payload: .runTerminalStateRecorded(
+                GraphRunTerminalPayload(
+                    state: state,
+                    reason: "graph_terminal_aggregation"
+                )
+            )
+        )
+        do {
+            _ = try await eventStore.append(
+                [event],
+                to: loaded.projection.runID,
+                expectedVersion: loaded.version
+            )
+            return try await load(loaded.projection.runID)
+        } catch {
+            throw GraphOrchestrationError.persistence(
+                error.localizedDescription
+            )
+        }
+    }
+
+    private func aggregateTerminalState(
+        projection: GraphExecutionProjection,
+        definition: GraphExecutableDefinition
+    ) -> ReconciledExecutionState? {
+        let latest = Dictionary(
+            grouping: projection.attempts,
+            by: \.nodeID
+        ).mapValues { attempts in
+            attempts.max { $0.ordinal < $1.ordinal }!
+        }
+        let nodeIDs = definition.scheduling.nodes.map(\.id)
+        if nodeIDs.allSatisfy({ latest[$0]?.state == .completed }) {
+            return .completed
+        }
+        for nodeID in nodeIDs {
+            guard let attempt = latest[nodeID] else { continue }
+            if [.failed, .interrupted, .orphaned].contains(attempt.state) {
+                let policy = definition.schedulerPolicy.retryPolicy
+                let category = attempt.statusReason ?? "execution_failure"
+                let retryAllowed = attempt.ordinal < policy.maximumAttempts
+                    && !policy.nonRetryableFailureCategories.contains(category)
+                    && (policy.retryableFailureCategories.isEmpty
+                        || policy.retryableFailureCategories.contains(category))
+                if !retryAllowed {
+                    let suppressionExists = projection.scheduling.records
+                        .contains {
+                            $0.attemptID == attempt.id
+                                && $0.eventType
+                                    == GraphExecutionEventType
+                                        .retrySuppressed.rawValue
+                        }
+                    guard suppressionExists else { return nil }
+                    return .failed
+                }
+            }
+        }
+        let cancelled = latest.values.filter { $0.state == .cancelled }
+        if !cancelled.isEmpty,
+           nodeIDs.allSatisfy({
+            latest[$0]?.state == .completed
+                || latest[$0]?.state == .cancelled
+                || projection.scheduling.pendingCancellation(nodeID: $0)
+                    != nil
+           }) {
+            return .cancelled
+        }
+        return nil
+    }
+
+    private func terminalState(
+        _ status: GraphExecutorResponseStatus
+    ) -> ReconciledExecutionState {
+        switch status {
+        case .succeeded:
+            .completed
+        case .failed:
+            .failed
+        case .cancelled:
+            .cancelled
+        case .interrupted:
+            .interrupted
+        default:
+            .failed
+        }
+    }
+
+    private func report(
+        loaded: Loaded,
+        initialVersion: UInt64,
+        status: GraphOrchestrationCycleStatus,
+        logicalTime: Date,
+        evaluationID: String? = nil,
+        claim: GraphExecutorClaim? = nil,
+        persistedCount: Int = 0,
+        executorOperation: GraphExecutorOperation? = nil,
+        executorInvocations: Int = 0,
+        denials: [GraphSchedulingReasonCode] = [],
+        adapterStatus: GraphExecutorResponseStatus? = nil
+    ) -> GraphOrchestrationCycleReport {
+        GraphOrchestrationCycleReport(
+            runID: loaded.projection.runID,
+            status: status,
+            logicalTime: logicalTime,
+            previousVersion: initialVersion,
+            streamVersion: loaded.version,
+            schedulerEvaluationID: evaluationID,
+            claimedNodeID: claim?.nodeID,
+            claimID: claim?.id,
+            executorOperation: executorOperation,
+            executorStatus: adapterStatus,
+            persistedEventCount: persistedCount,
+            executorInvocationCount: executorInvocations,
+            runState: loaded.projection.run?.state ?? .pending,
+            policyDenials: denials
+        )
+    }
+}

--- a/Sources/OpenIslandCore/GraphOrchestrationService.swift
+++ b/Sources/OpenIslandCore/GraphOrchestrationService.swift
@@ -810,7 +810,9 @@ public struct DefaultGraphOrchestrationService:
         var persisted = persisted
         var invocations = invocations
         var terminalObservation = initialObservation
-        if initialObservation.status == .succeeded,
+        if (initialObservation.status == .succeeded
+                || context.specification.adapterKind
+                    == GraphLocalProcessSpecification.adapterKind),
            operation != .collectResult {
             let refreshed = try refreshedContext(context, loaded: current)
             terminalObservation = try await invokeCollect(refreshed)

--- a/Sources/OpenIslandCore/GraphOrchestrationService.swift
+++ b/Sources/OpenIslandCore/GraphOrchestrationService.swift
@@ -467,7 +467,7 @@ public struct DefaultGraphOrchestrationService:
             current = try await load(request.runID)
         }
 
-        guard let claim else {
+        guard var claim else {
             return report(
                 loaded: current,
                 initialVersion: initial.version,
@@ -477,6 +477,39 @@ public struct DefaultGraphOrchestrationService:
                 persistedCount: persisted,
                 denials: schedulingDenials(current.projection)
             )
+        }
+        if shouldRenew(
+            claim: claim,
+            logicalTime: request.logicalTime,
+            leaseDurationSeconds: definition.schedulerPolicy
+                .defaultLeaseDurationSeconds
+        ) {
+            let renewed = try await schedulingRepository.renewLease(
+                GraphExecutorLeaseRenewalRequest(
+                    runID: request.runID,
+                    claimID: claim.id,
+                    executorID: claim.executorID,
+                    expectedGeneration: claim.leaseGeneration,
+                    expectedVersion: current.version,
+                    logicalTime: request.logicalTime,
+                    leaseDurationSeconds: definition.schedulerPolicy
+                        .defaultLeaseDurationSeconds,
+                    producer: producer,
+                    recordedAt: request.logicalTime
+                )
+            )
+            persisted += renewed.appendResult.appendedCount
+            current = try await load(request.runID)
+            guard let renewedClaim = current.projection.scheduling
+                .activeClaim(
+                    nodeID: claim.nodeID,
+                    at: request.logicalTime
+                ) else {
+                throw GraphOrchestrationError.persistence(
+                    "renewed executor claim is not active."
+                )
+            }
+            claim = renewedClaim
         }
         let execution = try executionContext(
             claim: claim,
@@ -1165,6 +1198,16 @@ public struct DefaultGraphOrchestrationService:
         projection.scheduling.cancellations.filter {
             $0.state == .requested && $0.claimID == nil
         }.sorted { $0.id < $1.id }.first
+    }
+
+    private func shouldRenew(
+        claim: GraphExecutorClaim,
+        logicalTime: Date,
+        leaseDurationSeconds: UInt64
+    ) -> Bool {
+        let remaining = claim.leaseExpiry.timeIntervalSince(logicalTime)
+        return remaining > 0
+            && remaining <= TimeInterval(leaseDurationSeconds) / 2
     }
 
     private func timeoutKind(

--- a/Sources/OpenIslandCore/GraphOrchestrationService.swift
+++ b/Sources/OpenIslandCore/GraphOrchestrationService.swift
@@ -447,6 +447,14 @@ public struct DefaultGraphOrchestrationService:
                 claimMaterial
             )
             let claimID = "claim-\(claimDigest)"
+            let durableEligibility = current.projection.scheduling.retries
+                .filter { $0.nodeID == nodeID }
+                .map(\.eligibleAt)
+                .max() ?? request.logicalTime
+            let claimLogicalTime = max(
+                request.logicalTime,
+                durableEligibility
+            )
             let claimed = try await schedulingRepository.attemptClaim(
                 GraphExecutorClaimRequest(
                     runID: request.runID,
@@ -455,16 +463,30 @@ public struct DefaultGraphOrchestrationService:
                     executor: executor.capabilities,
                     evaluationID: evaluationID,
                     expectedVersion: current.version,
-                    logicalTime: request.logicalTime,
+                    logicalTime: claimLogicalTime,
                     leaseDurationSeconds: definition.schedulerPolicy
                         .defaultLeaseDurationSeconds,
                     producer: producer,
-                    recordedAt: request.logicalTime
+                    recordedAt: claimLogicalTime
                 )
             )
             persisted += claimed.appendResult.appendedCount
-            claim = claimed.claim
             current = try await load(request.runID)
+            guard let grantedClaimID = claimed.claim?.id else {
+                throw GraphOrchestrationError.persistence(
+                    "claim grant did not return an executor claim."
+                )
+            }
+            guard let persistedClaim = current.projection.scheduling.claims
+                .first(where: {
+                    $0.claim.id == grantedClaimID
+                        && $0.status == .active
+                })?.claim else {
+                throw GraphOrchestrationError.persistence(
+                    "granted executor claim is missing from durable history."
+                )
+            }
+            claim = persistedClaim
         }
 
         guard var claim else {
@@ -500,11 +522,10 @@ public struct DefaultGraphOrchestrationService:
             )
             persisted += renewed.appendResult.appendedCount
             current = try await load(request.runID)
-            guard let renewedClaim = current.projection.scheduling
-                .activeClaim(
-                    nodeID: claim.nodeID,
-                    at: request.logicalTime
-                ) else {
+            guard let renewedClaim = current.projection.scheduling.claims
+                .first(where: {
+                    $0.claim.id == claim.id && $0.status == .active
+                })?.claim else {
                 throw GraphOrchestrationError.persistence(
                     "renewed executor claim is not active."
                 )
@@ -515,7 +536,7 @@ public struct DefaultGraphOrchestrationService:
             claim: claim,
             definition: definition,
             projection: current.projection,
-            logicalTime: request.logicalTime
+            logicalTime: max(request.logicalTime, claim.leaseStart)
         )
 
         if let timeout = timeoutKind(
@@ -810,9 +831,11 @@ public struct DefaultGraphOrchestrationService:
         var persisted = persisted
         var invocations = invocations
         var terminalObservation = initialObservation
-        if (initialObservation.status == .succeeded
-                || context.specification.adapterKind
-                    == GraphLocalProcessSpecification.adapterKind),
+        let shouldCollectResult = initialObservation.status == .succeeded
+            || (initialObservation.status == .failed
+                && context.specification.adapterKind
+                    == GraphLocalProcessSpecification.adapterKind)
+        if shouldCollectResult,
            operation != .collectResult {
             let refreshed = try refreshedContext(context, loaded: current)
             terminalObservation = try await invokeCollect(refreshed)
@@ -1070,7 +1093,7 @@ public struct DefaultGraphOrchestrationService:
             priorObservationCount: observations.filter {
                 $0.operation == .observe
             }.count,
-            logicalTime: logicalTime
+            logicalTime: max(logicalTime, claim.leaseStart)
         )
     }
 

--- a/Sources/OpenIslandCore/GraphOrchestrationService.swift
+++ b/Sources/OpenIslandCore/GraphOrchestrationService.swift
@@ -1386,7 +1386,7 @@ public struct DefaultGraphOrchestrationService:
         for nodeID in nodeIDs {
             guard let attempt = latest[nodeID] else { continue }
             if [.failed, .interrupted, .orphaned].contains(attempt.state) {
-                let policy = definition.schedulerPolicy.retryPolicy
+                let policy = definition.schedulerPolicy.retryPolicy(for: nodeID)
                 let category = attempt.statusReason ?? "execution_failure"
                 let retryAllowed = attempt.ordinal < policy.maximumAttempts
                     && !policy.nonRetryableFailureCategories.contains(category)

--- a/Sources/OpenIslandCore/GraphScheduling.swift
+++ b/Sources/OpenIslandCore/GraphScheduling.swift
@@ -475,6 +475,7 @@ public struct GraphSchedulingRecord:
 }
 
 public struct GraphSchedulingProjection: Equatable, Codable, Sendable {
+    public var evaluations: [GraphSchedulerEvaluationPayload]
     public var records: [GraphSchedulingRecord]
     public var claims: [GraphExecutorClaimRecord]
     public var retries: [GraphRetryRecord]
@@ -483,6 +484,7 @@ public struct GraphSchedulingProjection: Equatable, Codable, Sendable {
     public var completedEvaluationIDs: [String]
 
     public init(
+        evaluations: [GraphSchedulerEvaluationPayload] = [],
         records: [GraphSchedulingRecord] = [],
         claims: [GraphExecutorClaimRecord] = [],
         retries: [GraphRetryRecord] = [],
@@ -490,6 +492,7 @@ public struct GraphSchedulingProjection: Equatable, Codable, Sendable {
         timeouts: [GraphTimeoutDecision] = [],
         completedEvaluationIDs: [String] = []
     ) {
+        self.evaluations = evaluations
         self.records = records
         self.claims = claims
         self.retries = retries

--- a/Sources/OpenIslandCore/GraphScheduling.swift
+++ b/Sources/OpenIslandCore/GraphScheduling.swift
@@ -1039,9 +1039,10 @@ public enum GraphScheduler {
             )
         }
 
-        if let retry = input.projectedState.scheduling.retries
+        let existingRetry = input.projectedState.scheduling.retries
             .filter({ $0.nodeID == node.id })
-            .max(by: { $0.nextAttemptOrdinal < $1.nextAttemptOrdinal }),
+            .max(by: { $0.nextAttemptOrdinal < $1.nextAttemptOrdinal })
+        if let retry = existingRetry,
            retry.nextAttemptOrdinal == nextOrdinal,
            input.logicalTime < retry.eligibleAt {
             return NodeResult(
@@ -1051,7 +1052,8 @@ public enum GraphScheduler {
                 eligibleAt: retry.eligibleAt
             )
         }
-        if let latest,
+        if existingRetry?.nextAttemptOrdinal != nextOrdinal,
+           let latest,
            latest.state == .failed
                 || latest.state == .interrupted
                 || latest.state == .orphaned {

--- a/Sources/OpenIslandCore/GraphScheduling.swift
+++ b/Sources/OpenIslandCore/GraphScheduling.swift
@@ -242,6 +242,7 @@ public enum GraphSchedulingReasonCode:
     case executorCapabilityUnavailable = "executor_capability_unavailable"
     case graphDefinitionMismatch = "graph_definition_mismatch"
     case schedulerPolicyDenied = "scheduler_policy_denied"
+    case runNotStarted = "run_not_started"
     case runTerminal = "run_terminal"
     case claimGranted = "claim_granted"
     case claimRejected = "claim_rejected"
@@ -920,6 +921,15 @@ public enum GraphScheduler {
             return NodeResult(
                 phase: .blocked,
                 reason: .graphDefinitionMismatch,
+                attemptOrdinal: nextOrdinal,
+                eligibleAt: nil
+            )
+        }
+        guard input.projectedState.executableDefinition == nil
+                || input.projectedState.runStartRequestedAt != nil else {
+            return NodeResult(
+                phase: .pending,
+                reason: .runNotStarted,
                 attemptOrdinal: nextOrdinal,
                 eligibleAt: nil
             )

--- a/Sources/OpenIslandCore/GraphScheduling.swift
+++ b/Sources/OpenIslandCore/GraphScheduling.swift
@@ -528,7 +528,7 @@ public struct GraphSchedulingProjection: Equatable, Codable, Sendable {
         nodeID: String
     ) -> GraphCancellationRecord? {
         cancellations
-            .filter { $0.nodeID == nodeID && $0.state == .requested }
+            .filter { $0.nodeID == nodeID }
             .max {
                 if $0.requestedAt != $1.requestedAt {
                     return $0.requestedAt < $1.requestedAt
@@ -916,6 +916,14 @@ public enum GraphScheduler {
                 eligibleAt: nil
             )
         }
+        if let latest, latest.state == .completed || latest.state == .cancelled {
+            return NodeResult(
+                phase: .terminal,
+                reason: .terminalAttemptExists,
+                attemptOrdinal: latest.ordinal,
+                eligibleAt: nil
+            )
+        }
         if input.projectedState.scheduling.pendingCancellation(
             nodeID: node.id
         ) != nil {
@@ -923,14 +931,6 @@ public enum GraphScheduler {
                 phase: .cancellationPending,
                 reason: .cancellationPending,
                 attemptOrdinal: latest?.ordinal,
-                eligibleAt: nil
-            )
-        }
-        if let latest, latest.state == .completed || latest.state == .cancelled {
-            return NodeResult(
-                phase: .terminal,
-                reason: .terminalAttemptExists,
-                attemptOrdinal: latest.ordinal,
                 eligibleAt: nil
             )
         }

--- a/Sources/OpenIslandCore/GraphScheduling.swift
+++ b/Sources/OpenIslandCore/GraphScheduling.swift
@@ -181,6 +181,7 @@ public struct GraphSchedulerPolicy: Equatable, Codable, Sendable {
     public let policyID: String
     public let version: String
     public let retryPolicy: GraphRetryPolicy
+    public let nodeRetryPolicies: [String: GraphRetryPolicy]?
     public let defaultLeaseDurationSeconds: UInt64
     public let claimAcquisitionTimeoutSeconds: UInt64
     public let attemptExecutionTimeoutSeconds: UInt64
@@ -193,6 +194,7 @@ public struct GraphSchedulerPolicy: Equatable, Codable, Sendable {
         policyID: String,
         version: String,
         retryPolicy: GraphRetryPolicy,
+        nodeRetryPolicies: [String: GraphRetryPolicy]? = nil,
         defaultLeaseDurationSeconds: UInt64 = 60,
         claimAcquisitionTimeoutSeconds: UInt64 = 30,
         attemptExecutionTimeoutSeconds: UInt64 = 3_600,
@@ -204,6 +206,7 @@ public struct GraphSchedulerPolicy: Equatable, Codable, Sendable {
         self.policyID = policyID
         self.version = version
         self.retryPolicy = retryPolicy
+        self.nodeRetryPolicies = nodeRetryPolicies
         self.defaultLeaseDurationSeconds = max(1, defaultLeaseDurationSeconds)
         self.claimAcquisitionTimeoutSeconds = max(
             1,
@@ -219,6 +222,10 @@ public struct GraphSchedulerPolicy: Equatable, Codable, Sendable {
         )
         self.allowExpiredLeaseTakeover = allowExpiredLeaseTakeover
         self.schedulingEnabled = schedulingEnabled
+    }
+
+    public func retryPolicy(for nodeID: String) -> GraphRetryPolicy {
+        nodeRetryPolicies?[nodeID] ?? retryPolicy
     }
 }
 
@@ -1059,8 +1066,9 @@ public enum GraphScheduler {
                 || latest.state == .orphaned {
             let failureCategory = input.failureCategoriesByAttemptID[latest.id]
                 ?? "execution_failure"
+            let retryPolicy = input.policy.retryPolicy(for: node.id)
             guard retryAllowed(
-                policy: input.policy.retryPolicy,
+                policy: retryPolicy,
                 failureCategory: failureCategory,
                 failedOrdinal: latest.ordinal
             ) else {
@@ -1071,7 +1079,7 @@ public enum GraphScheduler {
                     eligibleAt: nil
                 )
             }
-            let delay = input.policy.retryPolicy.delaySeconds(
+            let delay = retryPolicy.delaySeconds(
                 runID: input.projectedState.runID,
                 nodeID: node.id,
                 nextAttemptOrdinal: nextOrdinal
@@ -1128,7 +1136,7 @@ public enum GraphScheduler {
         }
         let category = input.failureCategoriesByAttemptID[attempt.id]
             ?? "execution_failure"
-        let policy = input.policy.retryPolicy
+        let policy = input.policy.retryPolicy(for: node.id)
 
         if retryAllowed(
             policy: policy,

--- a/Sources/OpenIslandCore/GraphScheduling.swift
+++ b/Sources/OpenIslandCore/GraphScheduling.swift
@@ -548,8 +548,30 @@ public struct GraphSchedulerEvaluationPayload:
     public let graphDefinitionDigest: GraphContentDigest
     public let schedulerPolicyID: String
     public let schedulerPolicyVersion: String
+    public let schedulerPolicy: GraphSchedulerPolicy?
     public let logicalTime: Date
     public let availableCapabilityIdentities: [String]
+
+    public init(
+        evaluationID: String,
+        graphDefinitionVersion: String,
+        graphDefinitionDigest: GraphContentDigest,
+        schedulerPolicyID: String,
+        schedulerPolicyVersion: String,
+        schedulerPolicy: GraphSchedulerPolicy? = nil,
+        logicalTime: Date,
+        availableCapabilityIdentities: [String]
+    ) {
+        self.evaluationID = evaluationID
+        self.graphDefinitionVersion = graphDefinitionVersion
+        self.graphDefinitionDigest = graphDefinitionDigest
+        self.schedulerPolicyID = schedulerPolicyID
+        self.schedulerPolicyVersion = schedulerPolicyVersion
+        self.schedulerPolicy = schedulerPolicy
+        self.logicalTime = logicalTime
+        self.availableCapabilityIdentities =
+            availableCapabilityIdentities.sorted()
+    }
 }
 
 public struct GraphNodeSchedulingPayload:
@@ -719,6 +741,7 @@ public enum GraphScheduler {
                 input.availableExecutors
                     .map(\.capabilityIdentity)
                     .joined(separator: ","),
+                schedulingStateIdentity(input),
             ].joined(separator: "|")
         )
         guard !input.projectedState.scheduling.completedEvaluationIDs
@@ -740,6 +763,7 @@ public enum GraphScheduler {
             graphDefinitionDigest: input.definition.digest,
             schedulerPolicyID: input.policy.policyID,
             schedulerPolicyVersion: input.policy.version,
+            schedulerPolicy: input.policy,
             logicalTime: input.logicalTime,
             availableCapabilityIdentities: input.availableExecutors
                 .map(\.capabilityIdentity)
@@ -996,7 +1020,7 @@ public enum GraphScheduler {
             ordinal: latest?.ordinal ?? nextOrdinal,
             claims: input.existingClaims,
             time: input.logicalTime
-        ) {
+        ), latest?.state.isTerminal != true {
             return NodeResult(
                 phase: .claimed,
                 reason: .existingActiveClaim,
@@ -1206,6 +1230,46 @@ public enum GraphScheduler {
             guard let phase = states[$0]?.phase else { return true }
             return phase == .blocked || phase == .terminal
         }
+    }
+
+    private static func schedulingStateIdentity(
+        _ input: GraphSchedulingInput
+    ) -> String {
+        let run = input.projectedState.run.map {
+            "run:\($0.id):\($0.state.rawValue)"
+        } ?? "run:none"
+        let nodes = input.projectedState.nodes.sorted { $0.id < $1.id }
+            .map { "node:\($0.id):\($0.state.rawValue)" }
+        let attempts = input.projectedState.attempts.sorted {
+            if $0.nodeID != $1.nodeID { return $0.nodeID < $1.nodeID }
+            if $0.ordinal != $1.ordinal { return $0.ordinal < $1.ordinal }
+            return $0.id < $1.id
+        }.map {
+            "attempt:\($0.id):\($0.ordinal):\($0.state.rawValue)"
+        }
+        let claims = input.existingClaims.sorted {
+            $0.claim.id < $1.claim.id
+        }.map {
+            "claim:\($0.claim.id):\($0.status.rawValue):\($0.claim.leaseGeneration):\(iso8601($0.claim.leaseExpiry))"
+        }
+        let retries = input.projectedState.scheduling.retries.sorted {
+            if $0.nodeID != $1.nodeID { return $0.nodeID < $1.nodeID }
+            return $0.nextAttemptOrdinal < $1.nextAttemptOrdinal
+        }.map {
+            "retry:\($0.nodeID):\($0.nextAttemptOrdinal):\(iso8601($0.eligibleAt))"
+        }
+        let cancellations = input.projectedState.scheduling.cancellations
+            .sorted { $0.id < $1.id }
+            .map { "cancel:\($0.id):\($0.state.rawValue)" }
+        let timeouts = input.projectedState.scheduling.timeouts
+            .sorted { $0.id < $1.id }
+            .map { "timeout:\($0.id):\($0.kind.rawValue)" }
+        let failures = input.failureCategoriesByAttemptID.keys.sorted().map {
+            "failure:\($0):\(input.failureCategoriesByAttemptID[$0]!)"
+        }
+        return ([run] + nodes + attempts + claims + retries
+            + cancellations + timeouts + failures)
+            .joined(separator: ";")
     }
 
     private static func proposal(

--- a/Sources/OpenIslandCore/GraphScheduling.swift
+++ b/Sources/OpenIslandCore/GraphScheduling.swift
@@ -1,0 +1,1238 @@
+import CryptoKit
+import Foundation
+
+public enum GraphSchedulingSchema {
+    public static let definitionVersion = 1
+    public static let policyVersion = 1
+    public static let claimVersion = 1
+    public static let cancellationVersion = 1
+    public static let timeoutVersion = 1
+}
+
+public struct GraphSchedulingDefinitionNode:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public let id: String
+    public let title: String
+    public let dependencyNodeIDs: [String]
+    public let requiredCapabilities: [String]
+
+    public init(
+        id: String,
+        title: String,
+        dependencyNodeIDs: [String] = [],
+        requiredCapabilities: [String] = []
+    ) {
+        self.id = id
+        self.title = title
+        self.dependencyNodeIDs = dependencyNodeIDs.sorted()
+        self.requiredCapabilities = requiredCapabilities.sorted()
+    }
+}
+
+public struct GraphSchedulingDefinition: Equatable, Codable, Sendable {
+    public let schemaVersion: Int
+    public let graphID: String
+    public let version: String
+    public let digest: GraphContentDigest
+    public let nodes: [GraphSchedulingDefinitionNode]
+
+    public init(
+        schemaVersion: Int = GraphSchedulingSchema.definitionVersion,
+        graphID: String,
+        version: String,
+        digest: GraphContentDigest,
+        nodes: [GraphSchedulingDefinitionNode]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.graphID = graphID
+        self.version = version
+        self.digest = digest
+        self.nodes = nodes.sorted { $0.id < $1.id }
+    }
+}
+
+public struct GraphExecutorCapabilities: Equatable, Codable, Sendable {
+    public let executorID: String
+    public let capabilityIdentity: String
+    public let capabilities: [String]
+    public let hostID: String?
+
+    public init(
+        executorID: String,
+        capabilityIdentity: String,
+        capabilities: [String],
+        hostID: String? = nil
+    ) {
+        self.executorID = executorID
+        self.capabilityIdentity = capabilityIdentity
+        self.capabilities = capabilities.sorted()
+        self.hostID = hostID
+    }
+
+    public func satisfies(_ required: [String]) -> Bool {
+        Set(required).isSubset(of: Set(capabilities))
+    }
+}
+
+public enum GraphRetryTimeoutBehavior: String, Codable, Sendable {
+    case retry
+    case suppress
+}
+
+public enum GraphRetryCancellationBehavior: String, Codable, Sendable {
+    case suppress
+    case retryAfterAcknowledgement = "retry_after_acknowledgement"
+}
+
+public enum GraphDependencyFailureBehavior: String, Codable, Sendable {
+    case failClosed = "fail_closed"
+    case allowIndependent = "allow_independent"
+}
+
+public struct GraphRetryPolicy: Equatable, Codable, Sendable {
+    public let schemaVersion: Int
+    public let maximumAttempts: Int
+    public let retryableFailureCategories: [String]
+    public let nonRetryableFailureCategories: [String]
+    public let initialBackoffSeconds: UInt64
+    public let backoffMultiplier: UInt64
+    public let maximumBackoffSeconds: UInt64
+    public let jitterBasisPoints: UInt16
+    public let jitterSeed: String
+    public let timeoutBehavior: GraphRetryTimeoutBehavior
+    public let cancellationBehavior: GraphRetryCancellationBehavior
+    public let dependencyFailureBehavior: GraphDependencyFailureBehavior
+
+    public init(
+        schemaVersion: Int = GraphSchedulingSchema.policyVersion,
+        maximumAttempts: Int,
+        retryableFailureCategories: [String],
+        nonRetryableFailureCategories: [String] = [],
+        initialBackoffSeconds: UInt64 = 0,
+        backoffMultiplier: UInt64 = 2,
+        maximumBackoffSeconds: UInt64 = 3_600,
+        jitterBasisPoints: UInt16 = 0,
+        jitterSeed: String = "openisland",
+        timeoutBehavior: GraphRetryTimeoutBehavior = .retry,
+        cancellationBehavior: GraphRetryCancellationBehavior = .suppress,
+        dependencyFailureBehavior: GraphDependencyFailureBehavior = .failClosed
+    ) {
+        self.schemaVersion = schemaVersion
+        self.maximumAttempts = max(1, maximumAttempts)
+        self.retryableFailureCategories = retryableFailureCategories.sorted()
+        self.nonRetryableFailureCategories = nonRetryableFailureCategories.sorted()
+        self.initialBackoffSeconds = initialBackoffSeconds
+        self.backoffMultiplier = max(1, backoffMultiplier)
+        self.maximumBackoffSeconds = max(
+            initialBackoffSeconds,
+            maximumBackoffSeconds
+        )
+        self.jitterBasisPoints = min(jitterBasisPoints, 10_000)
+        self.jitterSeed = jitterSeed
+        self.timeoutBehavior = timeoutBehavior
+        self.cancellationBehavior = cancellationBehavior
+        self.dependencyFailureBehavior = dependencyFailureBehavior
+    }
+
+    public func delaySeconds(
+        runID: String,
+        nodeID: String,
+        nextAttemptOrdinal: Int
+    ) -> UInt64 {
+        let exponent = max(0, nextAttemptOrdinal - 2)
+        var base = initialBackoffSeconds
+
+        for _ in 0..<exponent {
+            let multiplied = base.multipliedReportingOverflow(
+                by: backoffMultiplier
+            )
+            base = multiplied.overflow
+                ? maximumBackoffSeconds
+                : min(multiplied.partialValue, maximumBackoffSeconds)
+        }
+
+        guard jitterBasisPoints > 0, base > 0 else {
+            return base
+        }
+        let material = "\(jitterSeed)|\(runID)|\(nodeID)|\(nextAttemptOrdinal)"
+        let digest = SHA256.hash(data: Data(material.utf8))
+        let value = digest.prefix(8).reduce(UInt64(0)) {
+            ($0 << 8) | UInt64($1)
+        }
+        let window = base.multipliedReportingOverflow(
+            by: UInt64(jitterBasisPoints)
+        ).partialValue / 10_000
+        guard window > 0 else {
+            return base
+        }
+        return min(
+            maximumBackoffSeconds,
+            base + (value % (window + 1))
+        )
+    }
+}
+
+public struct GraphSchedulerPolicy: Equatable, Codable, Sendable {
+    public let schemaVersion: Int
+    public let policyID: String
+    public let version: String
+    public let retryPolicy: GraphRetryPolicy
+    public let defaultLeaseDurationSeconds: UInt64
+    public let claimAcquisitionTimeoutSeconds: UInt64
+    public let attemptExecutionTimeoutSeconds: UInt64
+    public let cancellationAcknowledgementTimeoutSeconds: UInt64
+    public let allowExpiredLeaseTakeover: Bool
+    public let schedulingEnabled: Bool
+
+    public init(
+        schemaVersion: Int = GraphSchedulingSchema.policyVersion,
+        policyID: String,
+        version: String,
+        retryPolicy: GraphRetryPolicy,
+        defaultLeaseDurationSeconds: UInt64 = 60,
+        claimAcquisitionTimeoutSeconds: UInt64 = 30,
+        attemptExecutionTimeoutSeconds: UInt64 = 3_600,
+        cancellationAcknowledgementTimeoutSeconds: UInt64 = 30,
+        allowExpiredLeaseTakeover: Bool = true,
+        schedulingEnabled: Bool = true
+    ) {
+        self.schemaVersion = schemaVersion
+        self.policyID = policyID
+        self.version = version
+        self.retryPolicy = retryPolicy
+        self.defaultLeaseDurationSeconds = max(1, defaultLeaseDurationSeconds)
+        self.claimAcquisitionTimeoutSeconds = max(
+            1,
+            claimAcquisitionTimeoutSeconds
+        )
+        self.attemptExecutionTimeoutSeconds = max(
+            1,
+            attemptExecutionTimeoutSeconds
+        )
+        self.cancellationAcknowledgementTimeoutSeconds = max(
+            1,
+            cancellationAcknowledgementTimeoutSeconds
+        )
+        self.allowExpiredLeaseTakeover = allowExpiredLeaseTakeover
+        self.schedulingEnabled = schedulingEnabled
+    }
+}
+
+public enum GraphSchedulingReasonCode:
+    String,
+    Codable,
+    CaseIterable,
+    Sendable
+{
+    case dependenciesSatisfied = "dependencies_satisfied"
+    case dependencyFailed = "dependency_failed"
+    case dependencyCancelled = "dependency_cancelled"
+    case dependencyIncomplete = "dependency_incomplete"
+    case existingActiveClaim = "existing_active_claim"
+    case leaseExpired = "lease_expired"
+    case retryAllowed = "retry_allowed"
+    case retryExhausted = "retry_exhausted"
+    case retryBackoffActive = "retry_backoff_active"
+    case cancellationPending = "cancellation_pending"
+    case terminalAttemptExists = "terminal_attempt_exists"
+    case executorCapabilityUnavailable = "executor_capability_unavailable"
+    case graphDefinitionMismatch = "graph_definition_mismatch"
+    case schedulerPolicyDenied = "scheduler_policy_denied"
+    case runTerminal = "run_terminal"
+    case claimGranted = "claim_granted"
+    case claimRejected = "claim_rejected"
+    case claimReleased = "claim_released"
+    case leaseRenewed = "lease_renewed"
+    case cancellationAcknowledged = "cancellation_acknowledged"
+    case timeoutRecorded = "timeout_recorded"
+    case retryNotApplicable = "retry_not_applicable"
+}
+
+public enum GraphNodeSchedulingPhase: String, Codable, Sendable {
+    case pending
+    case blocked
+    case ready
+    case claimable
+    case claimed
+    case running
+    case retryWaiting = "retry_waiting"
+    case cancellationPending = "cancellation_pending"
+    case terminal
+}
+
+public enum GraphExecutorClaimStatus: String, Codable, Sendable {
+    case active
+    case expired
+    case released
+}
+
+public struct GraphExecutorClaim:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public let schemaVersion: Int
+    public let runID: String
+    public let nodeID: String
+    public let attemptOrdinal: Int
+    public let id: String
+    public let executorID: String
+    public let executorCapabilityIdentity: String
+    public let grantedSequence: UInt64
+    public let leaseStart: Date
+    public let leaseExpiry: Date
+    public let leaseGeneration: UInt64
+    public let hostID: String?
+
+    public init(
+        schemaVersion: Int = GraphSchedulingSchema.claimVersion,
+        runID: String,
+        nodeID: String,
+        attemptOrdinal: Int,
+        claimID: String,
+        executorID: String,
+        executorCapabilityIdentity: String,
+        grantedSequence: UInt64,
+        leaseStart: Date,
+        leaseExpiry: Date,
+        leaseGeneration: UInt64 = 1,
+        hostID: String? = nil
+    ) {
+        self.schemaVersion = schemaVersion
+        self.runID = runID
+        self.nodeID = nodeID
+        self.attemptOrdinal = attemptOrdinal
+        id = claimID
+        self.executorID = executorID
+        self.executorCapabilityIdentity = executorCapabilityIdentity
+        self.grantedSequence = grantedSequence
+        self.leaseStart = leaseStart
+        self.leaseExpiry = leaseExpiry
+        self.leaseGeneration = leaseGeneration
+        self.hostID = hostID
+    }
+
+    public func isValid(at logicalTime: Date) -> Bool {
+        leaseStart <= logicalTime && logicalTime < leaseExpiry
+    }
+}
+
+public struct GraphExecutorClaimRecord: Equatable, Codable, Sendable {
+    public var claim: GraphExecutorClaim
+    public var status: GraphExecutorClaimStatus
+    public var statusChangedAt: Date
+    public var reason: GraphSchedulingReasonCode
+
+    public init(
+        claim: GraphExecutorClaim,
+        status: GraphExecutorClaimStatus = .active,
+        statusChangedAt: Date,
+        reason: GraphSchedulingReasonCode = .claimGranted
+    ) {
+        self.claim = claim
+        self.status = status
+        self.statusChangedAt = statusChangedAt
+        self.reason = reason
+    }
+}
+
+public struct GraphRetryRecord: Equatable, Codable, Sendable {
+    public let nodeID: String
+    public let failedAttemptID: String
+    public let failedAttemptOrdinal: Int
+    public let nextAttemptOrdinal: Int
+    public let failureCategory: String
+    public let scheduledAt: Date
+    public let eligibleAt: Date
+    public let delaySeconds: UInt64
+    public let policy: GraphRetryPolicy
+    public let reason: GraphSchedulingReasonCode
+}
+
+public enum GraphCancellationState: String, Codable, Sendable {
+    case requested
+    case acknowledged
+}
+
+public struct GraphCancellationRecord:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public let schemaVersion: Int
+    public let id: String
+    public let runID: String
+    public let nodeID: String
+    public let attemptID: String?
+    public let claimID: String?
+    public let requestedBy: String
+    public let requestedAt: Date
+    public let reason: String?
+    public var state: GraphCancellationState
+    public var acknowledgedAt: Date?
+    public var acknowledgedByExecutorID: String?
+
+    public init(
+        schemaVersion: Int = GraphSchedulingSchema.cancellationVersion,
+        requestID: String,
+        runID: String,
+        nodeID: String,
+        attemptID: String?,
+        claimID: String?,
+        requestedBy: String,
+        requestedAt: Date,
+        reason: String?,
+        state: GraphCancellationState = .requested,
+        acknowledgedAt: Date? = nil,
+        acknowledgedByExecutorID: String? = nil
+    ) {
+        self.schemaVersion = schemaVersion
+        id = requestID
+        self.runID = runID
+        self.nodeID = nodeID
+        self.attemptID = attemptID
+        self.claimID = claimID
+        self.requestedBy = requestedBy
+        self.requestedAt = requestedAt
+        self.reason = reason
+        self.state = state
+        self.acknowledgedAt = acknowledgedAt
+        self.acknowledgedByExecutorID = acknowledgedByExecutorID
+    }
+}
+
+public enum GraphTimeoutKind: String, Codable, Sendable {
+    case claimAcquisition = "claim_acquisition"
+    case lease
+    case attemptExecution = "attempt_execution"
+    case cancellationAcknowledgement = "cancellation_acknowledgement"
+    case retryDelay = "retry_delay"
+}
+
+public struct GraphTimeoutDecision:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public let schemaVersion: Int
+    public let id: String
+    public let runID: String
+    public let nodeID: String
+    public let attemptID: String?
+    public let claimID: String?
+    public let kind: GraphTimeoutKind
+    public let deadline: Date
+    public let declaredAt: Date
+    public let reason: GraphSchedulingReasonCode
+
+    public init(
+        schemaVersion: Int = GraphSchedulingSchema.timeoutVersion,
+        timeoutID: String,
+        runID: String,
+        nodeID: String,
+        attemptID: String?,
+        claimID: String?,
+        kind: GraphTimeoutKind,
+        deadline: Date,
+        declaredAt: Date,
+        reason: GraphSchedulingReasonCode = .timeoutRecorded
+    ) {
+        self.schemaVersion = schemaVersion
+        id = timeoutID
+        self.runID = runID
+        self.nodeID = nodeID
+        self.attemptID = attemptID
+        self.claimID = claimID
+        self.kind = kind
+        self.deadline = deadline
+        self.declaredAt = declaredAt
+        self.reason = reason
+    }
+}
+
+public struct GraphSchedulingRecord:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public let id: String
+    public let sequence: UInt64
+    public let eventType: String
+    public let factClass: GraphExecutionEventFactClass
+    public let nodeID: String?
+    public let attemptID: String?
+    public let evaluationID: String?
+    public let reason: GraphSchedulingReasonCode?
+    public let occurredAt: Date
+}
+
+public struct GraphSchedulingProjection: Equatable, Codable, Sendable {
+    public var records: [GraphSchedulingRecord]
+    public var claims: [GraphExecutorClaimRecord]
+    public var retries: [GraphRetryRecord]
+    public var cancellations: [GraphCancellationRecord]
+    public var timeouts: [GraphTimeoutDecision]
+    public var completedEvaluationIDs: [String]
+
+    public init(
+        records: [GraphSchedulingRecord] = [],
+        claims: [GraphExecutorClaimRecord] = [],
+        retries: [GraphRetryRecord] = [],
+        cancellations: [GraphCancellationRecord] = [],
+        timeouts: [GraphTimeoutDecision] = [],
+        completedEvaluationIDs: [String] = []
+    ) {
+        self.records = records
+        self.claims = claims
+        self.retries = retries
+        self.cancellations = cancellations
+        self.timeouts = timeouts
+        self.completedEvaluationIDs = completedEvaluationIDs
+    }
+
+    public func activeClaim(
+        nodeID: String,
+        attemptOrdinal: Int? = nil,
+        at logicalTime: Date? = nil
+    ) -> GraphExecutorClaim? {
+        claims
+            .filter {
+                $0.claim.nodeID == nodeID
+                    && $0.status == .active
+                    && (attemptOrdinal == nil
+                        || $0.claim.attemptOrdinal == attemptOrdinal)
+                    && (logicalTime == nil
+                        || $0.claim.isValid(at: logicalTime!))
+            }
+            .map(\.claim)
+            .max {
+                if $0.leaseGeneration != $1.leaseGeneration {
+                    return $0.leaseGeneration < $1.leaseGeneration
+                }
+                return $0.id < $1.id
+            }
+    }
+
+    public func pendingCancellation(
+        nodeID: String
+    ) -> GraphCancellationRecord? {
+        cancellations
+            .filter { $0.nodeID == nodeID && $0.state == .requested }
+            .max {
+                if $0.requestedAt != $1.requestedAt {
+                    return $0.requestedAt < $1.requestedAt
+                }
+                return $0.id < $1.id
+            }
+    }
+}
+
+public struct GraphSchedulerEvaluationPayload:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let evaluationID: String
+    public let graphDefinitionVersion: String
+    public let graphDefinitionDigest: GraphContentDigest
+    public let schedulerPolicyID: String
+    public let schedulerPolicyVersion: String
+    public let logicalTime: Date
+    public let availableCapabilityIdentities: [String]
+}
+
+public struct GraphNodeSchedulingPayload:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let evaluationID: String
+    public let phase: GraphNodeSchedulingPhase
+    public let reason: GraphSchedulingReasonCode
+    public let attemptOrdinal: Int?
+    public let eligibleAt: Date?
+}
+
+public struct GraphExecutorClaimPayload: Equatable, Codable, Sendable {
+    public let claim: GraphExecutorClaim
+    public let reason: GraphSchedulingReasonCode
+}
+
+public struct GraphExecutorClaimRejectedPayload:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let claimID: String
+    public let nodeID: String
+    public let attemptOrdinal: Int
+    public let executorID: String
+    public let reason: GraphSchedulingReasonCode
+    public let conflictingClaimID: String?
+}
+
+public struct GraphExecutorLeaseEndedPayload:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let claimID: String
+    public let leaseGeneration: UInt64
+    public let reason: GraphSchedulingReasonCode
+}
+
+public struct GraphRetryScheduledPayload: Equatable, Codable, Sendable {
+    public let retry: GraphRetryRecord
+}
+
+public struct GraphRetrySuppressedPayload: Equatable, Codable, Sendable {
+    public let failedAttemptID: String
+    public let failedAttemptOrdinal: Int
+    public let failureCategory: String
+    public let policy: GraphRetryPolicy
+    public let reason: GraphSchedulingReasonCode
+}
+
+public struct GraphCancellationRequestedPayload:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let cancellation: GraphCancellationRecord
+}
+
+public struct GraphCancellationAcknowledgedPayload:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let requestID: String
+    public let claimID: String?
+    public let executorID: String
+    public let acknowledgedAt: Date
+}
+
+public struct GraphTimeoutDeclaredPayload: Equatable, Codable, Sendable {
+    public let timeout: GraphTimeoutDecision
+}
+
+public struct GraphDependencyFailurePropagatedPayload:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let evaluationID: String
+    public let dependencyNodeID: String
+    public let reason: GraphSchedulingReasonCode
+}
+
+public struct GraphSchedulerCycleCompletedPayload:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let evaluationID: String
+    public let proposedDecisionCount: Int
+}
+
+public struct GraphSchedulingProposedEvent: Equatable, Sendable {
+    public let id: String
+    public let nodeID: String?
+    public let attemptID: String?
+    public let occurredAt: Date
+    public let payload: GraphExecutionEventPayload
+}
+
+public struct GraphSchedulingDecision: Equatable, Sendable {
+    public let evaluationID: String
+    public let logicalTime: Date
+    public let proposedEvents: [GraphSchedulingProposedEvent]
+    public let phasesByNodeID: [String: GraphNodeSchedulingPhase]
+    public let reasonsByNodeID: [String: GraphSchedulingReasonCode]
+}
+
+public struct GraphSchedulingInput: Equatable, Sendable {
+    public let definition: GraphSchedulingDefinition
+    public let projectedState: GraphExecutionProjection
+    public let reconciledState: ExecutionReconciliationResult
+    public let policy: GraphSchedulerPolicy
+    public let logicalTime: Date
+    public let availableExecutors: [GraphExecutorCapabilities]
+    public let existingClaims: [GraphExecutorClaimRecord]
+    public let existingLeases: [GraphExecutorClaim]
+    public let failureCategoriesByAttemptID: [String: String]
+
+    public init(
+        definition: GraphSchedulingDefinition,
+        projectedState: GraphExecutionProjection,
+        reconciledState: ExecutionReconciliationResult,
+        policy: GraphSchedulerPolicy,
+        logicalTime: Date,
+        availableExecutors: [GraphExecutorCapabilities],
+        existingClaims: [GraphExecutorClaimRecord]? = nil,
+        existingLeases: [GraphExecutorClaim]? = nil,
+        failureCategoriesByAttemptID: [String: String] = [:]
+    ) {
+        self.definition = definition
+        self.projectedState = projectedState
+        self.reconciledState = reconciledState
+        self.policy = policy
+        self.logicalTime = logicalTime
+        self.availableExecutors = availableExecutors.sorted {
+            if $0.capabilityIdentity != $1.capabilityIdentity {
+                return $0.capabilityIdentity < $1.capabilityIdentity
+            }
+            return $0.executorID < $1.executorID
+        }
+        self.existingClaims = existingClaims
+            ?? projectedState.scheduling.claims
+        self.existingLeases = existingLeases
+            ?? projectedState.scheduling.claims.map(\.claim)
+        self.failureCategoriesByAttemptID = failureCategoriesByAttemptID
+    }
+}
+
+public enum GraphScheduler {
+    public static func evaluate(
+        _ input: GraphSchedulingInput
+    ) -> GraphSchedulingDecision {
+        let evaluationID = stableID(
+            [
+                input.projectedState.runID,
+                input.definition.graphID,
+                input.definition.version,
+                input.definition.digest.value,
+                input.policy.policyID,
+                input.policy.version,
+                iso8601(input.logicalTime),
+                input.availableExecutors
+                    .map(\.capabilityIdentity)
+                    .joined(separator: ","),
+            ].joined(separator: "|")
+        )
+        guard !input.projectedState.scheduling.completedEvaluationIDs
+            .contains(evaluationID) else {
+            return GraphSchedulingDecision(
+                evaluationID: evaluationID,
+                logicalTime: input.logicalTime,
+                proposedEvents: [],
+                phasesByNodeID: [:],
+                reasonsByNodeID: [:]
+            )
+        }
+
+        let state = schedulingStates(input)
+        var proposals: [GraphSchedulingProposedEvent] = []
+        let evaluation = GraphSchedulerEvaluationPayload(
+            evaluationID: evaluationID,
+            graphDefinitionVersion: input.definition.version,
+            graphDefinitionDigest: input.definition.digest,
+            schedulerPolicyID: input.policy.policyID,
+            schedulerPolicyVersion: input.policy.version,
+            logicalTime: input.logicalTime,
+            availableCapabilityIdentities: input.availableExecutors
+                .map(\.capabilityIdentity)
+        )
+        proposals.append(
+            proposal(
+                evaluationID: evaluationID,
+                key: "evaluation",
+                occurredAt: input.logicalTime,
+                payload: .schedulerEvaluationRecorded(evaluation)
+            )
+        )
+
+        for node in input.definition.nodes {
+            guard let result = state[node.id] else { continue }
+            let latestAttempt = latestAttempt(
+                nodeID: node.id,
+                attempts: input.reconciledState.attempts
+            )
+
+            if let retry = retryProposal(
+                input: input,
+                node: node,
+                latestAttempt: latestAttempt,
+                evaluationID: evaluationID
+            ) {
+                proposals.append(retry)
+            }
+
+            if result.phase == .blocked,
+               let dependencyID = firstFailedDependency(
+                    node,
+                    states: state
+               ) {
+                proposals.append(
+                    proposal(
+                        evaluationID: evaluationID,
+                        key: "dependency|\(node.id)|\(dependencyID)",
+                        nodeID: node.id,
+                        occurredAt: input.logicalTime,
+                        payload: .dependencyFailurePropagated(
+                            GraphDependencyFailurePropagatedPayload(
+                                evaluationID: evaluationID,
+                                dependencyNodeID: dependencyID,
+                                reason: result.reason
+                            )
+                        )
+                    )
+                )
+            }
+
+            let payload = GraphNodeSchedulingPayload(
+                evaluationID: evaluationID,
+                phase: result.phase,
+                reason: result.reason,
+                attemptOrdinal: result.attemptOrdinal,
+                eligibleAt: result.eligibleAt
+            )
+            proposals.append(
+                proposal(
+                    evaluationID: evaluationID,
+                    key: "node|\(node.id)|\(result.phase.rawValue)",
+                    nodeID: node.id,
+                    attemptID: latestAttempt?.id,
+                    occurredAt: input.logicalTime,
+                    payload: result.phase == .claimable
+                        ? .nodeBecameRunnable(payload)
+                        : .nodeSchedulingDeferred(payload)
+                )
+            )
+        }
+
+        proposals.append(
+            proposal(
+                evaluationID: evaluationID,
+                key: "completed",
+                occurredAt: input.logicalTime,
+                payload: .schedulerCycleCompleted(
+                    GraphSchedulerCycleCompletedPayload(
+                        evaluationID: evaluationID,
+                        proposedDecisionCount: proposals.count
+                    )
+                )
+            )
+        )
+        return GraphSchedulingDecision(
+            evaluationID: evaluationID,
+            logicalTime: input.logicalTime,
+            proposedEvents: proposals,
+            phasesByNodeID: state.mapValues(\.phase),
+            reasonsByNodeID: state.mapValues(\.reason)
+        )
+    }
+
+    private struct NodeResult {
+        let phase: GraphNodeSchedulingPhase
+        let reason: GraphSchedulingReasonCode
+        let attemptOrdinal: Int?
+        let eligibleAt: Date?
+    }
+
+    private static func schedulingStates(
+        _ input: GraphSchedulingInput
+    ) -> [String: NodeResult] {
+        let projectedRun = input.projectedState.run
+        let definitionMatches = projectedRun?.graphID == input.definition.graphID
+            && input.projectedState.graphDefinitionVersion
+                == input.definition.version
+            && input.projectedState.graphDefinitionDigest
+                == input.definition.digest
+        let reconciledNodes = Dictionary(
+            uniqueKeysWithValues: input.reconciledState.nodes.map {
+                ($0.id, $0)
+            }
+        )
+        var results: [String: NodeResult] = [:]
+
+        for _ in 0...input.definition.nodes.count {
+            var changed = false
+            for node in input.definition.nodes {
+                let result = evaluateNode(
+                    node,
+                    input: input,
+                    definitionMatches: definitionMatches,
+                    reconciledNode: reconciledNodes[node.id],
+                    dependencyResults: results
+                )
+                if results[node.id]?.phase != result.phase
+                    || results[node.id]?.reason != result.reason
+                    || results[node.id]?.eligibleAt != result.eligibleAt {
+                    results[node.id] = result
+                    changed = true
+                }
+            }
+            if !changed { break }
+        }
+        return results
+    }
+
+    private static func evaluateNode(
+        _ node: GraphSchedulingDefinitionNode,
+        input: GraphSchedulingInput,
+        definitionMatches: Bool,
+        reconciledNode: GraphNode?,
+        dependencyResults: [String: NodeResult]
+    ) -> NodeResult {
+        let latest = latestAttempt(
+            nodeID: node.id,
+            attempts: input.reconciledState.attempts
+        )
+        let nextOrdinal = (latest?.ordinal ?? 0) + 1
+
+        guard definitionMatches else {
+            return NodeResult(
+                phase: .blocked,
+                reason: .graphDefinitionMismatch,
+                attemptOrdinal: nextOrdinal,
+                eligibleAt: nil
+            )
+        }
+        guard input.policy.schedulingEnabled else {
+            return NodeResult(
+                phase: .pending,
+                reason: .schedulerPolicyDenied,
+                attemptOrdinal: nextOrdinal,
+                eligibleAt: nil
+            )
+        }
+        guard input.projectedState.run?.state.isTerminal != true else {
+            return NodeResult(
+                phase: .terminal,
+                reason: .runTerminal,
+                attemptOrdinal: latest?.ordinal,
+                eligibleAt: nil
+            )
+        }
+        if input.projectedState.scheduling.pendingCancellation(
+            nodeID: node.id
+        ) != nil {
+            return NodeResult(
+                phase: .cancellationPending,
+                reason: .cancellationPending,
+                attemptOrdinal: latest?.ordinal,
+                eligibleAt: nil
+            )
+        }
+        if let latest, latest.state == .completed || latest.state == .cancelled {
+            return NodeResult(
+                phase: .terminal,
+                reason: .terminalAttemptExists,
+                attemptOrdinal: latest.ordinal,
+                eligibleAt: nil
+            )
+        }
+
+        for dependencyID in node.dependencyNodeIDs {
+            if let dependency = dependencyResults[dependencyID] {
+                if dependency.phase == .blocked
+                    || dependency.phase == .terminal
+                        && reconciledState(
+                            dependencyID,
+                            input.reconciledState.nodes
+                        ) != .completed {
+                    let state = reconciledState(
+                        dependencyID,
+                        input.reconciledState.nodes
+                    )
+                    return NodeResult(
+                        phase: .blocked,
+                        reason: state == .cancelled
+                            ? .dependencyCancelled
+                            : .dependencyFailed,
+                        attemptOrdinal: nextOrdinal,
+                        eligibleAt: nil
+                    )
+                }
+            }
+            guard reconciledState(
+                dependencyID,
+                input.reconciledState.nodes
+            ) == .completed else {
+                return NodeResult(
+                    phase: .pending,
+                    reason: .dependencyIncomplete,
+                    attemptOrdinal: nextOrdinal,
+                    eligibleAt: nil
+                )
+            }
+        }
+
+        if let latest, latest.state == .running {
+            if let claim = activeClaim(
+                nodeID: node.id,
+                ordinal: latest.ordinal,
+                claims: input.existingClaims,
+                time: input.logicalTime
+            ) {
+                return NodeResult(
+                    phase: .running,
+                    reason: .existingActiveClaim,
+                    attemptOrdinal: claim.attemptOrdinal,
+                    eligibleAt: claim.leaseExpiry
+                )
+            }
+            return NodeResult(
+                phase: .ready,
+                reason: .leaseExpired,
+                attemptOrdinal: latest.ordinal,
+                eligibleAt: input.logicalTime
+            )
+        }
+        if let claim = activeClaim(
+            nodeID: node.id,
+            ordinal: latest?.ordinal ?? nextOrdinal,
+            claims: input.existingClaims,
+            time: input.logicalTime
+        ) {
+            return NodeResult(
+                phase: .claimed,
+                reason: .existingActiveClaim,
+                attemptOrdinal: claim.attemptOrdinal,
+                eligibleAt: claim.leaseExpiry
+            )
+        }
+
+        if let retry = input.projectedState.scheduling.retries
+            .filter({ $0.nodeID == node.id })
+            .max(by: { $0.nextAttemptOrdinal < $1.nextAttemptOrdinal }),
+           retry.nextAttemptOrdinal == nextOrdinal,
+           input.logicalTime < retry.eligibleAt {
+            return NodeResult(
+                phase: .retryWaiting,
+                reason: .retryBackoffActive,
+                attemptOrdinal: nextOrdinal,
+                eligibleAt: retry.eligibleAt
+            )
+        }
+        if let latest,
+           latest.state == .failed
+                || latest.state == .interrupted
+                || latest.state == .orphaned {
+            let failureCategory = input.failureCategoriesByAttemptID[latest.id]
+                ?? "execution_failure"
+            guard retryAllowed(
+                policy: input.policy.retryPolicy,
+                failureCategory: failureCategory,
+                failedOrdinal: latest.ordinal
+            ) else {
+                return NodeResult(
+                    phase: .terminal,
+                    reason: .retryExhausted,
+                    attemptOrdinal: latest.ordinal,
+                    eligibleAt: nil
+                )
+            }
+            let delay = input.policy.retryPolicy.delaySeconds(
+                runID: input.projectedState.runID,
+                nodeID: node.id,
+                nextAttemptOrdinal: nextOrdinal
+            )
+            let eligibleAt = input.logicalTime.addingTimeInterval(
+                TimeInterval(delay)
+            )
+            if input.logicalTime < eligibleAt {
+                return NodeResult(
+                    phase: .retryWaiting,
+                    reason: .retryBackoffActive,
+                    attemptOrdinal: nextOrdinal,
+                    eligibleAt: eligibleAt
+                )
+            }
+        }
+
+        guard input.availableExecutors.contains(where: {
+            $0.satisfies(node.requiredCapabilities)
+        }) else {
+            return NodeResult(
+                phase: .ready,
+                reason: .executorCapabilityUnavailable,
+                attemptOrdinal: nextOrdinal,
+                eligibleAt: nil
+            )
+        }
+        return NodeResult(
+            phase: .claimable,
+            reason: .dependenciesSatisfied,
+            attemptOrdinal: nextOrdinal,
+            eligibleAt: input.logicalTime
+        )
+    }
+
+    private static func retryProposal(
+        input: GraphSchedulingInput,
+        node: GraphSchedulingDefinitionNode,
+        latestAttempt: ExecutionAttempt?,
+        evaluationID: String
+    ) -> GraphSchedulingProposedEvent? {
+        guard let attempt = latestAttempt,
+              attempt.state == .failed
+                || attempt.state == .interrupted
+                || attempt.state == .orphaned else {
+            return nil
+        }
+        let nextOrdinal = attempt.ordinal + 1
+        guard !input.projectedState.scheduling.retries.contains(where: {
+            $0.nodeID == node.id
+                && $0.nextAttemptOrdinal == nextOrdinal
+        }) else {
+            return nil
+        }
+        let category = input.failureCategoriesByAttemptID[attempt.id]
+            ?? "execution_failure"
+        let policy = input.policy.retryPolicy
+
+        if retryAllowed(
+            policy: policy,
+            failureCategory: category,
+            failedOrdinal: attempt.ordinal
+        ) {
+            let delay = policy.delaySeconds(
+                runID: input.projectedState.runID,
+                nodeID: node.id,
+                nextAttemptOrdinal: nextOrdinal
+            )
+            let retry = GraphRetryRecord(
+                nodeID: node.id,
+                failedAttemptID: attempt.id,
+                failedAttemptOrdinal: attempt.ordinal,
+                nextAttemptOrdinal: nextOrdinal,
+                failureCategory: category,
+                scheduledAt: input.logicalTime,
+                eligibleAt: input.logicalTime.addingTimeInterval(
+                    TimeInterval(delay)
+                ),
+                delaySeconds: delay,
+                policy: policy,
+                reason: .retryAllowed
+            )
+            return proposal(
+                evaluationID: evaluationID,
+                key: "retry|\(node.id)|\(nextOrdinal)",
+                nodeID: node.id,
+                attemptID: attempt.id,
+                occurredAt: input.logicalTime,
+                payload: .retryScheduled(
+                    GraphRetryScheduledPayload(retry: retry)
+                )
+            )
+        }
+        return proposal(
+            evaluationID: evaluationID,
+            key: "retry-suppressed|\(node.id)|\(attempt.ordinal)",
+            nodeID: node.id,
+            attemptID: attempt.id,
+            occurredAt: input.logicalTime,
+            payload: .retrySuppressed(
+                GraphRetrySuppressedPayload(
+                    failedAttemptID: attempt.id,
+                    failedAttemptOrdinal: attempt.ordinal,
+                    failureCategory: category,
+                    policy: policy,
+                    reason: .retryExhausted
+                )
+            )
+        )
+    }
+
+    private static func retryAllowed(
+        policy: GraphRetryPolicy,
+        failureCategory: String,
+        failedOrdinal: Int
+    ) -> Bool {
+        failedOrdinal < policy.maximumAttempts
+            && !policy.nonRetryableFailureCategories.contains(
+                failureCategory
+            )
+            && (policy.retryableFailureCategories.isEmpty
+                || policy.retryableFailureCategories.contains(
+                    failureCategory
+                ))
+    }
+
+    private static func activeClaim(
+        nodeID: String,
+        ordinal: Int,
+        claims: [GraphExecutorClaimRecord],
+        time: Date
+    ) -> GraphExecutorClaim? {
+        claims
+            .filter {
+                $0.claim.nodeID == nodeID
+                    && $0.claim.attemptOrdinal == ordinal
+                    && $0.status == .active
+                    && $0.claim.isValid(at: time)
+            }
+            .map(\.claim)
+            .max { $0.id < $1.id }
+    }
+
+    private static func latestAttempt(
+        nodeID: String,
+        attempts: [ExecutionAttempt]
+    ) -> ExecutionAttempt? {
+        attempts.filter { $0.nodeID == nodeID }.max {
+            if $0.ordinal != $1.ordinal {
+                return $0.ordinal < $1.ordinal
+            }
+            return $0.id < $1.id
+        }
+    }
+
+    private static func reconciledState(
+        _ nodeID: String,
+        _ nodes: [GraphNode]
+    ) -> ReconciledExecutionState? {
+        nodes.first { $0.id == nodeID }?.state
+    }
+
+    private static func firstFailedDependency(
+        _ node: GraphSchedulingDefinitionNode,
+        states: [String: NodeResult]
+    ) -> String? {
+        node.dependencyNodeIDs.sorted().first {
+            guard let phase = states[$0]?.phase else { return true }
+            return phase == .blocked || phase == .terminal
+        }
+    }
+
+    private static func proposal(
+        evaluationID: String,
+        key: String,
+        nodeID: String? = nil,
+        attemptID: String? = nil,
+        occurredAt: Date,
+        payload: GraphExecutionEventPayload
+    ) -> GraphSchedulingProposedEvent {
+        GraphSchedulingProposedEvent(
+            id: "schedule-\(stableID("\(evaluationID)|\(key)"))",
+            nodeID: nodeID,
+            attemptID: attemptID,
+            occurredAt: occurredAt,
+            payload: payload
+        )
+    }
+
+    package static func stableID(_ value: String) -> String {
+        SHA256.hash(data: Data(value.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+            .prefix(24)
+            .description
+    }
+
+    private static func iso8601(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
+    }
+}

--- a/Sources/OpenIslandCore/GraphSchedulingRepository.swift
+++ b/Sources/OpenIslandCore/GraphSchedulingRepository.swift
@@ -382,43 +382,34 @@ public struct DefaultGraphSchedulingRepository:
         _ request: GraphSchedulerEvaluationRequest
     ) async throws -> GraphSchedulingTransactionResult {
         let loaded = try await load(runID: request.runID)
+        if request.expectedVersion < loaded.stream.currentVersion {
+            let expectedProjection = try replay(
+                runID: request.runID,
+                events: loaded.stream.events.filter {
+                    $0.streamSequence <= request.expectedVersion
+                }
+            )
+            let redeliveredDecision = try schedulingDecision(
+                request,
+                projection: expectedProjection
+            )
+            if loaded.projection.scheduling.completedEvaluationIDs
+                .contains(redeliveredDecision.evaluationID) {
+                return unchanged(loaded)
+            }
+        }
+        let decision = try schedulingDecision(
+            request,
+            projection: loaded.projection
+        )
+        guard !decision.proposedEvents.isEmpty else {
+            return unchanged(loaded)
+        }
         try requireVersion(
             request.expectedVersion,
             actual: loaded.stream.currentVersion,
             runID: request.runID
         )
-        guard let reconciled = GraphExecutionProjectionReconciler.reconcile(
-            projection: loaded.projection,
-            evidenceOutcome: .available(GraphProcessEvidence()),
-            observedAt: request.logicalTime
-        ) else {
-            throw GraphSchedulingRepositoryError.corruptHistory(
-                "Run \(request.runID) has no run projection."
-            )
-        }
-        let decision = GraphScheduler.evaluate(
-            GraphSchedulingInput(
-                definition: request.definition,
-                projectedState: loaded.projection,
-                reconciledState: reconciled,
-                policy: request.policy,
-                logicalTime: request.logicalTime,
-                availableExecutors: request.availableExecutors,
-                failureCategoriesByAttemptID:
-                    request.failureCategoriesByAttemptID
-            )
-        )
-        guard !decision.proposedEvents.isEmpty else {
-            return GraphSchedulingTransactionResult(
-                appendResult: GraphExecutionAppendResult(
-                    previousVersion: loaded.stream.currentVersion,
-                    newVersion: loaded.stream.currentVersion,
-                    appendedCount: 0,
-                    deduplicatedCount: 0
-                ),
-                projection: loaded.projection
-            )
-        }
         let envelopes = envelopes(
             proposals: decision.proposedEvents,
             runID: request.runID,
@@ -441,6 +432,33 @@ public struct DefaultGraphSchedulingRepository:
         )
     }
 
+    private func schedulingDecision(
+        _ request: GraphSchedulerEvaluationRequest,
+        projection: GraphExecutionProjection
+    ) throws -> GraphSchedulingDecision {
+        guard let reconciled = GraphExecutionProjectionReconciler.reconcile(
+            projection: projection,
+            evidenceOutcome: .available(GraphProcessEvidence()),
+            observedAt: request.logicalTime
+        ) else {
+            throw GraphSchedulingRepositoryError.corruptHistory(
+                "Run \(request.runID) has no run projection."
+            )
+        }
+        return GraphScheduler.evaluate(
+            GraphSchedulingInput(
+                definition: request.definition,
+                projectedState: projection,
+                reconciledState: reconciled,
+                policy: request.policy,
+                logicalTime: request.logicalTime,
+                availableExecutors: request.availableExecutors,
+                failureCategoriesByAttemptID:
+                    request.failureCategoriesByAttemptID
+            )
+        )
+    }
+
     public func attemptClaim(
         _ request: GraphExecutorClaimRequest
     ) async throws -> GraphExecutorClaimResult {
@@ -450,7 +468,15 @@ public struct DefaultGraphSchedulingRepository:
             where: { $0.claim.id == request.claimID }
         ) {
             guard existing.claim.executorID == request.executor.executorID,
-                  existing.claim.nodeID == request.nodeID else {
+                  existing.claim.nodeID == request.nodeID,
+                  existing.claim.executorCapabilityIdentity
+                    == request.executor.capabilityIdentity,
+                  existing.claim.hostID == request.executor.hostID,
+                  existing.claim.leaseStart == request.logicalTime,
+                  existing.claim.leaseExpiry
+                    == request.logicalTime.addingTimeInterval(
+                        TimeInterval(request.leaseDurationSeconds)
+                    ) else {
                 throw conflict(
                     .claimIdentityCollision,
                     "Claim ID \(request.claimID) is already associated with another owner.",
@@ -489,6 +515,15 @@ public struct DefaultGraphSchedulingRepository:
             throw conflict(
                 .cancellationPending,
                 "Node \(request.nodeID) has a pending cancellation."
+            )
+        }
+        guard loaded.projection.scheduling.records.last(where: {
+            $0.eventType
+                == GraphExecutionEventType.schedulerCycleCompleted.rawValue
+        })?.evaluationID == request.evaluationID else {
+            throw conflict(
+                .schedulerEvaluationMissing,
+                "Claim must reference the latest completed scheduler evaluation."
             )
         }
         guard let runnable = loaded.projection.scheduling.records.last(
@@ -792,6 +827,15 @@ public struct DefaultGraphSchedulingRepository:
             )
         }
         if record.status == .released {
+            guard record.claim.executorID == request.executorID,
+                  record.claim.leaseGeneration
+                    == request.expectedGeneration,
+                  record.statusChangedAt == request.logicalTime else {
+                throw conflict(
+                    .claimAlreadyReleased,
+                    "Released claim redelivery has contradictory content."
+                )
+            }
             return unchanged(loaded)
         }
         try requireVersion(
@@ -1010,9 +1054,17 @@ public struct DefaultGraphSchedulingRepository:
         _ request: GraphCancellationTerminalRequest
     ) async throws -> GraphSchedulingTransactionResult {
         let loaded = try await load(runID: request.runID)
-        if loaded.stream.events.contains(where: {
+        if let existing = loaded.stream.events.first(where: {
             $0.id == "cancellation-terminal-\(request.requestID)"
         }) {
+            guard existing.occurredAt == request.logicalTime,
+                  case let .attemptCancelled(payload) = existing.payload,
+                  payload.reason == request.reason else {
+                throw conflict(
+                    .invalidRequest,
+                    "Terminal cancellation redelivery has contradictory content."
+                )
+            }
             return unchanged(loaded)
         }
         guard let cancellation = loaded.projection.scheduling
@@ -1029,8 +1081,15 @@ public struct DefaultGraphSchedulingRepository:
             actual: loaded.stream.currentVersion,
             runID: request.runID
         )
-        if cancellation.claimID != nil,
-           cancellation.state != .acknowledged {
+        let cancellationClaim = cancellation.claimID.flatMap { claimID in
+            loaded.projection.scheduling.claims.first {
+                $0.claim.id == claimID
+            }
+        }
+        if cancellation.state != .acknowledged,
+           let cancellationClaim,
+           cancellationClaim.status == .active,
+           cancellationClaim.claim.isValid(at: request.logicalTime) {
             throw conflict(
                 .cancellationPending,
                 "Claimed cancellation must be acknowledged before terminal declaration."
@@ -1093,15 +1152,15 @@ public struct DefaultGraphSchedulingRepository:
             )
         }
 
-        if let claimID = cancellation.claimID,
-           let claim = loaded.projection.scheduling.claims.first(
-                where: {
-                    $0.claim.id == claimID && $0.status == .active
-                }
-           )?.claim {
+        if let cancellationClaim,
+           cancellationClaim.status == .active {
+            let claim = cancellationClaim.claim
+            let leaseExpired = !claim.isValid(at: request.logicalTime)
             events.append(
                 envelope(
-                    id: "claim-release-\(claim.id)-\(claim.leaseGeneration)",
+                    id: leaseExpired
+                        ? "claim-expired-\(claim.id)-\(claim.leaseGeneration)"
+                        : "claim-release-\(claim.id)-\(claim.leaseGeneration)",
                     runID: request.runID,
                     nodeID: claim.nodeID,
                     attemptID: terminalAttempt.id,
@@ -1110,13 +1169,21 @@ public struct DefaultGraphSchedulingRepository:
                     recordedAt: request.recordedAt,
                     producer: request.producer,
                     correlationID: request.requestID,
-                    payload: .executorClaimReleased(
-                        GraphExecutorLeaseEndedPayload(
-                            claimID: claim.id,
-                            leaseGeneration: claim.leaseGeneration,
-                            reason: .claimReleased
+                    payload: leaseExpired
+                        ? .executorLeaseExpired(
+                            GraphExecutorLeaseEndedPayload(
+                                claimID: claim.id,
+                                leaseGeneration: claim.leaseGeneration,
+                                reason: .leaseExpired
+                            )
                         )
-                    )
+                        : .executorClaimReleased(
+                            GraphExecutorLeaseEndedPayload(
+                                claimID: claim.id,
+                                leaseGeneration: claim.leaseGeneration,
+                                reason: .claimReleased
+                            )
+                        )
                 )
             )
             sequence += 1

--- a/Sources/OpenIslandCore/GraphSchedulingRepository.swift
+++ b/Sources/OpenIslandCore/GraphSchedulingRepository.swift
@@ -1,0 +1,995 @@
+import Foundation
+
+public enum GraphSchedulingConflictReason:
+    String,
+    Codable,
+    Sendable
+{
+    case expectedVersionConflict = "expected_version_conflict"
+    case graphDefinitionMismatch = "graph_definition_mismatch"
+    case schedulerEvaluationMissing = "scheduler_evaluation_missing"
+    case nodeNotClaimable = "node_not_claimable"
+    case existingActiveClaim = "existing_active_claim"
+    case claimIdentityCollision = "claim_identity_collision"
+    case executorCapabilityUnavailable =
+        "executor_capability_unavailable"
+    case leaseGenerationMismatch = "lease_generation_mismatch"
+    case leaseExpired = "lease_expired"
+    case claimNotFound = "claim_not_found"
+    case claimAlreadyReleased = "claim_already_released"
+    case cancellationPending = "cancellation_pending"
+    case cancellationNotFound = "cancellation_not_found"
+    case cancellationAlreadyAcknowledged =
+        "cancellation_already_acknowledged"
+    case staleCancellationAcknowledgement =
+        "stale_cancellation_acknowledgement"
+    case retryBackoffActive = "retry_backoff_active"
+    case retryExhausted = "retry_exhausted"
+    case runTerminal = "run_terminal"
+    case attemptTerminal = "attempt_terminal"
+    case invalidRequest = "invalid_request"
+}
+
+public enum GraphSchedulingRepositoryError:
+    Error,
+    Equatable,
+    Sendable
+{
+    case conflict(
+        reason: GraphSchedulingConflictReason,
+        message: String,
+        expectedVersion: UInt64?,
+        actualVersion: UInt64?
+    )
+    case corruptHistory(String)
+    case persistence(String)
+}
+
+extension GraphSchedulingRepositoryError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .conflict(reason, message, expected, actual):
+            let versions = expected.map { expected in
+                " expected=\(expected) actual=\(actual.map(String.init) ?? "unknown")"
+            } ?? ""
+            return "Scheduling conflict \(reason.rawValue): \(message)\(versions)"
+        case let .corruptHistory(message):
+            return "Scheduling history is corrupt: \(message)"
+        case let .persistence(message):
+            return "Scheduling persistence failed: \(message)"
+        }
+    }
+}
+
+public struct GraphSchedulerEvaluationRequest: Equatable, Sendable {
+    public let runID: String
+    public let expectedVersion: UInt64
+    public let definition: GraphSchedulingDefinition
+    public let policy: GraphSchedulerPolicy
+    public let logicalTime: Date
+    public let availableExecutors: [GraphExecutorCapabilities]
+    public let failureCategoriesByAttemptID: [String: String]
+    public let producer: GraphExecutionProducer
+    public let recordedAt: Date
+
+    public init(
+        runID: String,
+        expectedVersion: UInt64,
+        definition: GraphSchedulingDefinition,
+        policy: GraphSchedulerPolicy,
+        logicalTime: Date,
+        availableExecutors: [GraphExecutorCapabilities],
+        failureCategoriesByAttemptID: [String: String] = [:],
+        producer: GraphExecutionProducer,
+        recordedAt: Date
+    ) {
+        self.runID = runID
+        self.expectedVersion = expectedVersion
+        self.definition = definition
+        self.policy = policy
+        self.logicalTime = logicalTime
+        self.availableExecutors = availableExecutors
+        self.failureCategoriesByAttemptID = failureCategoriesByAttemptID
+        self.producer = producer
+        self.recordedAt = recordedAt
+    }
+}
+
+public struct GraphExecutorClaimRequest: Equatable, Sendable {
+    public let runID: String
+    public let nodeID: String
+    public let claimID: String
+    public let executor: GraphExecutorCapabilities
+    public let evaluationID: String
+    public let expectedVersion: UInt64
+    public let logicalTime: Date
+    public let leaseDurationSeconds: UInt64
+    public let producer: GraphExecutionProducer
+    public let recordedAt: Date
+
+    public init(
+        runID: String,
+        nodeID: String,
+        claimID: String,
+        executor: GraphExecutorCapabilities,
+        evaluationID: String,
+        expectedVersion: UInt64,
+        logicalTime: Date,
+        leaseDurationSeconds: UInt64,
+        producer: GraphExecutionProducer,
+        recordedAt: Date
+    ) {
+        self.runID = runID
+        self.nodeID = nodeID
+        self.claimID = claimID
+        self.executor = executor
+        self.evaluationID = evaluationID
+        self.expectedVersion = expectedVersion
+        self.logicalTime = logicalTime
+        self.leaseDurationSeconds = max(1, leaseDurationSeconds)
+        self.producer = producer
+        self.recordedAt = recordedAt
+    }
+}
+
+public enum GraphExecutorClaimOutcome: String, Codable, Sendable {
+    case granted
+    case rejected
+    case deduplicated
+}
+
+public struct GraphExecutorClaimResult: Equatable, Sendable {
+    public let outcome: GraphExecutorClaimOutcome
+    public let claim: GraphExecutorClaim?
+    public let conflictingClaimID: String?
+    public let appendResult: GraphExecutionAppendResult
+    public let conflictReason: GraphSchedulingConflictReason?
+}
+
+public struct GraphExecutorLeaseRenewalRequest: Equatable, Sendable {
+    public let runID: String
+    public let claimID: String
+    public let executorID: String
+    public let expectedGeneration: UInt64
+    public let expectedVersion: UInt64
+    public let logicalTime: Date
+    public let leaseDurationSeconds: UInt64
+    public let producer: GraphExecutionProducer
+    public let recordedAt: Date
+
+    public init(
+        runID: String,
+        claimID: String,
+        executorID: String,
+        expectedGeneration: UInt64,
+        expectedVersion: UInt64,
+        logicalTime: Date,
+        leaseDurationSeconds: UInt64,
+        producer: GraphExecutionProducer,
+        recordedAt: Date
+    ) {
+        self.runID = runID
+        self.claimID = claimID
+        self.executorID = executorID
+        self.expectedGeneration = expectedGeneration
+        self.expectedVersion = expectedVersion
+        self.logicalTime = logicalTime
+        self.leaseDurationSeconds = max(1, leaseDurationSeconds)
+        self.producer = producer
+        self.recordedAt = recordedAt
+    }
+}
+
+public struct GraphExecutorClaimReleaseRequest: Equatable, Sendable {
+    public let runID: String
+    public let claimID: String
+    public let executorID: String
+    public let expectedGeneration: UInt64
+    public let expectedVersion: UInt64
+    public let logicalTime: Date
+    public let producer: GraphExecutionProducer
+    public let recordedAt: Date
+
+    public init(
+        runID: String,
+        claimID: String,
+        executorID: String,
+        expectedGeneration: UInt64,
+        expectedVersion: UInt64,
+        logicalTime: Date,
+        producer: GraphExecutionProducer,
+        recordedAt: Date
+    ) {
+        self.runID = runID
+        self.claimID = claimID
+        self.executorID = executorID
+        self.expectedGeneration = expectedGeneration
+        self.expectedVersion = expectedVersion
+        self.logicalTime = logicalTime
+        self.producer = producer
+        self.recordedAt = recordedAt
+    }
+}
+
+public struct GraphSchedulingTransactionResult: Equatable, Sendable {
+    public let appendResult: GraphExecutionAppendResult
+    public let projection: GraphExecutionProjection
+}
+
+public protocol GraphSchedulingRepository: Sendable {
+    func evaluateAndAppend(
+        _ request: GraphSchedulerEvaluationRequest
+    ) async throws -> GraphSchedulingTransactionResult
+
+    func attemptClaim(
+        _ request: GraphExecutorClaimRequest
+    ) async throws -> GraphExecutorClaimResult
+
+    func renewLease(
+        _ request: GraphExecutorLeaseRenewalRequest
+    ) async throws -> GraphSchedulingTransactionResult
+
+    func releaseClaim(
+        _ request: GraphExecutorClaimReleaseRequest
+    ) async throws -> GraphSchedulingTransactionResult
+}
+
+public struct DefaultGraphSchedulingRepository:
+    GraphSchedulingRepository,
+    Sendable
+{
+    private let eventStore: any GraphExecutionEventStore
+
+    public init(eventStore: any GraphExecutionEventStore) {
+        self.eventStore = eventStore
+    }
+
+    public func evaluateAndAppend(
+        _ request: GraphSchedulerEvaluationRequest
+    ) async throws -> GraphSchedulingTransactionResult {
+        let loaded = try await load(runID: request.runID)
+        try requireVersion(
+            request.expectedVersion,
+            actual: loaded.stream.currentVersion,
+            runID: request.runID
+        )
+        guard let reconciled = GraphExecutionProjectionReconciler.reconcile(
+            projection: loaded.projection,
+            evidenceOutcome: .available(GraphProcessEvidence()),
+            observedAt: request.logicalTime
+        ) else {
+            throw GraphSchedulingRepositoryError.corruptHistory(
+                "Run \(request.runID) has no run projection."
+            )
+        }
+        let decision = GraphScheduler.evaluate(
+            GraphSchedulingInput(
+                definition: request.definition,
+                projectedState: loaded.projection,
+                reconciledState: reconciled,
+                policy: request.policy,
+                logicalTime: request.logicalTime,
+                availableExecutors: request.availableExecutors,
+                failureCategoriesByAttemptID:
+                    request.failureCategoriesByAttemptID
+            )
+        )
+        guard !decision.proposedEvents.isEmpty else {
+            return GraphSchedulingTransactionResult(
+                appendResult: GraphExecutionAppendResult(
+                    previousVersion: loaded.stream.currentVersion,
+                    newVersion: loaded.stream.currentVersion,
+                    appendedCount: 0,
+                    deduplicatedCount: 0
+                ),
+                projection: loaded.projection
+            )
+        }
+        let envelopes = envelopes(
+            proposals: decision.proposedEvents,
+            runID: request.runID,
+            startingAfter: loaded.stream.currentVersion,
+            producer: request.producer,
+            recordedAt: request.recordedAt,
+            correlationID: decision.evaluationID
+        )
+        let append = try await append(
+            envelopes,
+            runID: request.runID,
+            expectedVersion: request.expectedVersion
+        )
+        return GraphSchedulingTransactionResult(
+            appendResult: append,
+            projection: try replay(
+                runID: request.runID,
+                events: loaded.stream.events + envelopes
+            )
+        )
+    }
+
+    public func attemptClaim(
+        _ request: GraphExecutorClaimRequest
+    ) async throws -> GraphExecutorClaimResult {
+        let loaded = try await load(runID: request.runID)
+
+        if let existing = loaded.projection.scheduling.claims.first(
+            where: { $0.claim.id == request.claimID }
+        ) {
+            guard existing.claim.executorID == request.executor.executorID,
+                  existing.claim.nodeID == request.nodeID else {
+                throw conflict(
+                    .claimIdentityCollision,
+                    "Claim ID \(request.claimID) is already associated with another owner.",
+                    expected: request.expectedVersion,
+                    actual: loaded.stream.currentVersion
+                )
+            }
+            return GraphExecutorClaimResult(
+                outcome: .deduplicated,
+                claim: existing.claim,
+                conflictingClaimID: nil,
+                appendResult: GraphExecutionAppendResult(
+                    previousVersion: loaded.stream.currentVersion,
+                    newVersion: loaded.stream.currentVersion,
+                    appendedCount: 0,
+                    deduplicatedCount: 1
+                ),
+                conflictReason: nil
+            )
+        }
+
+        try requireVersion(
+            request.expectedVersion,
+            actual: loaded.stream.currentVersion,
+            runID: request.runID
+        )
+        guard loaded.projection.run?.state.isTerminal != true else {
+            throw conflict(
+                .runTerminal,
+                "Terminal runs cannot grant executor claims."
+            )
+        }
+        guard loaded.projection.scheduling.pendingCancellation(
+            nodeID: request.nodeID
+        ) == nil else {
+            throw conflict(
+                .cancellationPending,
+                "Node \(request.nodeID) has a pending cancellation."
+            )
+        }
+        guard let runnable = loaded.projection.scheduling.records.last(
+            where: {
+                $0.nodeID == request.nodeID
+                    && $0.evaluationID == request.evaluationID
+                    && $0.eventType
+                        == GraphExecutionEventType
+                            .nodeBecameRunnable.rawValue
+            }
+        ), runnable.reason == .dependenciesSatisfied else {
+            throw conflict(
+                .schedulerEvaluationMissing,
+                "No matching runnable decision exists for node \(request.nodeID)."
+            )
+        }
+        guard let evaluation = loaded.projection.scheduling.evaluations
+            .first(where: {
+                $0.evaluationID == request.evaluationID
+            }),
+            evaluation.availableCapabilityIdentities.contains(
+                request.executor.capabilityIdentity
+            ) else {
+            throw conflict(
+                .executorCapabilityUnavailable,
+                "Executor capability \(request.executor.capabilityIdentity) was not available for the scheduler evaluation."
+            )
+        }
+
+        let latestAttempt = loaded.projection.attempts
+            .filter { $0.nodeID == request.nodeID }
+            .max { $0.ordinal < $1.ordinal }
+        let attemptOrdinal: Int
+        let attemptID: String
+        let createAttempt: Bool
+
+        if let latestAttempt, !latestAttempt.state.isTerminal {
+            attemptOrdinal = latestAttempt.ordinal
+            attemptID = latestAttempt.id
+            createAttempt = false
+        } else if let latestAttempt {
+            let next = latestAttempt.ordinal + 1
+            guard let retry = loaded.projection.scheduling.retries.first(
+                where: {
+                    $0.nodeID == request.nodeID
+                        && $0.nextAttemptOrdinal == next
+                }
+            ) else {
+                throw conflict(
+                    .attemptTerminal,
+                    "Terminal attempt \(latestAttempt.id) has no durable retry decision."
+                )
+            }
+            guard request.logicalTime >= retry.eligibleAt else {
+                throw conflict(
+                    .retryBackoffActive,
+                    "Retry is not eligible until \(retry.eligibleAt)."
+                )
+            }
+            attemptOrdinal = next
+            attemptID = stableAttemptID(
+                runID: request.runID,
+                nodeID: request.nodeID,
+                ordinal: next
+            )
+            createAttempt = true
+        } else {
+            attemptOrdinal = 1
+            attemptID = stableAttemptID(
+                runID: request.runID,
+                nodeID: request.nodeID,
+                ordinal: 1
+            )
+            createAttempt = true
+        }
+
+        var prefix: [GraphExecutionEventEnvelope] = []
+        var nextSequence = loaded.stream.currentVersion + 1
+
+        for record in loaded.projection.scheduling.claims
+            where record.claim.nodeID == request.nodeID
+                && record.claim.attemptOrdinal == attemptOrdinal
+                && record.status == .active {
+            if record.claim.isValid(at: request.logicalTime) {
+                return try await rejectClaim(
+                    request,
+                    attemptOrdinal: attemptOrdinal,
+                    attemptID: attemptID,
+                    conflictingClaimID: record.claim.id,
+                    loaded: loaded
+                )
+            }
+            prefix.append(
+                envelope(
+                    id: "claim-expired-\(record.claim.id)-\(record.claim.leaseGeneration)",
+                    runID: request.runID,
+                    nodeID: request.nodeID,
+                    attemptID: attemptID,
+                    sequence: nextSequence,
+                    occurredAt: request.logicalTime,
+                    recordedAt: request.recordedAt,
+                    producer: request.producer,
+                    correlationID: request.claimID,
+                    payload: .executorLeaseExpired(
+                        GraphExecutorLeaseEndedPayload(
+                            claimID: record.claim.id,
+                            leaseGeneration:
+                                record.claim.leaseGeneration,
+                            reason: .leaseExpired
+                        )
+                    )
+                )
+            )
+            nextSequence += 1
+        }
+
+        if createAttempt {
+            prefix.append(
+                envelope(
+                    id: attemptID,
+                    runID: request.runID,
+                    nodeID: request.nodeID,
+                    attemptID: attemptID,
+                    sequence: nextSequence,
+                    occurredAt: request.logicalTime,
+                    recordedAt: request.recordedAt,
+                    producer: request.producer,
+                    correlationID: attemptID,
+                    payload: .attemptCreated(
+                        GraphAttemptCreatedPayload(
+                            ordinal: attemptOrdinal,
+                            executorID: nil
+                        )
+                    )
+                )
+            )
+            nextSequence += 1
+        }
+
+        let grantedSequence = nextSequence + 1
+        let claim = GraphExecutorClaim(
+            runID: request.runID,
+            nodeID: request.nodeID,
+            attemptOrdinal: attemptOrdinal,
+            claimID: request.claimID,
+            executorID: request.executor.executorID,
+            executorCapabilityIdentity:
+                request.executor.capabilityIdentity,
+            grantedSequence: grantedSequence,
+            leaseStart: request.logicalTime,
+            leaseExpiry: request.logicalTime.addingTimeInterval(
+                TimeInterval(request.leaseDurationSeconds)
+            ),
+            hostID: request.executor.hostID
+        )
+        let payload = GraphExecutorClaimPayload(
+            claim: claim,
+            reason: .claimGranted
+        )
+        prefix.append(
+            envelope(
+                id: "claim-request-\(request.claimID)",
+                runID: request.runID,
+                nodeID: request.nodeID,
+                attemptID: attemptID,
+                sequence: nextSequence,
+                occurredAt: request.logicalTime,
+                recordedAt: request.recordedAt,
+                producer: request.producer,
+                correlationID: request.claimID,
+                payload: .executorClaimRequested(payload)
+            )
+        )
+        prefix.append(
+            envelope(
+                id: "claim-grant-\(request.claimID)",
+                runID: request.runID,
+                nodeID: request.nodeID,
+                attemptID: attemptID,
+                sequence: grantedSequence,
+                occurredAt: request.logicalTime,
+                recordedAt: request.recordedAt,
+                producer: request.producer,
+                correlationID: request.claimID,
+                payload: .executorClaimGranted(payload)
+            )
+        )
+        let append = try await append(
+            prefix,
+            runID: request.runID,
+            expectedVersion: request.expectedVersion
+        )
+        return GraphExecutorClaimResult(
+            outcome: .granted,
+            claim: claim,
+            conflictingClaimID: nil,
+            appendResult: append,
+            conflictReason: nil
+        )
+    }
+
+    public func renewLease(
+        _ request: GraphExecutorLeaseRenewalRequest
+    ) async throws -> GraphSchedulingTransactionResult {
+        let loaded = try await load(runID: request.runID)
+        guard let currentRecord = loaded.projection.scheduling.claims
+            .first(where: { $0.claim.id == request.claimID }) else {
+            throw conflict(
+                .claimNotFound,
+                "Claim \(request.claimID) does not exist."
+            )
+        }
+        let current = currentRecord.claim
+        let targetGeneration = request.expectedGeneration + 1
+        let targetExpiry = request.logicalTime.addingTimeInterval(
+            TimeInterval(request.leaseDurationSeconds)
+        )
+
+        if current.leaseGeneration == targetGeneration,
+           current.executorID == request.executorID,
+           current.leaseStart == request.logicalTime,
+           current.leaseExpiry == targetExpiry {
+            return unchanged(loaded)
+        }
+        try requireVersion(
+            request.expectedVersion,
+            actual: loaded.stream.currentVersion,
+            runID: request.runID
+        )
+        guard currentRecord.status == .active,
+              current.executorID == request.executorID else {
+            throw conflict(
+                .claimAlreadyReleased,
+                "Claim \(request.claimID) is not owned by the requester."
+            )
+        }
+        guard current.leaseGeneration == request.expectedGeneration else {
+            throw conflict(
+                .leaseGenerationMismatch,
+                "Lease generation does not match current ownership."
+            )
+        }
+        guard request.logicalTime < current.leaseExpiry else {
+            throw conflict(
+                .leaseExpired,
+                "Expired leases cannot be renewed."
+            )
+        }
+        let renewed = GraphExecutorClaim(
+            runID: current.runID,
+            nodeID: current.nodeID,
+            attemptOrdinal: current.attemptOrdinal,
+            claimID: current.id,
+            executorID: current.executorID,
+            executorCapabilityIdentity:
+                current.executorCapabilityIdentity,
+            grantedSequence: current.grantedSequence,
+            leaseStart: request.logicalTime,
+            leaseExpiry: targetExpiry,
+            leaseGeneration: targetGeneration,
+            hostID: current.hostID
+        )
+        let event = envelope(
+            id: "lease-renew-\(current.id)-\(targetGeneration)",
+            runID: request.runID,
+            nodeID: current.nodeID,
+            attemptID: attemptID(
+                nodeID: current.nodeID,
+                ordinal: current.attemptOrdinal,
+                projection: loaded.projection
+            ),
+            sequence: loaded.stream.currentVersion + 1,
+            occurredAt: request.logicalTime,
+            recordedAt: request.recordedAt,
+            producer: request.producer,
+            correlationID: current.id,
+            payload: .executorLeaseRenewed(
+                GraphExecutorClaimPayload(
+                    claim: renewed,
+                    reason: .leaseRenewed
+                )
+            )
+        )
+        return try await appendTransaction(
+            [event],
+            loaded: loaded,
+            expectedVersion: request.expectedVersion
+        )
+    }
+
+    public func releaseClaim(
+        _ request: GraphExecutorClaimReleaseRequest
+    ) async throws -> GraphSchedulingTransactionResult {
+        let loaded = try await load(runID: request.runID)
+        guard let record = loaded.projection.scheduling.claims.first(
+            where: { $0.claim.id == request.claimID }
+        ) else {
+            throw conflict(
+                .claimNotFound,
+                "Claim \(request.claimID) does not exist."
+            )
+        }
+        if record.status == .released {
+            return unchanged(loaded)
+        }
+        try requireVersion(
+            request.expectedVersion,
+            actual: loaded.stream.currentVersion,
+            runID: request.runID
+        )
+        guard record.status == .active,
+              record.claim.executorID == request.executorID else {
+            throw conflict(
+                .claimAlreadyReleased,
+                "Claim \(request.claimID) is not active for this owner."
+            )
+        }
+        guard record.claim.leaseGeneration
+                == request.expectedGeneration else {
+            throw conflict(
+                .leaseGenerationMismatch,
+                "Lease generation does not match current ownership."
+            )
+        }
+        let event = envelope(
+            id: "claim-release-\(record.claim.id)-\(record.claim.leaseGeneration)",
+            runID: request.runID,
+            nodeID: record.claim.nodeID,
+            attemptID: attemptID(
+                nodeID: record.claim.nodeID,
+                ordinal: record.claim.attemptOrdinal,
+                projection: loaded.projection
+            ),
+            sequence: loaded.stream.currentVersion + 1,
+            occurredAt: request.logicalTime,
+            recordedAt: request.recordedAt,
+            producer: request.producer,
+            correlationID: record.claim.id,
+            payload: .executorClaimReleased(
+                GraphExecutorLeaseEndedPayload(
+                    claimID: record.claim.id,
+                    leaseGeneration: record.claim.leaseGeneration,
+                    reason: .claimReleased
+                )
+            )
+        )
+        return try await appendTransaction(
+            [event],
+            loaded: loaded,
+            expectedVersion: request.expectedVersion
+        )
+    }
+
+    private func rejectClaim(
+        _ request: GraphExecutorClaimRequest,
+        attemptOrdinal: Int,
+        attemptID: String,
+        conflictingClaimID: String,
+        loaded: LoadedSchedulingHistory
+    ) async throws -> GraphExecutorClaimResult {
+        let placeholder = GraphExecutorClaim(
+            runID: request.runID,
+            nodeID: request.nodeID,
+            attemptOrdinal: attemptOrdinal,
+            claimID: request.claimID,
+            executorID: request.executor.executorID,
+            executorCapabilityIdentity:
+                request.executor.capabilityIdentity,
+            grantedSequence: 0,
+            leaseStart: request.logicalTime,
+            leaseExpiry: request.logicalTime,
+            hostID: request.executor.hostID
+        )
+        let requestEvent = envelope(
+            id: "claim-request-\(request.claimID)",
+            runID: request.runID,
+            nodeID: request.nodeID,
+            attemptID: attemptID,
+            sequence: loaded.stream.currentVersion + 1,
+            occurredAt: request.logicalTime,
+            recordedAt: request.recordedAt,
+            producer: request.producer,
+            correlationID: request.claimID,
+            payload: .executorClaimRequested(
+                GraphExecutorClaimPayload(
+                    claim: placeholder,
+                    reason: .claimRejected
+                )
+            )
+        )
+        let rejection = envelope(
+            id: "claim-reject-\(request.claimID)",
+            runID: request.runID,
+            nodeID: request.nodeID,
+            attemptID: attemptID,
+            sequence: loaded.stream.currentVersion + 2,
+            occurredAt: request.logicalTime,
+            recordedAt: request.recordedAt,
+            producer: request.producer,
+            correlationID: request.claimID,
+            payload: .executorClaimRejected(
+                GraphExecutorClaimRejectedPayload(
+                    claimID: request.claimID,
+                    nodeID: request.nodeID,
+                    attemptOrdinal: attemptOrdinal,
+                    executorID: request.executor.executorID,
+                    reason: .existingActiveClaim,
+                    conflictingClaimID: conflictingClaimID
+                )
+            )
+        )
+        let append = try await append(
+            [requestEvent, rejection],
+            runID: request.runID,
+            expectedVersion: request.expectedVersion
+        )
+        return GraphExecutorClaimResult(
+            outcome: .rejected,
+            claim: nil,
+            conflictingClaimID: conflictingClaimID,
+            appendResult: append,
+            conflictReason: .existingActiveClaim
+        )
+    }
+
+    private struct LoadedSchedulingHistory {
+        let stream: GraphExecutionEventStream
+        let projection: GraphExecutionProjection
+    }
+
+    private func load(
+        runID: String
+    ) async throws -> LoadedSchedulingHistory {
+        do {
+            let stream = try await eventStore.read(
+                runID: runID,
+                afterVersion: 0
+            )
+            return LoadedSchedulingHistory(
+                stream: stream,
+                projection: try replay(
+                    runID: runID,
+                    events: stream.events
+                )
+            )
+        } catch let error as GraphExecutionReplayError {
+            throw GraphSchedulingRepositoryError.corruptHistory(
+                error.localizedDescription
+            )
+        } catch let error as GraphExecutionPersistenceError {
+            throw mappedPersistence(error)
+        } catch {
+            throw GraphSchedulingRepositoryError.persistence(
+                error.localizedDescription
+            )
+        }
+    }
+
+    private func appendTransaction(
+        _ events: [GraphExecutionEventEnvelope],
+        loaded: LoadedSchedulingHistory,
+        expectedVersion: UInt64
+    ) async throws -> GraphSchedulingTransactionResult {
+        let appendResult = try await append(
+            events,
+            runID: loaded.stream.runID,
+            expectedVersion: expectedVersion
+        )
+        return GraphSchedulingTransactionResult(
+            appendResult: appendResult,
+            projection: try replay(
+                runID: loaded.stream.runID,
+                events: loaded.stream.events + events
+            )
+        )
+    }
+
+    private func append(
+        _ events: [GraphExecutionEventEnvelope],
+        runID: String,
+        expectedVersion: UInt64
+    ) async throws -> GraphExecutionAppendResult {
+        do {
+            return try await eventStore.append(
+                events,
+                to: runID,
+                expectedVersion: expectedVersion
+            )
+        } catch let error as GraphExecutionPersistenceError {
+            throw mappedPersistence(error)
+        } catch {
+            throw GraphSchedulingRepositoryError.persistence(
+                error.localizedDescription
+            )
+        }
+    }
+
+    private func replay(
+        runID: String,
+        events: [GraphExecutionEventEnvelope]
+    ) throws -> GraphExecutionProjection {
+        do {
+            return try GraphExecutionProjector.replay(
+                runID: runID,
+                events: events
+            ).projection
+        } catch {
+            throw GraphSchedulingRepositoryError.corruptHistory(
+                error.localizedDescription
+            )
+        }
+    }
+
+    private func requireVersion(
+        _ expected: UInt64,
+        actual: UInt64,
+        runID: String
+    ) throws {
+        guard expected == actual else {
+            throw conflict(
+                .expectedVersionConflict,
+                "Run \(runID) changed concurrently.",
+                expected: expected,
+                actual: actual
+            )
+        }
+    }
+
+    private func mappedPersistence(
+        _ error: GraphExecutionPersistenceError
+    ) -> GraphSchedulingRepositoryError {
+        if case let .expectedVersionConflict(_, expected, actual) = error {
+            return conflict(
+                .expectedVersionConflict,
+                error.localizedDescription,
+                expected: expected,
+                actual: actual
+            )
+        }
+        return .persistence(error.localizedDescription)
+    }
+
+    private func conflict(
+        _ reason: GraphSchedulingConflictReason,
+        _ message: String,
+        expected: UInt64? = nil,
+        actual: UInt64? = nil
+    ) -> GraphSchedulingRepositoryError {
+        .conflict(
+            reason: reason,
+            message: message,
+            expectedVersion: expected,
+            actualVersion: actual
+        )
+    }
+
+    private func unchanged(
+        _ loaded: LoadedSchedulingHistory
+    ) -> GraphSchedulingTransactionResult {
+        GraphSchedulingTransactionResult(
+            appendResult: GraphExecutionAppendResult(
+                previousVersion: loaded.stream.currentVersion,
+                newVersion: loaded.stream.currentVersion,
+                appendedCount: 0,
+                deduplicatedCount: 1
+            ),
+            projection: loaded.projection
+        )
+    }
+
+    private func envelopes(
+        proposals: [GraphSchedulingProposedEvent],
+        runID: String,
+        startingAfter version: UInt64,
+        producer: GraphExecutionProducer,
+        recordedAt: Date,
+        correlationID: String
+    ) -> [GraphExecutionEventEnvelope] {
+        proposals.enumerated().map { index, proposal in
+            envelope(
+                id: proposal.id,
+                runID: runID,
+                nodeID: proposal.nodeID,
+                attemptID: proposal.attemptID,
+                sequence: version + UInt64(index) + 1,
+                occurredAt: proposal.occurredAt,
+                recordedAt: recordedAt,
+                producer: producer,
+                correlationID: correlationID,
+                payload: proposal.payload
+            )
+        }
+    }
+
+    private func envelope(
+        id: String,
+        runID: String,
+        nodeID: String? = nil,
+        attemptID: String? = nil,
+        sequence: UInt64,
+        occurredAt: Date,
+        recordedAt: Date,
+        producer: GraphExecutionProducer,
+        correlationID: String,
+        payload: GraphExecutionEventPayload
+    ) -> GraphExecutionEventEnvelope {
+        GraphExecutionEventEnvelope(
+            id: id,
+            runID: runID,
+            nodeID: nodeID,
+            attemptID: attemptID,
+            streamSequence: sequence,
+            occurredAt: occurredAt,
+            recordedAt: recordedAt,
+            producer: producer,
+            correlationID: correlationID,
+            payload: payload
+        )
+    }
+
+    private func stableAttemptID(
+        runID: String,
+        nodeID: String,
+        ordinal: Int
+    ) -> String {
+        "attempt-\(GraphScheduler.stableID("\(runID)|\(nodeID)|\(ordinal)"))"
+    }
+
+    private func attemptID(
+        nodeID: String,
+        ordinal: Int,
+        projection: GraphExecutionProjection
+    ) -> String? {
+        projection.attempts.first {
+            $0.nodeID == nodeID && $0.ordinal == ordinal
+        }?.id
+    }
+}

--- a/Sources/OpenIslandCore/GraphSchedulingRepository.swift
+++ b/Sources/OpenIslandCore/GraphSchedulingRepository.swift
@@ -211,6 +211,124 @@ public struct GraphExecutorClaimReleaseRequest: Equatable, Sendable {
     }
 }
 
+public struct GraphCancellationCommandRequest: Equatable, Sendable {
+    public let runID: String
+    public let nodeID: String
+    public let attemptID: String?
+    public let requestID: String
+    public let requestedBy: String
+    public let reason: String?
+    public let expectedVersion: UInt64
+    public let logicalTime: Date
+    public let producer: GraphExecutionProducer
+    public let recordedAt: Date
+
+    public init(
+        runID: String,
+        nodeID: String,
+        attemptID: String? = nil,
+        requestID: String,
+        requestedBy: String,
+        reason: String? = nil,
+        expectedVersion: UInt64,
+        logicalTime: Date,
+        producer: GraphExecutionProducer,
+        recordedAt: Date
+    ) {
+        self.runID = runID
+        self.nodeID = nodeID
+        self.attemptID = attemptID
+        self.requestID = requestID
+        self.requestedBy = requestedBy
+        self.reason = reason
+        self.expectedVersion = expectedVersion
+        self.logicalTime = logicalTime
+        self.producer = producer
+        self.recordedAt = recordedAt
+    }
+}
+
+public struct GraphCancellationAcknowledgementRequest:
+    Equatable,
+    Sendable
+{
+    public let runID: String
+    public let requestID: String
+    public let claimID: String?
+    public let executorID: String
+    public let expectedVersion: UInt64
+    public let logicalTime: Date
+    public let producer: GraphExecutionProducer
+    public let recordedAt: Date
+
+    public init(
+        runID: String,
+        requestID: String,
+        claimID: String?,
+        executorID: String,
+        expectedVersion: UInt64,
+        logicalTime: Date,
+        producer: GraphExecutionProducer,
+        recordedAt: Date
+    ) {
+        self.runID = runID
+        self.requestID = requestID
+        self.claimID = claimID
+        self.executorID = executorID
+        self.expectedVersion = expectedVersion
+        self.logicalTime = logicalTime
+        self.producer = producer
+        self.recordedAt = recordedAt
+    }
+}
+
+public struct GraphCancellationTerminalRequest: Equatable, Sendable {
+    public let runID: String
+    public let requestID: String
+    public let expectedVersion: UInt64
+    public let logicalTime: Date
+    public let reason: String?
+    public let producer: GraphExecutionProducer
+    public let recordedAt: Date
+
+    public init(
+        runID: String,
+        requestID: String,
+        expectedVersion: UInt64,
+        logicalTime: Date,
+        reason: String? = nil,
+        producer: GraphExecutionProducer,
+        recordedAt: Date
+    ) {
+        self.runID = runID
+        self.requestID = requestID
+        self.expectedVersion = expectedVersion
+        self.logicalTime = logicalTime
+        self.reason = reason
+        self.producer = producer
+        self.recordedAt = recordedAt
+    }
+}
+
+public struct GraphTimeoutCommandRequest: Equatable, Sendable {
+    public let decision: GraphTimeoutDecision
+    public let expectedVersion: UInt64
+    public let producer: GraphExecutionProducer
+    public let recordedAt: Date
+
+    public init(
+        decision: GraphTimeoutDecision,
+        expectedVersion: UInt64,
+        producer: GraphExecutionProducer,
+        recordedAt: Date
+    ) {
+        self.decision = decision
+        self.expectedVersion = expectedVersion
+        self.producer = producer
+        self.recordedAt = recordedAt
+    }
+}
+
 public struct GraphSchedulingTransactionResult: Equatable, Sendable {
     public let appendResult: GraphExecutionAppendResult
     public let projection: GraphExecutionProjection
@@ -231,6 +349,22 @@ public protocol GraphSchedulingRepository: Sendable {
 
     func releaseClaim(
         _ request: GraphExecutorClaimReleaseRequest
+    ) async throws -> GraphSchedulingTransactionResult
+
+    func requestCancellation(
+        _ request: GraphCancellationCommandRequest
+    ) async throws -> GraphSchedulingTransactionResult
+
+    func acknowledgeCancellation(
+        _ request: GraphCancellationAcknowledgementRequest
+    ) async throws -> GraphSchedulingTransactionResult
+
+    func declareCancellationTerminal(
+        _ request: GraphCancellationTerminalRequest
+    ) async throws -> GraphSchedulingTransactionResult
+
+    func recordTimeout(
+        _ request: GraphTimeoutCommandRequest
     ) async throws -> GraphSchedulingTransactionResult
 }
 
@@ -703,6 +837,393 @@ public struct DefaultGraphSchedulingRepository:
         )
         return try await appendTransaction(
             [event],
+            loaded: loaded,
+            expectedVersion: request.expectedVersion
+        )
+    }
+
+    public func requestCancellation(
+        _ request: GraphCancellationCommandRequest
+    ) async throws -> GraphSchedulingTransactionResult {
+        let loaded = try await load(runID: request.runID)
+        if let existing = loaded.projection.scheduling.cancellations
+            .first(where: { $0.id == request.requestID }) {
+            guard existing.runID == request.runID,
+                  existing.nodeID == request.nodeID,
+                  (request.attemptID == nil
+                    || existing.attemptID == request.attemptID),
+                  existing.requestedBy == request.requestedBy,
+                  existing.requestedAt == request.logicalTime,
+                  existing.reason == request.reason else {
+                throw conflict(
+                    .invalidRequest,
+                    "Cancellation ID \(request.requestID) has contradictory content."
+                )
+            }
+            return unchanged(loaded)
+        }
+        try requireVersion(
+            request.expectedVersion,
+            actual: loaded.stream.currentVersion,
+            runID: request.runID
+        )
+        guard loaded.projection.run?.state.isTerminal != true else {
+            throw conflict(
+                .runTerminal,
+                "Terminal runs cannot be cancelled again."
+            )
+        }
+        guard loaded.projection.nodes.contains(where: {
+            $0.id == request.nodeID
+        }) else {
+            throw conflict(
+                .invalidRequest,
+                "Node \(request.nodeID) is not registered."
+            )
+        }
+        let latestAttempt = loaded.projection.attempts
+            .filter { $0.nodeID == request.nodeID }
+            .max { $0.ordinal < $1.ordinal }
+        if let requestAttemptID = request.attemptID,
+           requestAttemptID != latestAttempt?.id {
+            throw conflict(
+                .invalidRequest,
+                "Cancellation attempt does not match the latest node attempt."
+            )
+        }
+        guard latestAttempt?.state.isTerminal != true else {
+            throw conflict(
+                .attemptTerminal,
+                "A terminal attempt cannot receive a cancellation request."
+            )
+        }
+        let claim = loaded.projection.scheduling.claims
+            .filter {
+                $0.claim.nodeID == request.nodeID
+                    && $0.status == .active
+            }
+            .max {
+                $0.claim.leaseGeneration < $1.claim.leaseGeneration
+            }?.claim
+        let cancellation = GraphCancellationRecord(
+            requestID: request.requestID,
+            runID: request.runID,
+            nodeID: request.nodeID,
+            attemptID: latestAttempt?.id,
+            claimID: claim?.id,
+            requestedBy: request.requestedBy,
+            requestedAt: request.logicalTime,
+            reason: request.reason
+        )
+        let event = envelope(
+            id: "cancellation-request-\(request.requestID)",
+            runID: request.runID,
+            nodeID: request.nodeID,
+            attemptID: latestAttempt?.id,
+            sequence: loaded.stream.currentVersion + 1,
+            occurredAt: request.logicalTime,
+            recordedAt: request.recordedAt,
+            producer: request.producer,
+            correlationID: request.requestID,
+            payload: .cancellationRequested(
+                GraphCancellationRequestedPayload(
+                    cancellation: cancellation
+                )
+            )
+        )
+        return try await appendTransaction(
+            [event],
+            loaded: loaded,
+            expectedVersion: request.expectedVersion
+        )
+    }
+
+    public func acknowledgeCancellation(
+        _ request: GraphCancellationAcknowledgementRequest
+    ) async throws -> GraphSchedulingTransactionResult {
+        let loaded = try await load(runID: request.runID)
+        guard let cancellation = loaded.projection.scheduling
+            .cancellations.first(where: {
+                $0.id == request.requestID
+            }) else {
+            throw conflict(
+                .cancellationNotFound,
+                "Cancellation \(request.requestID) does not exist."
+            )
+        }
+        if cancellation.state == .acknowledged {
+            guard cancellation.claimID == request.claimID,
+                  cancellation.acknowledgedByExecutorID
+                    == request.executorID,
+                  cancellation.acknowledgedAt == request.logicalTime else {
+                throw conflict(
+                    .staleCancellationAcknowledgement,
+                    "Cancellation was acknowledged by another owner."
+                )
+            }
+            return unchanged(loaded)
+        }
+        try requireVersion(
+            request.expectedVersion,
+            actual: loaded.stream.currentVersion,
+            runID: request.runID
+        )
+        guard let claimID = cancellation.claimID,
+              claimID == request.claimID,
+              let claimRecord = loaded.projection.scheduling.claims
+                .first(where: { $0.claim.id == claimID }),
+              claimRecord.status == .active,
+              claimRecord.claim.executorID == request.executorID,
+              claimRecord.claim.isValid(at: request.logicalTime) else {
+            throw conflict(
+                .staleCancellationAcknowledgement,
+                "Only the current valid claim owner may acknowledge cancellation."
+            )
+        }
+        let event = envelope(
+            id: "cancellation-ack-\(request.requestID)",
+            runID: request.runID,
+            nodeID: cancellation.nodeID,
+            attemptID: cancellation.attemptID,
+            sequence: loaded.stream.currentVersion + 1,
+            occurredAt: request.logicalTime,
+            recordedAt: request.recordedAt,
+            producer: request.producer,
+            correlationID: request.requestID,
+            payload: .cancellationAcknowledged(
+                GraphCancellationAcknowledgedPayload(
+                    requestID: request.requestID,
+                    claimID: request.claimID,
+                    executorID: request.executorID,
+                    acknowledgedAt: request.logicalTime
+                )
+            )
+        )
+        return try await appendTransaction(
+            [event],
+            loaded: loaded,
+            expectedVersion: request.expectedVersion
+        )
+    }
+
+    public func declareCancellationTerminal(
+        _ request: GraphCancellationTerminalRequest
+    ) async throws -> GraphSchedulingTransactionResult {
+        let loaded = try await load(runID: request.runID)
+        if loaded.stream.events.contains(where: {
+            $0.id == "cancellation-terminal-\(request.requestID)"
+        }) {
+            return unchanged(loaded)
+        }
+        guard let cancellation = loaded.projection.scheduling
+            .cancellations.first(where: {
+                $0.id == request.requestID
+            }) else {
+            throw conflict(
+                .cancellationNotFound,
+                "Cancellation \(request.requestID) does not exist."
+            )
+        }
+        try requireVersion(
+            request.expectedVersion,
+            actual: loaded.stream.currentVersion,
+            runID: request.runID
+        )
+        if cancellation.claimID != nil,
+           cancellation.state != .acknowledged {
+            throw conflict(
+                .cancellationPending,
+                "Claimed cancellation must be acknowledged before terminal declaration."
+            )
+        }
+        var events: [GraphExecutionEventEnvelope] = []
+        var sequence = loaded.stream.currentVersion + 1
+        var attempt = cancellation.attemptID.flatMap { id in
+            loaded.projection.attempts.first { $0.id == id }
+        }
+
+        if attempt == nil {
+            let ordinal = (loaded.projection.attempts
+                .filter { $0.nodeID == cancellation.nodeID }
+                .map(\.ordinal)
+                .max() ?? 0) + 1
+            let id = stableAttemptID(
+                runID: request.runID,
+                nodeID: cancellation.nodeID,
+                ordinal: ordinal
+            )
+            events.append(
+                envelope(
+                    id: id,
+                    runID: request.runID,
+                    nodeID: cancellation.nodeID,
+                    attemptID: id,
+                    sequence: sequence,
+                    occurredAt: request.logicalTime,
+                    recordedAt: request.recordedAt,
+                    producer: request.producer,
+                    correlationID: request.requestID,
+                    payload: .attemptCreated(
+                        GraphAttemptCreatedPayload(ordinal: ordinal)
+                    )
+                )
+            )
+            attempt = ExecutionAttempt(
+                id: id,
+                graphRunID: request.runID,
+                nodeID: cancellation.nodeID,
+                ordinal: ordinal,
+                createdAt: request.logicalTime,
+                updatedAt: request.logicalTime
+            )
+            sequence += 1
+        }
+        guard let terminalAttempt = attempt else {
+            throw GraphSchedulingRepositoryError.corruptHistory(
+                "Cancellation has no attempt."
+            )
+        }
+        guard !terminalAttempt.state.isTerminal else {
+            if terminalAttempt.state == .cancelled {
+                return unchanged(loaded)
+            }
+            throw conflict(
+                .attemptTerminal,
+                "Attempt \(terminalAttempt.id) already has another terminal result."
+            )
+        }
+
+        if let claimID = cancellation.claimID,
+           let claim = loaded.projection.scheduling.claims.first(
+                where: {
+                    $0.claim.id == claimID && $0.status == .active
+                }
+           )?.claim {
+            events.append(
+                envelope(
+                    id: "claim-release-\(claim.id)-\(claim.leaseGeneration)",
+                    runID: request.runID,
+                    nodeID: claim.nodeID,
+                    attemptID: terminalAttempt.id,
+                    sequence: sequence,
+                    occurredAt: request.logicalTime,
+                    recordedAt: request.recordedAt,
+                    producer: request.producer,
+                    correlationID: request.requestID,
+                    payload: .executorClaimReleased(
+                        GraphExecutorLeaseEndedPayload(
+                            claimID: claim.id,
+                            leaseGeneration: claim.leaseGeneration,
+                            reason: .claimReleased
+                        )
+                    )
+                )
+            )
+            sequence += 1
+        }
+        events.append(
+            envelope(
+                id: "cancellation-terminal-\(request.requestID)",
+                runID: request.runID,
+                nodeID: cancellation.nodeID,
+                attemptID: terminalAttempt.id,
+                sequence: sequence,
+                occurredAt: request.logicalTime,
+                recordedAt: request.recordedAt,
+                producer: request.producer,
+                correlationID: request.requestID,
+                payload: .attemptCancelled(
+                    GraphAttemptTerminalPayload(reason: request.reason)
+                )
+            )
+        )
+        return try await appendTransaction(
+            events,
+            loaded: loaded,
+            expectedVersion: request.expectedVersion
+        )
+    }
+
+    public func recordTimeout(
+        _ request: GraphTimeoutCommandRequest
+    ) async throws -> GraphSchedulingTransactionResult {
+        let loaded = try await load(runID: request.decision.runID)
+        if let existing = loaded.projection.scheduling.timeouts.first(
+            where: { $0.id == request.decision.id }
+        ) {
+            guard existing == request.decision else {
+                throw conflict(
+                    .invalidRequest,
+                    "Timeout ID \(request.decision.id) has contradictory content."
+                )
+            }
+            return unchanged(loaded)
+        }
+        try requireVersion(
+            request.expectedVersion,
+            actual: loaded.stream.currentVersion,
+            runID: request.decision.runID
+        )
+        guard request.decision.declaredAt >= request.decision.deadline else {
+            throw conflict(
+                .invalidRequest,
+                "A timeout cannot be declared before its durable deadline."
+            )
+        }
+        var events = [
+            envelope(
+                id: "timeout-\(request.decision.id)",
+                runID: request.decision.runID,
+                nodeID: request.decision.nodeID,
+                attemptID: request.decision.attemptID,
+                sequence: loaded.stream.currentVersion + 1,
+                occurredAt: request.decision.declaredAt,
+                recordedAt: request.recordedAt,
+                producer: request.producer,
+                correlationID: request.decision.id,
+                payload: .timeoutDeclared(
+                    GraphTimeoutDeclaredPayload(
+                        timeout: request.decision
+                    )
+                )
+            ),
+        ]
+        if request.decision.kind == .lease,
+           let claimID = request.decision.claimID,
+           let claim = loaded.projection.scheduling.claims.first(
+                where: {
+                    $0.claim.id == claimID && $0.status == .active
+                }
+           )?.claim {
+            guard request.decision.declaredAt >= claim.leaseExpiry else {
+                throw conflict(
+                    .invalidRequest,
+                    "Lease timeout precedes the current lease expiry."
+                )
+            }
+            events.append(
+                envelope(
+                    id: "claim-expired-\(claim.id)-\(claim.leaseGeneration)",
+                    runID: request.decision.runID,
+                    nodeID: claim.nodeID,
+                    attemptID: request.decision.attemptID,
+                    sequence: loaded.stream.currentVersion + 2,
+                    occurredAt: request.decision.declaredAt,
+                    recordedAt: request.recordedAt,
+                    producer: request.producer,
+                    correlationID: request.decision.id,
+                    payload: .executorLeaseExpired(
+                        GraphExecutorLeaseEndedPayload(
+                            claimID: claim.id,
+                            leaseGeneration: claim.leaseGeneration,
+                            reason: .leaseExpired
+                        )
+                    )
+                )
+            )
+        }
+        return try await appendTransaction(
+            events,
             loaded: loaded,
             expectedVersion: request.expectedVersion
         )

--- a/Sources/OpenIslandCore/GraphTemporalInspection.swift
+++ b/Sources/OpenIslandCore/GraphTemporalInspection.swift
@@ -212,6 +212,142 @@ public struct GraphAttemptInspection:
     public let statusReason: String?
 }
 
+public struct GraphExecutorClaimInspection:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public let id: String
+    public let nodeID: String
+    public let attemptOrdinal: Int
+    public let executorID: String
+    public let executorCapabilityIdentity: String
+    public let grantedSequence: UInt64
+    public let leaseStart: Date
+    public let leaseExpiry: Date
+    public let leaseGeneration: UInt64
+    public let status: GraphExecutorClaimStatus
+    public let statusChangedAt: Date
+    public let reason: GraphSchedulingReasonCode
+    public let hostIdentityPresent: Bool
+
+    public init(record: GraphExecutorClaimRecord) {
+        id = record.claim.id
+        nodeID = record.claim.nodeID
+        attemptOrdinal = record.claim.attemptOrdinal
+        executorID = record.claim.executorID
+        executorCapabilityIdentity =
+            record.claim.executorCapabilityIdentity
+        grantedSequence = record.claim.grantedSequence
+        leaseStart = record.claim.leaseStart
+        leaseExpiry = record.claim.leaseExpiry
+        leaseGeneration = record.claim.leaseGeneration
+        status = record.status
+        statusChangedAt = record.statusChangedAt
+        reason = record.reason
+        hostIdentityPresent = record.claim.hostID != nil
+    }
+}
+
+public struct GraphSchedulingInspection: Equatable, Codable, Sendable {
+    public let schemaVersion: Int
+    public let latestEvaluation: GraphSchedulerEvaluationPayload?
+    public let currentPolicy: GraphSchedulerPolicy?
+    public let activeClaims: [GraphExecutorClaimInspection]
+    public let claimHistory: [GraphExecutorClaimInspection]
+    public let retries: [GraphRetryRecord]
+    public let pendingCancellations: [GraphCancellationRecord]
+    public let cancellationHistory: [GraphCancellationRecord]
+    public let timeouts: [GraphTimeoutDecision]
+    public let reasonCodes: [GraphSchedulingReasonCode]
+    public let records: [GraphSchedulingRecord]
+
+    public init(
+        schemaVersion: Int,
+        latestEvaluation: GraphSchedulerEvaluationPayload?,
+        currentPolicy: GraphSchedulerPolicy?,
+        activeClaims: [GraphExecutorClaimInspection],
+        claimHistory: [GraphExecutorClaimInspection],
+        retries: [GraphRetryRecord],
+        pendingCancellations: [GraphCancellationRecord],
+        cancellationHistory: [GraphCancellationRecord],
+        timeouts: [GraphTimeoutDecision],
+        reasonCodes: [GraphSchedulingReasonCode],
+        records: [GraphSchedulingRecord]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.latestEvaluation = latestEvaluation
+        self.currentPolicy = currentPolicy
+        self.activeClaims = activeClaims
+        self.claimHistory = claimHistory
+        self.retries = retries
+        self.pendingCancellations = pendingCancellations
+        self.cancellationHistory = cancellationHistory
+        self.timeouts = timeouts
+        self.reasonCodes = reasonCodes
+        self.records = records
+    }
+
+    public init(
+        projection: GraphSchedulingProjection,
+        terminalNodeIDs: Set<String>
+    ) {
+        schemaVersion = GraphSchedulingSchema.definitionVersion
+        latestEvaluation = projection.evaluations.max {
+            if $0.logicalTime != $1.logicalTime {
+                return $0.logicalTime < $1.logicalTime
+            }
+            return $0.evaluationID < $1.evaluationID
+        }
+        currentPolicy = latestEvaluation?.schedulerPolicy
+        claimHistory = projection.claims
+            .map(GraphExecutorClaimInspection.init)
+            .sorted(by: claimInspectionIsOrderedBefore)
+        activeClaims = claimHistory.filter { $0.status == .active }
+        retries = projection.retries.sorted {
+            if $0.nodeID != $1.nodeID {
+                return $0.nodeID < $1.nodeID
+            }
+            return $0.nextAttemptOrdinal < $1.nextAttemptOrdinal
+        }
+        cancellationHistory = projection.cancellations.sorted {
+            if $0.nodeID != $1.nodeID {
+                return $0.nodeID < $1.nodeID
+            }
+            return $0.id < $1.id
+        }
+        pendingCancellations = cancellationHistory.filter {
+            !terminalNodeIDs.contains($0.nodeID)
+        }
+        timeouts = projection.timeouts.sorted {
+            if $0.declaredAt != $1.declaredAt {
+                return $0.declaredAt < $1.declaredAt
+            }
+            return $0.id < $1.id
+        }
+        reasonCodes = Array(
+            Set(projection.records.compactMap(\.reason))
+        ).sorted { $0.rawValue < $1.rawValue }
+        records = projection.records.sorted {
+            if $0.sequence != $1.sequence {
+                return $0.sequence < $1.sequence
+            }
+            return $0.id < $1.id
+        }
+    }
+}
+
+private func claimInspectionIsOrderedBefore(
+    _ lhs: GraphExecutorClaimInspection,
+    _ rhs: GraphExecutorClaimInspection
+) -> Bool {
+    if lhs.grantedSequence != rhs.grantedSequence {
+        return lhs.grantedSequence < rhs.grantedSequence
+    }
+    return lhs.id < rhs.id
+}
+
 public struct GraphRunInspection:
     Equatable,
     Codable,
@@ -228,8 +364,41 @@ public struct GraphRunInspection:
     public let checkpointNamespace: String
     public let graphDefinitionVersion: String?
     public let graphDefinitionDigest: GraphContentDigest?
+    public let scheduling: GraphSchedulingInspection?
     public let replayDiagnostics: [GraphReplayDiagnostic]
     public let repositoryDiagnostics: [GraphRepositoryDiagnostic]
+
+    public init(
+        summary: GraphRunInspectionSummary,
+        nodes: [GraphNodeInspection],
+        attempts: [GraphAttemptInspection],
+        checkpoints: [GraphCheckpointReference],
+        artifacts: [GraphArtifactInspection],
+        artifactsIncluded: Bool,
+        parentRunID: String?,
+        parentCheckpoint: GraphCheckpointReference?,
+        checkpointNamespace: String,
+        graphDefinitionVersion: String?,
+        graphDefinitionDigest: GraphContentDigest?,
+        scheduling: GraphSchedulingInspection? = nil,
+        replayDiagnostics: [GraphReplayDiagnostic],
+        repositoryDiagnostics: [GraphRepositoryDiagnostic]
+    ) {
+        self.summary = summary
+        self.nodes = nodes
+        self.attempts = attempts
+        self.checkpoints = checkpoints
+        self.artifacts = artifacts
+        self.artifactsIncluded = artifactsIncluded
+        self.parentRunID = parentRunID
+        self.parentCheckpoint = parentCheckpoint
+        self.checkpointNamespace = checkpointNamespace
+        self.graphDefinitionVersion = graphDefinitionVersion
+        self.graphDefinitionDigest = graphDefinitionDigest
+        self.scheduling = scheduling
+        self.replayDiagnostics = replayDiagnostics
+        self.repositoryDiagnostics = repositoryDiagnostics
+    }
 }
 
 public struct GraphInspectionEventFilter:
@@ -434,6 +603,7 @@ public struct GraphCausalExplanation:
     public let causalPredecessorNodeIDs: [String]
     public let blockingDependencyNodeIDs: [String]
     public let readinessRequirements: [String]
+    public let schedulerReasons: [GraphSchedulingReasonCode]?
     public let ignoredInputs: [GraphCausalReason]
 }
 
@@ -461,6 +631,11 @@ public enum GraphTemporalChangeCategory: String, Codable, Sendable {
     case evidence
     case reconciliation
     case causalExplanation = "causal_explanation"
+    case scheduler
+    case claim
+    case retry
+    case cancellation
+    case timeout
 }
 
 public struct GraphTemporalChange:
@@ -671,6 +846,12 @@ public struct DefaultGraphTemporalInspector:
                 replay.projected.graphDefinitionVersion,
             graphDefinitionDigest:
                 replay.projected.graphDefinitionDigest,
+            scheduling: GraphSchedulingInspection(
+                projection: replay.projected.scheduling,
+                terminalNodeIDs: Set(
+                    nodes.filter { $0.reconciledState.isTerminal }.map(\.id)
+                )
+            ),
             replayDiagnostics:
                 includeDiagnostics ? replay.replayDiagnostics : [],
             repositoryDiagnostics:
@@ -827,6 +1008,11 @@ public struct DefaultGraphTemporalInspector:
         compareArtifacts(
             left: leftResult.projected.artifacts,
             right: rightResult.projected.artifacts,
+            changes: &changes
+        )
+        compareScheduling(
+            left: leftResult.projected.scheduling,
+            right: rightResult.projected.scheduling,
             changes: &changes
         )
 
@@ -1438,6 +1624,13 @@ public struct DefaultGraphTemporalInspector:
             causalPredecessorNodeIDs: predecessors,
             blockingDependencyNodeIDs: blockers,
             readinessRequirements: requirements,
+            schedulerReasons: Array(
+                Set(
+                    result.projected.scheduling.records
+                        .filter { nodeID == nil || $0.nodeID == nodeID }
+                        .compactMap(\.reason)
+                )
+            ).sorted { $0.rawValue < $1.rawValue },
             ignoredInputs: ignored
         )
     }
@@ -1863,6 +2056,142 @@ public struct DefaultGraphTemporalInspector:
         }
     }
 
+    private func compareScheduling(
+        left: GraphSchedulingProjection,
+        right: GraphSchedulingProjection,
+        changes: inout [GraphTemporalChange]
+    ) {
+        appendChange(
+            category: .scheduler,
+            entityID: "latest",
+            field: "completed_evaluation",
+            left: left.records.last {
+                $0.eventType
+                    == GraphExecutionEventType
+                        .schedulerCycleCompleted.rawValue
+            }?.evaluationID,
+            right: right.records.last {
+                $0.eventType
+                    == GraphExecutionEventType
+                        .schedulerCycleCompleted.rawValue
+            }?.evaluationID,
+            to: &changes
+        )
+
+        let leftClaims = Dictionary(
+            uniqueKeysWithValues: left.claims.map { ($0.claim.id, $0) }
+        )
+        let rightClaims = Dictionary(
+            uniqueKeysWithValues: right.claims.map { ($0.claim.id, $0) }
+        )
+        for id in Set(leftClaims.keys).union(rightClaims.keys).sorted() {
+            appendChange(
+                category: .claim,
+                entityID: id,
+                field: "status",
+                left: leftClaims[id]?.status.rawValue,
+                right: rightClaims[id]?.status.rawValue,
+                to: &changes
+            )
+            appendChange(
+                category: .claim,
+                entityID: id,
+                field: "lease_generation",
+                left: leftClaims[id].map {
+                    String($0.claim.leaseGeneration)
+                },
+                right: rightClaims[id].map {
+                    String($0.claim.leaseGeneration)
+                },
+                to: &changes
+            )
+            appendChange(
+                category: .claim,
+                entityID: id,
+                field: "lease_expiry",
+                left: leftClaims[id].map {
+                    graphInspectionDateString($0.claim.leaseExpiry)
+                },
+                right: rightClaims[id].map {
+                    graphInspectionDateString($0.claim.leaseExpiry)
+                },
+                to: &changes
+            )
+        }
+
+        let leftRetries = Dictionary(
+            uniqueKeysWithValues: left.retries.map {
+                ("\($0.nodeID):\($0.nextAttemptOrdinal)", $0)
+            }
+        )
+        let rightRetries = Dictionary(
+            uniqueKeysWithValues: right.retries.map {
+                ("\($0.nodeID):\($0.nextAttemptOrdinal)", $0)
+            }
+        )
+        for id in Set(leftRetries.keys).union(rightRetries.keys).sorted() {
+            appendChange(
+                category: .retry,
+                entityID: id,
+                field: "eligible_at",
+                left: leftRetries[id].map {
+                    graphInspectionDateString($0.eligibleAt)
+                },
+                right: rightRetries[id].map {
+                    graphInspectionDateString($0.eligibleAt)
+                },
+                to: &changes
+            )
+        }
+
+        let leftCancellations = Dictionary(
+            uniqueKeysWithValues: left.cancellations.map { ($0.id, $0) }
+        )
+        let rightCancellations = Dictionary(
+            uniqueKeysWithValues: right.cancellations.map { ($0.id, $0) }
+        )
+        for id in Set(leftCancellations.keys)
+            .union(rightCancellations.keys).sorted() {
+            appendChange(
+                category: .cancellation,
+                entityID: id,
+                field: "state",
+                left: leftCancellations[id]?.state.rawValue,
+                right: rightCancellations[id]?.state.rawValue,
+                to: &changes
+            )
+        }
+
+        let leftTimeouts = Dictionary(
+            uniqueKeysWithValues: left.timeouts.map { ($0.id, $0) }
+        )
+        let rightTimeouts = Dictionary(
+            uniqueKeysWithValues: right.timeouts.map { ($0.id, $0) }
+        )
+        for id in Set(leftTimeouts.keys).union(rightTimeouts.keys).sorted() {
+            appendChange(
+                category: .timeout,
+                entityID: id,
+                field: "kind",
+                left: leftTimeouts[id]?.kind.rawValue,
+                right: rightTimeouts[id]?.kind.rawValue,
+                to: &changes
+            )
+            appendChange(
+                category: .timeout,
+                entityID: id,
+                field: "deadline",
+                left: leftTimeouts[id].map {
+                    graphInspectionDateString($0.deadline)
+                },
+                right: rightTimeouts[id].map {
+                    graphInspectionDateString($0.deadline)
+                },
+                to: &changes
+            )
+        }
+    }
+
     private func appendChange(
         category: GraphTemporalChangeCategory,
         entityID: String,
@@ -1970,6 +2299,10 @@ private func bounded(_ value: String?, limit: Int = 512) -> String? {
         return singleLine
     }
     return String(singleLine.prefix(limit))
+}
+
+private func graphInspectionDateString(_ date: Date) -> String {
+    ISO8601DateFormatter().string(from: date)
 }
 
 private func attemptIsOrderedBefore(

--- a/Sources/OpenIslandCore/GraphTemporalInspection.swift
+++ b/Sources/OpenIslandCore/GraphTemporalInspection.swift
@@ -1,0 +1,2043 @@
+import Foundation
+
+public enum GraphInspectionError: Error, Equatable, Sendable {
+    case runNotFound(String)
+    case checkpointNotFound(runID: String, checkpointID: String)
+    case invalidBoundary(runID: String, requested: UInt64, head: UInt64)
+    case incompatibleSchema(String)
+    case corruptHistory(String)
+    case persistence(String)
+    case evidenceUnavailable(String)
+}
+
+extension GraphInspectionError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .runNotFound(runID):
+            "Graph run \(runID) was not found."
+        case let .checkpointNotFound(runID, checkpointID):
+            "Checkpoint \(checkpointID) was not found in run \(runID)."
+        case let .invalidBoundary(runID, requested, head):
+            "Run \(runID) cannot replay to sequence \(requested); its head is \(head)."
+        case let .incompatibleSchema(message):
+            "Incompatible graph schema: \(message)"
+        case let .corruptHistory(message):
+            "Corrupt graph history: \(message)"
+        case let .persistence(message):
+            "Graph persistence failure: \(message)"
+        case let .evidenceUnavailable(message):
+            "Required process evidence is unavailable: \(message)"
+        }
+    }
+}
+
+public enum GraphReplayBoundaryKind: String, Codable, Sendable {
+    case head
+    case sequence
+    case checkpoint
+}
+
+public struct GraphReplayBoundary: Equatable, Codable, Sendable {
+    public let kind: GraphReplayBoundaryKind
+    public let sequence: UInt64?
+    public let checkpointID: String?
+
+    public init(
+        kind: GraphReplayBoundaryKind,
+        sequence: UInt64? = nil,
+        checkpointID: String? = nil
+    ) {
+        self.kind = kind
+        self.sequence = sequence
+        self.checkpointID = checkpointID
+    }
+
+    public static let head = GraphReplayBoundary(kind: .head)
+
+    public static func sequence(_ value: UInt64) -> GraphReplayBoundary {
+        GraphReplayBoundary(kind: .sequence, sequence: value)
+    }
+
+    public static func checkpoint(_ id: String) -> GraphReplayBoundary {
+        GraphReplayBoundary(kind: .checkpoint, checkpointID: id)
+    }
+}
+
+public struct GraphTemporalReference: Equatable, Codable, Sendable {
+    public let runID: String
+    public let boundary: GraphReplayBoundary
+
+    public init(
+        runID: String,
+        boundary: GraphReplayBoundary = .head
+    ) {
+        self.runID = runID
+        self.boundary = boundary
+    }
+}
+
+public enum GraphInspectionEvidenceMode: String, Codable, Sendable {
+    case configured
+    case withoutLiveEvidence
+    case requireAvailable
+}
+
+public struct GraphEvidenceInspection: Equatable, Codable, Sendable {
+    public let status: String
+    public let reason: String?
+
+    public init(status: String, reason: String?) {
+        self.status = status
+        self.reason = reason
+    }
+}
+
+public enum GraphRedactionReason: String, Codable, Sendable {
+    case sensitiveByDefault = "sensitive_by_default"
+    case sensitivityClassification = "sensitivity_classification"
+    case credentialBearingValue = "credential_bearing_value"
+    case unsupportedPayload = "unsupported_payload"
+}
+
+public struct GraphRedactionRecord: Equatable, Codable, Sendable {
+    public let field: String
+    public let reason: GraphRedactionReason
+
+    public init(field: String, reason: GraphRedactionReason) {
+        self.field = field
+        self.reason = reason
+    }
+}
+
+public struct GraphArtifactInspection:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public let schemaVersion: Int
+    public let id: String
+    public let digestAlgorithm: String
+    public let digest: String
+    public let mediaType: String
+    public let logicalRole: String
+    public let producingRunID: String
+    public let producingNodeID: String
+    public let producingAttemptID: String
+    public let createdAt: Date
+    public let storageScheme: String
+    public let sensitivity: GraphArtifactSensitivity
+    public let redactions: [GraphRedactionRecord]
+
+    public init(reference: GraphArtifactReference) {
+        schemaVersion = reference.schemaVersion
+        id = reference.id
+        digestAlgorithm = reference.contentDigest.algorithm
+        digest = reference.contentDigest.value
+        mediaType = reference.mediaType
+        logicalRole = reference.logicalRole
+        producingRunID = reference.producingRunID
+        producingNodeID = reference.producingNodeID
+        producingAttemptID = reference.producingAttemptID
+        createdAt = reference.createdAt
+        storageScheme = reference.storage.scheme
+        sensitivity = reference.sensitivity
+        redactions = [
+            GraphRedactionRecord(
+                field: "storage.opaqueReference",
+                reason: reference.sensitivity == .unspecified
+                    ? .sensitiveByDefault
+                    : .sensitivityClassification
+            ),
+        ]
+    }
+}
+
+public struct GraphRunInspectionSummary:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public var id: String {
+        runID
+    }
+
+    public let runID: String
+    public let graphID: String
+    public let persistedState: ReconciledExecutionState
+    public let reconciledState: ReconciledExecutionState
+    public let streamVersion: UInt64
+    public let nodeCount: Int
+    public let attemptCount: Int
+    public let artifactCount: Int
+    public let createdAt: Date
+    public let updatedAt: Date
+    public let snapshotDisposition: GraphSnapshotDisposition
+    public let evidence: GraphEvidenceInspection
+}
+
+public struct GraphNodeInspection:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public let id: String
+    public let title: String
+    public let dependencyNodeIDs: [String]
+    public let executorID: String?
+    public let persistedState: ReconciledExecutionState
+    public let reconciledState: ReconciledExecutionState
+    public let activeAttemptID: String?
+    public let updatedAt: Date
+}
+
+public struct GraphAttemptInspection:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public let id: String
+    public let nodeID: String
+    public let ordinal: Int
+    public let persistedState: ReconciledExecutionState
+    public let reconciledState: ReconciledExecutionState
+    public let hasProcessIdentity: Bool
+    public let createdAt: Date
+    public let updatedAt: Date
+    public let startedAt: Date?
+    public let finishedAt: Date?
+    public let statusReason: String?
+}
+
+public struct GraphRunInspection:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let summary: GraphRunInspectionSummary
+    public let nodes: [GraphNodeInspection]
+    public let attempts: [GraphAttemptInspection]
+    public let checkpoints: [GraphCheckpointReference]
+    public let artifacts: [GraphArtifactInspection]
+    public let artifactsIncluded: Bool
+    public let parentRunID: String?
+    public let parentCheckpoint: GraphCheckpointReference?
+    public let checkpointNamespace: String
+    public let graphDefinitionVersion: String?
+    public let graphDefinitionDigest: GraphContentDigest?
+    public let replayDiagnostics: [GraphReplayDiagnostic]
+    public let repositoryDiagnostics: [GraphRepositoryDiagnostic]
+}
+
+public struct GraphInspectionEventFilter:
+    Equatable,
+    Sendable
+{
+    public let nodeID: String?
+    public let attemptID: String?
+    public let eventTypes: Set<String>
+    public let since: Date?
+    public let until: Date?
+    public let afterSequence: UInt64
+    public let limit: Int
+
+    public init(
+        nodeID: String? = nil,
+        attemptID: String? = nil,
+        eventTypes: Set<String> = [],
+        since: Date? = nil,
+        until: Date? = nil,
+        afterSequence: UInt64 = 0,
+        limit: Int = 100
+    ) {
+        self.nodeID = nodeID
+        self.attemptID = attemptID
+        self.eventTypes = eventTypes
+        self.since = since
+        self.until = until
+        self.afterSequence = afterSequence
+        self.limit = max(1, min(limit, 10_000))
+    }
+
+    public func matches(_ event: GraphExecutionEventEnvelope) -> Bool {
+        if let nodeID, event.nodeID != nodeID {
+            return false
+        }
+        if let attemptID, event.attemptID != attemptID {
+            return false
+        }
+        if !eventTypes.isEmpty, !eventTypes.contains(event.eventType) {
+            return false
+        }
+        if let since, event.occurredAt < since {
+            return false
+        }
+        if let until, event.occurredAt > until {
+            return false
+        }
+        return true
+    }
+}
+
+public struct GraphInspectionEventRecord:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public let schemaVersion: Int
+    public let id: String
+    public let runID: String
+    public let nodeID: String?
+    public let attemptID: String?
+    public let streamSequence: UInt64
+    public let occurredAt: Date
+    public let recordedAt: Date
+    public let eventType: String
+    public let factClass: GraphExecutionEventFactClass
+    public let producerID: String
+    public let correlationID: String?
+    public let causationID: String?
+    public let payloadVersion: Int
+    public let redactions: [GraphRedactionRecord]
+
+    public init(event: GraphExecutionEventEnvelope) {
+        schemaVersion = event.schemaVersion
+        id = event.id
+        runID = event.runID
+        nodeID = event.nodeID
+        attemptID = event.attemptID
+        streamSequence = event.streamSequence
+        occurredAt = event.occurredAt
+        recordedAt = event.recordedAt
+        eventType = event.eventType
+        factClass = event.factClass
+        producerID = event.producer.id
+        correlationID = event.correlationID
+        causationID = event.causationID
+        payloadVersion = event.payloadVersion
+
+        switch event.payload {
+        case .artifactRecorded:
+            redactions = [
+                GraphRedactionRecord(
+                    field: "payload.artifact.storage.opaqueReference",
+                    reason: .sensitiveByDefault
+                ),
+            ]
+        case .unknown:
+            redactions = [
+                GraphRedactionRecord(
+                    field: "payload",
+                    reason: .unsupportedPayload
+                ),
+            ]
+        default:
+            redactions = []
+        }
+    }
+}
+
+public struct GraphInspectionEventPage:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let runID: String
+    public let headVersion: UInt64
+    public let scannedThroughSequence: UInt64
+    public let hasMore: Bool
+    public let events: [GraphInspectionEventRecord]
+}
+
+public enum GraphCausalSubjectKind: String, Codable, Sendable {
+    case run
+    case node
+    case attempt
+    case dependency
+    case event
+    case evidence
+}
+
+public enum GraphCausalReasonCode: String, Codable, CaseIterable, Sendable {
+    case runTerminalDeclaration = "run_terminal_declaration"
+    case runDerivedFromNode = "run_derived_from_node"
+    case attemptTerminalDeclaration = "attempt_terminal_declaration"
+    case matchingProcessExit = "matching_process_exit"
+    case validHeartbeat = "valid_heartbeat"
+    case missingProcessIdentity = "missing_process_identity"
+    case missingExecutorEvidence = "missing_executor_evidence"
+    case evidenceUnavailable = "evidence_unavailable"
+    case evidenceStale = "evidence_stale"
+    case evidencePermissionDenied = "evidence_permission_denied"
+    case evidenceAdapterFailed = "evidence_adapter_failed"
+    case evidenceIdentityMismatch = "evidence_identity_mismatch"
+    case dependencyFailed = "dependency_failed"
+    case dependencyInterrupted = "dependency_interrupted"
+    case dependencyOrphaned = "dependency_orphaned"
+    case dependencyBlocked = "dependency_blocked"
+    case dependencyCancelled = "dependency_cancelled"
+    case dependencyPending = "dependency_pending"
+    case dependencyRunning = "dependency_running"
+    case dependencyMissing = "dependency_missing"
+    case dependenciesCompleted = "dependencies_completed"
+    case noExecutionAttempt = "no_execution_attempt"
+    case unknownEventIgnored = "unknown_event_ignored"
+    case persistedState = "persisted_state"
+}
+
+public enum GraphCausalEdgeKind: String, Codable, Sendable {
+    case caused
+    case blocked
+    case observed
+    case derived
+    case ignored
+}
+
+public struct GraphCausalReason:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public let id: String
+    public let code: GraphCausalReasonCode
+    public let subjectKind: GraphCausalSubjectKind
+    public let subjectID: String
+    public let state: ReconciledExecutionState?
+    public let message: String
+    public let supportingEventID: String?
+    public let dependencyNodeID: String?
+}
+
+public struct GraphCausalEdge: Equatable, Codable, Sendable {
+    public let fromReasonID: String
+    public let toReasonID: String
+    public let kind: GraphCausalEdgeKind
+}
+
+public struct GraphCausalExplanation:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let runID: String
+    public let nodeID: String?
+    public let state: ReconciledExecutionState
+    public let summary: String
+    public let reasons: [GraphCausalReason]
+    public let edges: [GraphCausalEdge]
+    public let shortestCausalChain: [String]
+    public let causalPredecessorNodeIDs: [String]
+    public let blockingDependencyNodeIDs: [String]
+    public let readinessRequirements: [String]
+    public let ignoredInputs: [GraphCausalReason]
+}
+
+public struct GraphTemporalReplayResult: Equatable, Sendable {
+    public let runID: String
+    public let boundary: UInt64
+    public let headVersion: UInt64
+    public let projected: GraphExecutionProjection
+    public let reconciled: ExecutionReconciliationResult?
+    public let snapshotDisposition: GraphSnapshotDisposition
+    public let snapshotStreamVersion: UInt64?
+    public let replayedEventCount: Int
+    public let evidence: GraphEvidenceInspection
+    public let replayDiagnostics: [GraphReplayDiagnostic]
+    public let repositoryDiagnostics: [GraphRepositoryDiagnostic]
+}
+
+public enum GraphTemporalChangeCategory: String, Codable, Sendable {
+    case graphDefinition = "graph_definition"
+    case run
+    case node
+    case attempt
+    case eventRange = "event_range"
+    case artifact
+    case evidence
+    case reconciliation
+    case causalExplanation = "causal_explanation"
+}
+
+public struct GraphTemporalChange:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let category: GraphTemporalChangeCategory
+    public let entityID: String
+    public let field: String
+    public let left: String?
+    public let right: String?
+}
+
+public struct GraphTemporalDiffResult:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let left: GraphTemporalReference
+    public let right: GraphTemporalReference
+    public let leftBoundary: UInt64
+    public let rightBoundary: UInt64
+    public let changes: [GraphTemporalChange]
+}
+
+public protocol GraphTemporalInspecting: Sendable {
+    func listRuns(
+        state: ReconciledExecutionState?,
+        limit: Int
+    ) async throws -> [GraphRunInspectionSummary]
+
+    func inspect(
+        runID: String,
+        includeArtifacts: Bool,
+        includeDiagnostics: Bool
+    ) async throws -> GraphRunInspection
+
+    func eventPage(
+        runID: String,
+        filter: GraphInspectionEventFilter
+    ) async throws -> GraphInspectionEventPage
+
+    func checkpoints(
+        runID: String
+    ) async throws -> [GraphCheckpointReference]
+
+    func replay(
+        reference: GraphTemporalReference,
+        evidenceMode: GraphInspectionEvidenceMode
+    ) async throws -> GraphTemporalReplayResult
+
+    func diff(
+        left: GraphTemporalReference,
+        right: GraphTemporalReference
+    ) async throws -> GraphTemporalDiffResult
+
+    func explain(
+        runID: String,
+        nodeID: String?
+    ) async throws -> GraphCausalExplanation
+
+    func causalPredecessors(
+        runID: String,
+        nodeID: String
+    ) async throws -> [String]
+
+    func blockingDependencies(
+        runID: String,
+        nodeID: String
+    ) async throws -> [String]
+
+    func artifacts(
+        runID: String
+    ) async throws -> [GraphArtifactInspection]
+}
+
+public struct DefaultGraphTemporalInspector:
+    GraphTemporalInspecting,
+    Sendable
+{
+    private let readStore: any GraphExecutionReadStore
+    private let snapshotStore: any GraphExecutionSnapshotReadStore
+    private let evidenceSource: any ProcessEvidenceSource
+    private let pageSize: Int
+
+    public init(
+        readStore: any GraphExecutionReadStore,
+        snapshotStore: any GraphExecutionSnapshotReadStore,
+        evidenceSource: any ProcessEvidenceSource =
+            UnavailableProcessEvidenceSource(),
+        pageSize: Int = 500
+    ) {
+        self.readStore = readStore
+        self.snapshotStore = snapshotStore
+        self.evidenceSource = evidenceSource
+        self.pageSize = max(1, min(pageSize, 10_000))
+    }
+
+    public func listRuns(
+        state: ReconciledExecutionState? = nil,
+        limit: Int = 100
+    ) async throws -> [GraphRunInspectionSummary] {
+        let descriptors = try await mappedPersistence {
+            try await readStore.listStreams()
+        }
+        var summaries: [GraphRunInspectionSummary] = []
+
+        for descriptor in descriptors {
+            let replay = try await load(
+                reference: GraphTemporalReference(
+                    runID: descriptor.runID
+                ),
+                evidenceMode: .withoutLiveEvidence
+            )
+            guard let summary = makeSummary(replay) else {
+                continue
+            }
+            if state == nil || summary.reconciledState == state {
+                summaries.append(summary)
+            }
+        }
+
+        return Array(
+            summaries
+                .sorted {
+                    if $0.updatedAt != $1.updatedAt {
+                        return $0.updatedAt > $1.updatedAt
+                    }
+                    return $0.runID < $1.runID
+                }
+                .prefix(max(1, min(limit, 10_000)))
+        )
+    }
+
+    public func inspect(
+        runID: String,
+        includeArtifacts: Bool = false,
+        includeDiagnostics: Bool = false
+    ) async throws -> GraphRunInspection {
+        let replay = try await load(
+            reference: GraphTemporalReference(runID: runID),
+            evidenceMode: .withoutLiveEvidence
+        )
+        guard let summary = makeSummary(replay) else {
+            throw GraphInspectionError.corruptHistory(
+                "Run \(runID) has no run-created projection."
+            )
+        }
+        let reconciledNodes = Dictionary(
+            uniqueKeysWithValues:
+                (replay.reconciled?.nodes ?? []).map { ($0.id, $0) }
+        )
+        let reconciledAttempts = Dictionary(
+            uniqueKeysWithValues:
+                (replay.reconciled?.attempts ?? []).map { ($0.id, $0) }
+        )
+        let nodes = replay.projected.nodes.map { node in
+            GraphNodeInspection(
+                id: node.id,
+                title: node.title,
+                dependencyNodeIDs: node.dependencyNodeIDs.sorted(),
+                executorID: node.executorID,
+                persistedState: node.state,
+                reconciledState: reconciledNodes[node.id]?.state
+                    ?? node.state,
+                activeAttemptID:
+                    reconciledNodes[node.id]?.activeAttemptID
+                        ?? node.activeAttemptID,
+                updatedAt: reconciledNodes[node.id]?.updatedAt
+                    ?? node.updatedAt
+            )
+        }.sorted { $0.id < $1.id }
+        let attempts = replay.projected.attempts.map { attempt in
+            let reconciled = reconciledAttempts[attempt.id]
+            return GraphAttemptInspection(
+                id: attempt.id,
+                nodeID: attempt.nodeID,
+                ordinal: attempt.ordinal,
+                persistedState: attempt.state,
+                reconciledState: reconciled?.state ?? attempt.state,
+                hasProcessIdentity: attempt.processIdentity != nil,
+                createdAt: attempt.createdAt,
+                updatedAt: reconciled?.updatedAt ?? attempt.updatedAt,
+                startedAt: reconciled?.startedAt ?? attempt.startedAt,
+                finishedAt: reconciled?.finishedAt ?? attempt.finishedAt,
+                statusReason:
+                    bounded(reconciled?.statusReason ?? attempt.statusReason)
+            )
+        }.sorted(by: attemptIsOrderedBefore)
+
+        return GraphRunInspection(
+            summary: summary,
+            nodes: nodes,
+            attempts: attempts,
+            checkpoints: replay.projected.namedCheckpoints.sorted(
+                by: checkpointIsOrderedBefore
+            ),
+            artifacts: includeArtifacts
+                ? replay.projected.artifacts.map(GraphArtifactInspection.init)
+                    .sorted { $0.id < $1.id }
+                : [],
+            artifactsIncluded: includeArtifacts,
+            parentRunID: replay.projected.parentRunID,
+            parentCheckpoint: replay.projected.parentCheckpoint,
+            checkpointNamespace: replay.projected.checkpointNamespace,
+            graphDefinitionVersion:
+                replay.projected.graphDefinitionVersion,
+            graphDefinitionDigest:
+                replay.projected.graphDefinitionDigest,
+            replayDiagnostics:
+                includeDiagnostics ? replay.replayDiagnostics : [],
+            repositoryDiagnostics:
+                includeDiagnostics ? replay.repositoryDiagnostics : []
+        )
+    }
+
+    public func eventPage(
+        runID: String,
+        filter: GraphInspectionEventFilter
+    ) async throws -> GraphInspectionEventPage {
+        let descriptor = try await requireStream(runID)
+        var cursor = filter.afterSequence
+        var selected: [GraphInspectionEventRecord] = []
+        var hasMore = cursor < descriptor.currentVersion
+
+        while hasMore, selected.count < filter.limit {
+            let rawPage = try await mappedPersistence {
+                try await readStore.readPage(
+                    runID: runID,
+                    afterVersion: cursor,
+                    limit: min(pageSize, filter.limit - selected.count + 64)
+                )
+            }
+
+            guard !rawPage.events.isEmpty else {
+                break
+            }
+
+            var scannedThrough = cursor
+
+            for event in rawPage.events {
+                scannedThrough = event.streamSequence
+
+                if filter.matches(event) {
+                    selected.append(
+                        GraphInspectionEventRecord(event: event)
+                    )
+                    if selected.count == filter.limit {
+                        break
+                    }
+                }
+            }
+
+            cursor = scannedThrough
+            hasMore = cursor < descriptor.currentVersion
+        }
+
+        return GraphInspectionEventPage(
+            runID: runID,
+            headVersion: descriptor.currentVersion,
+            scannedThroughSequence: cursor,
+            hasMore: hasMore,
+            events: selected
+        )
+    }
+
+    public func checkpoints(
+        runID: String
+    ) async throws -> [GraphCheckpointReference] {
+        let result = try await load(
+            reference: GraphTemporalReference(runID: runID),
+            evidenceMode: .withoutLiveEvidence
+        )
+        return result.projected.namedCheckpoints.sorted(
+            by: checkpointIsOrderedBefore
+        )
+    }
+
+    public func replay(
+        reference: GraphTemporalReference,
+        evidenceMode: GraphInspectionEvidenceMode =
+            .withoutLiveEvidence
+    ) async throws -> GraphTemporalReplayResult {
+        try await load(
+            reference: reference,
+            evidenceMode: evidenceMode
+        )
+    }
+
+    public func diff(
+        left: GraphTemporalReference,
+        right: GraphTemporalReference
+    ) async throws -> GraphTemporalDiffResult {
+        let leftResult = try await load(
+            reference: left,
+            evidenceMode: .withoutLiveEvidence
+        )
+        let rightResult = try await load(
+            reference: right,
+            evidenceMode: .withoutLiveEvidence
+        )
+        let leftEventIDs = try await eventIDs(
+            runID: left.runID,
+            through: leftResult.boundary
+        )
+        let rightEventIDs = try await eventIDs(
+            runID: right.runID,
+            through: rightResult.boundary
+        )
+        var changes: [GraphTemporalChange] = []
+
+        appendChange(
+            category: .graphDefinition,
+            entityID: left.runID,
+            field: "version",
+            left: leftResult.projected.graphDefinitionVersion,
+            right: rightResult.projected.graphDefinitionVersion,
+            to: &changes
+        )
+        appendChange(
+            category: .graphDefinition,
+            entityID: left.runID,
+            field: "digest",
+            left: leftResult.projected.graphDefinitionDigest?.value,
+            right: rightResult.projected.graphDefinitionDigest?.value,
+            to: &changes
+        )
+        appendChange(
+            category: .run,
+            entityID: left.runID,
+            field: "persisted_state",
+            left: leftResult.projected.run?.state.rawValue,
+            right: rightResult.projected.run?.state.rawValue,
+            to: &changes
+        )
+        appendChange(
+            category: .reconciliation,
+            entityID: left.runID,
+            field: "run_state",
+            left: leftResult.reconciled?.run.state.rawValue,
+            right: rightResult.reconciled?.run.state.rawValue,
+            to: &changes
+        )
+        appendChange(
+            category: .evidence,
+            entityID: left.runID,
+            field: "status",
+            left: leftResult.evidence.status,
+            right: rightResult.evidence.status,
+            to: &changes
+        )
+
+        compareNodes(
+            left: leftResult,
+            right: rightResult,
+            changes: &changes
+        )
+        compareAttempts(
+            left: leftResult,
+            right: rightResult,
+            changes: &changes
+        )
+        compareArtifacts(
+            left: leftResult.projected.artifacts,
+            right: rightResult.projected.artifacts,
+            changes: &changes
+        )
+
+        let leftOnly = leftEventIDs.subtracting(rightEventIDs).sorted()
+        let rightOnly = rightEventIDs.subtracting(leftEventIDs).sorted()
+        appendChange(
+            category: .eventRange,
+            entityID: left.runID == right.runID
+                ? left.runID
+                : "\(left.runID)|\(right.runID)",
+            field: "event_ids",
+            left: leftOnly.isEmpty ? nil : leftOnly.joined(separator: ","),
+            right:
+                rightOnly.isEmpty ? nil : rightOnly.joined(separator: ","),
+            to: &changes
+        )
+
+        let nodeIDs = Set(leftResult.projected.nodes.map(\.id))
+            .intersection(rightResult.projected.nodes.map(\.id))
+            .sorted()
+        for nodeID in nodeIDs {
+            let leftExplanation = explanation(
+                result: leftResult,
+                nodeID: nodeID,
+                events: []
+            )
+            let rightExplanation = explanation(
+                result: rightResult,
+                nodeID: nodeID,
+                events: []
+            )
+            appendChange(
+                category: .causalExplanation,
+                entityID: nodeID,
+                field: "reason_codes",
+                left: leftExplanation.reasons.map(\.code.rawValue)
+                    .joined(separator: ","),
+                right: rightExplanation.reasons.map(\.code.rawValue)
+                    .joined(separator: ","),
+                to: &changes
+            )
+        }
+
+        changes.sort(by: changeIsOrderedBefore)
+        return GraphTemporalDiffResult(
+            left: left,
+            right: right,
+            leftBoundary: leftResult.boundary,
+            rightBoundary: rightResult.boundary,
+            changes: changes
+        )
+    }
+
+    public func explain(
+        runID: String,
+        nodeID: String? = nil
+    ) async throws -> GraphCausalExplanation {
+        let result = try await load(
+            reference: GraphTemporalReference(runID: runID),
+            evidenceMode: .withoutLiveEvidence
+        )
+        if let nodeID,
+           !result.projected.nodes.contains(where: { $0.id == nodeID }) {
+            throw GraphInspectionError.corruptHistory(
+                "Run \(runID) has no node \(nodeID)."
+            )
+        }
+        let events = try await allEvents(
+            runID: runID,
+            through: result.boundary
+        )
+        return explanation(
+            result: result,
+            nodeID: nodeID,
+            events: events
+        )
+    }
+
+    public func causalPredecessors(
+        runID: String,
+        nodeID: String
+    ) async throws -> [String] {
+        let result = try await load(
+            reference: GraphTemporalReference(runID: runID),
+            evidenceMode: .withoutLiveEvidence
+        )
+        return predecessorIDs(
+            nodeID: nodeID,
+            nodes: result.reconciled?.nodes
+                ?? result.projected.nodes
+        )
+    }
+
+    public func blockingDependencies(
+        runID: String,
+        nodeID: String
+    ) async throws -> [String] {
+        let result = try await load(
+            reference: GraphTemporalReference(runID: runID),
+            evidenceMode: .withoutLiveEvidence
+        )
+        let nodes = result.reconciled?.nodes ?? result.projected.nodes
+        let byID = Dictionary(uniqueKeysWithValues: nodes.map { ($0.id, $0) })
+        return predecessorIDs(nodeID: nodeID, nodes: nodes).filter {
+            byID[$0]?.state.preventsDependentExecution == true
+                || byID[$0] == nil
+        }
+    }
+
+    public func artifacts(
+        runID: String
+    ) async throws -> [GraphArtifactInspection] {
+        let result = try await load(
+            reference: GraphTemporalReference(runID: runID),
+            evidenceMode: .withoutLiveEvidence
+        )
+        return result.projected.artifacts
+            .map(GraphArtifactInspection.init)
+            .sorted { $0.id < $1.id }
+    }
+
+    private func load(
+        reference: GraphTemporalReference,
+        evidenceMode: GraphInspectionEvidenceMode
+    ) async throws -> GraphTemporalReplayResult {
+        let descriptor = try await requireStream(reference.runID)
+        let boundary = try await resolveBoundary(
+            reference,
+            head: descriptor.currentVersion
+        )
+        var diagnostics: [GraphRepositoryDiagnostic] = []
+        let snapshotLoad = await loadSnapshot(
+            runID: reference.runID,
+            through: boundary,
+            diagnostics: &diagnostics
+        )
+        var snapshot = snapshotLoad.snapshot
+        var snapshotDisposition = snapshotLoad.disposition
+
+        if let loadedSnapshot = snapshot,
+           loadedSnapshot.streamVersion > boundary {
+            diagnostics.append(
+                GraphRepositoryDiagnostic(
+                    category: .snapshot,
+                    message: "Snapshot is ahead of the requested replay boundary and was bypassed."
+                )
+            )
+            snapshotDisposition = .aheadOfStream
+            snapshot = nil
+        } else if let loadedSnapshot = snapshot,
+                  loadedSnapshot.streamVersion < boundary {
+            snapshotDisposition = .stale
+        }
+
+        let events = try await events(
+            runID: reference.runID,
+            after: snapshot?.streamVersion ?? 0,
+            through: boundary
+        )
+        let replay: GraphExecutionReplayResult
+
+        do {
+            replay = try GraphExecutionProjector.replay(
+                runID: reference.runID,
+                events: events,
+                initialProjection: snapshot?.projectedState
+            )
+        } catch let error as GraphExecutionReplayError {
+            throw mappedReplay(error)
+        } catch {
+            throw GraphInspectionError.corruptHistory(
+                error.localizedDescription
+            )
+        }
+        guard replay.projection.run != nil else {
+            throw GraphInspectionError.corruptHistory(
+                "Run \(reference.runID) has no run-created event."
+            )
+        }
+
+        diagnostics.append(
+            GraphRepositoryDiagnostic(
+                category: .replay,
+                message: "Replayed \(replay.replayedEventCount) event(s) through stream version \(replay.projection.streamVersion)."
+            )
+        )
+        let observedAt = stableObservedAt(
+            projection: replay.projection,
+            events: events
+        )
+        let evidenceOutcome = await evidence(
+            mode: evidenceMode,
+            boundary: boundary,
+            head: descriptor.currentVersion,
+            projection: replay.projection,
+            observedAt: observedAt
+        )
+        if evidenceMode == .requireAvailable {
+            guard case .available = evidenceOutcome else {
+                throw GraphInspectionError.evidenceUnavailable(
+                    evidenceReason(evidenceOutcome)
+                        ?? evidenceOutcome.status
+                )
+            }
+        }
+        diagnostics.append(
+            GraphRepositoryDiagnostic(
+                category: .evidence,
+                message: "Process evidence status: \(evidenceOutcome.status)."
+            )
+        )
+        let reconciled = GraphExecutionProjectionReconciler.reconcile(
+            projection: replay.projection,
+            evidenceOutcome: evidenceOutcome,
+            observedAt: observedAt
+        )
+
+        if let reconciled {
+            diagnostics.append(
+                GraphRepositoryDiagnostic(
+                    category: .reconciliation,
+                    message: "Reconciled run to \(reconciled.run.state.rawValue)."
+                )
+            )
+        }
+
+        return GraphTemporalReplayResult(
+            runID: reference.runID,
+            boundary: boundary,
+            headVersion: descriptor.currentVersion,
+            projected: replay.projection,
+            reconciled: reconciled,
+            snapshotDisposition: snapshotDisposition,
+            snapshotStreamVersion: snapshot?.streamVersion,
+            replayedEventCount: replay.replayedEventCount,
+            evidence: GraphEvidenceInspection(
+                status: evidenceOutcome.status,
+                reason: bounded(evidenceReason(evidenceOutcome))
+            ),
+            replayDiagnostics: replay.diagnostics,
+            repositoryDiagnostics: diagnostics
+        )
+    }
+
+    private func requireStream(
+        _ runID: String
+    ) async throws -> GraphExecutionStreamDescriptor {
+        let descriptor = try await mappedPersistence {
+            try await readStore.streamDescriptor(runID: runID)
+        }
+        guard let descriptor else {
+            throw GraphInspectionError.runNotFound(runID)
+        }
+        return descriptor
+    }
+
+    private func resolveBoundary(
+        _ reference: GraphTemporalReference,
+        head: UInt64
+    ) async throws -> UInt64 {
+        let boundary: UInt64
+
+        switch reference.boundary.kind {
+        case .head:
+            boundary = head
+        case .sequence:
+            guard let sequence = reference.boundary.sequence else {
+                throw GraphInspectionError.invalidBoundary(
+                    runID: reference.runID,
+                    requested: 0,
+                    head: head
+                )
+            }
+            boundary = sequence
+        case .checkpoint:
+            guard let checkpointID =
+                    reference.boundary.checkpointID else {
+                throw GraphInspectionError.checkpointNotFound(
+                    runID: reference.runID,
+                    checkpointID: "<missing>"
+                )
+            }
+            let headResult = try await load(
+                reference: GraphTemporalReference(
+                    runID: reference.runID,
+                    boundary: .sequence(head)
+                ),
+                evidenceMode: .withoutLiveEvidence
+            )
+            guard let checkpoint =
+                    headResult.projected.namedCheckpoints.first(
+                        where: { $0.checkpointID == checkpointID }
+                    ) else {
+                throw GraphInspectionError.checkpointNotFound(
+                    runID: reference.runID,
+                    checkpointID: checkpointID
+                )
+            }
+            boundary = checkpoint.streamVersion
+        }
+
+        guard boundary <= head else {
+            throw GraphInspectionError.invalidBoundary(
+                runID: reference.runID,
+                requested: boundary,
+                head: head
+            )
+        }
+        return boundary
+    }
+
+    private func loadSnapshot(
+        runID: String,
+        through boundary: UInt64,
+        diagnostics: inout [GraphRepositoryDiagnostic]
+    ) async -> (
+        snapshot: GraphExecutionSnapshot?,
+        disposition: GraphSnapshotDisposition
+    ) {
+        do {
+            guard let snapshot = try await snapshotStore.loadLatest(
+                runID: runID,
+                throughVersion: boundary
+            ) else {
+                return (nil, .missing)
+            }
+            guard snapshot.schemaVersion
+                    == GraphExecutionSchema.snapshotVersion else {
+                diagnostics.append(
+                    GraphRepositoryDiagnostic(
+                        category: .snapshot,
+                        message: "Snapshot schema is incompatible and was bypassed."
+                    )
+                )
+                return (nil, .incompatible)
+            }
+            guard snapshot.runID == runID,
+                  snapshot.projectedState.runID == runID,
+                  snapshot.streamVersion
+                    == snapshot.projectedState.streamVersion,
+                  snapshot.graphDefinitionVersion
+                    == snapshot.projectedState.graphDefinitionVersion,
+                  snapshot.graphDefinitionDigest
+                    == snapshot.projectedState.graphDefinitionDigest else {
+                diagnostics.append(
+                    GraphRepositoryDiagnostic(
+                        category: .snapshot,
+                        message: "Snapshot metadata is internally inconsistent and was bypassed."
+                    )
+                )
+                return (nil, .corrupt)
+            }
+            return (
+                snapshot,
+                snapshot.streamVersion == boundary ? .current : .stale
+            )
+        } catch {
+            diagnostics.append(
+                GraphRepositoryDiagnostic(
+                    category: .snapshot,
+                    message: "Snapshot load failed and full replay was used: \(bounded(error.localizedDescription) ?? "unknown error")"
+                )
+            )
+            return (nil, .corrupt)
+        }
+    }
+
+    private func events(
+        runID: String,
+        after: UInt64,
+        through boundary: UInt64
+    ) async throws -> [GraphExecutionEventEnvelope] {
+        var cursor = after
+        var result: [GraphExecutionEventEnvelope] = []
+
+        while cursor < boundary {
+            let page = try await mappedPersistence {
+                try await readStore.readPage(
+                    runID: runID,
+                    afterVersion: cursor,
+                    limit: pageSize
+                )
+            }
+            let boundedEvents = page.events.filter {
+                $0.streamSequence <= boundary
+            }
+            guard !boundedEvents.isEmpty else {
+                throw GraphInspectionError.corruptHistory(
+                    "Run \(runID) cannot advance replay after sequence \(cursor)."
+                )
+            }
+            result.append(contentsOf: boundedEvents)
+            cursor = boundedEvents.last!.streamSequence
+        }
+
+        return result
+    }
+
+    private func allEvents(
+        runID: String,
+        through boundary: UInt64
+    ) async throws -> [GraphExecutionEventEnvelope] {
+        try await events(runID: runID, after: 0, through: boundary)
+    }
+
+    private func eventIDs(
+        runID: String,
+        through boundary: UInt64
+    ) async throws -> Set<String> {
+        Set(
+            try await allEvents(runID: runID, through: boundary)
+                .map(\.id)
+        )
+    }
+
+    private func evidence(
+        mode: GraphInspectionEvidenceMode,
+        boundary: UInt64,
+        head: UInt64,
+        projection: GraphExecutionProjection,
+        observedAt: Date
+    ) async -> GraphProcessEvidenceOutcome {
+        guard mode != .withoutLiveEvidence else {
+            return .unavailable(
+                reason: "Live process evidence was disabled for deterministic inspection."
+            )
+        }
+        guard boundary == head else {
+            return .unavailable(
+                reason: "Historical replay does not apply current live process evidence."
+            )
+        }
+        return await evidenceSource.evidence(
+            for: GraphProcessEvidenceRequest(
+                runID: projection.runID,
+                attempts: projection.attempts,
+                observedAt: observedAt
+            )
+        )
+    }
+
+    private func makeSummary(
+        _ result: GraphTemporalReplayResult
+    ) -> GraphRunInspectionSummary? {
+        guard let run = result.projected.run else {
+            return nil
+        }
+        return GraphRunInspectionSummary(
+            runID: run.id,
+            graphID: run.graphID,
+            persistedState: run.state,
+            reconciledState: result.reconciled?.run.state ?? run.state,
+            streamVersion: result.boundary,
+            nodeCount: result.projected.nodes.count,
+            attemptCount: result.projected.attempts.count,
+            artifactCount: result.projected.artifacts.count,
+            createdAt: run.createdAt,
+            updatedAt: result.reconciled?.run.updatedAt ?? run.updatedAt,
+            snapshotDisposition: result.snapshotDisposition,
+            evidence: result.evidence
+        )
+    }
+
+    private func explanation(
+        result: GraphTemporalReplayResult,
+        nodeID: String?,
+        events: [GraphExecutionEventEnvelope]
+    ) -> GraphCausalExplanation {
+        let reconciled = result.reconciled
+        let nodes = reconciled?.nodes ?? result.projected.nodes
+        let attempts = reconciled?.attempts ?? result.projected.attempts
+        let nodeByID = Dictionary(
+            uniqueKeysWithValues: nodes.map { ($0.id, $0) }
+        )
+        let state: ReconciledExecutionState
+        let subjectID: String
+        var reasons: [GraphCausalReason] = []
+        var edges: [GraphCausalEdge] = []
+        var requirements: [String] = []
+        var shortest: [String] = []
+
+        if let nodeID, let node = nodeByID[nodeID] {
+            state = node.state
+            subjectID = nodeID
+            let attempt = attempts
+                .filter { $0.nodeID == nodeID }
+                .max(by: attemptIsOrderedBefore)
+            let primary = primaryNodeReason(
+                node: node,
+                attempt: attempt,
+                nodeByID: nodeByID,
+                events: events,
+                evidence: result.evidence
+            )
+            reasons.append(primary)
+            shortest.append(primary.id)
+
+            if state == .blocked {
+                let path = shortestBlockingPath(
+                    from: nodeID,
+                    nodeByID: nodeByID
+                )
+                var previous = primary.id
+                for dependencyID in path.dropFirst() {
+                    let dependency = nodeByID[dependencyID]
+                    let reason = dependencyReason(
+                        nodeID: dependencyID,
+                        state: dependency?.state
+                    )
+                    reasons.append(reason)
+                    edges.append(
+                        GraphCausalEdge(
+                            fromReasonID: reason.id,
+                            toReasonID: previous,
+                            kind: .blocked
+                        )
+                    )
+                    shortest.append(reason.id)
+                    previous = reason.id
+                }
+            }
+
+            requirements = readinessRequirements(
+                node: node,
+                nodeByID: nodeByID
+            )
+        } else {
+            let run = reconciled?.run ?? result.projected.run!
+            state = run.state
+            subjectID = run.id
+            let event = events.last {
+                $0.eventType
+                    == GraphExecutionEventType
+                        .runTerminalStateRecorded.rawValue
+            }
+            let sourceNode = nodes.first {
+                $0.state == state && state != .pending
+            }
+            let code: GraphCausalReasonCode =
+                event == nil ? .runDerivedFromNode : .runTerminalDeclaration
+            let reason = GraphCausalReason(
+                id: reasonID(code, subjectID),
+                code: code,
+                subjectKind: .run,
+                subjectID: subjectID,
+                state: state,
+                message: event == nil
+                    ? "Run state is derived from reconciled node state\(sourceNode.map { " \($0.id)" } ?? "")."
+                    : "An authoritative run terminal event established this state.",
+                supportingEventID: event?.id,
+                dependencyNodeID: sourceNode?.id
+            )
+            reasons.append(reason)
+            shortest.append(reason.id)
+        }
+
+        var ignored: [GraphCausalReason] = []
+        for event in result.projected.unknownEvents {
+            ignored.append(
+                GraphCausalReason(
+                    id: reasonID(.unknownEventIgnored, event.id),
+                    code: .unknownEventIgnored,
+                    subjectKind: .event,
+                    subjectID: event.id,
+                    state: nil,
+                    message: "Unknown event \(event.eventType) was retained without applying semantics.",
+                    supportingEventID: event.id,
+                    dependencyNodeID: nil
+                )
+            )
+        }
+        if let evidenceReason = evidenceCausalReason(
+            result.evidence,
+            subjectID: subjectID
+        ) {
+            ignored.append(evidenceReason)
+        }
+
+        reasons = uniqueReasons(reasons).sorted { $0.id < $1.id }
+        ignored = uniqueReasons(ignored).sorted { $0.id < $1.id }
+        edges.sort {
+            if $0.fromReasonID != $1.fromReasonID {
+                return $0.fromReasonID < $1.fromReasonID
+            }
+            if $0.toReasonID != $1.toReasonID {
+                return $0.toReasonID < $1.toReasonID
+            }
+            return $0.kind.rawValue < $1.kind.rawValue
+        }
+        let predecessors = nodeID.map {
+            predecessorIDs(nodeID: $0, nodes: nodes)
+        } ?? []
+        let blockers = predecessors.filter {
+            nodeByID[$0]?.state.preventsDependentExecution == true
+                || nodeByID[$0] == nil
+        }
+        let summary = nodeID.map {
+            "Node \($0) is \(state.rawValue): \(reasons.first?.message ?? "no causal detail available")"
+        } ?? "Run \(result.runID) is \(state.rawValue): \(reasons.first?.message ?? "no causal detail available")"
+
+        return GraphCausalExplanation(
+            runID: result.runID,
+            nodeID: nodeID,
+            state: state,
+            summary: summary,
+            reasons: reasons,
+            edges: edges,
+            shortestCausalChain: shortest,
+            causalPredecessorNodeIDs: predecessors,
+            blockingDependencyNodeIDs: blockers,
+            readinessRequirements: requirements,
+            ignoredInputs: ignored
+        )
+    }
+
+    private func primaryNodeReason(
+        node: GraphNode,
+        attempt: ExecutionAttempt?,
+        nodeByID: [String: GraphNode],
+        events: [GraphExecutionEventEnvelope],
+        evidence: GraphEvidenceInspection
+    ) -> GraphCausalReason {
+        if node.state == .blocked {
+            let blocker = node.dependencyNodeIDs.sorted().first {
+                nodeByID[$0]?.state.preventsDependentExecution == true
+                    || nodeByID[$0] == nil
+            }
+            return GraphCausalReason(
+                id: reasonID(.dependencyBlocked, node.id),
+                code: .dependencyBlocked,
+                subjectKind: .node,
+                subjectID: node.id,
+                state: node.state,
+                message: blocker.map {
+                    "Dependency \($0) prevents this node from running."
+                } ?? "A dependency prevents this node from running.",
+                supportingEventID: nil,
+                dependencyNodeID: blocker
+            )
+        }
+        if node.state == .ready {
+            return GraphCausalReason(
+                id: reasonID(.dependenciesCompleted, node.id),
+                code: .dependenciesCompleted,
+                subjectKind: .node,
+                subjectID: node.id,
+                state: node.state,
+                message: "All required dependencies are completed.",
+                supportingEventID: nil,
+                dependencyNodeID: nil
+            )
+        }
+        guard let attempt else {
+            return GraphCausalReason(
+                id: reasonID(.noExecutionAttempt, node.id),
+                code: .noExecutionAttempt,
+                subjectKind: .node,
+                subjectID: node.id,
+                state: node.state,
+                message: node.dependencyNodeIDs.isEmpty
+                    ? "No execution attempt has been created."
+                    : "No attempt exists and dependencies are not all completed.",
+                supportingEventID: nil,
+                dependencyNodeID: nil
+            )
+        }
+        let terminalEvent = events.last {
+            $0.attemptID == attempt.id
+                && [
+                    GraphExecutionEventType.attemptCompleted.rawValue,
+                    GraphExecutionEventType.attemptFailed.rawValue,
+                    GraphExecutionEventType.attemptInterrupted.rawValue,
+                    GraphExecutionEventType.attemptOrphaned.rawValue,
+                    GraphExecutionEventType.attemptCancelled.rawValue,
+                ].contains($0.eventType)
+        }
+        if let terminalEvent {
+            return GraphCausalReason(
+                id: reasonID(.attemptTerminalDeclaration, attempt.id),
+                code: .attemptTerminalDeclaration,
+                subjectKind: .attempt,
+                subjectID: attempt.id,
+                state: attempt.state,
+                message: "An authoritative attempt terminal event established this state.",
+                supportingEventID: terminalEvent.id,
+                dependencyNodeID: nil
+            )
+        }
+        let exitEvent = events.last {
+            $0.attemptID == attempt.id
+                && $0.eventType
+                    == GraphExecutionEventType.processExitObserved.rawValue
+        }
+        if let exitEvent, attempt.state == .interrupted {
+            return GraphCausalReason(
+                id: reasonID(.matchingProcessExit, attempt.id),
+                code: .matchingProcessExit,
+                subjectKind: .attempt,
+                subjectID: attempt.id,
+                state: attempt.state,
+                message: "A matching process exit was observed without a terminal workflow declaration.",
+                supportingEventID: exitEvent.id,
+                dependencyNodeID: nil
+            )
+        }
+        if attempt.state == .orphaned {
+            return GraphCausalReason(
+                id: reasonID(.missingExecutorEvidence, attempt.id),
+                code: .missingExecutorEvidence,
+                subjectKind: .attempt,
+                subjectID: attempt.id,
+                state: attempt.state,
+                message: "The recorded process identity has no matching current executor evidence.",
+                supportingEventID: nil,
+                dependencyNodeID: nil
+            )
+        }
+        if attempt.state == .interrupted, !attemptHasIdentity(attempt) {
+            return GraphCausalReason(
+                id: reasonID(.missingProcessIdentity, attempt.id),
+                code: .missingProcessIdentity,
+                subjectKind: .attempt,
+                subjectID: attempt.id,
+                state: attempt.state,
+                message: "The running attempt had no recoverable process identity.",
+                supportingEventID: nil,
+                dependencyNodeID: nil
+            )
+        }
+        if attempt.state == .running {
+            return GraphCausalReason(
+                id: reasonID(.validHeartbeat, attempt.id),
+                code: .validHeartbeat,
+                subjectKind: .attempt,
+                subjectID: attempt.id,
+                state: attempt.state,
+                message: "Current evidence supports the running attempt.",
+                supportingEventID: nil,
+                dependencyNodeID: nil
+            )
+        }
+        return GraphCausalReason(
+            id: reasonID(.persistedState, attempt.id),
+            code: .persistedState,
+            subjectKind: .attempt,
+            subjectID: attempt.id,
+            state: attempt.state,
+            message: "The state is derived from persisted attempt history.",
+            supportingEventID: nil,
+            dependencyNodeID: nil
+        )
+    }
+
+    private func dependencyReason(
+        nodeID: String,
+        state: ReconciledExecutionState?
+    ) -> GraphCausalReason {
+        let code: GraphCausalReasonCode
+        switch state {
+        case .failed:
+            code = .dependencyFailed
+        case .interrupted:
+            code = .dependencyInterrupted
+        case .orphaned:
+            code = .dependencyOrphaned
+        case .blocked:
+            code = .dependencyBlocked
+        case .cancelled:
+            code = .dependencyCancelled
+        case .running:
+            code = .dependencyRunning
+        case .pending, .ready:
+            code = .dependencyPending
+        case .completed:
+            code = .dependenciesCompleted
+        case nil:
+            code = .dependencyMissing
+        }
+        return GraphCausalReason(
+            id: reasonID(code, nodeID),
+            code: code,
+            subjectKind: .dependency,
+            subjectID: nodeID,
+            state: state,
+            message: state.map {
+                "Dependency \(nodeID) is \($0.rawValue)."
+            } ?? "Dependency \(nodeID) is missing from the graph projection.",
+            supportingEventID: nil,
+            dependencyNodeID: nodeID
+        )
+    }
+
+    private func evidenceCausalReason(
+        _ evidence: GraphEvidenceInspection,
+        subjectID: String
+    ) -> GraphCausalReason? {
+        let code: GraphCausalReasonCode
+        switch evidence.status {
+        case "unavailable":
+            code = .evidenceUnavailable
+        case "stale":
+            code = .evidenceStale
+        case "permission_denied":
+            code = .evidencePermissionDenied
+        case "adapter_failed":
+            code = .evidenceAdapterFailed
+        case "identity_mismatch":
+            code = .evidenceIdentityMismatch
+        default:
+            return nil
+        }
+        return GraphCausalReason(
+            id: reasonID(code, subjectID),
+            code: code,
+            subjectKind: .evidence,
+            subjectID: subjectID,
+            state: nil,
+            message: evidence.reason
+                ?? "Process evidence status is \(evidence.status).",
+            supportingEventID: nil,
+            dependencyNodeID: nil
+        )
+    }
+
+    private func shortestBlockingPath(
+        from nodeID: String,
+        nodeByID: [String: GraphNode]
+    ) -> [String] {
+        var path = [nodeID]
+        var current = nodeID
+        var visited = Set([nodeID])
+
+        while let node = nodeByID[current] {
+            guard let next = node.dependencyNodeIDs.sorted().first(
+                where: {
+                    nodeByID[$0]?.state.preventsDependentExecution == true
+                        || nodeByID[$0] == nil
+                }
+            ), !visited.contains(next) else {
+                break
+            }
+            path.append(next)
+            visited.insert(next)
+            current = next
+        }
+        return path
+    }
+
+    private func predecessorIDs(
+        nodeID: String,
+        nodes: [GraphNode]
+    ) -> [String] {
+        let byID = Dictionary(uniqueKeysWithValues: nodes.map { ($0.id, $0) })
+        var result = Set<String>()
+        var pending = byID[nodeID]?.dependencyNodeIDs.sorted() ?? []
+
+        while let next = pending.first {
+            pending.removeFirst()
+            guard result.insert(next).inserted else {
+                continue
+            }
+            pending.append(contentsOf: byID[next]?.dependencyNodeIDs ?? [])
+            pending.sort()
+        }
+        return result.sorted()
+    }
+
+    private func readinessRequirements(
+        node: GraphNode,
+        nodeByID: [String: GraphNode]
+    ) -> [String] {
+        if node.state == .ready || node.state == .running
+            || node.state == .completed {
+            return []
+        }
+        if node.dependencyNodeIDs.isEmpty {
+            return ["Create an execution attempt for node \(node.id)."]
+        }
+        return node.dependencyNodeIDs.sorted().compactMap { dependencyID in
+            guard nodeByID[dependencyID]?.state != .completed else {
+                return nil
+            }
+            return "Dependency \(dependencyID) must reach completed state."
+        }
+    }
+
+    private func compareNodes(
+        left: GraphTemporalReplayResult,
+        right: GraphTemporalReplayResult,
+        changes: inout [GraphTemporalChange]
+    ) {
+        let leftNodes = Dictionary(
+            uniqueKeysWithValues: left.projected.nodes.map { ($0.id, $0) }
+        )
+        let rightNodes = Dictionary(
+            uniqueKeysWithValues: right.projected.nodes.map { ($0.id, $0) }
+        )
+        let leftReconciled = Dictionary(
+            uniqueKeysWithValues:
+                (left.reconciled?.nodes ?? []).map { ($0.id, $0) }
+        )
+        let rightReconciled = Dictionary(
+            uniqueKeysWithValues:
+                (right.reconciled?.nodes ?? []).map { ($0.id, $0) }
+        )
+
+        for id in Set(leftNodes.keys).union(rightNodes.keys).sorted() {
+            appendChange(
+                category: .node,
+                entityID: id,
+                field: "presence",
+                left: leftNodes[id] == nil ? nil : "present",
+                right: rightNodes[id] == nil ? nil : "present",
+                to: &changes
+            )
+            appendChange(
+                category: .node,
+                entityID: id,
+                field: "persisted_state",
+                left: leftNodes[id]?.state.rawValue,
+                right: rightNodes[id]?.state.rawValue,
+                to: &changes
+            )
+            appendChange(
+                category: .reconciliation,
+                entityID: id,
+                field: "node_state",
+                left: leftReconciled[id]?.state.rawValue,
+                right: rightReconciled[id]?.state.rawValue,
+                to: &changes
+            )
+            appendChange(
+                category: .node,
+                entityID: id,
+                field: "dependencies",
+                left: leftNodes[id]?.dependencyNodeIDs.sorted()
+                    .joined(separator: ","),
+                right: rightNodes[id]?.dependencyNodeIDs.sorted()
+                    .joined(separator: ","),
+                to: &changes
+            )
+        }
+    }
+
+    private func compareAttempts(
+        left: GraphTemporalReplayResult,
+        right: GraphTemporalReplayResult,
+        changes: inout [GraphTemporalChange]
+    ) {
+        let leftAttempts = Dictionary(
+            uniqueKeysWithValues: left.projected.attempts.map {
+                ($0.id, $0)
+            }
+        )
+        let rightAttempts = Dictionary(
+            uniqueKeysWithValues: right.projected.attempts.map {
+                ($0.id, $0)
+            }
+        )
+        let leftReconciled = Dictionary(
+            uniqueKeysWithValues:
+                (left.reconciled?.attempts ?? []).map { ($0.id, $0) }
+        )
+        let rightReconciled = Dictionary(
+            uniqueKeysWithValues:
+                (right.reconciled?.attempts ?? []).map { ($0.id, $0) }
+        )
+
+        for id in Set(leftAttempts.keys).union(rightAttempts.keys).sorted() {
+            appendChange(
+                category: .attempt,
+                entityID: id,
+                field: "presence",
+                left: leftAttempts[id] == nil ? nil : "present",
+                right: rightAttempts[id] == nil ? nil : "present",
+                to: &changes
+            )
+            appendChange(
+                category: .attempt,
+                entityID: id,
+                field: "persisted_state",
+                left: leftAttempts[id]?.state.rawValue,
+                right: rightAttempts[id]?.state.rawValue,
+                to: &changes
+            )
+            appendChange(
+                category: .reconciliation,
+                entityID: id,
+                field: "attempt_state",
+                left: leftReconciled[id]?.state.rawValue,
+                right: rightReconciled[id]?.state.rawValue,
+                to: &changes
+            )
+            appendChange(
+                category: .attempt,
+                entityID: id,
+                field: "ordinal",
+                left: leftAttempts[id].map { String($0.ordinal) },
+                right: rightAttempts[id].map { String($0.ordinal) },
+                to: &changes
+            )
+        }
+    }
+
+    private func compareArtifacts(
+        left: [GraphArtifactReference],
+        right: [GraphArtifactReference],
+        changes: inout [GraphTemporalChange]
+    ) {
+        let leftArtifacts = Dictionary(
+            uniqueKeysWithValues: left.map { ($0.id, $0) }
+        )
+        let rightArtifacts = Dictionary(
+            uniqueKeysWithValues: right.map { ($0.id, $0) }
+        )
+
+        for id in Set(leftArtifacts.keys).union(rightArtifacts.keys).sorted() {
+            appendChange(
+                category: .artifact,
+                entityID: id,
+                field: "digest",
+                left: leftArtifacts[id]?.contentDigest.value,
+                right: rightArtifacts[id]?.contentDigest.value,
+                to: &changes
+            )
+            appendChange(
+                category: .artifact,
+                entityID: id,
+                field: "producer_attempt",
+                left: leftArtifacts[id]?.producingAttemptID,
+                right: rightArtifacts[id]?.producingAttemptID,
+                to: &changes
+            )
+        }
+    }
+
+    private func appendChange(
+        category: GraphTemporalChangeCategory,
+        entityID: String,
+        field: String,
+        left: String?,
+        right: String?,
+        to changes: inout [GraphTemporalChange]
+    ) {
+        guard left != right else {
+            return
+        }
+        changes.append(
+            GraphTemporalChange(
+                category: category,
+                entityID: entityID,
+                field: field,
+                left: left,
+                right: right
+            )
+        )
+    }
+
+    private func stableObservedAt(
+        projection: GraphExecutionProjection,
+        events: [GraphExecutionEventEnvelope]
+    ) -> Date {
+        let eventDate = events.reduce(Date(timeIntervalSince1970: 0)) {
+            max($0, max($1.occurredAt, $1.recordedAt))
+        }
+        return max(
+            eventDate,
+            projection.run?.updatedAt
+                ?? Date(timeIntervalSince1970: 0)
+        )
+    }
+
+    private func evidenceReason(
+        _ outcome: GraphProcessEvidenceOutcome
+    ) -> String? {
+        switch outcome {
+        case .available:
+            nil
+        case let .unavailable(reason),
+             let .stale(_, reason),
+             let .permissionDenied(reason),
+             let .adapterFailed(reason),
+             let .identityMismatch(_, reason):
+            reason
+        }
+    }
+
+    private func mappedPersistence<Value: Sendable>(
+        _ operation: () async throws -> Value
+    ) async throws -> Value {
+        do {
+            return try await operation()
+        } catch let error as GraphExecutionPersistenceError {
+            switch error {
+            case let .unsupportedSchemaVersion(artifact, found, supported):
+                throw GraphInspectionError.incompatibleSchema(
+                    "\(artifact) version \(found), supported \(supported)"
+                )
+            case let .corruptRecord(message):
+                throw GraphInspectionError.corruptHistory(message)
+            default:
+                throw GraphInspectionError.persistence(
+                    error.localizedDescription
+                )
+            }
+        } catch let error as GraphInspectionError {
+            throw error
+        } catch {
+            throw GraphInspectionError.persistence(
+                error.localizedDescription
+            )
+        }
+    }
+
+    private func mappedReplay(
+        _ error: GraphExecutionReplayError
+    ) -> GraphInspectionError {
+        switch error {
+        case let .unsupportedEnvelopeSchema(found, supported):
+            .incompatibleSchema(
+                "event envelope version \(found), supported \(supported)"
+            )
+        case let .unsupportedPayloadSchema(eventType, found, supported):
+            .incompatibleSchema(
+                "\(eventType) payload version \(found), supported \(supported)"
+            )
+        default:
+            .corruptHistory(error.localizedDescription)
+        }
+    }
+}
+
+private func bounded(_ value: String?, limit: Int = 512) -> String? {
+    guard let value else {
+        return nil
+    }
+    let singleLine = value
+        .replacingOccurrences(of: "\r", with: " ")
+        .replacingOccurrences(of: "\n", with: " ")
+    guard singleLine.count > limit else {
+        return singleLine
+    }
+    return String(singleLine.prefix(limit))
+}
+
+private func attemptIsOrderedBefore(
+    _ lhs: ExecutionAttempt,
+    _ rhs: ExecutionAttempt
+) -> Bool {
+    if lhs.nodeID != rhs.nodeID {
+        return lhs.nodeID < rhs.nodeID
+    }
+    if lhs.ordinal != rhs.ordinal {
+        return lhs.ordinal < rhs.ordinal
+    }
+    return lhs.id < rhs.id
+}
+
+private func attemptIsOrderedBefore(
+    _ lhs: GraphAttemptInspection,
+    _ rhs: GraphAttemptInspection
+) -> Bool {
+    if lhs.nodeID != rhs.nodeID {
+        return lhs.nodeID < rhs.nodeID
+    }
+    if lhs.ordinal != rhs.ordinal {
+        return lhs.ordinal < rhs.ordinal
+    }
+    return lhs.id < rhs.id
+}
+
+private func checkpointIsOrderedBefore(
+    _ lhs: GraphCheckpointReference,
+    _ rhs: GraphCheckpointReference
+) -> Bool {
+    if lhs.streamVersion != rhs.streamVersion {
+        return lhs.streamVersion < rhs.streamVersion
+    }
+    return lhs.checkpointID < rhs.checkpointID
+}
+
+private func changeIsOrderedBefore(
+    _ lhs: GraphTemporalChange,
+    _ rhs: GraphTemporalChange
+) -> Bool {
+    if lhs.category != rhs.category {
+        return lhs.category.rawValue < rhs.category.rawValue
+    }
+    if lhs.entityID != rhs.entityID {
+        return lhs.entityID < rhs.entityID
+    }
+    return lhs.field < rhs.field
+}
+
+private func reasonID(
+    _ code: GraphCausalReasonCode,
+    _ subjectID: String
+) -> String {
+    "\(code.rawValue):\(subjectID)"
+}
+
+private func uniqueReasons(
+    _ reasons: [GraphCausalReason]
+) -> [GraphCausalReason] {
+    var byID: [String: GraphCausalReason] = [:]
+    for reason in reasons {
+        byID[reason.id] = reason
+    }
+    return Array(byID.values)
+}
+
+private func attemptHasIdentity(_ attempt: ExecutionAttempt) -> Bool {
+    attempt.processIdentity != nil
+}

--- a/Sources/OpenIslandCore/GraphTemporalInspection.swift
+++ b/Sources/OpenIslandCore/GraphTemporalInspection.swift
@@ -778,7 +778,7 @@ public struct DefaultGraphTemporalInspector:
     ) async throws -> GraphRunInspection {
         let replay = try await load(
             reference: GraphTemporalReference(runID: runID),
-            evidenceMode: .withoutLiveEvidence
+            evidenceMode: .configured
         )
         guard let summary = makeSummary(replay) else {
             throw GraphInspectionError.corruptHistory(

--- a/Sources/OpenIslandCore/OpenAICompatibleGraphExecutor.swift
+++ b/Sources/OpenIslandCore/OpenAICompatibleGraphExecutor.swift
@@ -1,0 +1,563 @@
+import CryptoKit
+import Foundation
+
+public struct OpenAICompatibleGraphExecutor:
+    GraphExecutorAdapter,
+    Sendable
+{
+    public static let adapterKind = "openai_compatible"
+
+    public let capabilities: GraphExecutorCapabilities
+
+    private let session: URLSession
+    private let environment: [String: String]
+    private let state: OpenAICompatibleExecutionState
+
+    public init(
+        executorID: String = "openisland.openai-compatible",
+        capabilityIdentity: String = "openai-compatible-v1",
+        capabilities: [String] = ["agent", "model-inference"],
+        session: URLSession = .shared,
+        environment: [String: String] =
+            ProcessInfo.processInfo.environment
+    ) {
+        self.capabilities = GraphExecutorCapabilities(
+            executorID: executorID,
+            capabilityIdentity: capabilityIdentity,
+            capabilities: capabilities,
+            hostID: "local-http"
+        )
+        self.session = session
+        self.environment = environment
+        state = OpenAICompatibleExecutionState()
+    }
+
+    public func prepare(
+        _ request: GraphExecutorPrepareRequest
+    ) async throws -> GraphExecutorPrepareResponse {
+        let validation = validate(request.context)
+
+        return GraphExecutorPrepareResponse(
+            observation: observation(
+                operation: .prepare,
+                status: validation == nil ? .accepted : .rejected,
+                context: request.context,
+                failure: validation
+            )
+        )
+    }
+
+    public func start(
+        _ request: GraphExecutorStartRequest
+    ) async throws -> GraphExecutorStartResponse {
+        if let failure = validate(request.context) {
+            return GraphExecutorStartResponse(
+                observation: observation(
+                    operation: .start,
+                    status: .rejected,
+                    context: request.context,
+                    failure: failure
+                )
+            )
+        }
+
+        let context = request.context
+        let key = executionKey(context)
+
+        await state.start(key: key) {
+            await performRequest(context)
+        }
+
+        return GraphExecutorStartResponse(
+            observation: observation(
+                operation: .start,
+                status: .started,
+                context: context
+            )
+        )
+    }
+
+    public func observe(
+        _ request: GraphExecutorObserveRequest
+    ) async throws -> GraphExecutorObserveResponse {
+        let result = await state.result(for: executionKey(request.context))
+
+        return GraphExecutorObserveResponse(
+            observation: observation(
+                operation: .observe,
+                status: result.status,
+                context: request.context,
+                failure: result.failure
+            )
+        )
+    }
+
+    public func requestCancellation(
+        _ request: GraphExecutorCancellationRequest
+    ) async throws -> GraphExecutorCancellationResponse {
+        await state.cancel(key: executionKey(request.context))
+
+        return GraphExecutorCancellationResponse(
+            observation: observation(
+                operation: .requestCancellation,
+                status: .cancelled,
+                context: request.context
+            )
+        )
+    }
+
+    public func collectResult(
+        _ request: GraphExecutorCollectResultRequest
+    ) async throws -> GraphExecutorCollectResultResponse {
+        let result = await state.result(for: executionKey(request.context))
+
+        let artifacts: [GraphExecutorProducedArtifact]
+        if result.status == .succeeded, let data = result.data {
+            artifacts = [artifact(data: data)]
+        } else {
+            artifacts = []
+        }
+
+        return GraphExecutorCollectResultResponse(
+            observation: observation(
+                operation: .collectResult,
+                status: result.status,
+                context: request.context,
+                failure: result.failure,
+                artifacts: artifacts
+            )
+        )
+    }
+
+    public func cleanup(
+        _ request: GraphExecutorCleanupRequest
+    ) async throws -> GraphExecutorCleanupResponse {
+        await state.remove(key: executionKey(request.context))
+
+        return GraphExecutorCleanupResponse(
+            observation: observation(
+                operation: .cleanup,
+                status: .accepted,
+                context: request.context
+            )
+        )
+    }
+
+    public func recover(
+        _ request: GraphExecutorRecoverRequest
+    ) async throws -> GraphExecutorRecoverResponse {
+        let result = await state.result(for: executionKey(request.context))
+
+        return GraphExecutorRecoverResponse(
+            observation: observation(
+                operation: .recover,
+                status: result.status == .unavailable
+                    ? .interrupted
+                    : result.status,
+                context: request.context,
+                failure: result.status == .unavailable
+                    ? GraphExecutorFailure(
+                        category: "http_execution_state_unavailable",
+                        retryable: true
+                    )
+                    : result.failure
+            )
+        )
+    }
+
+    private func validate(
+        _ context: GraphExecutorCommandContext
+    ) -> GraphExecutorFailure? {
+        guard context.specification.adapterKind == Self.adapterKind else {
+            return GraphExecutorFailure(
+                category: "invalid_adapter_kind",
+                retryable: false
+            )
+        }
+
+        guard context.specification.operation == "chat_completion" else {
+            return GraphExecutorFailure(
+                category: "unsupported_http_operation",
+                retryable: false
+            )
+        }
+
+        guard stringParameter("endpoint", context: context)
+            .flatMap(URL.init(string:)) != nil
+        else {
+            return GraphExecutorFailure(
+                category: "invalid_http_endpoint",
+                retryable: false
+            )
+        }
+
+        guard let model = stringParameter("model", context: context),
+              !model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return GraphExecutorFailure(
+                category: "missing_model",
+                retryable: false
+            )
+        }
+
+        do {
+            _ = try prompt(context)
+        } catch {
+            return GraphExecutorFailure(
+                category: "missing_or_unreadable_prompt",
+                retryable: false
+            )
+        }
+
+        return nil
+    }
+
+    private func performRequest(
+        _ context: GraphExecutorCommandContext
+    ) async -> OpenAICompatibleExecutionResult {
+        do {
+            guard let endpointString = stringParameter(
+                "endpoint",
+                context: context
+            ), let baseURL = URL(string: endpointString),
+              let model = stringParameter("model", context: context)
+            else {
+                return .failed(
+                    category: "invalid_http_configuration",
+                    retryable: false
+                )
+            }
+
+            let url = chatCompletionsURL(baseURL)
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.timeoutInterval = TimeInterval(
+                context.timeoutPolicy.executionSeconds
+            )
+            request.setValue(
+                "application/json",
+                forHTTPHeaderField: "Content-Type"
+            )
+            request.setValue(
+                "application/json",
+                forHTTPHeaderField: "Accept"
+            )
+
+            if let apiKey = environment["OPENAI_API_KEY"],
+               !apiKey.isEmpty {
+                request.setValue(
+                    "Bearer \(apiKey)",
+                    forHTTPHeaderField: "Authorization"
+                )
+            }
+
+            var messages: [[String: String]] = []
+
+            if let system = stringParameter("system", context: context),
+               !system.trimmingCharacters(
+                    in: .whitespacesAndNewlines
+               ).isEmpty {
+                messages.append([
+                    "role": "system",
+                    "content": system,
+                ])
+            }
+
+            messages.append([
+                "role": "user",
+                "content": try prompt(context),
+            ])
+
+            request.httpBody = try JSONSerialization.data(
+                withJSONObject: [
+                    "model": model,
+                    "messages": messages,
+                    "stream": false,
+                ],
+                options: [.sortedKeys]
+            )
+
+            let (data, response) = try await session.data(for: request)
+
+            guard let http = response as? HTTPURLResponse else {
+                return .failed(
+                    category: "non_http_response",
+                    retryable: true
+                )
+            }
+
+            guard (200 ... 299).contains(http.statusCode) else {
+                return .failed(
+                    category: "http_status_\(http.statusCode)",
+                    retryable: http.statusCode == 408
+                        || http.statusCode == 429
+                        || (500 ... 599).contains(http.statusCode)
+                )
+            }
+
+            guard (try? JSONSerialization.jsonObject(with: data)) != nil else {
+                return .failed(
+                    category: "invalid_chat_completion_response",
+                    retryable: false
+                )
+            }
+
+            return .succeeded(data)
+        } catch is CancellationError {
+            return .cancelled
+        } catch let error as URLError {
+            return .failed(
+                category: "url_error_\(error.code.rawValue)",
+                retryable: true
+            )
+        } catch {
+            return .failed(
+                category: "http_executor_error",
+                retryable: false
+            )
+        }
+    }
+
+    private func prompt(
+        _ context: GraphExecutorCommandContext
+    ) throws -> String {
+        var sections: [String] = []
+
+        if let literal = stringParameter("prompt", context: context) {
+            let trimmed = literal.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            )
+            if !trimmed.isEmpty {
+                sections.append(trimmed)
+            }
+        }
+
+        for artifact in context.inputArtifacts {
+            switch artifact.storage.scheme {
+            case "inline":
+                sections.append(artifact.storage.opaqueReference)
+
+            case "file":
+                let data = try Data(
+                    contentsOf: URL(
+                        fileURLWithPath:
+                            artifact.storage.opaqueReference
+                    ),
+                    options: .mappedIfSafe
+                )
+                guard let text = String(data: data, encoding: .utf8) else {
+                    throw OpenAICompatibleExecutorError
+                        .nonTextInputArtifact(artifact.id)
+                }
+                sections.append(text)
+
+            default:
+                continue
+            }
+        }
+
+        let result = sections
+            .map {
+                $0.trimmingCharacters(
+                    in: .whitespacesAndNewlines
+                )
+            }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n\n")
+
+        guard !result.isEmpty else {
+            throw OpenAICompatibleExecutorError.missingPrompt
+        }
+
+        return result
+    }
+
+    private func stringParameter(
+        _ name: String,
+        context: GraphExecutorCommandContext
+    ) -> String? {
+        guard case let .string(value) =
+            context.specification.parameters[name]
+        else {
+            return nil
+        }
+
+        return value
+    }
+
+    private func chatCompletionsURL(_ baseURL: URL) -> URL {
+        if baseURL.path.hasSuffix("/chat/completions") {
+            return baseURL
+        }
+
+        return baseURL
+            .appendingPathComponent("chat")
+            .appendingPathComponent("completions")
+    }
+
+    private func executionKey(
+        _ context: GraphExecutorCommandContext
+    ) -> String {
+        [
+            context.identity.runID,
+            context.identity.nodeID,
+            context.identity.attemptID,
+            context.identity.claimID,
+            String(context.identity.leaseGeneration),
+        ].joined(separator: "|")
+    }
+
+    private func observation(
+        operation: GraphExecutorOperation,
+        status: GraphExecutorResponseStatus,
+        context: GraphExecutorCommandContext,
+        failure: GraphExecutorFailure? = nil,
+        artifacts: [GraphExecutorProducedArtifact] = []
+    ) -> GraphExecutorObservation {
+        let material = [
+            executionKey(context),
+            operation.rawValue,
+            String(context.priorObservationCount),
+            status.rawValue,
+        ].joined(separator: "|")
+
+        return GraphExecutorObservation(
+            id: "http-\(DefaultGraphMutationService.stableID(material))",
+            operation: operation,
+            identity: context.identity,
+            status: status,
+            observedAt: context.logicalTime,
+            failure: failure,
+            artifacts: artifacts
+        )
+    }
+
+    private func artifact(
+        data: Data
+    ) -> GraphExecutorProducedArtifact {
+        let digest = SHA256.hash(data: data)
+            .map { String(format: "%02x", $0) }
+            .joined()
+
+        return GraphExecutorProducedArtifact(
+            contentDigest: GraphContentDigest(
+                algorithm: "sha256",
+                value: digest
+            ),
+            mediaType: "application/json",
+            role: .nodeOutput,
+            storage: GraphArtifactStorageLocator(
+                scheme: "inline",
+                opaqueReference:
+                    String(data: data, encoding: .utf8) ?? "{}"
+            )
+        )
+    }
+}
+
+private enum OpenAICompatibleExecutorError: Error {
+    case missingPrompt
+    case nonTextInputArtifact(String)
+}
+
+private struct OpenAICompatibleExecutionResult: Sendable {
+    let status: GraphExecutorResponseStatus
+    let data: Data?
+    let failure: GraphExecutorFailure?
+
+    static let running = OpenAICompatibleExecutionResult(
+        status: .stillRunning,
+        data: nil,
+        failure: nil
+    )
+
+    static let unavailable = OpenAICompatibleExecutionResult(
+        status: .unavailable,
+        data: nil,
+        failure: nil
+    )
+
+    static let cancelled = OpenAICompatibleExecutionResult(
+        status: .cancelled,
+        data: nil,
+        failure: nil
+    )
+
+    static func succeeded(
+        _ data: Data
+    ) -> OpenAICompatibleExecutionResult {
+        OpenAICompatibleExecutionResult(
+            status: .succeeded,
+            data: data,
+            failure: nil
+        )
+    }
+
+    static func failed(
+        category: String,
+        retryable: Bool
+    ) -> OpenAICompatibleExecutionResult {
+        OpenAICompatibleExecutionResult(
+            status: .failed,
+            data: nil,
+            failure: GraphExecutorFailure(
+                category: category,
+                retryable: retryable
+            )
+        )
+    }
+}
+
+private actor OpenAICompatibleExecutionState {
+    private var results:
+        [String: OpenAICompatibleExecutionResult] = [:]
+    private var tasks: [String: Task<Void, Never>] = [:]
+
+    func start(
+        key: String,
+        operation: @escaping @Sendable () async
+            -> OpenAICompatibleExecutionResult
+    ) {
+        guard tasks[key] == nil, results[key] == nil else {
+            return
+        }
+
+        results[key] = .running
+
+        tasks[key] = Task {
+            let result = await operation()
+            complete(key: key, result: result)
+        }
+    }
+
+    func result(
+        for key: String
+    ) -> OpenAICompatibleExecutionResult {
+        results[key] ?? .unavailable
+    }
+
+    func cancel(key: String) {
+        tasks[key]?.cancel()
+        tasks[key] = nil
+        results[key] = .cancelled
+    }
+
+    func remove(key: String) {
+        tasks[key]?.cancel()
+        tasks[key] = nil
+        results[key] = nil
+    }
+
+    private func complete(
+        key: String,
+        result: OpenAICompatibleExecutionResult
+    ) {
+        guard results[key]?.status != .cancelled else {
+            tasks[key] = nil
+            return
+        }
+
+        results[key] = result
+        tasks[key] = nil
+    }
+}

--- a/Sources/OpenIslandCore/OpenCodeSessionRegistry.swift
+++ b/Sources/OpenIslandCore/OpenCodeSessionRegistry.swift
@@ -10,6 +10,7 @@ public struct OpenCodeTrackedSessionRecord: Equatable, Codable, Sendable {
     public var updatedAt: Date
     public var jumpTarget: JumpTarget?
     public var openCodeMetadata: OpenCodeSessionMetadata?
+    public var observability: AgentSessionObservability?
 
     public init(
         sessionID: String,
@@ -20,7 +21,8 @@ public struct OpenCodeTrackedSessionRecord: Equatable, Codable, Sendable {
         phase: SessionPhase,
         updatedAt: Date,
         jumpTarget: JumpTarget? = nil,
-        openCodeMetadata: OpenCodeSessionMetadata? = nil
+        openCodeMetadata: OpenCodeSessionMetadata? = nil,
+        observability: AgentSessionObservability? = nil
     ) {
         self.sessionID = sessionID
         self.title = title
@@ -31,6 +33,7 @@ public struct OpenCodeTrackedSessionRecord: Equatable, Codable, Sendable {
         self.updatedAt = updatedAt
         self.jumpTarget = jumpTarget
         self.openCodeMetadata = openCodeMetadata
+        self.observability = observability
     }
 
     public init(session: AgentSession) {
@@ -43,7 +46,8 @@ public struct OpenCodeTrackedSessionRecord: Equatable, Codable, Sendable {
             phase: session.phase,
             updatedAt: session.updatedAt,
             jumpTarget: session.jumpTarget,
-            openCodeMetadata: session.openCodeMetadata
+            openCodeMetadata: session.openCodeMetadata,
+            observability: session.observability
         )
     }
 
@@ -58,7 +62,8 @@ public struct OpenCodeTrackedSessionRecord: Equatable, Codable, Sendable {
             summary: summary,
             updatedAt: updatedAt,
             jumpTarget: jumpTarget,
-            openCodeMetadata: openCodeMetadata
+            openCodeMetadata: openCodeMetadata,
+            observability: observability ?? AgentSessionObservability()
         )
     }
 
@@ -78,6 +83,7 @@ public struct OpenCodeTrackedSessionRecord: Equatable, Codable, Sendable {
         case updatedAt
         case jumpTarget
         case openCodeMetadata
+        case observability
     }
 
     public init(from decoder: any Decoder) throws {
@@ -91,6 +97,7 @@ public struct OpenCodeTrackedSessionRecord: Equatable, Codable, Sendable {
         updatedAt = try container.decode(Date.self, forKey: .updatedAt)
         jumpTarget = try container.decodeIfPresent(JumpTarget.self, forKey: .jumpTarget)
         openCodeMetadata = try container.decodeIfPresent(OpenCodeSessionMetadata.self, forKey: .openCodeMetadata)
+        observability = try container.decodeIfPresent(AgentSessionObservability.self, forKey: .observability)
     }
 
     public func encode(to encoder: any Encoder) throws {
@@ -104,6 +111,7 @@ public struct OpenCodeTrackedSessionRecord: Equatable, Codable, Sendable {
         try container.encode(updatedAt, forKey: .updatedAt)
         try container.encodeIfPresent(jumpTarget, forKey: .jumpTarget)
         try container.encodeIfPresent(openCodeMetadata, forKey: .openCodeMetadata)
+        try container.encodeIfPresent(observability, forKey: .observability)
     }
 }
 

--- a/Sources/OpenIslandCore/RoutingGraphExecutor.swift
+++ b/Sources/OpenIslandCore/RoutingGraphExecutor.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+public struct RoutingGraphExecutor: GraphExecutorAdapter, Sendable {
+    public let capabilities: GraphExecutorCapabilities
+    private let adapters: [String: any GraphExecutorAdapter]
+
+    public init(adapters: [String: any GraphExecutorAdapter]) {
+        self.adapters = adapters
+        capabilities = GraphExecutorCapabilities(
+            executorID: "openisland.workspace-router",
+            capabilityIdentity: "workspace-router-v1",
+            capabilities: Array(Set(adapters.values.flatMap {
+                $0.capabilities.capabilities
+            })),
+            hostID: "local"
+        )
+    }
+
+    public func prepare(_ request: GraphExecutorPrepareRequest) async throws
+        -> GraphExecutorPrepareResponse
+    {
+        try await adapter(request.context).prepare(request)
+    }
+
+    public func start(_ request: GraphExecutorStartRequest) async throws
+        -> GraphExecutorStartResponse
+    {
+        try await adapter(request.context).start(request)
+    }
+
+    public func observe(_ request: GraphExecutorObserveRequest) async throws
+        -> GraphExecutorObserveResponse
+    {
+        try await adapter(request.context).observe(request)
+    }
+
+    public func requestCancellation(
+        _ request: GraphExecutorCancellationRequest
+    ) async throws -> GraphExecutorCancellationResponse {
+        try await adapter(request.context).requestCancellation(request)
+    }
+
+    public func collectResult(
+        _ request: GraphExecutorCollectResultRequest
+    ) async throws -> GraphExecutorCollectResultResponse {
+        try await adapter(request.context).collectResult(request)
+    }
+
+    public func cleanup(_ request: GraphExecutorCleanupRequest) async throws
+        -> GraphExecutorCleanupResponse
+    {
+        try await adapter(request.context).cleanup(request)
+    }
+
+    public func recover(_ request: GraphExecutorRecoverRequest) async throws
+        -> GraphExecutorRecoverResponse
+    {
+        try await adapter(request.context).recover(request)
+    }
+
+    private func adapter(
+        _ context: GraphExecutorCommandContext
+    ) throws -> any GraphExecutorAdapter {
+        guard let adapter = adapters[context.specification.adapterKind] else {
+            throw GraphExecutorAdapterError.unsupportedAdapter(
+                context.specification.adapterKind
+            )
+        }
+        return adapter
+    }
+}
+
+public struct RoutingGraphExecutionConfirmationPolicy:
+    GraphExecutionConfirmationPolicy,
+    Sendable
+{
+    private let supportedAdapterKinds: Set<String>
+
+    public init(supportedAdapterKinds: Set<String>) {
+        self.supportedAdapterKinds = supportedAdapterKinds
+    }
+
+    public func permits(
+        operation: GraphExecutorOperation,
+        context: GraphExecutorCommandContext
+    ) -> Bool {
+        supportedAdapterKinds.contains(context.specification.adapterKind)
+    }
+}

--- a/Sources/OpenIslandCore/SQLiteGraphExecutionStore.swift
+++ b/Sources/OpenIslandCore/SQLiteGraphExecutionStore.swift
@@ -3,7 +3,9 @@ import SQLite3
 
 public actor SQLiteGraphExecutionStore:
     GraphExecutionEventStore,
-    GraphExecutionSnapshotStore
+    GraphExecutionSnapshotStore,
+    GraphExecutionReadStore,
+    GraphExecutionSnapshotReadStore
 {
     public static let currentDatabaseSchemaVersion = 1
 
@@ -264,6 +266,177 @@ public actor SQLiteGraphExecutionStore:
         )
     }
 
+    public func listStreams() throws -> [GraphExecutionStreamDescriptor] {
+        let database = try Self.openConfiguredDatabase(
+            at: databasePath
+        )
+        defer { sqlite3_close(database) }
+        let statement = try Self.prepare(
+            database,
+            sql: """
+            SELECT run_id, current_version
+            FROM graph_execution_streams
+            ORDER BY run_id ASC;
+            """
+        )
+        defer { sqlite3_finalize(statement) }
+        var streams: [GraphExecutionStreamDescriptor] = []
+
+        while true {
+            let result = sqlite3_step(statement)
+
+            if result == SQLITE_DONE {
+                break
+            }
+
+            guard result == SQLITE_ROW else {
+                throw Self.storageError(
+                    database,
+                    operation: "list graph execution streams"
+                )
+            }
+
+            streams.append(
+                GraphExecutionStreamDescriptor(
+                    runID: try Self.textColumn(
+                        statement,
+                        index: 0,
+                        name: "run_id"
+                    ),
+                    currentVersion: UInt64(
+                        bitPattern: sqlite3_column_int64(statement, 1)
+                    )
+                )
+            )
+        }
+
+        return streams
+    }
+
+    public func streamDescriptor(
+        runID: String
+    ) throws -> GraphExecutionStreamDescriptor? {
+        let database = try Self.openConfiguredDatabase(
+            at: databasePath
+        )
+        defer { sqlite3_close(database) }
+        let statement = try Self.prepare(
+            database,
+            sql: """
+            SELECT current_version
+            FROM graph_execution_streams
+            WHERE run_id = ?;
+            """
+        )
+        defer { sqlite3_finalize(statement) }
+        try Self.bind(runID, at: 1, statement: statement)
+        let result = sqlite3_step(statement)
+
+        if result == SQLITE_DONE {
+            return nil
+        }
+
+        guard result == SQLITE_ROW else {
+            throw Self.storageError(
+                database,
+                operation: "read graph execution stream"
+            )
+        }
+
+        return GraphExecutionStreamDescriptor(
+            runID: runID,
+            currentVersion: UInt64(
+                bitPattern: sqlite3_column_int64(statement, 0)
+            )
+        )
+    }
+
+    public func readPage(
+        runID: String,
+        afterVersion: UInt64,
+        limit: Int
+    ) throws -> GraphExecutionEventPage {
+        let pageLimit = max(1, min(limit, 10_000))
+        let database = try Self.openConfiguredDatabase(
+            at: databasePath
+        )
+        defer { sqlite3_close(database) }
+        let currentVersion = try Self.currentVersion(
+            runID: runID,
+            database: database
+        )
+        let statement = try Self.prepare(
+            database,
+            sql: """
+            SELECT
+                event_id,
+                stream_sequence,
+                envelope_schema_version,
+                event_type,
+                payload_version,
+                event_json
+            FROM graph_execution_events
+            WHERE run_id = ? AND stream_sequence > ?
+            ORDER BY stream_sequence ASC, event_id ASC
+            LIMIT ?;
+            """
+        )
+        defer { sqlite3_finalize(statement) }
+        try Self.bind(runID, at: 1, statement: statement)
+        sqlite3_bind_int64(
+            statement,
+            2,
+            Int64(bitPattern: afterVersion)
+        )
+        sqlite3_bind_int(statement, 3, Int32(pageLimit))
+        var events: [GraphExecutionEventEnvelope] = []
+        var expectedSequence = afterVersion + 1
+
+        while true {
+            let result = sqlite3_step(statement)
+
+            if result == SQLITE_DONE {
+                break
+            }
+
+            guard result == SQLITE_ROW else {
+                throw Self.storageError(
+                    database,
+                    operation: "read graph execution event page"
+                )
+            }
+
+            let event = try Self.validatedEvent(
+                statement: statement,
+                expectedRunID: runID
+            )
+
+            guard event.streamSequence == expectedSequence else {
+                throw GraphExecutionPersistenceError.corruptRecord(
+                    "Run \(runID) expected sequence \(expectedSequence), found \(event.streamSequence)."
+                )
+            }
+
+            events.append(event)
+            expectedSequence += 1
+        }
+
+        if afterVersion < currentVersion, events.isEmpty {
+            throw GraphExecutionPersistenceError.corruptRecord(
+                "Run \(runID) has no event after sequence \(afterVersion), but its head is \(currentVersion)."
+            )
+        }
+
+        let nextVersion = events.last?.streamSequence ?? afterVersion
+        return GraphExecutionEventPage(
+            runID: runID,
+            afterVersion: afterVersion,
+            currentVersion: currentVersion,
+            events: events,
+            hasMore: nextVersion < currentVersion
+        )
+    }
+
     public func loadLatest(
         runID: String
     ) throws -> GraphExecutionSnapshot? {
@@ -306,6 +479,70 @@ public actor SQLiteGraphExecutionStore:
             name: "snapshot_json"
         )
         let snapshot = try Self.decodeSnapshot(data)
+
+        guard snapshot.runID == runID,
+              snapshot.streamVersion == storedVersion,
+              snapshot.schemaVersion == storedSchemaVersion else {
+            throw GraphExecutionPersistenceError.corruptRecord(
+                "Snapshot \(runID)@\(storedVersion) indexed metadata does not match its payload."
+            )
+        }
+
+        return snapshot
+    }
+
+    public func loadLatest(
+        runID: String,
+        throughVersion: UInt64
+    ) throws -> GraphExecutionSnapshot? {
+        let database = try Self.openConfiguredDatabase(
+            at: databasePath
+        )
+        defer { sqlite3_close(database) }
+        let sql = """
+        SELECT
+            stream_version,
+            snapshot_schema_version,
+            snapshot_json
+        FROM graph_execution_snapshots
+        WHERE run_id = ? AND stream_version <= ?
+        ORDER BY stream_version DESC
+        LIMIT 1;
+        """
+        let statement = try Self.prepare(database, sql: sql)
+        defer { sqlite3_finalize(statement) }
+        try Self.bind(runID, at: 1, statement: statement)
+        sqlite3_bind_int64(
+            statement,
+            2,
+            Int64(bitPattern: throughVersion)
+        )
+        let result = sqlite3_step(statement)
+
+        if result == SQLITE_DONE {
+            return nil
+        }
+
+        guard result == SQLITE_ROW else {
+            throw Self.storageError(
+                database,
+                operation: "load bounded snapshot"
+            )
+        }
+
+        let storedVersion = UInt64(
+            bitPattern: sqlite3_column_int64(statement, 0)
+        )
+        let storedSchemaVersion = Int(
+            sqlite3_column_int(statement, 1)
+        )
+        let snapshot = try Self.decodeSnapshot(
+            Self.dataColumn(
+                statement,
+                index: 2,
+                name: "snapshot_json"
+            )
+        )
 
         guard snapshot.runID == runID,
               snapshot.streamVersion == storedVersion,
@@ -882,6 +1119,51 @@ public actor SQLiteGraphExecutionStore:
                 "Unable to decode event envelope: \(error.localizedDescription)"
             )
         }
+    }
+
+    private static func validatedEvent(
+        statement: OpaquePointer,
+        expectedRunID: String
+    ) throws -> GraphExecutionEventEnvelope {
+        let storedID = try textColumn(
+            statement,
+            index: 0,
+            name: "event_id"
+        )
+        let storedSequence = UInt64(
+            bitPattern: sqlite3_column_int64(statement, 1)
+        )
+        let storedEnvelopeVersion = Int(
+            sqlite3_column_int(statement, 2)
+        )
+        let storedEventType = try textColumn(
+            statement,
+            index: 3,
+            name: "event_type"
+        )
+        let storedPayloadVersion = Int(
+            sqlite3_column_int(statement, 4)
+        )
+        let event = try decodeEvent(
+            dataColumn(
+                statement,
+                index: 5,
+                name: "event_json"
+            )
+        )
+
+        guard event.id == storedID,
+              event.runID == expectedRunID,
+              event.streamSequence == storedSequence,
+              event.schemaVersion == storedEnvelopeVersion,
+              event.eventType == storedEventType,
+              event.payloadVersion == storedPayloadVersion else {
+            throw GraphExecutionPersistenceError.corruptRecord(
+                "Event \(storedID) indexed metadata does not match its envelope."
+            )
+        }
+
+        return event
     }
 
     private static func decodeSnapshot(

--- a/Sources/OpenIslandCore/SQLiteGraphExecutionStore.swift
+++ b/Sources/OpenIslandCore/SQLiteGraphExecutionStore.swift
@@ -1,0 +1,1039 @@
+import Foundation
+import SQLite3
+
+public actor SQLiteGraphExecutionStore:
+    GraphExecutionEventStore,
+    GraphExecutionSnapshotStore
+{
+    public static let currentDatabaseSchemaVersion = 1
+
+    private let databasePath: String
+
+    public static func defaultDatabasePath() throws -> String {
+        let applicationSupport = try FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+
+        return applicationSupport
+            .appendingPathComponent("OpenIsland", isDirectory: true)
+            .appendingPathComponent("graph-execution.sqlite")
+            .path
+    }
+
+    public init(databasePath: String) throws {
+        self.databasePath = databasePath
+        try Self.createParentDirectoryIfNeeded(databasePath)
+        let database = try Self.openDatabase(at: databasePath)
+        defer { sqlite3_close(database) }
+        try Self.configure(database)
+        try Self.migrate(database)
+    }
+
+    public func append(
+        _ events: [GraphExecutionEventEnvelope],
+        to runID: String,
+        expectedVersion: UInt64
+    ) throws -> GraphExecutionAppendResult {
+        let normalized = try Self.normalize(events)
+        let database = try Self.openConfiguredDatabase(
+            at: databasePath
+        )
+        defer { sqlite3_close(database) }
+        try Self.execute(database, sql: "BEGIN IMMEDIATE;")
+        var committed = false
+
+        defer {
+            if !committed {
+                try? Self.execute(database, sql: "ROLLBACK;")
+            }
+        }
+
+        let currentVersion = try Self.currentVersion(
+            runID: runID,
+            database: database
+        )
+
+        for event in normalized where event.runID != runID {
+            throw GraphExecutionPersistenceError.invalidRunID(
+                expected: runID,
+                actual: event.runID
+            )
+        }
+
+        var newEvents: [GraphExecutionEventEnvelope] = []
+
+        for event in normalized {
+            guard event.schemaVersion
+                    <= GraphExecutionSchema.eventEnvelopeVersion else {
+                throw GraphExecutionPersistenceError
+                    .unsupportedSchemaVersion(
+                        artifact: "event envelope",
+                        found: event.schemaVersion,
+                        supported: GraphExecutionSchema.eventEnvelopeVersion
+                    )
+            }
+
+            if let existing = try Self.event(
+                withID: event.id,
+                database: database
+            ) {
+                guard existing == event else {
+                    throw GraphExecutionPersistenceError
+                        .eventIDCollision(eventID: event.id)
+                }
+            } else {
+                newEvents.append(event)
+            }
+        }
+
+        let duplicateCount = events.count - newEvents.count
+
+        if newEvents.isEmpty {
+            try Self.execute(database, sql: "COMMIT;")
+            committed = true
+            return GraphExecutionAppendResult(
+                previousVersion: currentVersion,
+                newVersion: currentVersion,
+                appendedCount: 0,
+                deduplicatedCount: duplicateCount
+            )
+        }
+
+        guard expectedVersion == currentVersion else {
+            throw GraphExecutionPersistenceError
+                .expectedVersionConflict(
+                    runID: runID,
+                    expected: expectedVersion,
+                    actual: currentVersion
+                )
+        }
+
+        var expectedSequence = currentVersion + 1
+
+        for event in newEvents {
+            guard event.streamSequence == expectedSequence else {
+                if try Self.eventExists(
+                    runID: runID,
+                    sequence: event.streamSequence,
+                    database: database
+                ) {
+                    throw GraphExecutionPersistenceError
+                        .sequenceConflict(
+                            runID: runID,
+                            sequence: event.streamSequence
+                        )
+                }
+
+                throw GraphExecutionPersistenceError.sequenceGap(
+                    expected: expectedSequence,
+                    actual: event.streamSequence
+                )
+            }
+
+            try Self.insert(event, database: database)
+            expectedSequence += 1
+        }
+
+        let newVersion = newEvents.last?.streamSequence
+            ?? currentVersion
+        try Self.setCurrentVersion(
+            runID: runID,
+            from: currentVersion,
+            to: newVersion,
+            database: database
+        )
+        try Self.execute(database, sql: "COMMIT;")
+        committed = true
+
+        return GraphExecutionAppendResult(
+            previousVersion: currentVersion,
+            newVersion: newVersion,
+            appendedCount: newEvents.count,
+            deduplicatedCount: duplicateCount
+        )
+    }
+
+    public func read(
+        runID: String,
+        afterVersion: UInt64
+    ) throws -> GraphExecutionEventStream {
+        let database = try Self.openConfiguredDatabase(
+            at: databasePath
+        )
+        defer { sqlite3_close(database) }
+        let currentVersion = try Self.currentVersion(
+            runID: runID,
+            database: database
+        )
+        let sql = """
+        SELECT
+            event_id,
+            stream_sequence,
+            envelope_schema_version,
+            event_type,
+            payload_version,
+            event_json
+        FROM graph_execution_events
+        WHERE run_id = ? AND stream_sequence > ?
+        ORDER BY stream_sequence ASC, event_id ASC;
+        """
+        let statement = try Self.prepare(database, sql: sql)
+        defer { sqlite3_finalize(statement) }
+        try Self.bind(runID, at: 1, statement: statement)
+        sqlite3_bind_int64(
+            statement,
+            2,
+            Int64(bitPattern: afterVersion)
+        )
+        var events: [GraphExecutionEventEnvelope] = []
+        var expectedSequence = afterVersion + 1
+
+        while true {
+            let result = sqlite3_step(statement)
+
+            if result == SQLITE_DONE {
+                break
+            }
+
+            guard result == SQLITE_ROW else {
+                throw Self.storageError(database, operation: "read events")
+            }
+
+            let storedID = try Self.textColumn(
+                statement,
+                index: 0,
+                name: "event_id"
+            )
+            let storedSequence = UInt64(
+                bitPattern: sqlite3_column_int64(statement, 1)
+            )
+            let storedEnvelopeVersion = Int(
+                sqlite3_column_int(statement, 2)
+            )
+            let storedEventType = try Self.textColumn(
+                statement,
+                index: 3,
+                name: "event_type"
+            )
+            let storedPayloadVersion = Int(
+                sqlite3_column_int(statement, 4)
+            )
+            let data = try Self.dataColumn(
+                statement,
+                index: 5,
+                name: "event_json"
+            )
+            let event = try Self.decodeEvent(data)
+
+            guard storedSequence == expectedSequence else {
+                throw GraphExecutionPersistenceError.corruptRecord(
+                    "Run \(runID) expected sequence \(expectedSequence), found \(storedSequence)."
+                )
+            }
+
+            guard event.id == storedID,
+                  event.runID == runID,
+                  event.streamSequence == storedSequence,
+                  event.schemaVersion == storedEnvelopeVersion,
+                  event.eventType == storedEventType,
+                  event.payloadVersion == storedPayloadVersion else {
+                throw GraphExecutionPersistenceError.corruptRecord(
+                    "Event \(storedID) indexed metadata does not match its envelope."
+                )
+            }
+
+            events.append(event)
+            expectedSequence += 1
+        }
+
+        if afterVersion < currentVersion,
+           expectedSequence - 1 != currentVersion {
+            throw GraphExecutionPersistenceError.corruptRecord(
+                "Run \(runID) stream head is \(currentVersion), but records end at \(expectedSequence - 1)."
+            )
+        }
+
+        return GraphExecutionEventStream(
+            runID: runID,
+            afterVersion: afterVersion,
+            currentVersion: currentVersion,
+            events: events
+        )
+    }
+
+    public func loadLatest(
+        runID: String
+    ) throws -> GraphExecutionSnapshot? {
+        let database = try Self.openConfiguredDatabase(
+            at: databasePath
+        )
+        defer { sqlite3_close(database) }
+        let sql = """
+        SELECT
+            stream_version,
+            snapshot_schema_version,
+            snapshot_json
+        FROM graph_execution_snapshots
+        WHERE run_id = ?
+        ORDER BY stream_version DESC
+        LIMIT 1;
+        """
+        let statement = try Self.prepare(database, sql: sql)
+        defer { sqlite3_finalize(statement) }
+        try Self.bind(runID, at: 1, statement: statement)
+        let result = sqlite3_step(statement)
+
+        if result == SQLITE_DONE {
+            return nil
+        }
+
+        guard result == SQLITE_ROW else {
+            throw Self.storageError(database, operation: "load snapshot")
+        }
+
+        let storedVersion = UInt64(
+            bitPattern: sqlite3_column_int64(statement, 0)
+        )
+        let storedSchemaVersion = Int(
+            sqlite3_column_int(statement, 1)
+        )
+        let data = try Self.dataColumn(
+            statement,
+            index: 2,
+            name: "snapshot_json"
+        )
+        let snapshot = try Self.decodeSnapshot(data)
+
+        guard snapshot.runID == runID,
+              snapshot.streamVersion == storedVersion,
+              snapshot.schemaVersion == storedSchemaVersion else {
+            throw GraphExecutionPersistenceError.corruptRecord(
+                "Snapshot \(runID)@\(storedVersion) indexed metadata does not match its payload."
+            )
+        }
+
+        return snapshot
+    }
+
+    public func save(
+        _ snapshot: GraphExecutionSnapshot
+    ) throws {
+        let database = try Self.openConfiguredDatabase(
+            at: databasePath
+        )
+        defer { sqlite3_close(database) }
+        try Self.execute(database, sql: "BEGIN IMMEDIATE;")
+        var committed = false
+
+        defer {
+            if !committed {
+                try? Self.execute(database, sql: "ROLLBACK;")
+            }
+        }
+
+        if let existing = try Self.snapshot(
+            runID: snapshot.runID,
+            streamVersion: snapshot.streamVersion,
+            database: database
+        ) {
+            guard existing == snapshot else {
+                throw GraphExecutionPersistenceError.corruptRecord(
+                    "Snapshot \(snapshot.runID)@\(snapshot.streamVersion) already exists with different content."
+                )
+            }
+
+            try Self.execute(database, sql: "COMMIT;")
+            committed = true
+            return
+        }
+
+        let sql = """
+        INSERT INTO graph_execution_snapshots (
+            run_id,
+            stream_version,
+            snapshot_schema_version,
+            graph_definition_version,
+            graph_definition_digest,
+            created_at,
+            snapshot_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?);
+        """
+        let statement = try Self.prepare(database, sql: sql)
+        defer { sqlite3_finalize(statement) }
+        try Self.bind(snapshot.runID, at: 1, statement: statement)
+        sqlite3_bind_int64(
+            statement,
+            2,
+            Int64(bitPattern: snapshot.streamVersion)
+        )
+        sqlite3_bind_int(
+            statement,
+            3,
+            Int32(snapshot.schemaVersion)
+        )
+        try Self.bind(
+            snapshot.graphDefinitionVersion,
+            at: 4,
+            statement: statement
+        )
+        try Self.bind(
+            snapshot.graphDefinitionDigest.value,
+            at: 5,
+            statement: statement
+        )
+        sqlite3_bind_double(
+            statement,
+            6,
+            snapshot.createdAt.timeIntervalSince1970
+        )
+        try Self.bind(
+            try Self.encode(snapshot),
+            at: 7,
+            statement: statement
+        )
+
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw Self.storageError(database, operation: "insert snapshot")
+        }
+
+        try Self.execute(database, sql: "COMMIT;")
+        committed = true
+    }
+
+    public func databaseSchemaVersion() throws -> Int {
+        let database = try Self.openConfiguredDatabase(
+            at: databasePath
+        )
+        defer { sqlite3_close(database) }
+        let statement = try Self.prepare(
+            database,
+            sql: "PRAGMA user_version;"
+        )
+        defer { sqlite3_finalize(statement) }
+
+        guard sqlite3_step(statement) == SQLITE_ROW else {
+            throw Self.storageError(
+                database,
+                operation: "read schema version"
+            )
+        }
+
+        return Int(sqlite3_column_int(statement, 0))
+    }
+
+    private static func createParentDirectoryIfNeeded(
+        _ path: String
+    ) throws {
+        guard path != ":memory:" else {
+            return
+        }
+
+        let directory = URL(fileURLWithPath: path)
+            .deletingLastPathComponent()
+
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+    }
+
+    private static func openConfiguredDatabase(
+        at path: String
+    ) throws -> OpaquePointer {
+        let database = try openDatabase(at: path)
+
+        do {
+            try configure(database)
+            return database
+        } catch {
+            sqlite3_close(database)
+            throw error
+        }
+    }
+
+    private static func openDatabase(
+        at path: String
+    ) throws -> OpaquePointer {
+        var database: OpaquePointer?
+        let flags = SQLITE_OPEN_READWRITE
+            | SQLITE_OPEN_CREATE
+            | SQLITE_OPEN_FULLMUTEX
+        let result = sqlite3_open_v2(path, &database, flags, nil)
+
+        guard result == SQLITE_OK, let database else {
+            let message = database.map {
+                String(cString: sqlite3_errmsg($0))
+            } ?? "unknown open error"
+
+            if let database {
+                sqlite3_close(database)
+            }
+
+            throw GraphExecutionPersistenceError.storageFailure(
+                "Unable to open \(path): \(message)"
+            )
+        }
+
+        sqlite3_busy_timeout(database, 5_000)
+        return database
+    }
+
+    private static func configure(
+        _ database: OpaquePointer
+    ) throws {
+        try execute(database, sql: "PRAGMA foreign_keys = ON;")
+        try execute(database, sql: "PRAGMA journal_mode = WAL;")
+        try execute(database, sql: "PRAGMA synchronous = FULL;")
+    }
+
+    private static func migrate(
+        _ database: OpaquePointer
+    ) throws {
+        let version = try userVersion(database)
+
+        guard version <= currentDatabaseSchemaVersion else {
+            throw GraphExecutionPersistenceError
+                .unsupportedSchemaVersion(
+                    artifact: "SQLite database",
+                    found: version,
+                    supported: currentDatabaseSchemaVersion
+                )
+        }
+
+        guard version < 1 else {
+            return
+        }
+
+        try execute(database, sql: "BEGIN IMMEDIATE;")
+        var committed = false
+
+        defer {
+            if !committed {
+                try? execute(database, sql: "ROLLBACK;")
+            }
+        }
+
+        let lockedVersion = try userVersion(database)
+
+        if lockedVersion >= 1 {
+            try execute(database, sql: "COMMIT;")
+            committed = true
+            return
+        }
+
+        try execute(
+            database,
+            sql: """
+            CREATE TABLE graph_schema_migrations (
+                version INTEGER PRIMARY KEY,
+                applied_at REAL NOT NULL
+            );
+
+            CREATE TABLE graph_execution_streams (
+                run_id TEXT PRIMARY KEY,
+                current_version INTEGER NOT NULL CHECK(current_version >= 0)
+            );
+
+            CREATE TABLE graph_execution_events (
+                event_id TEXT PRIMARY KEY,
+                run_id TEXT NOT NULL,
+                stream_sequence INTEGER NOT NULL CHECK(stream_sequence > 0),
+                envelope_schema_version INTEGER NOT NULL,
+                event_type TEXT NOT NULL,
+                payload_version INTEGER NOT NULL,
+                occurred_at REAL NOT NULL,
+                recorded_at REAL NOT NULL,
+                event_json BLOB NOT NULL,
+                UNIQUE(run_id, stream_sequence)
+            );
+
+            CREATE INDEX graph_execution_events_run_sequence
+                ON graph_execution_events(run_id, stream_sequence);
+
+            CREATE TABLE graph_execution_snapshots (
+                run_id TEXT NOT NULL,
+                stream_version INTEGER NOT NULL CHECK(stream_version >= 0),
+                snapshot_schema_version INTEGER NOT NULL,
+                graph_definition_version TEXT NOT NULL,
+                graph_definition_digest TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                snapshot_json BLOB NOT NULL,
+                PRIMARY KEY(run_id, stream_version)
+            );
+
+            CREATE INDEX graph_execution_snapshots_latest
+                ON graph_execution_snapshots(run_id, stream_version DESC);
+
+            INSERT INTO graph_schema_migrations(version, applied_at)
+                VALUES (1, unixepoch('subsec'));
+
+            PRAGMA user_version = 1;
+            """
+        )
+        try execute(database, sql: "COMMIT;")
+        committed = true
+    }
+
+    private static func userVersion(
+        _ database: OpaquePointer
+    ) throws -> Int {
+        let statement = try prepare(
+            database,
+            sql: "PRAGMA user_version;"
+        )
+        defer { sqlite3_finalize(statement) }
+
+        guard sqlite3_step(statement) == SQLITE_ROW else {
+            throw storageError(
+                database,
+                operation: "read user_version"
+            )
+        }
+
+        return Int(sqlite3_column_int(statement, 0))
+    }
+
+    private static func currentVersion(
+        runID: String,
+        database: OpaquePointer
+    ) throws -> UInt64 {
+        let statement = try prepare(
+            database,
+            sql: """
+            SELECT current_version
+            FROM graph_execution_streams
+            WHERE run_id = ?;
+            """
+        )
+        defer { sqlite3_finalize(statement) }
+        try bind(runID, at: 1, statement: statement)
+        let result = sqlite3_step(statement)
+
+        if result == SQLITE_DONE {
+            return 0
+        }
+
+        guard result == SQLITE_ROW else {
+            throw storageError(database, operation: "read stream head")
+        }
+
+        return UInt64(
+            bitPattern: sqlite3_column_int64(statement, 0)
+        )
+    }
+
+    private static func setCurrentVersion(
+        runID: String,
+        from previousVersion: UInt64,
+        to newVersion: UInt64,
+        database: OpaquePointer
+    ) throws {
+        let statement = try prepare(
+            database,
+            sql: """
+            INSERT INTO graph_execution_streams(run_id, current_version)
+            VALUES (?, ?)
+            ON CONFLICT(run_id) DO UPDATE SET
+                current_version = excluded.current_version
+            WHERE graph_execution_streams.current_version = ?;
+            """
+        )
+        defer { sqlite3_finalize(statement) }
+        try bind(runID, at: 1, statement: statement)
+        sqlite3_bind_int64(
+            statement,
+            2,
+            Int64(bitPattern: newVersion)
+        )
+        sqlite3_bind_int64(
+            statement,
+            3,
+            Int64(bitPattern: previousVersion)
+        )
+
+        guard sqlite3_step(statement) == SQLITE_DONE,
+              sqlite3_changes(database) == 1 else {
+            throw GraphExecutionPersistenceError
+                .expectedVersionConflict(
+                    runID: runID,
+                    expected: previousVersion,
+                    actual: try currentVersion(
+                        runID: runID,
+                        database: database
+                    )
+                )
+        }
+    }
+
+    private static func insert(
+        _ event: GraphExecutionEventEnvelope,
+        database: OpaquePointer
+    ) throws {
+        let statement = try prepare(
+            database,
+            sql: """
+            INSERT INTO graph_execution_events (
+                event_id,
+                run_id,
+                stream_sequence,
+                envelope_schema_version,
+                event_type,
+                payload_version,
+                occurred_at,
+                recorded_at,
+                event_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+            """
+        )
+        defer { sqlite3_finalize(statement) }
+        try bind(event.id, at: 1, statement: statement)
+        try bind(event.runID, at: 2, statement: statement)
+        sqlite3_bind_int64(
+            statement,
+            3,
+            Int64(bitPattern: event.streamSequence)
+        )
+        sqlite3_bind_int(
+            statement,
+            4,
+            Int32(event.schemaVersion)
+        )
+        try bind(event.eventType, at: 5, statement: statement)
+        sqlite3_bind_int(
+            statement,
+            6,
+            Int32(event.payloadVersion)
+        )
+        sqlite3_bind_double(
+            statement,
+            7,
+            event.occurredAt.timeIntervalSince1970
+        )
+        sqlite3_bind_double(
+            statement,
+            8,
+            event.recordedAt.timeIntervalSince1970
+        )
+        try bind(
+            try encode(event),
+            at: 9,
+            statement: statement
+        )
+
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            let code = sqlite3_extended_errcode(database)
+
+            if code & 0xFF == SQLITE_CONSTRAINT {
+                throw GraphExecutionPersistenceError
+                    .sequenceConflict(
+                        runID: event.runID,
+                        sequence: event.streamSequence
+                    )
+            }
+
+            throw storageError(database, operation: "insert event")
+        }
+    }
+
+    private static func event(
+        withID eventID: String,
+        database: OpaquePointer
+    ) throws -> GraphExecutionEventEnvelope? {
+        let statement = try prepare(
+            database,
+            sql: """
+            SELECT event_json
+            FROM graph_execution_events
+            WHERE event_id = ?;
+            """
+        )
+        defer { sqlite3_finalize(statement) }
+        try bind(eventID, at: 1, statement: statement)
+        let result = sqlite3_step(statement)
+
+        if result == SQLITE_DONE {
+            return nil
+        }
+
+        guard result == SQLITE_ROW else {
+            throw storageError(database, operation: "read event ID")
+        }
+
+        return try decodeEvent(
+            dataColumn(statement, index: 0, name: "event_json")
+        )
+    }
+
+    private static func eventExists(
+        runID: String,
+        sequence: UInt64,
+        database: OpaquePointer
+    ) throws -> Bool {
+        let statement = try prepare(
+            database,
+            sql: """
+            SELECT 1
+            FROM graph_execution_events
+            WHERE run_id = ? AND stream_sequence = ?;
+            """
+        )
+        defer { sqlite3_finalize(statement) }
+        try bind(runID, at: 1, statement: statement)
+        sqlite3_bind_int64(
+            statement,
+            2,
+            Int64(bitPattern: sequence)
+        )
+        return sqlite3_step(statement) == SQLITE_ROW
+    }
+
+    private static func snapshot(
+        runID: String,
+        streamVersion: UInt64,
+        database: OpaquePointer
+    ) throws -> GraphExecutionSnapshot? {
+        let statement = try prepare(
+            database,
+            sql: """
+            SELECT snapshot_json
+            FROM graph_execution_snapshots
+            WHERE run_id = ? AND stream_version = ?;
+            """
+        )
+        defer { sqlite3_finalize(statement) }
+        try bind(runID, at: 1, statement: statement)
+        sqlite3_bind_int64(
+            statement,
+            2,
+            Int64(bitPattern: streamVersion)
+        )
+        let result = sqlite3_step(statement)
+
+        if result == SQLITE_DONE {
+            return nil
+        }
+
+        guard result == SQLITE_ROW else {
+            throw storageError(database, operation: "read snapshot")
+        }
+
+        return try decodeSnapshot(
+            dataColumn(statement, index: 0, name: "snapshot_json")
+        )
+    }
+
+    private static func normalize(
+        _ events: [GraphExecutionEventEnvelope]
+    ) throws -> [GraphExecutionEventEnvelope] {
+        var byID: [String: GraphExecutionEventEnvelope] = [:]
+
+        for event in events {
+            if let existing = byID[event.id],
+               existing != event {
+                throw GraphExecutionPersistenceError.eventIDCollision(
+                    eventID: event.id
+                )
+            }
+
+            byID[event.id] = event
+        }
+
+        return byID.values.sorted {
+            if $0.streamSequence != $1.streamSequence {
+                return $0.streamSequence < $1.streamSequence
+            }
+
+            return $0.id < $1.id
+        }
+    }
+
+    private static func encode<Value: Encodable>(
+        _ value: Value
+    ) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        encoder.dateEncodingStrategy = .secondsSince1970
+
+        do {
+            return try encoder.encode(value)
+        } catch {
+            throw GraphExecutionPersistenceError.storageFailure(
+                "Unable to encode persisted value: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    private static func decodeEvent(
+        _ data: Data
+    ) throws -> GraphExecutionEventEnvelope {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+
+        do {
+            return try decoder.decode(
+                GraphExecutionEventEnvelope.self,
+                from: data
+            )
+        } catch {
+            throw GraphExecutionPersistenceError.corruptRecord(
+                "Unable to decode event envelope: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    private static func decodeSnapshot(
+        _ data: Data
+    ) throws -> GraphExecutionSnapshot {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+
+        do {
+            return try decoder.decode(
+                GraphExecutionSnapshot.self,
+                from: data
+            )
+        } catch {
+            throw GraphExecutionPersistenceError.corruptRecord(
+                "Unable to decode snapshot: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    private static func execute(
+        _ database: OpaquePointer,
+        sql: String
+    ) throws {
+        var errorMessage: UnsafeMutablePointer<CChar>?
+        let result = sqlite3_exec(
+            database,
+            sql,
+            nil,
+            nil,
+            &errorMessage
+        )
+
+        guard result == SQLITE_OK else {
+            let message = errorMessage.map {
+                String(cString: $0)
+            } ?? String(cString: sqlite3_errmsg(database))
+            sqlite3_free(errorMessage)
+            throw GraphExecutionPersistenceError.storageFailure(message)
+        }
+    }
+
+    private static func prepare(
+        _ database: OpaquePointer,
+        sql: String
+    ) throws -> OpaquePointer {
+        var statement: OpaquePointer?
+
+        guard sqlite3_prepare_v2(
+            database,
+            sql,
+            -1,
+            &statement,
+            nil
+        ) == SQLITE_OK, let statement else {
+            throw storageError(database, operation: "prepare SQL")
+        }
+
+        return statement
+    }
+
+    private static func bind(
+        _ value: String,
+        at index: Int32,
+        statement: OpaquePointer
+    ) throws {
+        let result = value.withCString {
+            sqlite3_bind_text(
+                statement,
+                index,
+                $0,
+                -1,
+                sqliteTransient
+            )
+        }
+
+        guard result == SQLITE_OK else {
+            throw GraphExecutionPersistenceError.storageFailure(
+                "Unable to bind text value."
+            )
+        }
+    }
+
+    private static func bind(
+        _ value: Data,
+        at index: Int32,
+        statement: OpaquePointer
+    ) throws {
+        let result = value.withUnsafeBytes { bytes in
+            sqlite3_bind_blob(
+                statement,
+                index,
+                bytes.baseAddress,
+                Int32(bytes.count),
+                sqliteTransient
+            )
+        }
+
+        guard result == SQLITE_OK else {
+            throw GraphExecutionPersistenceError.storageFailure(
+                "Unable to bind data value."
+            )
+        }
+    }
+
+    private static func textColumn(
+        _ statement: OpaquePointer,
+        index: Int32,
+        name: String
+    ) throws -> String {
+        guard let value = sqlite3_column_text(statement, index) else {
+            throw GraphExecutionPersistenceError.corruptRecord(
+                "Column \(name) is null."
+            )
+        }
+
+        return String(cString: value)
+    }
+
+    private static func dataColumn(
+        _ statement: OpaquePointer,
+        index: Int32,
+        name: String
+    ) throws -> Data {
+        let count = Int(sqlite3_column_bytes(statement, index))
+
+        guard count >= 0,
+              let bytes = sqlite3_column_blob(statement, index)
+                ?? (count == 0 ? UnsafeRawPointer(bitPattern: 1) : nil)
+        else {
+            throw GraphExecutionPersistenceError.corruptRecord(
+                "Column \(name) is null."
+            )
+        }
+
+        if count == 0 {
+            return Data()
+        }
+
+        return Data(bytes: bytes, count: count)
+    }
+
+    private static func storageError(
+        _ database: OpaquePointer,
+        operation: String
+    ) -> GraphExecutionPersistenceError {
+        .storageFailure(
+            "\(operation): \(String(cString: sqlite3_errmsg(database)))"
+        )
+    }
+
+    private static var sqliteTransient: sqlite3_destructor_type {
+        unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+    }
+}

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -57,6 +57,8 @@ public struct SessionState: Equatable, Sendable {
         switch event {
         case let .sessionStarted(payload):
             let preservedFirstSeenAt = sessionsByID[payload.sessionID]?.firstSeenAt
+            let preservedObservability = sessionsByID[payload.sessionID]?.observability
+                ?? AgentSessionObservability()
             var session = AgentSession(
                 id: payload.sessionID,
                 title: payload.title,
@@ -72,7 +74,8 @@ public struct SessionState: Equatable, Sendable {
                 claudeMetadata: payload.claudeMetadata?.isEmpty == true ? nil : payload.claudeMetadata,
                 geminiMetadata: payload.geminiMetadata?.isEmpty == true ? nil : payload.geminiMetadata,
                 openCodeMetadata: payload.openCodeMetadata?.isEmpty == true ? nil : payload.openCodeMetadata,
-                cursorMetadata: payload.cursorMetadata?.isEmpty == true ? nil : payload.cursorMetadata
+                cursorMetadata: payload.cursorMetadata?.isEmpty == true ? nil : payload.cursorMetadata,
+                observability: preservedObservability
             )
             session.isRemote = payload.isRemote
             session.isHookManaged = payload.origin == .live
@@ -222,6 +225,8 @@ public struct SessionState: Equatable, Sendable {
             session.updatedAt = payload.timestamp
             upsert(session)
         }
+
+        recordObservability(for: event)
     }
 
     public mutating func resolvePermission(
@@ -258,6 +263,14 @@ public struct SessionState: Equatable, Sendable {
             }
         }
 
+        session.observability.record(
+            AgentTimelineEvent(
+                timestamp: timestamp,
+                kind: resolution.isApproved ? .status : .completion,
+                title: resolution.isApproved ? "Permission approved" : "Permission denied",
+                detail: session.summary
+            )
+        )
         upsert(session)
     }
 
@@ -275,6 +288,14 @@ public struct SessionState: Equatable, Sendable {
         let summary = response.displaySummary
         session.summary = summary.isEmpty ? "Answered the question." : "Answered: \(summary)"
         session.updatedAt = timestamp
+        session.observability.record(
+            AgentTimelineEvent(
+                timestamp: timestamp,
+                kind: .status,
+                title: "Question answered",
+                detail: session.summary
+            )
+        )
         upsert(session)
     }
 
@@ -432,6 +453,14 @@ public struct SessionState: Equatable, Sendable {
         session.isSessionEnded = true
         session.phase = .completed
         session.updatedAt = .now
+        session.observability.record(
+            AgentTimelineEvent(
+                timestamp: session.updatedAt,
+                kind: .completion,
+                title: "Session dismissed",
+                detail: session.summary
+            )
+        )
         upsert(session)
     }
 
@@ -445,5 +474,15 @@ public struct SessionState: Equatable, Sendable {
 
     private mutating func upsert(_ session: AgentSession) {
         sessionsByID[session.id] = session
+    }
+
+    private mutating func recordObservability(for event: AgentEvent) {
+        guard var session = sessionsByID[event.sessionID],
+              let timelineEvent = event.timelineEvent else {
+            return
+        }
+
+        session.observability.record(timelineEvent)
+        upsert(session)
     }
 }

--- a/Sources/OpenIslandCore/SupervisedLocalProcessExecutor.swift
+++ b/Sources/OpenIslandCore/SupervisedLocalProcessExecutor.swift
@@ -17,6 +17,7 @@ public actor SupervisedLocalProcessExecutor: GraphExecutorAdapter {
     private let crashPoint: GraphLocalProcessCrashPoint?
     private var processes: [String: Process] = [:]
     private var exitWaiters: [String: [CheckedContinuation<Void, Never>]] = [:]
+    private var exitObservers: [UUID: AsyncStream<String>.Continuation] = [:]
 
     public init(
         executorID: String = "openisland.local-process",
@@ -366,6 +367,16 @@ public actor SupervisedLocalProcessExecutor: GraphExecutorAdapter {
         }
     }
 
+    public func exitEvents() -> AsyncStream<String> {
+        let id = UUID()
+        return AsyncStream { continuation in
+            exitObservers[id] = continuation
+            continuation.onTermination = { [weak self] _ in
+                Task { await self?.removeExitObserver(id) }
+            }
+        }
+    }
+
     public func launchRecord(
         id: String
     ) async throws -> GraphLocalProcessLaunchRecord? {
@@ -599,6 +610,11 @@ public actor SupervisedLocalProcessExecutor: GraphExecutorAdapter {
         }
         let waiters = exitWaiters.removeValue(forKey: launchID) ?? []
         waiters.forEach { $0.resume() }
+        exitObservers.values.forEach { $0.yield(launchID) }
+    }
+
+    private func removeExitObserver(_ id: UUID) {
+        exitObservers.removeValue(forKey: id)
     }
 
     private func resolvedRecord(

--- a/Sources/OpenIslandCore/SupervisedLocalProcessExecutor.swift
+++ b/Sources/OpenIslandCore/SupervisedLocalProcessExecutor.swift
@@ -1,0 +1,1023 @@
+import CryptoKit
+import Darwin
+import Foundation
+
+public enum GraphLocalProcessCrashPoint: String, Codable, Sendable {
+    case beforeSpawn = "before_spawn"
+    case afterSpawnAcceptance = "after_spawn_acceptance"
+}
+
+public actor SupervisedLocalProcessExecutor: GraphExecutorAdapter {
+    public nonisolated let capabilities: GraphExecutorCapabilities
+
+    private let launchStore: GraphLocalProcessLaunchStore
+    private let logStore: GraphProcessLogStore
+    private let inspector: any GraphProcessInspecting
+    private let executorInstanceID: String
+    private let crashPoint: GraphLocalProcessCrashPoint?
+    private var processes: [String: Process] = [:]
+    private var exitWaiters: [String: [CheckedContinuation<Void, Never>]] = [:]
+
+    public init(
+        executorID: String = "openisland.local-process",
+        executorInstanceID: String = UUID().uuidString,
+        hostID: String = Host.current().localizedName ?? "localhost",
+        capabilities: [String] = ["local-process", "compendium"],
+        launchStore: GraphLocalProcessLaunchStore,
+        logStore: GraphProcessLogStore = GraphProcessLogStore(),
+        inspector: any GraphProcessInspecting = DarwinGraphProcessInspector(),
+        crashPoint: GraphLocalProcessCrashPoint? = nil
+    ) {
+        self.capabilities = GraphExecutorCapabilities(
+            executorID: executorID,
+            capabilityIdentity: "supervised-local-process-v1",
+            capabilities: capabilities,
+            hostID: hostID
+        )
+        self.executorInstanceID = executorInstanceID
+        self.launchStore = launchStore
+        self.logStore = logStore
+        self.inspector = inspector
+        self.crashPoint = crashPoint
+    }
+
+    public func prepare(
+        _ request: GraphExecutorPrepareRequest
+    ) async throws -> GraphExecutorPrepareResponse {
+        do {
+            let (_, record) = try await resolvedRecord(
+                request.context,
+                createIfMissing: true
+            )
+            return GraphExecutorPrepareResponse(
+                observation: observation(
+                    operation: .prepare,
+                    status: .accepted,
+                    context: request.context,
+                    record: record
+                )
+            )
+        } catch {
+            return GraphExecutorPrepareResponse(
+                observation: rejected(
+                    operation: .prepare,
+                    context: request.context,
+                    error: error
+                )
+            )
+        }
+    }
+
+    public func start(
+        _ request: GraphExecutorStartRequest
+    ) async throws -> GraphExecutorStartResponse {
+        GraphExecutorStartResponse(
+            observation: try await launch(
+                request.context,
+                operation: .start
+            )
+        )
+    }
+
+    public func observe(
+        _ request: GraphExecutorObserveRequest
+    ) async throws -> GraphExecutorObserveResponse {
+        do {
+            let (resolved, record) = try await resolvedRecord(
+                request.context,
+                createIfMissing: false
+            )
+            let refreshed = try await refreshExitIfNeeded(record)
+            return GraphExecutorObserveResponse(
+                observation: terminalOrRunningObservation(
+                    operation: .observe,
+                    context: request.context,
+                    resolved: resolved,
+                    record: refreshed
+                )
+            )
+        } catch {
+            return GraphExecutorObserveResponse(
+                observation: rejected(
+                    operation: .observe,
+                    context: request.context,
+                    error: error
+                )
+            )
+        }
+    }
+
+    public func requestCancellation(
+        _ request: GraphExecutorCancellationRequest
+    ) async throws -> GraphExecutorCancellationResponse {
+        do {
+            let (resolved, current) = try await resolvedRecord(
+                request.context,
+                createIfMissing: false
+            )
+            var record = try await refreshExitIfNeeded(current)
+            if record.exit != nil {
+                return GraphExecutorCancellationResponse(
+                    observation: observation(
+                        operation: .requestCancellation,
+                        status: .cancelled,
+                        context: request.context,
+                        record: record
+                    )
+                )
+            }
+            if record.cancellationRequestedAt == nil {
+                record = try await launchStore.update(id: record.id) {
+                    $0.cancellationRequestedAt = request.context.logicalTime
+                }
+                let classification = inspector.classify(record.identity)
+                guard classification == .matchingRunning else {
+                    return GraphExecutorCancellationResponse(
+                        observation: recoveryFailureObservation(
+                            operation: .requestCancellation,
+                            classification: classification,
+                            context: request.context,
+                            record: record
+                        )
+                    )
+                }
+                try signal(record, signal: SIGTERM)
+            }
+            let deadline = record.cancellationRequestedAt!
+                .addingTimeInterval(
+                    TimeInterval(
+                        request.context.timeoutPolicy
+                            .cancellationAcknowledgementSeconds
+                    )
+                )
+            if request.context.logicalTime >= deadline,
+               record.cancellationEscalatedAt == nil {
+                let classification = inspector.classify(record.identity)
+                guard classification == .matchingRunning else {
+                    record = try await refreshExitIfNeeded(record)
+                    return GraphExecutorCancellationResponse(
+                        observation: terminalOrRunningObservation(
+                            operation: .requestCancellation,
+                            context: request.context,
+                            resolved: resolved,
+                            record: record,
+                            cancellationTerminal: true
+                        )
+                    )
+                }
+                try signal(record, signal: SIGKILL)
+                record = try await launchStore.update(id: record.id) {
+                    $0.cancellationEscalatedAt = request.context.logicalTime
+                }
+            }
+            record = try await refreshExitIfNeeded(record)
+            return GraphExecutorCancellationResponse(
+                observation: observation(
+                    operation: .requestCancellation,
+                    status: record.exit == nil ? .stillRunning : .cancelled,
+                    context: request.context,
+                    record: record
+                )
+            )
+        } catch {
+            return GraphExecutorCancellationResponse(
+                observation: rejected(
+                    operation: .requestCancellation,
+                    context: request.context,
+                    error: error
+                )
+            )
+        }
+    }
+
+    public func collectResult(
+        _ request: GraphExecutorCollectResultRequest
+    ) async throws -> GraphExecutorCollectResultResponse {
+        do {
+            let (resolved, current) = try await resolvedRecord(
+                request.context,
+                createIfMissing: false
+            )
+            let record = try await refreshExitIfNeeded(current)
+            guard record.exit != nil else {
+                return GraphExecutorCollectResultResponse(
+                    observation: observation(
+                        operation: .collectResult,
+                        status: .stillRunning,
+                        context: request.context,
+                        record: record
+                    )
+                )
+            }
+            let terminal = terminalStatus(record: record, resolved: resolved)
+            var artifacts = try collectLogs(record: record)
+            do {
+                artifacts.append(
+                    contentsOf: try collectDeclaredArtifacts(resolved: resolved)
+                )
+            } catch {
+                if terminal.status == .succeeded {
+                    return GraphExecutorCollectResultResponse(
+                        observation: observation(
+                            operation: .collectResult,
+                            status: .failed,
+                            context: request.context,
+                            record: record,
+                            failure: GraphExecutorFailure(
+                                category: "artifact_collection_failure",
+                                retryable: false
+                            ),
+                            artifacts: artifacts
+                        )
+                    )
+                }
+            }
+            return GraphExecutorCollectResultResponse(
+                observation: observation(
+                    operation: .collectResult,
+                    status: terminal.status,
+                    context: request.context,
+                    record: record,
+                    failure: terminal.failure,
+                    artifacts: artifacts
+                )
+            )
+        } catch {
+            return GraphExecutorCollectResultResponse(
+                observation: rejected(
+                    operation: .collectResult,
+                    context: request.context,
+                    error: error
+                )
+            )
+        }
+    }
+
+    public func cleanup(
+        _ request: GraphExecutorCleanupRequest
+    ) async throws -> GraphExecutorCleanupResponse {
+        do {
+            let (_, current) = try await resolvedRecord(
+                request.context,
+                createIfMissing: false
+            )
+            var record = try await refreshExitIfNeeded(current)
+            if record.exit == nil,
+               inspector.classify(record.identity) == .matchingRunning {
+                try signal(record, signal: SIGKILL)
+            }
+            processes.removeValue(forKey: record.id)
+            record = try await launchStore.update(id: record.id) {
+                $0.lifecycle = .cleaned
+                $0.cleanedAt = request.context.logicalTime
+            }
+            return GraphExecutorCleanupResponse(
+                observation: observation(
+                    operation: .cleanup,
+                    status: .accepted,
+                    context: request.context,
+                    record: record
+                )
+            )
+        } catch GraphLocalProcessRuntimeError.launchRecordMissing {
+            return GraphExecutorCleanupResponse(
+                observation: observation(
+                    operation: .cleanup,
+                    status: .accepted,
+                    context: request.context
+                )
+            )
+        } catch {
+            return GraphExecutorCleanupResponse(
+                observation: rejected(
+                    operation: .cleanup,
+                    context: request.context,
+                    error: error
+                )
+            )
+        }
+    }
+
+    public func recover(
+        _ request: GraphExecutorRecoverRequest
+    ) async throws -> GraphExecutorRecoverResponse {
+        do {
+            let (resolved, record) = try await resolvedRecord(
+                request.context,
+                createIfMissing: true
+            )
+            if record.lifecycle == .prepared,
+               record.identity.process.processID == nil {
+                return GraphExecutorRecoverResponse(
+                    observation: try await launch(
+                        request.context,
+                        operation: .recover
+                    )
+                )
+            }
+            let refreshed = try await refreshExitIfNeeded(record)
+            if refreshed.exit != nil {
+                return GraphExecutorRecoverResponse(
+                    observation: terminalOrRunningObservation(
+                        operation: .recover,
+                        context: request.context,
+                        resolved: resolved,
+                        record: refreshed
+                    )
+                )
+            }
+            let classification = inspector.classify(refreshed.identity)
+            if classification == .matchingRunning {
+                return GraphExecutorRecoverResponse(
+                    observation: observation(
+                        operation: .recover,
+                        status: .started,
+                        context: request.context,
+                        record: refreshed
+                    )
+                )
+            }
+            return GraphExecutorRecoverResponse(
+                observation: recoveryFailureObservation(
+                    operation: .recover,
+                    classification: classification,
+                    context: request.context,
+                    record: refreshed
+                )
+            )
+        } catch {
+            return GraphExecutorRecoverResponse(
+                observation: rejected(
+                    operation: .recover,
+                    context: request.context,
+                    error: error
+                )
+            )
+        }
+    }
+
+    public func waitForExit(launchRecordID: String) async {
+        if let record = try? await launchStore.record(id: launchRecordID),
+           record.exit != nil {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            exitWaiters[launchRecordID, default: []].append(continuation)
+        }
+    }
+
+    public func launchRecord(
+        id: String
+    ) async throws -> GraphLocalProcessLaunchRecord? {
+        try await launchStore.record(id: id)
+    }
+
+    public func logs(
+        launchRecordID: String,
+        channel: GraphProcessLogChannel? = nil,
+        afterSequence: UInt64 = 0,
+        limit: Int = 500
+    ) async throws -> GraphProcessLogPage {
+        guard let record = try await launchStore.record(id: launchRecordID) else {
+            throw GraphLocalProcessRuntimeError
+                .launchRecordMissing(launchRecordID)
+        }
+        return try logStore.read(
+            indexURL: URL(fileURLWithPath: record.logIndexPath),
+            channel: channel,
+            afterSequence: afterSequence,
+            limit: limit,
+            redactionLabels: record.redactionLabels
+        )
+    }
+
+    public func waitForLog(
+        launchRecordID: String,
+        containing text: String,
+        timeout: TimeInterval = 5
+    ) async throws -> Bool {
+        guard let record = try await launchStore.record(id: launchRecordID) else {
+            throw GraphLocalProcessRuntimeError
+                .launchRecordMissing(launchRecordID)
+        }
+        let store = logStore
+        let indexURL = URL(fileURLWithPath: record.logIndexPath)
+        return await Task.detached {
+            store.waitForText(
+                indexURL: indexURL,
+                containing: text,
+                timeout: timeout
+            )
+        }.value
+    }
+
+    private func launch(
+        _ context: GraphExecutorCommandContext,
+        operation: GraphExecutorOperation
+    ) async throws -> GraphExecutorObservation {
+        do {
+            let (resolved, existing) = try await resolvedRecord(
+                context,
+                createIfMissing: true
+            )
+            if existing.identity.process.processID != nil {
+                let refreshed = try await refreshExitIfNeeded(existing)
+                if refreshed.exit != nil {
+                    return terminalOrRunningObservation(
+                        operation: operation,
+                        context: context,
+                        resolved: resolved,
+                        record: refreshed
+                    )
+                }
+                let classification = inspector.classify(refreshed.identity)
+                return classification == .matchingRunning
+                    ? observation(
+                        operation: operation,
+                        status: .started,
+                        context: context,
+                        record: refreshed
+                    )
+                    : recoveryFailureObservation(
+                        operation: operation,
+                        classification: classification,
+                        context: context,
+                        record: refreshed
+                    )
+            }
+            if crashPoint == .beforeSpawn {
+                throw GraphExecutorAdapterError.simulatedCrash(
+                    GraphLocalProcessCrashPoint.beforeSpawn.rawValue
+                )
+            }
+            let process = Process()
+            let stdoutPipe = Pipe()
+            let stderrPipe = Pipe()
+            process.executableURL = resolved.executableURL
+            process.arguments = resolved.arguments
+            process.currentDirectoryURL = resolved.workingDirectoryURL
+            process.environment = resolved.environment
+            process.standardInput = FileHandle.nullDevice
+            process.standardOutput = stdoutPipe
+            process.standardError = stderrPipe
+            configure(
+                stdoutPipe.fileHandleForReading,
+                channel: .stdout,
+                record: existing,
+                resolved: resolved
+            )
+            configure(
+                stderrPipe.fileHandleForReading,
+                channel: .stderr,
+                record: existing,
+                resolved: resolved
+            )
+            process.terminationHandler = { [weak self] terminated in
+                stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                stderrPipe.fileHandleForReading.readabilityHandler = nil
+                let reason = terminated.terminationReason == .exit
+                    ? "exit" : "uncaught_signal"
+                Task {
+                    await self?.didTerminate(
+                        launchID: existing.id,
+                        status: terminated.terminationStatus,
+                        reason: reason
+                    )
+                }
+            }
+            try process.run()
+            let pid = process.processIdentifier
+            let processGroupID: Int32? = setpgid(pid, pid) == 0 ? pid : nil
+            let snapshot = DarwinGraphProcessInspector.snapshot(pid: pid)
+            let acceptedAt = Date(
+                timeIntervalSince1970: floor(Date().timeIntervalSince1970)
+            )
+            let processIdentity = ProcessIdentity(
+                hostID: capabilities.hostID ?? "localhost",
+                launchID: existing.id,
+                processID: pid,
+                startedAt: acceptedAt
+            )
+            var durableIdentity = existing.identity
+            durableIdentity = GraphDurableProcessIdentity(
+                process: processIdentity,
+                birthIdentity: snapshot?.birthIdentity,
+                executablePath: snapshot?.executablePath
+                    ?? resolved.executableURL.path,
+                executableIdentity: existing.identity.executableIdentity,
+                invocationDigest: existing.identity.invocationDigest,
+                workspaceIdentity: existing.identity.workspaceIdentity,
+                runID: existing.identity.runID,
+                nodeID: existing.identity.nodeID,
+                attemptID: existing.identity.attemptID,
+                attemptOrdinal: existing.identity.attemptOrdinal,
+                claimID: existing.identity.claimID,
+                leaseGeneration: context.identity.leaseGeneration,
+                executorID: existing.identity.executorID,
+                executorInstanceID: executorInstanceID,
+                processGroupID: processGroupID,
+                launchRecordID: existing.id
+            )
+            let record = try await launchStore.update(id: existing.id) {
+                $0.lifecycle = .running
+                $0.identity = durableIdentity
+                $0.acceptedAt = acceptedAt
+            }
+            processes[existing.id] = process
+            if !process.isRunning {
+                await didTerminate(
+                    launchID: existing.id,
+                    status: process.terminationStatus,
+                    reason: process.terminationReason == .exit
+                        ? "exit" : "uncaught_signal"
+                )
+            }
+            if crashPoint == .afterSpawnAcceptance {
+                throw GraphExecutorAdapterError.simulatedCrash(
+                    GraphLocalProcessCrashPoint.afterSpawnAcceptance.rawValue
+                )
+            }
+            return observation(
+                operation: operation,
+                status: .started,
+                context: context,
+                record: record
+            )
+        } catch let error as GraphExecutorAdapterError {
+            throw error
+        } catch {
+            return rejected(operation: operation, context: context, error: error)
+        }
+    }
+
+    private func configure(
+        _ handle: FileHandle,
+        channel: GraphProcessLogChannel,
+        record: GraphLocalProcessLaunchRecord,
+        resolved: GraphResolvedLocalProcessSpecification
+    ) {
+        let indexURL = URL(fileURLWithPath: record.logIndexPath)
+        let streamPath = channel == .stdout
+            ? record.stdoutLogPath : record.stderrLogPath
+        let streamURL = URL(fileURLWithPath: streamPath)
+        let maximumBytes = resolved.specification.logPolicy.maximumBytesPerStream
+        let redactions = resolved.redactionValues
+        let launchID = record.id
+        let store = logStore
+        handle.readabilityHandler = { readable in
+            let data = readable.availableData
+            guard !data.isEmpty else {
+                readable.readabilityHandler = nil
+                return
+            }
+            try? store.append(
+                launchID: launchID,
+                channel: channel,
+                data: data,
+                indexURL: indexURL,
+                streamURL: streamURL,
+                maximumBytes: maximumBytes,
+                redactionValues: redactions
+            )
+        }
+    }
+
+    private func didTerminate(
+        launchID: String,
+        status: Int32,
+        reason: String
+    ) async {
+        _ = try? await launchStore.update(id: launchID) { record in
+            if record.exit == nil {
+                record.lifecycle = .exited
+                record.exit = GraphLocalProcessExitRecord(
+                    terminationStatus: status,
+                    terminationReason: reason,
+                    observedAt: Date()
+                )
+            }
+        }
+        let waiters = exitWaiters.removeValue(forKey: launchID) ?? []
+        waiters.forEach { $0.resume() }
+    }
+
+    private func resolvedRecord(
+        _ context: GraphExecutorCommandContext,
+        createIfMissing: Bool
+    ) async throws -> (
+        GraphResolvedLocalProcessSpecification,
+        GraphLocalProcessLaunchRecord
+    ) {
+        let specification = try GraphLocalProcessSpecification(
+            immutableSpecification: context.specification
+        )
+        let resolved = try GraphLocalProcessSpecificationResolver.resolve(
+            specification,
+            context: context
+        )
+        let launchID = Self.launchID(context.identity)
+        let invocationDigest = try Self.invocationDigest(
+            context: context,
+            resolved: resolved
+        )
+        if var record = try await launchStore.record(id: launchID) {
+            try validate(
+                record,
+                context: context,
+                invocationDigest: invocationDigest
+            )
+            if context.identity.leaseGeneration > record.identity.leaseGeneration {
+                record = try await launchStore.update(id: launchID) {
+                    $0.identity.leaseGeneration = context.identity.leaseGeneration
+                }
+            }
+            return (resolved, record)
+        }
+        guard createIfMissing else {
+            throw GraphLocalProcessRuntimeError.launchRecordMissing(launchID)
+        }
+        let logDirectory = try await launchStore.logDirectory(id: launchID)
+        let executableIdentity = try Self.executableIdentity(
+            resolved.executableURL
+        )
+        let identity = GraphDurableProcessIdentity(
+            process: ProcessIdentity(
+                hostID: capabilities.hostID ?? "localhost",
+                launchID: launchID
+            ),
+            birthIdentity: nil,
+            executablePath: resolved.executableURL.path,
+            executableIdentity: executableIdentity,
+            invocationDigest: invocationDigest,
+            workspaceIdentity: Self.digest(resolved.workspaceURL.path),
+            runID: context.identity.runID,
+            nodeID: context.identity.nodeID,
+            attemptID: context.identity.attemptID,
+            attemptOrdinal: context.identity.attemptOrdinal,
+            claimID: context.identity.claimID,
+            leaseGeneration: context.identity.leaseGeneration,
+            executorID: context.identity.executorID,
+            executorInstanceID: executorInstanceID,
+            processGroupID: nil,
+            launchRecordID: launchID
+        )
+        let record = GraphLocalProcessLaunchRecord(
+            id: launchID,
+            lifecycle: .prepared,
+            identity: identity,
+            preparedAt: context.logicalTime,
+            stdoutLogPath: logDirectory
+                .appendingPathComponent("stdout.log").path,
+            stderrLogPath: logDirectory
+                .appendingPathComponent("stderr.log").path,
+            logIndexPath: logDirectory
+                .appendingPathComponent("entries.jsonl").path,
+            redactionLabels: specification.logPolicy.sensitiveEnvironmentKeys
+        )
+        try await launchStore.save(record)
+        return (resolved, record)
+    }
+
+    private func validate(
+        _ record: GraphLocalProcessLaunchRecord,
+        context: GraphExecutorCommandContext,
+        invocationDigest: String
+    ) throws {
+        let identity = record.identity
+        guard identity.runID == context.identity.runID,
+              identity.nodeID == context.identity.nodeID,
+              identity.attemptID == context.identity.attemptID,
+              identity.attemptOrdinal == context.identity.attemptOrdinal,
+              identity.claimID == context.identity.claimID,
+              identity.executorID == context.identity.executorID,
+              identity.invocationDigest == invocationDigest else {
+            throw GraphLocalProcessRuntimeError.launchRecordConflict(record.id)
+        }
+        guard context.identity.leaseGeneration >= identity.leaseGeneration else {
+            throw GraphLocalProcessRuntimeError.staleLeaseGeneration(
+                expectedAtLeast: identity.leaseGeneration,
+                actual: context.identity.leaseGeneration
+            )
+        }
+    }
+
+    private func refreshExitIfNeeded(
+        _ record: GraphLocalProcessLaunchRecord
+    ) async throws -> GraphLocalProcessLaunchRecord {
+        if record.exit != nil { return record }
+        if let process = processes[record.id], !process.isRunning {
+            await didTerminate(
+                launchID: record.id,
+                status: process.terminationStatus,
+                reason: process.terminationReason == .exit
+                    ? "exit" : "uncaught_signal"
+            )
+            return try await launchStore.record(id: record.id) ?? record
+        }
+        if processes[record.id] == nil,
+           inspector.classify(record.identity) == .matchingExited {
+            return try await launchStore.update(id: record.id) {
+                $0.lifecycle = .exited
+                $0.exit = GraphLocalProcessExitRecord(
+                    terminationStatus: -1,
+                    terminationReason: "exit_not_observed_after_restart",
+                    observedAt: Date()
+                )
+            }
+        }
+        return record
+    }
+
+    private func signal(
+        _ record: GraphLocalProcessLaunchRecord,
+        signal: Int32
+    ) throws {
+        guard inspector.classify(record.identity) == .matchingRunning,
+              let pid = record.identity.process.processID else {
+            throw GraphLocalProcessRuntimeError.identityMismatch(record.id)
+        }
+        let result: Int32
+        if let group = record.identity.processGroupID, group == pid {
+            result = Darwin.kill(-group, signal)
+        } else {
+            result = Darwin.kill(pid, signal)
+        }
+        guard result == 0 || errno == ESRCH else {
+            throw GraphLocalProcessRuntimeError.identityMismatch(record.id)
+        }
+    }
+
+    private func terminalOrRunningObservation(
+        operation: GraphExecutorOperation,
+        context: GraphExecutorCommandContext,
+        resolved: GraphResolvedLocalProcessSpecification,
+        record: GraphLocalProcessLaunchRecord,
+        cancellationTerminal: Bool = false
+    ) -> GraphExecutorObservation {
+        guard record.exit != nil else {
+            let classification = inspector.classify(record.identity)
+            return classification == .matchingRunning
+                ? observation(
+                    operation: operation,
+                    status: .stillRunning,
+                    context: context,
+                    record: record
+                )
+                : recoveryFailureObservation(
+                    operation: operation,
+                    classification: classification,
+                    context: context,
+                    record: record
+                )
+        }
+        if cancellationTerminal || record.cancellationRequestedAt != nil {
+            return observation(
+                operation: operation,
+                status: .cancelled,
+                context: context,
+                record: record
+            )
+        }
+        let terminal = terminalStatus(record: record, resolved: resolved)
+        return observation(
+            operation: operation,
+            status: terminal.status,
+            context: context,
+            record: record,
+            failure: terminal.failure
+        )
+    }
+
+    private func terminalStatus(
+        record: GraphLocalProcessLaunchRecord,
+        resolved: GraphResolvedLocalProcessSpecification
+    ) -> (status: GraphExecutorResponseStatus, failure: GraphExecutorFailure?) {
+        guard let exit = record.exit else { return (.stillRunning, nil) }
+        if record.cancellationRequestedAt != nil { return (.cancelled, nil) }
+        if exit.terminationStatus == 0, exit.terminationReason == "exit" {
+            return (.succeeded, nil)
+        }
+        if exit.terminationStatus == -1 {
+            return (
+                .interrupted,
+                GraphExecutorFailure(
+                    category: "process_exit_unobserved",
+                    retryable: true
+                )
+            )
+        }
+        let retryable = resolved.specification.retryableExitCodes
+            .contains(exit.terminationStatus)
+        let category = exit.terminationReason == "uncaught_signal"
+            ? "process_signal_\(exit.terminationStatus)"
+            : "process_exit_\(exit.terminationStatus)"
+        return (
+            .failed,
+            GraphExecutorFailure(category: category, retryable: retryable)
+        )
+    }
+
+    private func recoveryFailureObservation(
+        operation: GraphExecutorOperation,
+        classification: GraphProcessRecoveryClassification,
+        context: GraphExecutorCommandContext,
+        record: GraphLocalProcessLaunchRecord
+    ) -> GraphExecutorObservation {
+        let status: GraphExecutorResponseStatus = classification == .identityMismatch
+            ? .identityMismatch : .interrupted
+        return observation(
+            operation: operation,
+            status: status,
+            context: context,
+            record: record,
+            failure: GraphExecutorFailure(
+                category: "process_\(classification.rawValue)",
+                retryable: classification != .identityMismatch
+            )
+        )
+    }
+
+    private func collectDeclaredArtifacts(
+        resolved: GraphResolvedLocalProcessSpecification
+    ) throws -> [GraphExecutorProducedArtifact] {
+        try resolved.specification.outputArtifacts.compactMap { declaration in
+            guard let url = resolved.artifactURLs[declaration.role],
+                  FileManager.default.fileExists(atPath: url.path) else {
+                throw GraphLocalProcessRuntimeError
+                    .artifactMissing(declaration.relativePath)
+            }
+            let attributes = try FileManager.default.attributesOfItem(
+                atPath: url.path
+            )
+            let size = (attributes[.size] as? NSNumber)?.intValue ?? 0
+            guard size <= declaration.maximumBytes else {
+                throw GraphLocalProcessRuntimeError.artifactTooLarge(
+                    declaration.relativePath,
+                    declaration.maximumBytes
+                )
+            }
+            return try producedArtifact(
+                url: url,
+                mediaType: declaration.mediaType,
+                role: declaration.role,
+                sensitivity: declaration.sensitivity
+            )
+        }
+    }
+
+    private func collectLogs(
+        record: GraphLocalProcessLaunchRecord
+    ) throws -> [GraphExecutorProducedArtifact] {
+        try [record.stdoutLogPath, record.stderrLogPath].compactMap { path in
+            let url = URL(fileURLWithPath: path)
+            guard FileManager.default.fileExists(atPath: path) else {
+                return nil
+            }
+            return try producedArtifact(
+                url: url,
+                mediaType: "text/plain; charset=utf-8",
+                role: .executionLog,
+                sensitivity: record.redactionLabels.isEmpty
+                    ? .internalUse : .redacted
+            )
+        }
+    }
+
+    private func producedArtifact(
+        url: URL,
+        mediaType: String,
+        role: GraphArtifactRole,
+        sensitivity: GraphArtifactSensitivity
+    ) throws -> GraphExecutorProducedArtifact {
+        let data = try Data(contentsOf: url, options: .mappedIfSafe)
+        return GraphExecutorProducedArtifact(
+            contentDigest: GraphContentDigest(
+                algorithm: "sha256",
+                value: Self.digest(data)
+            ),
+            mediaType: mediaType,
+            role: role,
+            storage: GraphArtifactStorageLocator(
+                scheme: "file",
+                opaqueReference: url.standardizedFileURL.path
+            ),
+            sensitivity: sensitivity
+        )
+    }
+
+    private func rejected(
+        operation: GraphExecutorOperation,
+        context: GraphExecutorCommandContext,
+        error: Error
+    ) -> GraphExecutorObservation {
+        let status: GraphExecutorResponseStatus
+        if case GraphLocalProcessRuntimeError.staleLeaseGeneration = error {
+            status = .staleClaim
+        } else if case GraphLocalProcessRuntimeError.identityMismatch = error {
+            status = .identityMismatch
+        } else {
+            status = .rejected
+        }
+        return observation(
+            operation: operation,
+            status: status,
+            context: context,
+            failure: GraphExecutorFailure(
+                category: error is GraphLocalProcessSpecificationError
+                    ? "invalid_process_specification"
+                    : "local_process_runtime_error",
+                retryable: false
+            )
+        )
+    }
+
+    private func observation(
+        operation: GraphExecutorOperation,
+        status: GraphExecutorResponseStatus,
+        context: GraphExecutorCommandContext,
+        record: GraphLocalProcessLaunchRecord? = nil,
+        failure: GraphExecutorFailure? = nil,
+        artifacts: [GraphExecutorProducedArtifact] = []
+    ) -> GraphExecutorObservation {
+        let material = [
+            context.identity.runID,
+            context.identity.nodeID,
+            context.identity.attemptID,
+            context.identity.claimID,
+            String(context.identity.leaseGeneration),
+            operation.rawValue,
+            String(context.priorObservationCount),
+            status.rawValue,
+            record?.exit.map { "\($0.terminationReason):\($0.terminationStatus)" }
+                ?? "active",
+        ].joined(separator: "|")
+        return GraphExecutorObservation(
+            id: "local-\(DefaultGraphMutationService.stableID(material))",
+            operation: operation,
+            identity: context.identity,
+            status: status,
+            observedAt: context.logicalTime,
+            processIdentity: record?.identity.process.processID == nil
+                ? nil : record?.identity.process,
+            failure: failure,
+            artifacts: artifacts
+        )
+    }
+
+    public nonisolated static func launchID(
+        _ identity: GraphExecutorInteractionIdentity
+    ) -> String {
+        let material = [
+            identity.runID,
+            identity.nodeID,
+            identity.attemptID,
+            String(identity.attemptOrdinal),
+            identity.claimID,
+            identity.executorID,
+        ].joined(separator: "|")
+        return "launch-\(DefaultGraphMutationService.stableID(material))"
+    }
+
+    private static func invocationDigest(
+        context: GraphExecutorCommandContext,
+        resolved: GraphResolvedLocalProcessSpecification
+    ) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        let specData = try encoder.encode(context.specification)
+        let material = [
+            specData.base64EncodedString(),
+            resolved.executableURL.path,
+            resolved.workingDirectoryURL.path,
+            resolved.arguments.joined(separator: "\u{0}"),
+            context.inputArtifacts.map {
+                "\($0.logicalRole):\($0.contentDigest.value)"
+            }.sorted().joined(separator: "|"),
+        ].joined(separator: "|")
+        return digest(material)
+    }
+
+    private static func executableIdentity(_ url: URL) throws -> String {
+        let attributes = try FileManager.default.attributesOfItem(
+            atPath: url.path
+        )
+        let material = [
+            url.standardizedFileURL.path,
+            String(describing: attributes[.systemNumber] ?? ""),
+            String(describing: attributes[.systemFileNumber] ?? ""),
+            String(describing: attributes[.size] ?? ""),
+            String(describing: attributes[.modificationDate] ?? ""),
+        ].joined(separator: "|")
+        return digest(material)
+    }
+
+    private static func digest(_ value: String) -> String {
+        digest(Data(value.utf8))
+    }
+
+    private static func digest(_ data: Data) -> String {
+        SHA256.hash(data: data)
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+}

--- a/Sources/OpenIslandCore/SupervisedLocalProcessExecutor.swift
+++ b/Sources/OpenIslandCore/SupervisedLocalProcessExecutor.swift
@@ -932,6 +932,8 @@ public actor SupervisedLocalProcessExecutor: GraphExecutorAdapter {
             status = .staleClaim
         } else if case GraphLocalProcessRuntimeError.identityMismatch = error {
             status = .identityMismatch
+        } else if error is GraphLocalProcessSpecificationError {
+            status = .failed
         } else {
             status = .rejected
         }

--- a/Sources/OpenIslandCore/SupervisedLocalProcessExecutor.swift
+++ b/Sources/OpenIslandCore/SupervisedLocalProcessExecutor.swift
@@ -859,6 +859,7 @@ public actor SupervisedLocalProcessExecutor: GraphExecutorAdapter {
         try resolved.specification.outputArtifacts.compactMap { declaration in
             guard let url = resolved.artifactURLs[declaration.role],
                   FileManager.default.fileExists(atPath: url.path) else {
+                if !declaration.required { return nil }
                 throw GraphLocalProcessRuntimeError
                     .artifactMissing(declaration.relativePath)
             }

--- a/Sources/OpenIslandCore/TerminalGraphCompatibility.swift
+++ b/Sources/OpenIslandCore/TerminalGraphCompatibility.swift
@@ -1,0 +1,970 @@
+import CryptoKit
+import Foundation
+
+public enum TerminalGraphEnvironmentValueKind:
+    String,
+    Codable,
+    Sendable
+{
+    case identifier
+    case path
+    case endpoint
+    case port
+    case unknown
+}
+
+public struct TerminalGraphEnvironmentEntry:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let name: String
+    public let kind: TerminalGraphEnvironmentValueKind
+    public let value: String?
+    public let redacted: Bool
+    public let redactionReason: GraphRedactionReason?
+
+    public init(
+        name: String,
+        kind: TerminalGraphEnvironmentValueKind,
+        value: String?,
+        redacted: Bool,
+        redactionReason: GraphRedactionReason? = nil
+    ) {
+        self.name = name
+        self.kind = kind
+        self.value = value
+        self.redacted = redacted
+        self.redactionReason = redactionReason
+    }
+}
+
+public struct TerminalGraphEnvironmentContext:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let schemaVersion: Int
+    public let detected: Bool
+    public let nodeID: String?
+    public let workspaceID: String?
+    public let projectID: String?
+    public let groupID: String?
+    public let externalContextID: String?
+    public let projectRoot: String?
+    public let worktreeRoot: String?
+    public let values: [TerminalGraphEnvironmentEntry]
+
+    public init(
+        schemaVersion: Int = 1,
+        detected: Bool,
+        nodeID: String? = nil,
+        workspaceID: String? = nil,
+        projectID: String? = nil,
+        groupID: String? = nil,
+        externalContextID: String? = nil,
+        projectRoot: String? = nil,
+        worktreeRoot: String? = nil,
+        values: [TerminalGraphEnvironmentEntry] = []
+    ) {
+        self.schemaVersion = schemaVersion
+        self.detected = detected
+        self.nodeID = nodeID
+        self.workspaceID = workspaceID
+        self.projectID = projectID
+        self.groupID = groupID
+        self.externalContextID = externalContextID
+        self.projectRoot = projectRoot
+        self.worktreeRoot = worktreeRoot
+        self.values = values.sorted { $0.name < $1.name }
+    }
+}
+
+public enum TerminalGraphEnvironmentDiscovery {
+    private static let recognized: [String: TerminalGraphEnvironmentValueKind] = [
+        "TG_NODE_ID": .identifier,
+        "TG_WORKSPACE_ID": .identifier,
+        "TG_PROJECT_ID": .identifier,
+        "TG_GROUP_ID": .identifier,
+        "TG_EXTERNAL_CONTEXT_ID": .identifier,
+        "TG_PROJECT_ROOT": .path,
+        "TG_WORKTREE_ROOT": .path,
+        "TG_MCP_URL": .endpoint,
+        "TG_PORT_IN": .port,
+        "TG_PORT_OUT": .port,
+    ]
+
+    public static func discover(
+        environment: [String: String]
+    ) -> TerminalGraphEnvironmentContext {
+        let terminalValues = environment
+            .filter { $0.key.hasPrefix("TG_") }
+            .sorted { $0.key < $1.key }
+        var entries: [TerminalGraphEnvironmentEntry] = []
+
+        for (name, rawValue) in terminalValues {
+            let kind = recognized[name] ?? .unknown
+            entries.append(
+                sanitizedEntry(
+                    name: name,
+                    rawValue: rawValue,
+                    kind: kind
+                )
+            )
+        }
+
+        let byName = Dictionary(
+            uniqueKeysWithValues: entries.map { ($0.name, $0) }
+        )
+        return TerminalGraphEnvironmentContext(
+            detected: !terminalValues.isEmpty,
+            nodeID: byName["TG_NODE_ID"]?.value,
+            workspaceID: byName["TG_WORKSPACE_ID"]?.value,
+            projectID: byName["TG_PROJECT_ID"]?.value,
+            groupID: byName["TG_GROUP_ID"]?.value,
+            externalContextID:
+                byName["TG_EXTERNAL_CONTEXT_ID"]?.value,
+            projectRoot: byName["TG_PROJECT_ROOT"]?.value,
+            worktreeRoot: byName["TG_WORKTREE_ROOT"]?.value,
+            values: entries
+        )
+    }
+
+    private static func sanitizedEntry(
+        name: String,
+        rawValue: String,
+        kind: TerminalGraphEnvironmentValueKind
+    ) -> TerminalGraphEnvironmentEntry {
+        if secretLike(name) {
+            return TerminalGraphEnvironmentEntry(
+                name: name,
+                kind: kind,
+                value: nil,
+                redacted: true,
+                redactionReason: .credentialBearingValue
+            )
+        }
+        let singleLine = rawValue
+            .replacingOccurrences(of: "\0", with: "")
+            .replacingOccurrences(of: "\r", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+        guard !singleLine.isEmpty, singleLine.count <= 512 else {
+            return TerminalGraphEnvironmentEntry(
+                name: name,
+                kind: kind,
+                value: nil,
+                redacted: true,
+                redactionReason: .sensitiveByDefault
+            )
+        }
+        if kind == .unknown,
+           singleLine.hasPrefix("/") || containsCredentials(singleLine) {
+            return TerminalGraphEnvironmentEntry(
+                name: name,
+                kind: kind,
+                value: nil,
+                redacted: true,
+                redactionReason: .sensitiveByDefault
+            )
+        }
+        let value: String
+
+        switch kind {
+        case .path:
+            value = normalizedPath(singleLine)
+        case .endpoint:
+            guard let sanitized = sanitizedEndpoint(singleLine) else {
+                return TerminalGraphEnvironmentEntry(
+                    name: name,
+                    kind: kind,
+                    value: nil,
+                    redacted: true,
+                    redactionReason: .credentialBearingValue
+                )
+            }
+            value = sanitized
+        case .identifier, .port, .unknown:
+            value = singleLine
+        }
+
+        return TerminalGraphEnvironmentEntry(
+            name: name,
+            kind: kind,
+            value: value,
+            redacted: false
+        )
+    }
+
+    private static func secretLike(_ name: String) -> Bool {
+        let upper = name.uppercased()
+        return [
+            "TOKEN",
+            "SECRET",
+            "PASSWORD",
+            "CREDENTIAL",
+            "AUTH",
+            "PRIVATE_KEY",
+            "API_KEY",
+        ].contains { upper.contains($0) }
+    }
+
+    private static func sanitizedEndpoint(
+        _ value: String
+    ) -> String? {
+        guard var components = URLComponents(string: value),
+              components.scheme != nil,
+              components.host != nil else {
+            return nil
+        }
+        components.user = nil
+        components.password = nil
+        components.query = nil
+        components.fragment = nil
+        return components.string
+    }
+
+    private static func containsCredentials(_ value: String) -> Bool {
+        guard let components = URLComponents(string: value) else {
+            return false
+        }
+        return components.user != nil || components.password != nil
+    }
+
+    private static func normalizedPath(_ value: String) -> String {
+        URL(fileURLWithPath: value)
+            .standardizedFileURL
+            .path
+    }
+}
+
+public struct GraphRepositoryPath:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let value: String?
+    public let redacted: Bool
+
+    public init(value: String?, redacted: Bool) {
+        self.value = value
+        self.redacted = redacted
+    }
+}
+
+public struct GraphRepositoryContext:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public var id: String {
+        repositoryIdentity
+    }
+
+    public let schemaVersion: Int
+    public let repositoryIdentity: String
+    public let canonicalProjectRoot: GraphRepositoryPath
+    public let worktreeRoot: GraphRepositoryPath
+    public let branch: String?
+    public let commit: String?
+    public let isDirty: Bool?
+    public let externalContextID: String?
+    public let sourceProjectAssociation: String?
+
+    public init(
+        schemaVersion: Int = 1,
+        repositoryIdentity: String,
+        canonicalProjectRoot: GraphRepositoryPath,
+        worktreeRoot: GraphRepositoryPath,
+        branch: String?,
+        commit: String?,
+        isDirty: Bool?,
+        externalContextID: String?,
+        sourceProjectAssociation: String?
+    ) {
+        self.schemaVersion = schemaVersion
+        self.repositoryIdentity = repositoryIdentity
+        self.canonicalProjectRoot = canonicalProjectRoot
+        self.worktreeRoot = worktreeRoot
+        self.branch = branch
+        self.commit = commit
+        self.isDirty = isDirty
+        self.externalContextID = externalContextID
+        self.sourceProjectAssociation = sourceProjectAssociation
+    }
+}
+
+public struct GraphWorkspaceContext:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let schemaVersion: Int
+    public let workspaceID: String?
+    public let externalContextID: String?
+    public let selectedRepositoryIdentity: String?
+    public let repositories: [GraphRepositoryContext]
+
+    public init(
+        schemaVersion: Int = 1,
+        workspaceID: String?,
+        externalContextID: String?,
+        selectedRepositoryIdentity: String?,
+        repositories: [GraphRepositoryContext]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.workspaceID = workspaceID
+        self.externalContextID = externalContextID
+        self.selectedRepositoryIdentity = selectedRepositoryIdentity
+        self.repositories = repositories.sorted {
+            $0.repositoryIdentity < $1.repositoryIdentity
+        }
+    }
+}
+
+public struct GraphCLIExecutionContext:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let schemaVersion: Int
+    public let terminalGraph: TerminalGraphEnvironmentContext
+    public let workspace: GraphWorkspaceContext?
+
+    public init(
+        schemaVersion: Int = 1,
+        terminalGraph: TerminalGraphEnvironmentContext,
+        workspace: GraphWorkspaceContext?
+    ) {
+        self.schemaVersion = schemaVersion
+        self.terminalGraph = terminalGraph
+        self.workspace = workspace
+    }
+}
+
+public protocol GraphRepositoryContextResolving: Sendable {
+    func resolve(
+        workingDirectory: String,
+        exposePaths: Bool,
+        externalContextID: String?,
+        sourceProjectAssociation: String?
+    ) -> GraphRepositoryContext?
+}
+
+public struct GitGraphRepositoryContextResolver:
+    GraphRepositoryContextResolving,
+    Sendable
+{
+    public init() {}
+
+    public func resolve(
+        workingDirectory: String,
+        exposePaths: Bool,
+        externalContextID: String?,
+        sourceProjectAssociation: String?
+    ) -> GraphRepositoryContext? {
+        guard let worktree = git(
+            ["rev-parse", "--show-toplevel"],
+            in: workingDirectory
+        ) else {
+            return nil
+        }
+        let normalizedWorktree = normalize(worktree)
+        let commonGitDirectory = git(
+            ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+            in: normalizedWorktree
+        )
+        let canonicalRoot: String
+
+        if let commonGitDirectory {
+            let normalizedCommon = normalize(commonGitDirectory)
+            canonicalRoot = URL(fileURLWithPath: normalizedCommon)
+                .lastPathComponent == ".git"
+                ? URL(fileURLWithPath: normalizedCommon)
+                    .deletingLastPathComponent().path
+                : normalizedWorktree
+        } else {
+            canonicalRoot = normalizedWorktree
+        }
+        let remote = git(
+            ["config", "--get", "remote.origin.url"],
+            in: normalizedWorktree
+        )
+        let identitySource = sanitizedRepositoryLocator(remote)
+            ?? canonicalRoot
+        let identity = stableIdentifier(identitySource)
+        let branch = git(
+            ["symbolic-ref", "--short", "-q", "HEAD"],
+            in: normalizedWorktree
+        )
+        let commit = git(
+            ["rev-parse", "HEAD"],
+            in: normalizedWorktree
+        )
+        let status = git(
+            ["status", "--porcelain", "--untracked-files=normal"],
+            in: normalizedWorktree,
+            allowEmpty: true
+        )
+
+        return GraphRepositoryContext(
+            repositoryIdentity: identity,
+            canonicalProjectRoot: GraphRepositoryPath(
+                value: exposePaths ? canonicalRoot : nil,
+                redacted: !exposePaths
+            ),
+            worktreeRoot: GraphRepositoryPath(
+                value: exposePaths ? normalizedWorktree : nil,
+                redacted: !exposePaths
+            ),
+            branch: branch,
+            commit: commit,
+            isDirty: status.map { !$0.isEmpty },
+            externalContextID: boundedIntegrationValue(
+                externalContextID
+            ),
+            sourceProjectAssociation: boundedIntegrationValue(
+                sourceProjectAssociation
+            )
+        )
+    }
+
+    private func git(
+        _ arguments: [String],
+        in directory: String,
+        allowEmpty: Bool = false
+    ) -> String? {
+        let process = Process()
+        let output = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = ["-C", directory] + arguments
+        process.standardOutput = output
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            let data = output.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else {
+                return nil
+            }
+            let value = String(
+                decoding: data,
+                as: UTF8.self
+            ).trimmingCharacters(in: .whitespacesAndNewlines)
+            return allowEmpty || !value.isEmpty ? value : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private func normalize(_ path: String) -> String {
+        URL(fileURLWithPath: path).standardizedFileURL.path
+    }
+
+    private func sanitizedRepositoryLocator(
+        _ value: String?
+    ) -> String? {
+        guard let value else {
+            return nil
+        }
+        if var components = URLComponents(string: value),
+           components.scheme != nil {
+            components.user = nil
+            components.password = nil
+            components.query = nil
+            components.fragment = nil
+            return components.string
+        }
+        if let separator = value.firstIndex(of: "@"),
+           value.contains(":") {
+            return String(value[value.index(after: separator)...])
+        }
+        return value
+    }
+}
+
+public enum GraphCLIContextDiscovery {
+    public static func discover(
+        environment: [String: String],
+        workingDirectory: String,
+        repositoryResolver: any GraphRepositoryContextResolving =
+            GitGraphRepositoryContextResolver()
+    ) -> GraphCLIExecutionContext {
+        let terminalGraph = TerminalGraphEnvironmentDiscovery.discover(
+            environment: environment
+        )
+        let repository = repositoryResolver.resolve(
+            workingDirectory:
+                terminalGraph.worktreeRoot
+                    ?? terminalGraph.projectRoot
+                    ?? workingDirectory,
+            exposePaths: terminalGraph.worktreeRoot != nil
+                || terminalGraph.projectRoot != nil,
+            externalContextID: terminalGraph.externalContextID,
+            sourceProjectAssociation: terminalGraph.projectID
+        )
+        let workspace = repository.map {
+            GraphWorkspaceContext(
+                workspaceID: terminalGraph.workspaceID,
+                externalContextID: terminalGraph.externalContextID,
+                selectedRepositoryIdentity: $0.repositoryIdentity,
+                repositories: [$0]
+            )
+        }
+        return GraphCLIExecutionContext(
+            terminalGraph: terminalGraph,
+            workspace: workspace
+        )
+    }
+}
+
+public enum GraphIntegrationPortKind: String, Codable, Sendable {
+    case stream
+    case signal
+    case state
+}
+
+public enum GraphIntegrationPortDirection:
+    String,
+    Codable,
+    Sendable
+{
+    case input
+    case output
+}
+
+public enum GraphIntegrationSemanticType:
+    String,
+    Codable,
+    CaseIterable,
+    Sendable
+{
+    case eventHistory = "stream.event_history"
+    case logRecords = "stream.log_records"
+    case jsonlRecords = "stream.jsonl_records"
+    case refreshSignal = "signal.refresh"
+    case selectSignal = "signal.select"
+    case openSignal = "signal.open"
+    case focusSignal = "signal.focus"
+    case completionSignal = "signal.completion"
+    case currentRunSummary = "state.current_run_summary"
+    case selectedRun = "state.selected_run"
+    case selectedCheckpoint = "state.selected_checkpoint"
+    case workspaceContext = "state.workspace_context"
+}
+
+public struct GraphIntegrationPort:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let id: String
+    public let kind: GraphIntegrationPortKind
+    public let direction: GraphIntegrationPortDirection
+    public let semanticType: GraphIntegrationSemanticType
+    public let label: String
+
+    public init(
+        id: String,
+        kind: GraphIntegrationPortKind,
+        direction: GraphIntegrationPortDirection,
+        semanticType: GraphIntegrationSemanticType,
+        label: String
+    ) {
+        self.id = id
+        self.kind = kind
+        self.direction = direction
+        self.semanticType = semanticType
+        self.label = label
+    }
+}
+
+public struct GraphWorkspaceLayoutHint:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let column: Int
+    public let row: Int
+
+    public init(column: Int, row: Int) {
+        self.column = column
+        self.row = row
+    }
+}
+
+public struct GraphWorkspaceSuggestedTerminal:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public let id: String
+    public let externalMappingKey: String
+    public let label: String
+    public let command: [String]
+    public let startupCommand: [String]?
+    public let repositoryIdentity: String?
+    public let worktreeRoot: GraphRepositoryPath?
+    public let logicalGroup: String
+    public let graphRunID: String
+    public let graphNodeID: String?
+    public let ports: [GraphIntegrationPort]
+    public let layout: GraphWorkspaceLayoutHint
+    public let sensitivity: GraphArtifactSensitivity
+}
+
+public enum GraphWorkspaceConnectionIntent:
+    String,
+    Codable,
+    Sendable
+{
+    case dependency
+    case provenance
+    case selection
+    case completion
+}
+
+public struct GraphWorkspaceSuggestedConnection:
+    Equatable,
+    Codable,
+    Sendable,
+    Identifiable
+{
+    public let id: String
+    public let fromMappingKey: String
+    public let toMappingKey: String
+    public let intent: GraphWorkspaceConnectionIntent
+    public let outputSemanticType: GraphIntegrationSemanticType
+    public let inputSemanticType: GraphIntegrationSemanticType
+    public let label: String
+}
+
+public struct GraphTerminalWorkspacePlan:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let schemaVersion: Int
+    public let planID: String
+    public let graphRunID: String
+    public let graphDefinitionVersion: String?
+    public let graphDefinitionDigest: String?
+    public let authority: String
+    public let workspaceContext: GraphWorkspaceContext?
+    public let terminals: [GraphWorkspaceSuggestedTerminal]
+    public let connections: [GraphWorkspaceSuggestedConnection]
+
+    public init(
+        schemaVersion: Int = 1,
+        planID: String,
+        graphRunID: String,
+        graphDefinitionVersion: String?,
+        graphDefinitionDigest: String?,
+        authority: String = "openisland",
+        workspaceContext: GraphWorkspaceContext?,
+        terminals: [GraphWorkspaceSuggestedTerminal],
+        connections: [GraphWorkspaceSuggestedConnection]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.planID = planID
+        self.graphRunID = graphRunID
+        self.graphDefinitionVersion = graphDefinitionVersion
+        self.graphDefinitionDigest = graphDefinitionDigest
+        self.authority = authority
+        self.workspaceContext = workspaceContext
+        self.terminals = terminals.sorted { $0.id < $1.id }
+        self.connections = connections.sorted { $0.id < $1.id }
+    }
+}
+
+public enum GraphTerminalWorkspacePlanBuilder {
+    public static func build(
+        inspection: GraphRunInspection,
+        workspaceContext: GraphWorkspaceContext?
+    ) -> GraphTerminalWorkspacePlan {
+        let repository = workspaceContext?.repositories.first {
+            $0.repositoryIdentity
+                == workspaceContext?.selectedRepositoryIdentity
+        }
+        let nodes = inspection.nodes.sorted { $0.id < $1.id }
+        let levels = dependencyLevels(nodes)
+        let grouped = Dictionary(grouping: nodes) {
+            levels[$0.id] ?? 0
+        }
+        var rowByNode: [String: Int] = [:]
+
+        for level in grouped.keys.sorted() {
+            for (row, node) in (grouped[level] ?? [])
+                .sorted(by: { $0.id < $1.id }).enumerated() {
+                rowByNode[node.id] = row
+            }
+        }
+        let terminals = nodes.map { node in
+            let mappingKey = externalMappingKey(
+                runID: inspection.summary.runID,
+                entityKind: "node",
+                entityID: node.id
+            )
+            return GraphWorkspaceSuggestedTerminal(
+                id: "terminal-\(mappingKey)",
+                externalMappingKey: mappingKey,
+                label: node.title,
+                command: [
+                    "openisland",
+                    "graph",
+                    "inspect",
+                    inspection.summary.runID,
+                    "--node",
+                    node.id,
+                    "--output",
+                    "json",
+                ],
+                startupCommand: nil,
+                repositoryIdentity: repository?.repositoryIdentity,
+                worktreeRoot: repository?.worktreeRoot,
+                logicalGroup: inspection.summary.graphID,
+                graphRunID: inspection.summary.runID,
+                graphNodeID: node.id,
+                ports: defaultPorts(nodeID: node.id),
+                layout: GraphWorkspaceLayoutHint(
+                    column: levels[node.id] ?? 0,
+                    row: rowByNode[node.id] ?? 0
+                ),
+                sensitivity: sensitivity(
+                    for: node.id,
+                    artifacts: inspection.artifacts
+                )
+            )
+        }
+        let byNode = Dictionary(
+            uniqueKeysWithValues: terminals.compactMap {
+                terminal in terminal.graphNodeID.map {
+                    ($0, terminal.externalMappingKey)
+                }
+            }
+        )
+        var connections: [GraphWorkspaceSuggestedConnection] = []
+
+        for node in nodes {
+            guard let target = byNode[node.id] else {
+                continue
+            }
+            for dependency in node.dependencyNodeIDs.sorted() {
+                guard let source = byNode[dependency] else {
+                    continue
+                }
+                let key = stableIdentifier(
+                    "\(inspection.summary.runID)|dependency|\(dependency)|\(node.id)"
+                )
+                connections.append(
+                    GraphWorkspaceSuggestedConnection(
+                        id: "connection-\(key)",
+                        fromMappingKey: source,
+                        toMappingKey: target,
+                        intent: .dependency,
+                        outputSemanticType: .currentRunSummary,
+                        inputSemanticType: .selectedRun,
+                        label: "dependency"
+                    )
+                )
+            }
+        }
+
+        return GraphTerminalWorkspacePlan(
+            planID: "workspace-plan-\(stableIdentifier(inspection.summary.runID))",
+            graphRunID: inspection.summary.runID,
+            graphDefinitionVersion:
+                inspection.graphDefinitionVersion,
+            graphDefinitionDigest:
+                inspection.graphDefinitionDigest?.value,
+            workspaceContext: workspaceContext,
+            terminals: terminals,
+            connections: connections
+        )
+    }
+
+    private static func defaultPorts(
+        nodeID: String
+    ) -> [GraphIntegrationPort] {
+        [
+            GraphIntegrationPort(
+                id: "\(nodeID)-refresh",
+                kind: .signal,
+                direction: .input,
+                semanticType: .refreshSignal,
+                label: "Refresh"
+            ),
+            GraphIntegrationPort(
+                id: "\(nodeID)-selection",
+                kind: .state,
+                direction: .input,
+                semanticType: .selectedRun,
+                label: "Selected run"
+            ),
+            GraphIntegrationPort(
+                id: "\(nodeID)-history",
+                kind: .stream,
+                direction: .output,
+                semanticType: .eventHistory,
+                label: "Event history"
+            ),
+            GraphIntegrationPort(
+                id: "\(nodeID)-summary",
+                kind: .state,
+                direction: .output,
+                semanticType: .currentRunSummary,
+                label: "Run summary"
+            ),
+            GraphIntegrationPort(
+                id: "\(nodeID)-completion",
+                kind: .signal,
+                direction: .output,
+                semanticType: .completionSignal,
+                label: "Completion"
+            ),
+        ]
+    }
+
+    private static func dependencyLevels(
+        _ nodes: [GraphNodeInspection]
+    ) -> [String: Int] {
+        var levels = Dictionary(
+            uniqueKeysWithValues: nodes.map { ($0.id, 0) }
+        )
+
+        for _ in 0..<nodes.count {
+            var changed = false
+            for node in nodes {
+                let proposed = (node.dependencyNodeIDs.compactMap {
+                    levels[$0]
+                }.max() ?? -1) + 1
+                if proposed > (levels[node.id] ?? 0) {
+                    levels[node.id] = proposed
+                    changed = true
+                }
+            }
+            if !changed {
+                break
+            }
+        }
+        return levels
+    }
+
+    private static func sensitivity(
+        for nodeID: String,
+        artifacts: [GraphArtifactInspection]
+    ) -> GraphArtifactSensitivity {
+        let ranking: [GraphArtifactSensitivity: Int] = [
+            .unspecified: 0,
+            .internalUse: 1,
+            .confidential: 2,
+            .restricted: 3,
+            .redacted: 4,
+        ]
+        return artifacts
+            .filter { $0.producingNodeID == nodeID }
+            .map(\.sensitivity)
+            .max {
+                (ranking[$0] ?? 0) < (ranking[$1] ?? 0)
+            } ?? .unspecified
+    }
+}
+
+public struct GraphExternalEntityMapping:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let openIslandMappingKey: String
+    public let externalEntityID: String
+
+    public init(
+        openIslandMappingKey: String,
+        externalEntityID: String
+    ) {
+        self.openIslandMappingKey = openIslandMappingKey
+        self.externalEntityID = externalEntityID
+    }
+}
+
+public struct GraphVisualizationSynchronizationRequest:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let schemaVersion: Int
+    public let plan: GraphTerminalWorkspacePlan
+    public let existingMappings: [GraphExternalEntityMapping]
+
+    public init(
+        schemaVersion: Int = 1,
+        plan: GraphTerminalWorkspacePlan,
+        existingMappings: [GraphExternalEntityMapping]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.plan = plan
+        self.existingMappings = existingMappings.sorted {
+            $0.openIslandMappingKey < $1.openIslandMappingKey
+        }
+    }
+}
+
+public struct GraphVisualizationSynchronizationResult:
+    Equatable,
+    Codable,
+    Sendable
+{
+    public let schemaVersion: Int
+    public let mappings: [GraphExternalEntityMapping]
+    public let diagnostics: [String]
+
+    public init(
+        schemaVersion: Int = 1,
+        mappings: [GraphExternalEntityMapping],
+        diagnostics: [String]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.mappings = mappings.sorted {
+            $0.openIslandMappingKey < $1.openIslandMappingKey
+        }
+        self.diagnostics = diagnostics.sorted()
+    }
+}
+
+public protocol GraphVisualizationSynchronizationAdapter: Sendable {
+    func synchronize(
+        _ request: GraphVisualizationSynchronizationRequest
+    ) async throws -> GraphVisualizationSynchronizationResult
+}
+
+private func stableIdentifier(_ value: String) -> String {
+    let digest = SHA256.hash(data: Data(value.utf8))
+    return digest.prefix(10).map { String(format: "%02x", $0) }
+        .joined()
+}
+
+private func externalMappingKey(
+    runID: String,
+    entityKind: String,
+    entityID: String
+) -> String {
+    "openisland-\(stableIdentifier("\(runID)|\(entityKind)|\(entityID)"))"
+}
+
+private func boundedIntegrationValue(
+    _ value: String?,
+    limit: Int = 256
+) -> String? {
+    guard let value else {
+        return nil
+    }
+    let singleLine = value
+        .replacingOccurrences(of: "\r", with: " ")
+        .replacingOccurrences(of: "\n", with: " ")
+    guard singleLine.count <= limit else {
+        return nil
+    }
+    return singleLine
+}

--- a/Sources/OpenIslandProcessFixtureAgent/OpenIslandProcessFixtureAgent.swift
+++ b/Sources/OpenIslandProcessFixtureAgent/OpenIslandProcessFixtureAgent.swift
@@ -1,0 +1,189 @@
+import Darwin
+import Foundation
+
+private struct Configuration {
+    var role = "architect"
+    var outputPath: String?
+    var inputPaths: [String] = []
+    var emitStderr = false
+    var failureCode: Int32?
+    var waitForCancellation = false
+    var ignoreTermination = false
+    var largeOutputBytes = 0
+    var invalidUTF8 = false
+    var failOnceDirectory: String?
+
+    init(arguments: [String]) {
+        var index = 0
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+            case "--role" where index + 1 < arguments.count:
+                role = arguments[index + 1]
+                index += 2
+            case "--output" where index + 1 < arguments.count:
+                outputPath = arguments[index + 1]
+                index += 2
+            case "--input" where index + 1 < arguments.count:
+                inputPaths.append(arguments[index + 1])
+                index += 2
+            case "--stderr":
+                emitStderr = true
+                index += 1
+            case "--failure-code" where index + 1 < arguments.count:
+                failureCode = Int32(arguments[index + 1])
+                index += 2
+            case "--wait-for-cancellation":
+                waitForCancellation = true
+                index += 1
+            case "--ignore-term":
+                ignoreTermination = true
+                index += 1
+            case "--large-output" where index + 1 < arguments.count:
+                largeOutputBytes = Int(arguments[index + 1]) ?? 0
+                index += 2
+            case "--invalid-utf8":
+                invalidUTF8 = true
+                index += 1
+            case "--fail-once-directory" where index + 1 < arguments.count:
+                failOnceDirectory = arguments[index + 1]
+                index += 2
+            default:
+                index += 1
+            }
+        }
+    }
+}
+
+@main
+private enum OpenIslandProcessFixtureAgent {
+    static func main() throws {
+        let configuration = Configuration(
+            arguments: Array(CommandLine.arguments.dropFirst())
+        )
+        if configuration.waitForCancellation {
+            if configuration.ignoreTermination {
+                signal(SIGTERM, SIG_IGN)
+            }
+            print("fixture role=\(configuration.role) waiting for cancellation")
+            fflush(stdout)
+            while true { pause() }
+        }
+        let inputs = try configuration.inputPaths.map { path -> Any in
+            let data = try Data(contentsOf: URL(fileURLWithPath: path))
+            return try JSONSerialization.jsonObject(with: data)
+        }
+        if configuration.emitStderr {
+            FileHandle.standardError.write(
+                Data("fixture diagnostic role=\(configuration.role)\n".utf8)
+            )
+        }
+        if let directory = configuration.failOnceDirectory {
+            let marker = URL(fileURLWithPath: directory, isDirectory: true)
+                .appendingPathComponent(
+                    ".openisland-fixture-\(configuration.role)-failed-once"
+                )
+            if !FileManager.default.fileExists(atPath: marker.path) {
+                try Data("failed-once\n".utf8).write(
+                    to: marker,
+                    options: .atomic
+                )
+                FileHandle.standardError.write(
+                    Data("scripted fail-once role=\(configuration.role)\n".utf8)
+                )
+                Darwin.exit(configuration.failureCode ?? 23)
+            }
+        }
+        if configuration.invalidUTF8 {
+            FileHandle.standardOutput.write(Data([0x66, 0x80, 0x6f, 0x0a]))
+        }
+        if configuration.largeOutputBytes > 0 {
+            let chunk = Data(repeating: UInt8(ascii: "x"), count: 4_096)
+            var remaining = configuration.largeOutputBytes
+            while remaining > 0 {
+                let count = min(remaining, chunk.count)
+                FileHandle.standardOutput.write(chunk.prefix(count))
+                remaining -= count
+            }
+            FileHandle.standardOutput.write(Data("\n".utf8))
+        } else {
+            print(
+                "fixture role=\(configuration.role) inputs=\(inputs.count)"
+            )
+        }
+        if let code = configuration.failureCode,
+           configuration.failOnceDirectory == nil {
+            FileHandle.standardError.write(
+                Data("scripted failure code=\(code)\n".utf8)
+            )
+            Darwin.exit(code)
+        }
+        guard let outputPath = configuration.outputPath else {
+            Darwin.exit(0)
+        }
+        let result = deterministicResult(
+            role: configuration.role,
+            inputs: inputs
+        )
+        let outputURL = URL(fileURLWithPath: outputPath)
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let data = try JSONSerialization.data(
+            withJSONObject: result,
+            options: [.sortedKeys, .withoutEscapingSlashes]
+        )
+        try data.write(to: outputURL, options: .atomic)
+    }
+
+    private static func deterministicResult(
+        role: String,
+        inputs: [Any]
+    ) -> [String: Any] {
+        switch role {
+        case "architect":
+            return [
+                "agent": role,
+                "sections": [
+                    "scope",
+                    "source-hierarchy",
+                    "dose-calculation-requirements",
+                    "quality-controls",
+                ],
+                "status": "complete",
+            ]
+        case "researcher":
+            return [
+                "agent": role,
+                "inputCount": inputs.count,
+                "findings": [
+                    ["id": "finding-1", "section": "scope"],
+                    ["id": "finding-2", "section": "quality-controls"],
+                ],
+                "status": "complete",
+            ]
+        case "graph":
+            return [
+                "agent": role,
+                "inputCount": inputs.count,
+                "nodes": ["finding-1", "finding-2"],
+                "edges": [["from": "finding-1", "to": "finding-2"]],
+                "status": "complete",
+            ]
+        case "reviewer":
+            return [
+                "agent": role,
+                "inputCount": inputs.count,
+                "verdict": "pass",
+                "status": "complete",
+            ]
+        default:
+            return [
+                "agent": role,
+                "inputCount": inputs.count,
+                "status": "complete",
+            ]
+        }
+    }
+}

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -174,8 +174,8 @@ struct AppModelSessionListTests {
             tool: .codex,
             origin: .live,
             attachmentState: .attached,
-            phase: .completed,
-            summary: "First Codex.app thread",
+            phase: .running,
+            summary: "First active Codex.app thread",
             updatedAt: now,
             jumpTarget: JumpTarget(
                 terminalApp: "Codex.app",
@@ -194,8 +194,8 @@ struct AppModelSessionListTests {
             tool: .codex,
             origin: .live,
             attachmentState: .attached,
-            phase: .completed,
-            summary: "Second Codex.app thread",
+            phase: .running,
+            summary: "Second active Codex.app thread",
             updatedAt: now.addingTimeInterval(-30),
             jumpTarget: JumpTarget(
                 terminalApp: "Codex.app",

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -759,6 +759,7 @@ struct AppModelSessionListTests {
     @Test
     func completionNotificationDefersTimedCollapseWhilePointerIsInside() {
         let model = AppModel()
+        model.pointerLocationAccessor = { NSPoint(x: -10_000, y: -10_000) }
         model.applyTrackedEvent(
             .sessionStarted(SessionStarted(
                 sessionID: "session-1",
@@ -797,6 +798,7 @@ struct AppModelSessionListTests {
     @Test
     func completionNotificationHoverCancelsPendingTimedCollapse() {
         let model = AppModel()
+        model.pointerLocationAccessor = { NSPoint(x: -10_000, y: -10_000) }
         model.state = SessionState(
             sessions: [
                 AgentSession(

--- a/Tests/OpenIslandAppTests/CodexDesktopSessionHygieneTests.swift
+++ b/Tests/OpenIslandAppTests/CodexDesktopSessionHygieneTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import OpenIslandCore
+import Testing
+@testable import OpenIslandApp
+
+@MainActor
+struct CodexDesktopSessionHygieneTests {
+    @Test
+    func appServerOnlySurfacesActiveNonEphemeralThreads() {
+        #expect(CodexAppServerCoordinator.shouldSurface(status: .active, ephemeral: false))
+        #expect(!CodexAppServerCoordinator.shouldSurface(status: .idle, ephemeral: false))
+        #expect(!CodexAppServerCoordinator.shouldSurface(status: .systemError, ephemeral: false))
+        #expect(!CodexAppServerCoordinator.shouldSurface(status: .active, ephemeral: true))
+    }
+
+    @Test
+    func rolloutFallbackOnlyRediscoversFreshRunningSessions() {
+        let now = Date(timeIntervalSince1970: 40_000)
+        let freshRunning = record(phase: .running, updatedAt: now.addingTimeInterval(-30))
+        let staleRunning = record(
+            sessionID: "stale-running",
+            phase: .running,
+            updatedAt: now.addingTimeInterval(-300)
+        )
+        let freshCompleted = record(
+            sessionID: "fresh-completed",
+            phase: .completed,
+            updatedAt: now.addingTimeInterval(-10)
+        )
+
+        #expect(SessionDiscoveryCoordinator.shouldRediscoverCodexAppRecord(freshRunning, now: now))
+        #expect(!SessionDiscoveryCoordinator.shouldRediscoverCodexAppRecord(staleRunning, now: now))
+        #expect(!SessionDiscoveryCoordinator.shouldRediscoverCodexAppRecord(freshCompleted, now: now))
+    }
+
+    @Test
+    func completedDesktopThreadIsNotVisibleWhenHostAppIsRunning() {
+        let startedAt = Date(timeIntervalSince1970: 50_000)
+        var state = SessionState()
+        state.apply(
+            .sessionStarted(
+                SessionStarted(
+                    sessionID: "desktop-thread",
+                    title: "Desktop thread",
+                    tool: .codex,
+                    origin: .live,
+                    summary: "Working",
+                    timestamp: startedAt,
+                    jumpTarget: JumpTarget(
+                        terminalApp: "Codex.app",
+                        workspaceName: "open-island",
+                        paneTitle: "Desktop thread",
+                        codexThreadID: "desktop-thread"
+                    )
+                )
+            )
+        )
+
+        #expect(state.session(id: "desktop-thread")?.isVisibleInIsland == true)
+
+        state.apply(
+            .activityUpdated(
+                SessionActivityUpdated(
+                    sessionID: "desktop-thread",
+                    summary: "Idle.",
+                    phase: .completed,
+                    timestamp: startedAt.addingTimeInterval(10)
+                )
+            )
+        )
+        state.markProcessLiveness(
+            aliveSessionIDs: ["desktop-thread"],
+            isCodexAppRunning: true
+        )
+
+        #expect(state.session(id: "desktop-thread")?.isProcessAlive == true)
+        #expect(state.session(id: "desktop-thread")?.isVisibleInIsland == false)
+        #expect(state.liveSessionCount == 0)
+    }
+
+    @Test
+    func attentionThreadDisappearsWhenDesktopHostStops() {
+        var session = AgentSession(
+            id: "desktop-approval",
+            title: "Desktop approval",
+            tool: .codex,
+            phase: .waitingForApproval,
+            summary: "Waiting for approval",
+            updatedAt: Date(timeIntervalSince1970: 60_000),
+            permissionRequest: PermissionRequest(
+                title: "Run command",
+                summary: "Waiting for approval",
+                affectedPath: "/tmp/worktree"
+            )
+        )
+        session.isCodexAppSession = true
+        session.isProcessAlive = true
+        var state = SessionState(sessions: [session])
+
+        #expect(state.liveAttentionCount == 1)
+
+        state.markProcessLiveness(aliveSessionIDs: [], isCodexAppRunning: false)
+
+        #expect(state.session(id: "desktop-approval")?.isProcessAlive == false)
+        #expect(state.session(id: "desktop-approval")?.isVisibleInIsland == false)
+        #expect(state.liveAttentionCount == 0)
+    }
+
+    private func record(
+        sessionID: String = "fresh-running",
+        phase: SessionPhase,
+        updatedAt: Date
+    ) -> CodexTrackedSessionRecord {
+        CodexTrackedSessionRecord(
+            sessionID: sessionID,
+            title: sessionID,
+            summary: "Summary",
+            phase: phase,
+            updatedAt: updatedAt
+        )
+    }
+}

--- a/Tests/OpenIslandAppTests/CodexDesktopSessionHygieneTests.swift
+++ b/Tests/OpenIslandAppTests/CodexDesktopSessionHygieneTests.swift
@@ -34,6 +34,49 @@ struct CodexDesktopSessionHygieneTests {
     }
 
     @Test
+    func completedDesktopThreadIsExcludedFromStartupRestoration() {
+        let record = CodexTrackedSessionRecord(
+            sessionID: "019f2afd-e6fd-7e11-bdd4-945caba06867",
+            title: "Codex · UHCLregistrationbot",
+            origin: .live,
+            attachmentState: .stale,
+            summary: "Turn completed.",
+            phase: .completed,
+            updatedAt: Date(timeIntervalSince1970: 45_000),
+            jumpTarget: JumpTarget(
+                terminalApp: "Codex.app",
+                workspaceName: "UHCLregistrationbot",
+                paneTitle: "Codex · UHCLregistrationbot",
+                codexThreadID: "019f2afd-e6fd-7e11-bdd4-945caba06867"
+            )
+        )
+
+        #expect(!record.shouldRestoreToLiveState)
+    }
+
+    @Test
+    func completedDesktopThreadIsExcludedFromActiveStatePersistence() {
+        let now = Date(timeIntervalSince1970: 47_000)
+        var completed = AgentSession(
+            id: "019f2afd-e6fd-7e11-bdd4-945caba06867",
+            title: "Codex · UHCLregistrationbot",
+            tool: .codex,
+            origin: .live,
+            phase: .completed,
+            summary: "Turn completed.",
+            updatedAt: now
+        )
+        completed.isCodexAppSession = true
+
+        var running = completed
+        running.id = "active-thread"
+        running.phase = .running
+
+        #expect(!SessionDiscoveryCoordinator.shouldPersistCodexSession(completed, now: now))
+        #expect(SessionDiscoveryCoordinator.shouldPersistCodexSession(running, now: now))
+    }
+
+    @Test
     func completedDesktopThreadIsNotVisibleWhenHostAppIsRunning() {
         let startedAt = Date(timeIntervalSince1970: 50_000)
         var state = SessionState()

--- a/Tests/OpenIslandAppTests/CompendiumLocalProcessEndToEndTests.swift
+++ b/Tests/OpenIslandAppTests/CompendiumLocalProcessEndToEndTests.swift
@@ -1,0 +1,486 @@
+import Darwin
+import Foundation
+import XCTest
+@testable import OpenIslandApp
+@testable import OpenIslandCore
+
+@MainActor
+final class CompendiumLocalProcessEndToEndTests: XCTestCase {
+    func testFourRealProcessesCompletePropagateAndRecoverAcrossRestart()
+        async throws
+    {
+        let fixture = try CompendiumEndToEndFixture()
+        let viewModel = try await fixture.preparedViewModel()
+
+        XCTAssertEqual(viewModel.document?.nodes.map(\.id), [
+            "architect", "graph", "researcher", "reviewer",
+        ])
+        XCTAssertEqual(viewModel.document?.edges.count, 3)
+        viewModel.validateDocument()
+        XCTAssertEqual(viewModel.lastCommandResult?.reasonCode, "definition_valid")
+
+        await viewModel.createRun()
+        await viewModel.startRun()
+        viewModel.run()
+        await viewModel.waitForLocalOrchestration()
+
+        XCTAssertEqual(
+            viewModel.inspection?.summary.persistedState,
+            .completed,
+            "last=\(String(describing: viewModel.lastCommandResult)) error=\(String(describing: viewModel.errorMessage)) history=\(viewModel.history?.events.suffix(8).map(\.eventType) ?? [])"
+        )
+        XCTAssertEqual(
+            Set(viewModel.inspection?.nodes.map(\.persistedState) ?? []),
+            [.completed]
+        )
+        let records = try await fixture.launchStore.records()
+        XCTAssertEqual(records.count, 4)
+        XCTAssertTrue(records.allSatisfy { $0.exit?.terminationStatus == 0 })
+        XCTAssertTrue(records.allSatisfy {
+            $0.identity.process.processID != nil
+                && $0.identity.birthIdentity != nil
+                && !$0.identity.invocationDigest.isEmpty
+                && !$0.identity.executableIdentity.isEmpty
+        })
+
+        let reviewerData = try Data(
+            contentsOf: fixture.workspaceURL
+                .appendingPathComponent("artifacts/reviewer.json")
+        )
+        let reviewer = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: reviewerData)
+                as? [String: Any]
+        )
+        XCTAssertEqual(reviewer["verdict"] as? String, "pass")
+        XCTAssertEqual(reviewer["inputCount"] as? Int, 3)
+
+        viewModel.selectNode("architect")
+        await viewModel.openLogs()
+        XCTAssertTrue(
+            viewModel.logPage?.entries.map(\.text).joined()
+                .contains("role=architect") == true
+        )
+        await viewModel.inspectHistory()
+        XCTAssertFalse(viewModel.history?.events.isEmpty ?? true)
+        XCTAssertNotNil(viewModel.explanation)
+
+        let exportURL = fixture.rootURL.appendingPathComponent("run-export.json")
+        await viewModel.exportRun(url: exportURL)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: exportURL.path))
+
+        let runID = try XCTUnwrap(viewModel.inspection?.summary.runID)
+        try fixture.assertCLIState(runID: runID, expectedState: "completed")
+
+        let restarted = try fixture.restartedService()
+        let restartedViewModel = GraphWorkspaceViewModel(
+            service: restarted,
+            defaults: fixture.defaults
+        )
+        await restartedViewModel.restoreState()
+        XCTAssertEqual(
+            restartedViewModel.inspection?.summary.runID,
+            runID
+        )
+        XCTAssertEqual(
+            restartedViewModel.inspection?.summary.persistedState,
+            .completed
+        )
+        restartedViewModel.selectNode("architect")
+        await restartedViewModel.openLogs()
+        XCTAssertFalse(restartedViewModel.logPage?.entries.isEmpty ?? true)
+    }
+
+    func testRetryableProcessFailureIsRetriedThroughWorkspacePolicy()
+        async throws
+    {
+        let fixture = try CompendiumEndToEndFixture()
+        var document = fixture.document
+        try appendArguments(
+            [
+                "--fail-once-directory", "${workspace}",
+                "--failure-code", "23",
+            ],
+            nodeID: "researcher",
+            document: &document
+        )
+        let viewModel = try await fixture.preparedViewModel(document: document)
+        await viewModel.createRun()
+        await viewModel.startRun()
+
+        try await fixture.launchAndFinish(nodeID: "architect", viewModel: viewModel)
+        try await fixture.launchAndFinish(nodeID: "researcher", viewModel: viewModel)
+        XCTAssertEqual(
+            viewModel.inspection?.nodes.first { $0.id == "researcher" }?
+                .persistedState,
+            .failed
+        )
+        viewModel.selectNode("researcher")
+        XCTAssertTrue(viewModel.decision(.retryNode).isEnabled)
+
+        await viewModel.retrySelectedNode()
+        XCTAssertEqual(
+            viewModel.lastCommandResult?.reasonCode,
+            "retry_requested"
+        )
+        viewModel.run()
+        await viewModel.waitForLocalOrchestration()
+
+        XCTAssertEqual(
+            viewModel.inspection?.summary.persistedState,
+            .completed,
+            "last=\(String(describing: viewModel.lastCommandResult)) error=\(String(describing: viewModel.errorMessage)) retries=\(viewModel.inspection?.scheduling?.retries ?? []) history=\(viewModel.history?.events.suffix(12).map(\.eventType) ?? [])"
+        )
+        XCTAssertEqual(
+            viewModel.inspection?.attempts
+                .filter { $0.nodeID == "researcher" }.count,
+            2
+        )
+    }
+
+    func testNonRetryableFailureBlocksDownstreamNodes() async throws {
+        let fixture = try CompendiumEndToEndFixture()
+        var document = fixture.document
+        try appendArguments(
+            ["--failure-code", "42"],
+            nodeID: "researcher",
+            document: &document
+        )
+        let viewModel = try await fixture.preparedViewModel(document: document)
+        await viewModel.createRun()
+        await viewModel.startRun()
+        viewModel.run()
+        await viewModel.waitForLocalOrchestration()
+
+        XCTAssertEqual(
+            viewModel.inspection?.nodes.first { $0.id == "researcher" }?
+                .persistedState,
+            .failed
+        )
+        XCTAssertEqual(
+            viewModel.inspection?.nodes.first { $0.id == "graph" }?
+                .reconciledState,
+            .blocked
+        )
+        XCTAssertEqual(
+            viewModel.inspection?.nodes.first { $0.id == "reviewer" }?
+                .reconciledState,
+            .blocked
+        )
+    }
+
+    func testWorkspaceCancellationTerminatesOwnedProcessAndNotUnrelatedProcess()
+        async throws
+    {
+        let fixture = try CompendiumEndToEndFixture()
+        var document = fixture.document
+        try replaceArguments(
+            ["--role", "architect", "--wait-for-cancellation"],
+            nodeID: "architect",
+            document: &document
+        )
+        let viewModel = try await fixture.preparedViewModel(document: document)
+        await viewModel.createRun()
+        await viewModel.startRun()
+        let record = try await fixture.launch(
+            nodeID: "architect",
+            viewModel: viewModel
+        )
+        let ready = try await fixture.executor.waitForLog(
+            launchRecordID: record.id,
+            containing: "waiting for cancellation"
+        )
+        XCTAssertTrue(ready)
+
+        let unrelated = Process()
+        unrelated.executableURL = fixture.executableURL
+        unrelated.arguments = [
+            "--role", "unrelated", "--wait-for-cancellation",
+        ]
+        unrelated.standardOutput = FileHandle.nullDevice
+        unrelated.standardError = FileHandle.nullDevice
+        try unrelated.run()
+        defer {
+            if unrelated.isRunning { unrelated.terminate() }
+            unrelated.waitUntilExit()
+        }
+
+        viewModel.selectNode("architect")
+        await viewModel.cancelSelectedNode()
+        XCTAssertEqual(
+            viewModel.lastCommandResult?.reasonCode,
+            "cancellation_requested"
+        )
+        await viewModel.step()
+        await fixture.executor.waitForExit(launchRecordID: record.id)
+        await viewModel.step()
+
+        XCTAssertTrue(unrelated.isRunning)
+        XCTAssertEqual(
+            viewModel.inspection?.nodes.first { $0.id == "architect" }?
+                .persistedState,
+            .cancelled
+        )
+        let terminatedPID = try XCTUnwrap(record.identity.process.processID)
+        XCTAssertEqual(Darwin.kill(terminatedPID, 0), -1)
+        if let groupID = record.identity.processGroupID {
+            XCTAssertEqual(groupID, terminatedPID)
+            XCTAssertEqual(Darwin.kill(-groupID, 0), -1)
+        }
+    }
+
+    func testExecutionTimeoutInterruptsAndCleansUpRealProcess() async throws {
+        let fixture = try CompendiumEndToEndFixture()
+        var document = fixture.document
+        try replaceArguments(
+            ["--role", "architect", "--wait-for-cancellation"],
+            nodeID: "architect",
+            document: &document
+        )
+        let index = try XCTUnwrap(
+            document.nodes.firstIndex { $0.id == "architect" }
+        )
+        document.nodes[index].timeoutPolicy = GraphExecutionTimeoutPolicy(
+            executionSeconds: 1,
+            cancellationAcknowledgementSeconds: 1
+        )
+        let viewModel = try await fixture.preparedViewModel(document: document)
+        await viewModel.createRun()
+        await viewModel.startRun()
+        let record = try await fixture.launch(
+            nodeID: "architect",
+            viewModel: viewModel
+        )
+        let ready = try await fixture.executor.waitForLog(
+            launchRecordID: record.id,
+            containing: "waiting for cancellation"
+        )
+        XCTAssertTrue(ready)
+        let runID = try XCTUnwrap(viewModel.inspection?.summary.runID)
+
+        let timedOut = await fixture.service.step(
+            runID: runID,
+            occurredAt: Date().addingTimeInterval(2)
+        )
+        await fixture.executor.waitForExit(launchRecordID: record.id)
+        await viewModel.refreshRunAndHistory()
+
+        XCTAssertTrue(
+            timedOut.accepted,
+            "\(timedOut.reasonCode): \(timedOut.diagnostics)"
+        )
+        XCTAssertEqual(
+            viewModel.inspection?.attempts.first { $0.nodeID == "architect" }?
+                .persistedState,
+            .interrupted
+        )
+        XCTAssertTrue(
+            viewModel.inspection?.scheduling?.timeouts.contains(where: {
+                $0.kind == .attemptExecution
+            }) == true
+        )
+    }
+}
+
+private struct CompendiumEndToEndFixture {
+    let rootURL: URL
+    let workspaceURL: URL
+    let runtimeURL: URL
+    let databasePath: String
+    let documentURL: URL
+    let executableURL: URL
+    let defaults: UserDefaults
+    let launchStore: GraphLocalProcessLaunchStore
+    let executor: SupervisedLocalProcessExecutor
+    let service: GraphWorkspaceService
+    let document: GraphDefinitionDocument
+
+    init() throws {
+        rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        workspaceURL = rootURL.appendingPathComponent(
+            "workspace",
+            isDirectory: true
+        )
+        runtimeURL = rootURL.appendingPathComponent(
+            "runtime",
+            isDirectory: true
+        )
+        databasePath = rootURL.appendingPathComponent("graph.sqlite").path
+        documentURL = rootURL.appendingPathComponent("compendium.json")
+        executableURL = try GraphWorkspaceBundledFixtures.fixtureExecutableURL()
+        defaults = try XCTUnwrap(
+            UserDefaults(suiteName: "CompendiumE2E-\(UUID().uuidString)")
+        )
+        try FileManager.default.createDirectory(
+            at: rootURL,
+            withIntermediateDirectories: true
+        )
+        launchStore = try GraphLocalProcessLaunchStore(rootURL: runtimeURL)
+        executor = SupervisedLocalProcessExecutor(launchStore: launchStore)
+        let store = try SQLiteGraphExecutionStore(databasePath: databasePath)
+        service = GraphWorkspaceService(
+            eventStore: store,
+            readStore: store,
+            snapshotStore: store,
+            processExecutor: executor,
+            launchStore: launchStore
+        )
+        document = try GraphWorkspaceBundledFixtures.loadCompendium(
+            executableURL: executableURL,
+            workspaceURL: workspaceURL
+        )
+    }
+
+    @MainActor
+    func preparedViewModel(
+        document: GraphDefinitionDocument? = nil
+    ) async throws -> GraphWorkspaceViewModel {
+        let selected = document ?? self.document
+        try GraphDefinitionDocumentCodec.save(selected, to: documentURL)
+        let viewModel = GraphWorkspaceViewModel(
+            service: service,
+            defaults: defaults
+        )
+        await viewModel.openDocument(url: documentURL)
+        return viewModel
+    }
+
+    func restartedService() throws -> GraphWorkspaceService {
+        let store = try SQLiteGraphExecutionStore(databasePath: databasePath)
+        let restartedLaunchStore = try GraphLocalProcessLaunchStore(
+            rootURL: runtimeURL
+        )
+        let restartedExecutor = SupervisedLocalProcessExecutor(
+            launchStore: restartedLaunchStore
+        )
+        return GraphWorkspaceService(
+            eventStore: store,
+            readStore: store,
+            snapshotStore: store,
+            processExecutor: restartedExecutor,
+            launchStore: restartedLaunchStore
+        )
+    }
+
+    @MainActor
+    func launch(
+        nodeID: String,
+        viewModel: GraphWorkspaceViewModel
+    ) async throws -> GraphLocalProcessLaunchRecord {
+        for _ in 0..<40 {
+            await viewModel.step()
+            if let record = try await launchStore.records()
+                .filter({
+                    $0.identity.runID == viewModel.inspection?.summary.runID
+                        && $0.identity.nodeID == nodeID
+                })
+                .max(by: {
+                    $0.identity.attemptOrdinal < $1.identity.attemptOrdinal
+                }) {
+                return record
+            }
+        }
+        throw GraphLocalProcessRuntimeError.launchRecordMissing(nodeID)
+    }
+
+    @MainActor
+    func launchAndFinish(
+        nodeID: String,
+        viewModel: GraphWorkspaceViewModel
+    ) async throws {
+        let record = try await launch(nodeID: nodeID, viewModel: viewModel)
+        await executor.waitForExit(launchRecordID: record.id)
+        for _ in 0..<10 {
+            await viewModel.step()
+            if let state = viewModel.inspection?.nodes.first(where: {
+                $0.id == nodeID
+            })?.persistedState, state.isTerminal {
+                return
+            }
+        }
+        throw GraphLocalProcessRuntimeError.launchRecordConflict(nodeID)
+    }
+
+    func assertCLIState(runID: String, expectedState: String) throws {
+        let cliURL = executableURL.deletingLastPathComponent()
+            .appendingPathComponent("openisland")
+        let process = Process()
+        process.executableURL = cliURL
+        process.arguments = [
+            "graph", "inspect", runID,
+            "--include-artifacts",
+            "--output", "json",
+            "--no-color",
+        ]
+        var environment = ProcessInfo.processInfo.environment
+        environment["OPENISLAND_GRAPH_DATABASE_PATH"] = databasePath
+        process.environment = environment
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+        try process.run()
+        process.waitUntilExit()
+        let output = String(
+            decoding: stdout.fileHandleForReading.readDataToEndOfFile(),
+            as: UTF8.self
+        )
+        let errorOutput = String(
+            decoding: stderr.fileHandleForReading.readDataToEndOfFile(),
+            as: UTF8.self
+        )
+        XCTAssertEqual(process.terminationStatus, 0, errorOutput)
+        XCTAssertTrue(output.contains(runID))
+        XCTAssertTrue(output.contains(expectedState))
+    }
+}
+
+private func appendArguments(
+    _ arguments: [String],
+    nodeID: String,
+    document: inout GraphDefinitionDocument
+) throws {
+    guard let index = document.nodes.firstIndex(where: { $0.id == nodeID }) else {
+        throw GraphDefinitionDocumentError.nodeNotFound(nodeID)
+    }
+    let source = try GraphLocalProcessSpecification(
+        immutableSpecification: document.nodes[index].specification
+    )
+    document.nodes[index].specification = try GraphLocalProcessSpecification(
+        executable: source.executable,
+        arguments: source.arguments + arguments,
+        workingDirectory: source.workingDirectory,
+        environment: source.environment,
+        inheritedEnvironment: source.inheritedEnvironment,
+        stdin: source.stdin,
+        outputArtifacts: source.outputArtifacts,
+        retryableExitCodes: source.retryableExitCodes,
+        logPolicy: source.logPolicy
+    ).immutableSpecification()
+    try document.validate()
+}
+
+private func replaceArguments(
+    _ arguments: [String],
+    nodeID: String,
+    document: inout GraphDefinitionDocument
+) throws {
+    guard let index = document.nodes.firstIndex(where: { $0.id == nodeID }) else {
+        throw GraphDefinitionDocumentError.nodeNotFound(nodeID)
+    }
+    let source = try GraphLocalProcessSpecification(
+        immutableSpecification: document.nodes[index].specification
+    )
+    document.nodes[index].specification = try GraphLocalProcessSpecification(
+        executable: source.executable,
+        arguments: arguments,
+        workingDirectory: source.workingDirectory,
+        environment: source.environment,
+        inheritedEnvironment: source.inheritedEnvironment,
+        stdin: source.stdin,
+        outputArtifacts: source.outputArtifacts,
+        retryableExitCodes: source.retryableExitCodes,
+        logPolicy: source.logPolicy
+    ).immutableSpecification()
+    try document.validate()
+}

--- a/Tests/OpenIslandAppTests/GraphRuntimeCatalogTests.swift
+++ b/Tests/OpenIslandAppTests/GraphRuntimeCatalogTests.swift
@@ -1,0 +1,204 @@
+import XCTest
+import OpenIslandCore
+@testable import OpenIslandApp
+
+final class GraphRuntimeCatalogTests: XCTestCase {
+    func testBuiltInProvidersExposeExecutableBindings() throws {
+        let providers = GraphRuntimeCatalogDiscovery.builtInProviders
+
+        let local = try XCTUnwrap(
+            providers.first { $0.id == .localProcess }
+        )
+        XCTAssertEqual(local.adapterKind, "local_process")
+        XCTAssertEqual(local.operation, "execute")
+        XCTAssertEqual(local.requiredCapabilities, ["local-process"])
+
+        let ollama = try XCTUnwrap(
+            providers.first { $0.id == .ollama }
+        )
+        XCTAssertEqual(ollama.adapterKind, "openai_compatible")
+        XCTAssertEqual(ollama.operation, "chat_completion")
+        XCTAssertEqual(ollama.endpoint, "http://127.0.0.1:11434/v1")
+        XCTAssertTrue(ollama.supportsModelDiscovery)
+
+        let qwen = try XCTUnwrap(
+            providers.first { $0.id == .qwenCode }
+        )
+        XCTAssertEqual(qwen.adapterKind, "local_process")
+        XCTAssertEqual(qwen.operation, "execute")
+        XCTAssertTrue(qwen.executableNames.contains("qwen"))
+    }
+
+    func testSnapshotFiltersModelsAndAgentsByProvider() {
+        let snapshot = GraphRuntimeCatalogSnapshot(
+            providers: GraphRuntimeCatalogDiscovery.builtInProviders,
+            models: [
+                GraphRuntimeModel(
+                    id: "ollama:qwen3.5:9b",
+                    name: "qwen3.5:9b",
+                    providerID: .ollama,
+                    details: "9B"
+                ),
+                GraphRuntimeModel(
+                    id: "other",
+                    name: "other",
+                    providerID: .openAICompatible,
+                    details: nil
+                ),
+            ],
+            agents: [
+                GraphRuntimeAgentProfile(
+                    id: "qwen:/usr/local/bin/qwen",
+                    name: "Qwen Code",
+                    providerID: .qwenCode,
+                    executable: "/usr/local/bin/qwen",
+                    details: nil
+                ),
+            ],
+            diagnostics: []
+        )
+
+        XCTAssertEqual(
+            snapshot.models(for: .ollama).map(\.name),
+            ["qwen3.5:9b"]
+        )
+        XCTAssertEqual(
+            snapshot.agents(for: .qwenCode).map(\.name),
+            ["Qwen Code"]
+        )
+        XCTAssertTrue(snapshot.agents(for: .ollama).isEmpty)
+    }
+
+    func testDiscoveredCLIProfileBindsToLocalProcessExecutor()
+        throws
+    {
+        let provider = try XCTUnwrap(
+            GraphRuntimeCatalogDiscovery.builtInProviders.first {
+                $0.id == .qwenCode
+            }
+        )
+
+        let agent = GraphRuntimeAgentProfile(
+            id: "qwen:/opt/homebrew/bin/qwen",
+            name: "Qwen Code",
+            providerID: .qwenCode,
+            executable: "/opt/homebrew/bin/qwen",
+            details: nil
+        )
+
+        let catalog = GraphRuntimeCatalogSnapshot(
+            providers: [provider],
+            models: [],
+            agents: [agent],
+            diagnostics: []
+        )
+
+        let binding = try GraphRuntimeNodeBindingFactory.make(
+            provider: provider,
+            model: "qwen3.5:9b",
+            agentProfileID: agent.id,
+            catalog: catalog
+        )
+
+        XCTAssertEqual(
+            binding.specification.adapterKind,
+            GraphLocalProcessSpecification.adapterKind
+        )
+        XCTAssertEqual(
+            binding.specification.operation,
+            GraphLocalProcessSpecification.operation
+        )
+        XCTAssertEqual(
+            binding.executorKind,
+            .supervisedLocalProcess
+        )
+        XCTAssertTrue(
+            binding.requiredCapabilities.contains("agent")
+        )
+
+        let process = try GraphLocalProcessSpecification(
+            immutableSpecification: binding.specification
+        )
+        XCTAssertEqual(
+            process.executable,
+            "/opt/homebrew/bin/qwen"
+        )
+        XCTAssertEqual(
+            process.inheritedEnvironment,
+            .allowlisted
+        )
+        XCTAssertTrue(
+            binding.environmentAllowlist.contains("PATH")
+        )
+    }
+
+    func testMissingCLIProfileRemainsExplicitlyUnbound()
+        throws
+    {
+        let provider = try XCTUnwrap(
+            GraphRuntimeCatalogDiscovery.builtInProviders.first {
+                $0.id == .geminiCLI
+            }
+        )
+
+        let binding = try GraphRuntimeNodeBindingFactory.make(
+            provider: provider,
+            model: "",
+            agentProfileID: "",
+            catalog: .empty
+        )
+
+        XCTAssertEqual(
+            binding.specification.adapterKind,
+            "generic_agent"
+        )
+        XCTAssertEqual(
+            binding.specification.operation,
+            "unbound"
+        )
+        XCTAssertEqual(
+            binding.executorKind,
+            .unboundAgent
+        )
+    }
+
+    func testOllamaBindingProducesOpenAICompatibleSpecification()
+        throws
+    {
+        let provider = try XCTUnwrap(
+            GraphRuntimeCatalogDiscovery.builtInProviders.first {
+                $0.id == .ollama
+            }
+        )
+
+        let binding = try GraphRuntimeNodeBindingFactory.make(
+            provider: provider,
+            model: "qwen3.5:9b",
+            agentProfileID: "",
+            catalog: .empty
+        )
+
+        XCTAssertEqual(
+            binding.specification.adapterKind,
+            "openai_compatible"
+        )
+        XCTAssertEqual(
+            binding.specification.operation,
+            "chat_completion"
+        )
+        XCTAssertEqual(
+            binding.executorKind,
+            .openAICompatible
+        )
+        XCTAssertEqual(
+            binding.specification.parameters["model"],
+            .string("qwen3.5:9b")
+        )
+        XCTAssertEqual(
+            binding.specification.parameters["endpoint"],
+            .string("http://127.0.0.1:11434/v1")
+        )
+    }
+
+
+}

--- a/Tests/OpenIslandAppTests/GraphWorkspaceTemplateTests.swift
+++ b/Tests/OpenIslandAppTests/GraphWorkspaceTemplateTests.swift
@@ -93,7 +93,7 @@ final class GraphWorkspaceTemplateTests: XCTestCase {
         XCTAssertTrue(source.contains("Create New Graph"))
         XCTAssertTrue(source.contains("Open Existing Graph"))
         XCTAssertTrue(source.contains("Open Recent Graph"))
-        XCTAssertTrue(source.contains("Open Example Graph"))
+        XCTAssertTrue(source.contains("Open Templates"))
         XCTAssertTrue(source.contains("Add your first node"))
         XCTAssertTrue(source.contains("Auto Layout"))
         XCTAssertTrue(source.contains("Reset Graph Zoom"))

--- a/Tests/OpenIslandAppTests/GraphWorkspaceTemplateTests.swift
+++ b/Tests/OpenIslandAppTests/GraphWorkspaceTemplateTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import XCTest
+@testable import OpenIslandApp
+@testable import OpenIslandCore
+
+@MainActor
+final class GraphWorkspaceTemplateTests: XCTestCase {
+    func testEveryBuiltInTemplateCreatesAnEditableDocumentWithoutGraphJSON()
+        throws
+    {
+        let root = try temporaryDirectory()
+        let executable = try GraphWorkspaceBundledFixtures.fixtureExecutableURL()
+
+        for template in GraphWorkspaceTemplate.allCases {
+            let request = GraphNewDocumentRequest(
+                template: template,
+                name: template.name,
+                graphID: "template-\(template.rawValue)",
+                definitionVersion: "1",
+                workspaceDirectory: root.path
+            )
+            let document = try GraphWorkspaceTemplateFactory.make(
+                request: request,
+                executableURL: executable,
+                workspaceURL: root,
+                now: Date(timeIntervalSince1970: 1),
+                author: "test"
+            )
+
+            XCTAssertEqual(document.name, template.name)
+            XCTAssertEqual(document.graphID, "template-\(template.rawValue)")
+            if template == .blank {
+                XCTAssertTrue(document.nodes.isEmpty)
+            } else {
+                XCTAssertFalse(document.nodes.isEmpty)
+                XCTAssertFalse(document.graphOutputs.isEmpty)
+                XCTAssertNoThrow(try document.validate())
+            }
+
+            let encoded = try GraphDefinitionDocumentCodec.encode(document)
+            XCTAssertEqual(
+                try GraphDefinitionDocumentCodec.decode(encoded),
+                document
+            )
+        }
+    }
+
+    func testTemplateTopologyMatchesDocumentedPatterns() throws {
+        let root = try temporaryDirectory()
+        let executable = try GraphWorkspaceBundledFixtures.fixtureExecutableURL()
+        var documents: [GraphWorkspaceTemplate: GraphDefinitionDocument] = [:]
+        for template in GraphWorkspaceTemplate.allCases where template != .blank {
+            documents[template] = try GraphWorkspaceTemplateFactory.make(
+                request: GraphNewDocumentRequest(
+                    template: template,
+                    name: template.name,
+                    graphID: template.rawValue,
+                    definitionVersion: "1"
+                ),
+                executableURL: executable,
+                workspaceURL: root
+            )
+        }
+
+        XCTAssertEqual(documents[.linearPipeline]?.nodes.count, 3)
+        XCTAssertEqual(documents[.fanOutFanIn]?.edges.count, 4)
+        XCTAssertEqual(documents[.reviewLoop]?.nodes.count, 5)
+        XCTAssertEqual(
+            documents[.compendiumFill]?.topologicalNodeIDs(),
+            ["architect", "researcher", "graph", "reviewer"]
+        )
+        XCTAssertEqual(
+            documents[.localProcessExample]?.topologicalNodeIDs(),
+            ["generate", "transform", "verify"]
+        )
+    }
+
+    func testNewGraphSheetAndWorkspaceSourceExposeTemplatesAndGuidance()
+        throws
+    {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: root.appendingPathComponent(
+                "Sources/OpenIslandApp/Views/GraphWorkspaceView.swift"
+            ),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(source.contains("GraphWorkspaceTemplate.allCases"))
+        XCTAssertTrue(source.contains("Create New Graph"))
+        XCTAssertTrue(source.contains("Open Existing Graph"))
+        XCTAssertTrue(source.contains("Open Recent Graph"))
+        XCTAssertTrue(source.contains("Open Example Graph"))
+        XCTAssertTrue(source.contains("Add your first node"))
+        XCTAssertTrue(source.contains("Auto Layout"))
+        XCTAssertTrue(source.contains("Reset Graph Zoom"))
+    }
+
+    func testLocalTemplatesCanBeEditedSavedAndRun() async throws {
+        let root = try temporaryDirectory()
+        let defaults = try XCTUnwrap(
+            UserDefaults(suiteName: "TemplateRun-\(UUID().uuidString)")
+        )
+        let service = try GraphWorkspaceService.inMemory(
+            rootURL: root.appendingPathComponent("runtime", isDirectory: true)
+        )
+        let viewModel = GraphWorkspaceViewModel(
+            service: service,
+            defaults: defaults
+        )
+
+        for template in [
+            GraphWorkspaceTemplate.localProcessExample,
+            .compendiumFill,
+        ] {
+            let graphID = "runnable-\(template.rawValue)"
+            viewModel.newDocument(request: GraphNewDocumentRequest(
+                template: template,
+                name: template.name,
+                graphID: graphID,
+                definitionVersion: "1",
+                workspaceDirectory: root.path
+            ))
+            let selected = try XCTUnwrap(viewModel.selectedNodeID)
+            viewModel.updateSelectedNodeIdentity(
+                name: "Edited \(viewModel.selectedNode?.name ?? selected)",
+                description: "Template remains an ordinary editable document",
+                tags: ["edited-template"]
+            )
+            let documentURL = root.appendingPathComponent("\(graphID).json")
+            await viewModel.saveDocument(url: documentURL)
+            XCTAssertTrue(FileManager.default.fileExists(atPath: documentURL.path))
+            await viewModel.prepareCreateRun()
+            await viewModel.confirmCreateRun()
+            await viewModel.startRun()
+            viewModel.run()
+            await viewModel.waitForLocalOrchestration()
+            XCTAssertEqual(
+                viewModel.inspection?.summary.persistedState,
+                .completed,
+                "template=\(template.name) last=\(String(describing: viewModel.lastCommandResult))"
+            )
+        }
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: url.appendingPathComponent("artifacts", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        return url
+    }
+}

--- a/Tests/OpenIslandAppTests/GraphWorkspaceTemplateTests.swift
+++ b/Tests/OpenIslandAppTests/GraphWorkspaceTemplateTests.swift
@@ -97,6 +97,13 @@ final class GraphWorkspaceTemplateTests: XCTestCase {
         XCTAssertTrue(source.contains("Add your first node"))
         XCTAssertTrue(source.contains("Auto Layout"))
         XCTAssertTrue(source.contains("Reset Graph Zoom"))
+        XCTAssertTrue(source.contains("Binding Source"))
+        XCTAssertTrue(source.contains("Connect Upstream Output"))
+        XCTAssertTrue(source.contains("Literal Value"))
+        XCTAssertTrue(source.contains("File Reference"))
+        XCTAssertTrue(source.contains("Secret Reference"))
+        XCTAssertTrue(source.contains("Backoff Multiplier"))
+        XCTAssertTrue(source.contains("selectedNodeValidationSection"))
     }
 
     func testLocalTemplatesCanBeEditedSavedAndRun() async throws {

--- a/Tests/OpenIslandAppTests/GraphWorkspaceTests.swift
+++ b/Tests/OpenIslandAppTests/GraphWorkspaceTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+import XCTest
+@testable import OpenIslandApp
+@testable import OpenIslandCore
+
+@MainActor
+final class GraphWorkspaceTests: XCTestCase {
+    func testEntryPointConfigurationIsDiscoverableAndAccessible() throws {
+        XCTAssertEqual(GraphWorkspaceEntryPoint.label, "Graph Workspace")
+        XCTAssertEqual(GraphWorkspaceEntryPoint.windowID, "graph-workspace")
+        XCTAssertEqual(GraphWorkspaceEntryPoint.shortcutKey, "g")
+
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let islandSource = try String(
+            contentsOf: root.appendingPathComponent(
+                "Sources/OpenIslandApp/Views/IslandPanelView.swift"
+            ),
+            encoding: .utf8
+        )
+        let appSource = try String(
+            contentsOf: root.appendingPathComponent(
+                "Sources/OpenIslandApp/OpenIslandApp.swift"
+            ),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(islandSource.contains("GraphWorkspaceEntryPoint.label"))
+        XCTAssertTrue(islandSource.contains(".accessibilityLabel(GraphWorkspaceEntryPoint.label)"))
+        XCTAssertTrue(appSource.contains("CommandGroup(after: .windowArrangement)"))
+        XCTAssertTrue(appSource.contains("CommandGroup(after: .newItem)"))
+        XCTAssertTrue(appSource.contains("modifiers: [.command, .shift]"))
+    }
+
+    func testRepeatedActivationUsesStableWindowOpenerAndFocusPath() {
+        let model = AppModel()
+        var activations = 0
+        model.openGraphWorkspaceWindow = { activations += 1 }
+
+        model.showGraphWorkspace()
+        model.showGraphWorkspace()
+
+        XCTAssertEqual(activations, 2)
+    }
+
+    func testEmptyWorkspaceDefinitionRunAndHistoryModesWork() async throws {
+        let fixture = try WorkspaceTestFixture()
+        let viewModel = fixture.viewModel()
+        viewModel.newDocument()
+
+        XCTAssertEqual(viewModel.mode, .definition)
+        XCTAssertEqual(viewModel.document?.nodes.count, 0)
+        XCTAssertFalse(viewModel.decision(.createRun).isEnabled)
+
+        viewModel.addNode()
+        XCTAssertEqual(viewModel.document?.nodes.count, 1)
+        XCTAssertTrue(viewModel.decision(.createRun).isEnabled)
+
+        await viewModel.createRun()
+        XCTAssertEqual(viewModel.mode, .run)
+        XCTAssertNotNil(viewModel.inspection)
+        XCTAssertTrue(viewModel.lastCommandResult?.accepted == true)
+        XCTAssertGreaterThan(viewModel.lastCommandResult?.streamVersion ?? 0, 0)
+
+        await viewModel.startRun()
+        viewModel.run()
+        await viewModel.waitForLocalOrchestration()
+        XCTAssertEqual(
+            viewModel.inspection?.summary.reconciledState,
+            .completed
+        )
+
+        await viewModel.inspectHistory()
+        XCTAssertEqual(viewModel.mode, .history)
+        XCTAssertFalse(viewModel.history?.events.isEmpty ?? true)
+        XCTAssertNotNil(viewModel.explanation)
+    }
+
+    func testTypedPolicyDenialsArePresentedWithoutStateFabrication() async throws {
+        let fixture = try WorkspaceTestFixture()
+        let viewModel = fixture.viewModel()
+        viewModel.newDocument()
+
+        let decision = viewModel.decision(.retryNode)
+        XCTAssertFalse(decision.isEnabled)
+        XCTAssertEqual(decision.reasonCode, "retry_requires_attempt")
+
+        await viewModel.retrySelectedNode()
+        XCTAssertEqual(
+            viewModel.lastCommandResult?.reasonCode,
+            "retry_requires_attempt"
+        )
+        XCTAssertNil(viewModel.inspection)
+    }
+
+    func testDocumentAndRunSelectionRestoreAcrossViewModelRestart() async throws {
+        let fixture = try WorkspaceTestFixture()
+        let first = fixture.viewModel()
+        first.newDocument()
+        first.addNode()
+        let documentURL = fixture.root.appendingPathComponent("restored.json")
+        await first.saveDocument(url: documentURL)
+        await first.createRun()
+        let runID = try XCTUnwrap(first.inspection?.summary.runID)
+
+        let restarted = fixture.viewModel()
+        await restarted.restoreState()
+
+        XCTAssertEqual(restarted.documentURL, documentURL)
+        XCTAssertEqual(restarted.document?.nodes.count, 1)
+        XCTAssertEqual(restarted.inspection?.summary.runID, runID)
+        XCTAssertEqual(restarted.mode, .run)
+    }
+
+    func testLayoutEditingDoesNotMutateExistingRunDefinition() async throws {
+        let fixture = try WorkspaceTestFixture()
+        let viewModel = fixture.viewModel()
+        viewModel.newDocument()
+        viewModel.addNode()
+        await viewModel.createRun()
+        let digest = viewModel.inspection?.graphDefinitionDigest
+        let nodeID = try XCTUnwrap(viewModel.document?.nodes.first?.id)
+
+        viewModel.moveNode(nodeID, to: GraphCanvasPoint(x: 700, y: 320))
+        await viewModel.refreshRunAndHistory()
+
+        XCTAssertEqual(viewModel.inspection?.graphDefinitionDigest, digest)
+    }
+}
+
+private struct WorkspaceTestFixture {
+    let root: URL
+    let defaults: UserDefaults
+    let service: GraphWorkspaceService
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true
+        )
+        defaults = try XCTUnwrap(
+            UserDefaults(suiteName: "GraphWorkspaceTests-\(UUID().uuidString)")
+        )
+        service = try GraphWorkspaceService.inMemory(
+            rootURL: root.appendingPathComponent("runtime", isDirectory: true)
+        )
+    }
+
+    @MainActor
+    func viewModel() -> GraphWorkspaceViewModel {
+        GraphWorkspaceViewModel(service: service, defaults: defaults)
+    }
+}

--- a/Tests/OpenIslandAppTests/GraphWorkspaceTests.swift
+++ b/Tests/OpenIslandAppTests/GraphWorkspaceTests.swift
@@ -128,6 +128,99 @@ final class GraphWorkspaceTests: XCTestCase {
 
         XCTAssertEqual(viewModel.inspection?.graphDefinitionDigest, digest)
     }
+
+    func testDocumentLifecycleTracksDirtySaveReopenAndRecentDocuments()
+        async throws
+    {
+        let fixture = try WorkspaceTestFixture()
+        let viewModel = fixture.viewModel()
+        viewModel.newDocument(
+            request: GraphNewDocumentRequest(
+                name: "Authored Graph",
+                graphID: "authored-graph",
+                definitionVersion: "1",
+                description: "Lifecycle test",
+                workspaceDirectory: fixture.root.path
+            )
+        )
+
+        XCTAssertTrue(viewModel.isDirty)
+        XCTAssertEqual(viewModel.document?.name, "Authored Graph")
+        let url = fixture.root.appendingPathComponent("authored.openisland-graph.json")
+        await viewModel.saveDocument(url: url)
+        XCTAssertFalse(viewModel.isDirty)
+        XCTAssertEqual(viewModel.recentDocumentURLs.first, url)
+
+        viewModel.addNode()
+        XCTAssertTrue(viewModel.isDirty)
+        await viewModel.revertDocument()
+        XCTAssertFalse(viewModel.isDirty)
+        XCTAssertEqual(viewModel.document?.nodes.count, 0)
+
+        let restarted = fixture.viewModel()
+        await restarted.openDocument(url: url)
+        XCTAssertEqual(restarted.document?.graphID, "authored-graph")
+        XCTAssertFalse(restarted.isDirty)
+        XCTAssertEqual(restarted.recentDocumentURLs.first, url)
+    }
+
+    func testExternalModificationPreventsSilentOverwrite() async throws {
+        let fixture = try WorkspaceTestFixture()
+        let viewModel = fixture.viewModel()
+        viewModel.newDocument()
+        let url = fixture.root.appendingPathComponent("conflict.json")
+        await viewModel.saveDocument(url: url)
+        viewModel.addNode()
+        try Data("external-change".utf8).write(to: url, options: .atomic)
+
+        await viewModel.refreshExternalModificationState()
+        XCTAssertTrue(viewModel.hasExternalModification)
+        await viewModel.saveDocument()
+
+        XCTAssertEqual(viewModel.lastCommandResult?.reasonCode, "definition_save_failed")
+        XCTAssertTrue(viewModel.isDirty)
+        XCTAssertEqual(try Data(contentsOf: url), Data("external-change".utf8))
+    }
+
+    func testUnsavedCloseSupportsCancelAndDiscard() async throws {
+        let fixture = try WorkspaceTestFixture()
+        let viewModel = fixture.viewModel()
+        viewModel.newDocument()
+
+        viewModel.requestCloseDocument()
+        XCTAssertEqual(viewModel.closeState, .confirmationRequired)
+        await viewModel.resolveCloseDocument(.cancel)
+        XCTAssertNotNil(viewModel.document)
+        XCTAssertEqual(viewModel.closeState, .idle)
+
+        viewModel.requestCloseDocument()
+        await viewModel.resolveCloseDocument(.discard)
+        XCTAssertNil(viewModel.document)
+        XCTAssertFalse(viewModel.isDirty)
+    }
+
+    func testAuthoringUndoRedoAndDefinitionDraftVersioning() async throws {
+        let fixture = try WorkspaceTestFixture()
+        let viewModel = fixture.viewModel()
+        viewModel.newDocument()
+        viewModel.addNode()
+        XCTAssertEqual(viewModel.document?.nodes.count, 1)
+        viewModel.undo()
+        XCTAssertEqual(viewModel.document?.nodes.count, 0)
+        viewModel.redo()
+        XCTAssertEqual(viewModel.document?.nodes.count, 1)
+
+        await viewModel.createRun()
+        XCTAssertEqual(viewModel.associatedRunCount, 1)
+        viewModel.updateSelectedNode(name: "Renamed", description: "")
+        XCTAssertTrue(viewModel.isDraft)
+        XCTAssertEqual(viewModel.document?.nodes.first?.id, "node-1")
+
+        viewModel.createNewDefinitionVersion()
+        XCTAssertEqual(viewModel.document?.definitionVersion, "2")
+        XCTAssertFalse(viewModel.isDraft)
+        XCTAssertEqual(viewModel.associatedRunCount, 0)
+    }
 }
 
 private struct WorkspaceTestFixture {

--- a/Tests/OpenIslandAppTests/GraphWorkspaceTests.swift
+++ b/Tests/OpenIslandAppTests/GraphWorkspaceTests.swift
@@ -221,6 +221,137 @@ final class GraphWorkspaceTests: XCTestCase {
         XCTAssertFalse(viewModel.isDraft)
         XCTAssertEqual(viewModel.associatedRunCount, 0)
     }
+
+    func testNodePaletteCreatesExplicitExecutableAndReferenceTypes() throws {
+        let fixture = try WorkspaceTestFixture()
+        let viewModel = fixture.viewModel()
+        viewModel.newDocument()
+
+        for type in GraphDefinitionNodeType.allCases {
+            viewModel.addNode(type: type)
+        }
+
+        XCTAssertEqual(
+            Set(viewModel.document?.nodes.map(\.nodeType) ?? []),
+            Set(GraphDefinitionNodeType.allCases)
+        )
+        XCTAssertEqual(
+            viewModel.document?.nodes.filter(\.nodeType.isExecutable).count,
+            3
+        )
+        XCTAssertEqual(
+            try viewModel.document?.executableDefinition().scheduling.nodes.count,
+            3
+        )
+    }
+
+    func testCompleteLocalProcessNodeAuthoringPreservesIdentityAndUndo()
+        throws
+    {
+        let fixture = try WorkspaceTestFixture()
+        let viewModel = fixture.viewModel()
+        viewModel.newDocument()
+        viewModel.addNode(type: .localProcess)
+        let stableID = try XCTUnwrap(viewModel.selectedNodeID)
+
+        viewModel.updateSelectedNodeIdentity(
+            name: "Generate",
+            description: "Create the source artifact",
+            tags: ["fixture", "authoring"]
+        )
+        viewModel.updateSelectedNodeCapabilities(
+            required: ["local-process", "filesystem-write"],
+            preferred: ["arm64"],
+            executorKind: .supervisedLocalProcess,
+            platformConstraints: ["macOS"]
+        )
+        viewModel.updateSelectedLocalProcess(
+            executable: "/usr/bin/printf",
+            arguments: ["%s", "payload"],
+            workingDirectory: ".",
+            inheritedEnvironment: .allowlisted,
+            stdin: .closed,
+            environmentAllowlist: ["LANG", "PATH"],
+            workspaceRoot: fixture.root.path
+        )
+        viewModel.addSelectedNodeArgument()
+        viewModel.updateSelectedNodeArgument(at: 2, value: "tail")
+        viewModel.moveSelectedNodeArgument(from: 2, offset: -1)
+        viewModel.removeSelectedNodeArgument(at: 2)
+        viewModel.addSelectedNodeInput()
+        viewModel.addSelectedNodeOutput()
+
+        var input = try XCTUnwrap(viewModel.selectedNode?.inputs.first)
+        input.name = "Source"
+        input.mediaType = "application/json"
+        input.binding = GraphNodeInputBinding(
+            kind: .fileReference,
+            fileReference: "inputs/source.json"
+        )
+        viewModel.updateSelectedNodeInput(input)
+        var output = try XCTUnwrap(viewModel.selectedNode?.outputs.first)
+        output.name = "Generated Document"
+        output.relativePath = "artifacts/generated.json"
+        output.mediaType = "application/json"
+        output.maximumBytes = 2 * 1_024 * 1_024
+        output.sensitivity = .confidential
+        output.downstreamVisibility = .directDependents
+        viewModel.updateSelectedNodeOutput(output)
+
+        let retry = GraphRetryPolicy(
+            maximumAttempts: 4,
+            retryableFailureCategories: ["timeout"],
+            initialBackoffSeconds: 2,
+            maximumBackoffSeconds: 20,
+            timeoutBehavior: .retry
+        )
+        viewModel.updateSelectedNodeRetry(
+            GraphNodeRetryConfiguration(
+                inheritsGraphDefault: false,
+                override: retry
+            )
+        )
+        viewModel.updateSelectedNodeTimeout(
+            GraphNodeTimeoutConfiguration(
+                inheritsGraphDefault: false,
+                executionSeconds: 45,
+                cancellationAcknowledgementSeconds: 7,
+                claimSeconds: 11
+            )
+        )
+
+        let node = try XCTUnwrap(viewModel.selectedNode)
+        let process = try GraphLocalProcessSpecification(
+            immutableSpecification: node.specification
+        )
+        XCTAssertEqual(node.id, stableID)
+        XCTAssertEqual(node.name, "Generate")
+        XCTAssertEqual(node.tags, ["authoring", "fixture"])
+        XCTAssertEqual(process.executable, "/usr/bin/printf")
+        XCTAssertEqual(process.arguments, ["%s", "tail"])
+        XCTAssertEqual(node.environmentAllowlist, ["LANG", "PATH"])
+        XCTAssertEqual(node.inputs.first?.binding?.fileReference, "inputs/source.json")
+        XCTAssertEqual(process.outputArtifacts.first?.stableID, output.id)
+        XCTAssertEqual(process.outputArtifacts.first?.required, true)
+        XCTAssertEqual(node.timeoutPolicy.executionSeconds, 45)
+        XCTAssertEqual(
+            try viewModel.document?.executableDefinition().schedulerPolicy
+                .retryPolicy(for: stableID).maximumAttempts,
+            4
+        )
+
+        let encoded = try GraphDefinitionDocumentCodec.encode(
+            XCTUnwrap(viewModel.document)
+        )
+        let reopened = try GraphDefinitionDocumentCodec.decode(encoded)
+        XCTAssertEqual(reopened.nodes.first?.id, stableID)
+        XCTAssertEqual(reopened.nodes.first?.outputs.first?.id, output.id)
+
+        viewModel.undo()
+        XCTAssertNotEqual(viewModel.selectedNode?.timeoutPolicy.executionSeconds, 45)
+        viewModel.redo()
+        XCTAssertEqual(viewModel.selectedNode?.timeoutPolicy.executionSeconds, 45)
+    }
 }
 
 private struct WorkspaceTestFixture {

--- a/Tests/OpenIslandAppTests/GraphWorkspaceTests.swift
+++ b/Tests/OpenIslandAppTests/GraphWorkspaceTests.swift
@@ -483,6 +483,98 @@ final class GraphWorkspaceTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedEdge?.sourceNodeID, source)
         XCTAssertEqual(viewModel.selectedEdge?.targetNodeID, target)
     }
+
+    func testValidationNavigationIncrementalUpdatesAndCreateRunInputGate()
+        async throws
+    {
+        let fixture = try WorkspaceTestFixture()
+        let viewModel = fixture.viewModel()
+        viewModel.newDocument()
+        viewModel.validateDocument()
+
+        XCTAssertTrue(viewModel.isShowingValidationPanel)
+        XCTAssertTrue(viewModel.validationDiagnostics.contains {
+            $0.code == .emptyGraph && $0.severity == .error
+        })
+
+        viewModel.addNode(type: .deterministicTest)
+        viewModel.addGraphInput()
+        await viewModel.refreshValidation()
+        let inputDiagnostic = try XCTUnwrap(
+            viewModel.validationDiagnostics.first {
+                $0.code == .missingRequiredInput
+                    && $0.target.kind == .graphInput
+            }
+        )
+        viewModel.selectValidationDiagnostic(inputDiagnostic)
+        XCTAssertTrue(viewModel.selectedNodeIDs.isEmpty)
+        XCTAssertNil(viewModel.selectedEdgeID)
+
+        await viewModel.prepareCreateRun()
+        XCTAssertTrue(viewModel.isShowingCreateRunSheet)
+        await viewModel.confirmCreateRun()
+        XCTAssertNil(viewModel.inspection)
+        XCTAssertEqual(
+            viewModel.lastCommandResult?.reasonCode,
+            "definition_validation_failed"
+        )
+
+        let inputID = try XCTUnwrap(viewModel.document?.graphInputs.first?.id)
+        viewModel.runCreationDraft.inputValues[inputID] = "resolved"
+        await viewModel.refreshValidation(
+            resolvedGraphInputIDs: viewModel.runCreationDraft.resolvedInputIDs
+        )
+        XCTAssertFalse(viewModel.validationDiagnostics.contains {
+            $0.severity == .error
+        })
+
+        await viewModel.confirmCreateRun()
+        XCTAssertEqual(viewModel.mode, .run)
+        XCTAssertEqual(
+            viewModel.runCreationDraft.backend,
+            .deterministicTest
+        )
+        XCTAssertTrue(viewModel.lastCommandResult?.accepted == true)
+    }
+
+    func testGraphInputOutputLifecycleAndDeterministicExecutorRouting()
+        async throws
+    {
+        let fixture = try WorkspaceTestFixture()
+        let viewModel = fixture.viewModel()
+        viewModel.newDocument()
+        viewModel.addNode(type: .deterministicTest)
+        let nodeID = try XCTUnwrap(viewModel.selectedNodeID)
+
+        viewModel.addGraphInput()
+        var graphInput = try XCTUnwrap(viewModel.document?.graphInputs.first)
+        graphInput.name = "Request"
+        graphInput.dataType = .json
+        graphInput.defaultValue = .object(["topic": .string("test")])
+        viewModel.updateGraphInput(graphInput)
+        viewModel.addGraphOutput()
+
+        let graphOutput = try XCTUnwrap(viewModel.document?.graphOutputs.first)
+        XCTAssertEqual(graphOutput.sourceNodeID, nodeID)
+        XCTAssertEqual(graphOutput.sourceOutputID, "output-node")
+
+        await viewModel.prepareCreateRun()
+        XCTAssertEqual(viewModel.runCreationDraft.backend, .deterministicTest)
+        await viewModel.confirmCreateRun()
+        await viewModel.startRun()
+        viewModel.run()
+        await viewModel.waitForLocalOrchestration()
+
+        XCTAssertEqual(
+            viewModel.inspection?.summary.persistedState,
+            .completed
+        )
+        XCTAssertEqual(
+            viewModel.inspection?.nodes.first?.persistedState,
+            .completed
+        )
+        XCTAssertFalse(viewModel.inspection?.artifacts.isEmpty ?? true)
+    }
 }
 
 private struct WorkspaceTestFixture {

--- a/Tests/OpenIslandAppTests/GraphWorkspaceTests.swift
+++ b/Tests/OpenIslandAppTests/GraphWorkspaceTests.swift
@@ -333,6 +333,7 @@ final class GraphWorkspaceTests: XCTestCase {
         XCTAssertEqual(node.inputs.first?.binding?.fileReference, "inputs/source.json")
         XCTAssertEqual(process.outputArtifacts.first?.stableID, output.id)
         XCTAssertEqual(process.outputArtifacts.first?.required, true)
+        XCTAssertEqual(node.workspace.writableRelativePaths, ["artifacts"])
         XCTAssertEqual(node.timeoutPolicy.executionSeconds, 45)
         XCTAssertEqual(
             try viewModel.document?.executableDefinition().schedulerPolicy

--- a/Tests/OpenIslandAppTests/GraphWorkspaceTests.swift
+++ b/Tests/OpenIslandAppTests/GraphWorkspaceTests.swift
@@ -352,6 +352,137 @@ final class GraphWorkspaceTests: XCTestCase {
         viewModel.redo()
         XCTAssertEqual(viewModel.selectedNode?.timeoutPolicy.executionSeconds, 45)
     }
+
+    func testTypedArtifactConnectionBindsStablePortsAndSupportsUndoDelete()
+        throws
+    {
+        let fixture = try WorkspaceTestFixture()
+        let viewModel = fixture.viewModel()
+        viewModel.newDocument()
+        viewModel.addNode(type: .localProcess)
+        let sourceID = try XCTUnwrap(viewModel.selectedNodeID)
+        viewModel.addSelectedNodeOutput()
+        var output = try XCTUnwrap(viewModel.selectedNode?.outputs.first)
+        output.mediaType = "application/json"
+        viewModel.updateSelectedNodeOutput(output)
+
+        viewModel.addNode(type: .localProcess)
+        let targetID = try XCTUnwrap(viewModel.selectedNodeID)
+        viewModel.addSelectedNodeInput()
+        var input = try XCTUnwrap(viewModel.selectedNode?.inputs.first)
+        input.mediaType = "application/json"
+        viewModel.updateSelectedNodeInput(input)
+
+        let decision = viewModel.connectNodes(
+            sourceNodeID: sourceID,
+            targetNodeID: targetID,
+            portType: .artifact,
+            sourceOutputID: output.id,
+            targetInputID: input.id
+        )
+
+        XCTAssertTrue(decision.isAllowed)
+        let edge = try XCTUnwrap(viewModel.selectedEdge)
+        XCTAssertEqual(edge.sourceOutputID, output.id)
+        XCTAssertEqual(edge.targetInputID, input.id)
+        let target = try XCTUnwrap(viewModel.document?.nodes.first {
+            $0.id == targetID
+        })
+        XCTAssertEqual(target.inputs.first?.binding?.sourceNodeID, sourceID)
+        XCTAssertEqual(target.inputs.first?.binding?.sourceOutputID, output.id)
+        XCTAssertEqual(target.inputArtifactRoles, [output.role])
+
+        var optionalEdge = edge
+        optionalEdge.isRequired = false
+        viewModel.updateSelectedEdge(optionalEdge)
+        XCTAssertEqual(viewModel.selectedEdge?.isRequired, false)
+
+        let duplicate = viewModel.connectNodes(
+            sourceNodeID: sourceID,
+            targetNodeID: targetID,
+            portType: .artifact,
+            sourceOutputID: output.id,
+            targetInputID: input.id
+        )
+        XCTAssertEqual(duplicate.rejection, .duplicateEdge)
+
+        viewModel.undo()
+        XCTAssertEqual(viewModel.selectedEdge?.isRequired, true)
+        viewModel.undo()
+        XCTAssertTrue(viewModel.document?.edges.isEmpty == true)
+        viewModel.redo()
+        XCTAssertEqual(viewModel.document?.edges.count, 1)
+        viewModel.selectEdge(try XCTUnwrap(viewModel.document?.edges.first?.id))
+        viewModel.deleteSelection()
+        XCTAssertTrue(viewModel.document?.edges.isEmpty == true)
+    }
+
+    func testConnectionPathsRejectSelfCycleVisualAndMediaMismatch() throws {
+        let fixture = try WorkspaceTestFixture()
+        let viewModel = fixture.viewModel()
+        viewModel.newDocument()
+        viewModel.addNode(type: .localProcess)
+        let first = try XCTUnwrap(viewModel.selectedNodeID)
+        viewModel.addSelectedNodeOutput()
+        let output = try XCTUnwrap(viewModel.selectedNode?.outputs.first)
+        viewModel.addNode(type: .localProcess)
+        let second = try XCTUnwrap(viewModel.selectedNodeID)
+        viewModel.addSelectedNodeInput()
+        var input = try XCTUnwrap(viewModel.selectedNode?.inputs.first)
+        input.mediaType = "text/plain"
+        viewModel.updateSelectedNodeInput(input)
+
+        XCTAssertEqual(
+            viewModel.connectNodes(sourceNodeID: first, targetNodeID: first)
+                .rejection,
+            .selfEdge
+        )
+        XCTAssertEqual(
+            viewModel.connectNodes(
+                sourceNodeID: first,
+                targetNodeID: second,
+                portType: .artifact,
+                sourceOutputID: output.id,
+                targetInputID: input.id
+            ).rejection,
+            .incompatibleMediaType
+        )
+        XCTAssertTrue(
+            viewModel.connectNodes(sourceNodeID: first, targetNodeID: second)
+                .isAllowed
+        )
+        XCTAssertEqual(
+            viewModel.connectNodes(sourceNodeID: second, targetNodeID: first)
+                .rejection,
+            .cycle
+        )
+
+        viewModel.addNode(type: .annotation)
+        let annotation = try XCTUnwrap(viewModel.selectedNodeID)
+        XCTAssertEqual(
+            viewModel.connectNodes(sourceNodeID: annotation, targetNodeID: first)
+                .rejection,
+            .nonExecutableDependency
+        )
+    }
+
+    func testKeyboardDependencyWorkflowUsesSameValidatedConnectionPath() throws {
+        let fixture = try WorkspaceTestFixture()
+        let viewModel = fixture.viewModel()
+        viewModel.newDocument()
+        viewModel.addNode(type: .localProcess)
+        let source = try XCTUnwrap(viewModel.selectedNodeID)
+        viewModel.addNode(type: .localProcess)
+        let target = try XCTUnwrap(viewModel.selectedNodeID)
+
+        viewModel.beginDependencyCreation(from: source)
+        viewModel.completeDependencyCreation(to: target)
+
+        XCTAssertNil(viewModel.dependencySourceNodeID)
+        XCTAssertEqual(viewModel.document?.edges.count, 1)
+        XCTAssertEqual(viewModel.selectedEdge?.sourceNodeID, source)
+        XCTAssertEqual(viewModel.selectedEdge?.targetNodeID, target)
+    }
 }
 
 private struct WorkspaceTestFixture {

--- a/Tests/OpenIslandAppTests/GraphWorkspaceTests.swift
+++ b/Tests/OpenIslandAppTests/GraphWorkspaceTests.swift
@@ -45,6 +45,32 @@ final class GraphWorkspaceTests: XCTestCase {
         XCTAssertEqual(activations, 2)
     }
 
+    func testAllNewGraphEntryPointsPresentTemplateConfiguration() throws {
+        let fixture = try WorkspaceTestFixture()
+        let viewModel = fixture.viewModel()
+
+        XCTAssertFalse(viewModel.isShowingNewGraphSheet)
+        viewModel.presentNewGraphSheet()
+        XCTAssertTrue(viewModel.isShowingNewGraphSheet)
+
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: root.appendingPathComponent(
+                "Sources/OpenIslandApp/Views/GraphWorkspaceView.swift"
+            ),
+            encoding: .utf8
+        )
+        XCTAssertTrue(source.contains("viewModel?.presentNewGraphSheet()"))
+        XCTAssertGreaterThanOrEqual(
+            source.components(separatedBy: "viewModel.presentNewGraphSheet()").count - 1,
+            2
+        )
+        XCTAssertTrue(source.contains("isPresented: $viewModel.isShowingNewGraphSheet"))
+    }
+
     func testEmptyWorkspaceDefinitionRunAndHistoryModesWork() async throws {
         let fixture = try WorkspaceTestFixture()
         let viewModel = fixture.viewModel()

--- a/Tests/OpenIslandAppTests/UIAuthoredGraphEndToEndTests.swift
+++ b/Tests/OpenIslandAppTests/UIAuthoredGraphEndToEndTests.swift
@@ -1,0 +1,366 @@
+import Foundation
+import XCTest
+@testable import OpenIslandApp
+@testable import OpenIslandCore
+
+@MainActor
+final class UIAuthoredGraphEndToEndTests: XCTestCase {
+    func testBlankGraphBecomesDurableThreeProcessRunWithCLIParity()
+        async throws
+    {
+        let fixture = try UIAuthoredGraphFixture(name: "three-process")
+        let viewModel = fixture.viewModel()
+        viewModel.newDocument(request: fixture.blankRequest(name: "Three Process"))
+
+        let generate = try addLocalStage(
+            "generate",
+            outputRole: .nodeOutput,
+            inputRole: nil,
+            fixture: fixture,
+            viewModel: viewModel
+        )
+        let transform = try addLocalStage(
+            "transform",
+            outputRole: .structuredResult,
+            inputRole: .nodeOutput,
+            fixture: fixture,
+            viewModel: viewModel
+        )
+        let verify = try addLocalStage(
+            "verify",
+            outputRole: .diagnostic,
+            inputRole: .structuredResult,
+            fixture: fixture,
+            viewModel: viewModel
+        )
+        try connectArtifact(generate, transform, viewModel: viewModel)
+        try connectArtifact(transform, verify, viewModel: viewModel)
+
+        try await saveCloseReopenValidate(
+            viewModel: viewModel,
+            documentURL: fixture.documentURL
+        )
+        try await executeToCompletion(viewModel: viewModel)
+
+        XCTAssertEqual(
+            viewModel.inspection?.summary.persistedState,
+            .completed
+        )
+        XCTAssertGreaterThanOrEqual(viewModel.inspection?.artifacts.count ?? 0, 3)
+        XCTAssertTrue(fixture.artifactExists("generate.json"))
+        XCTAssertTrue(fixture.artifactExists("transform.json"))
+        XCTAssertTrue(fixture.artifactExists("verify.json"))
+
+        viewModel.selectNode(generate.nodeID)
+        await viewModel.openLogs()
+        XCTAssertTrue(
+            viewModel.logPage?.entries.map(\.text).joined()
+                .contains("role=generate") == true
+        )
+
+        let runID = try XCTUnwrap(viewModel.inspection?.summary.runID)
+        try fixture.assertCLIState(runID: runID, expectedState: "completed")
+        let restarted = GraphWorkspaceViewModel(
+            service: try fixture.restartedService(),
+            defaults: fixture.defaults
+        )
+        await restarted.restoreState()
+        XCTAssertEqual(restarted.inspection?.summary.runID, runID)
+        XCTAssertEqual(restarted.inspection?.summary.persistedState, .completed)
+    }
+
+    func testCompendiumFillIsBuiltFromBlankThroughAuthoringCommands()
+        async throws
+    {
+        let fixture = try UIAuthoredGraphFixture(name: "compendium-fill")
+        let viewModel = fixture.viewModel()
+        viewModel.newDocument(request: fixture.blankRequest(name: "Compendium Fill"))
+
+        let architect = try addLocalStage(
+            "architect",
+            outputRole: .nodeOutput,
+            inputRole: nil,
+            fixture: fixture,
+            viewModel: viewModel
+        )
+        let researcher = try addLocalStage(
+            "researcher",
+            outputRole: .structuredResult,
+            inputRole: .nodeOutput,
+            fixture: fixture,
+            viewModel: viewModel
+        )
+        let graph = try addLocalStage(
+            "graph",
+            outputRole: .diagnostic,
+            inputRole: .structuredResult,
+            fixture: fixture,
+            viewModel: viewModel
+        )
+        let reviewer = try addLocalStage(
+            "reviewer",
+            outputRole: .structuredResult,
+            inputRole: .diagnostic,
+            fixture: fixture,
+            viewModel: viewModel
+        )
+        try connectArtifact(architect, researcher, viewModel: viewModel)
+        try connectArtifact(researcher, graph, viewModel: viewModel)
+        try connectArtifact(graph, reviewer, viewModel: viewModel)
+
+        XCTAssertEqual(viewModel.document?.name, "Compendium Fill")
+        XCTAssertEqual(viewModel.document?.nodes.count, 4)
+        XCTAssertEqual(viewModel.document?.edges.count, 3)
+        try await saveCloseReopenValidate(
+            viewModel: viewModel,
+            documentURL: fixture.documentURL
+        )
+        try await executeToCompletion(viewModel: viewModel)
+
+        XCTAssertEqual(
+            viewModel.inspection?.summary.persistedState,
+            .completed
+        )
+        XCTAssertEqual(
+            Set(viewModel.inspection?.nodes.map(\.persistedState) ?? []),
+            [.completed]
+        )
+        let reviewerData = try Data(
+            contentsOf: fixture.artifactURL("reviewer.json")
+        )
+        let reviewerResult = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: reviewerData)
+                as? [String: Any]
+        )
+        XCTAssertEqual(reviewerResult["verdict"] as? String, "pass")
+        XCTAssertEqual(reviewerResult["inputCount"] as? Int, 1)
+    }
+
+    private func addLocalStage(
+        _ name: String,
+        outputRole: GraphArtifactRole,
+        inputRole: GraphArtifactRole?,
+        fixture: UIAuthoredGraphFixture,
+        viewModel: GraphWorkspaceViewModel
+    ) throws -> AuthoredStage {
+        viewModel.addNode(type: .localProcess)
+        let nodeID = try XCTUnwrap(viewModel.selectedNodeID)
+        viewModel.updateSelectedNodeIdentity(
+            name: name.capitalized,
+            description: "UI-authored \(name) process",
+            tags: ["ui-authored", "local-process"]
+        )
+        var inputID: String?
+        if let inputRole {
+            viewModel.addSelectedNodeInput()
+            var input = try XCTUnwrap(viewModel.selectedNode?.inputs.first)
+            input.name = inputRole.rawValue
+            input.mediaType = "application/json"
+            viewModel.updateSelectedNodeInput(input)
+            inputID = input.id
+        }
+        viewModel.addSelectedNodeOutput()
+        var output = try XCTUnwrap(viewModel.selectedNode?.outputs.first)
+        output.name = outputRole.rawValue
+        output.role = outputRole
+        output.relativePath = "artifacts/\(name).json"
+        output.mediaType = "application/json"
+        viewModel.updateSelectedNodeOutput(output)
+
+        var arguments = ["--role", name]
+        if let inputRole {
+            arguments += ["--input", "${input:\(inputRole.rawValue)}"]
+        }
+        arguments += ["--output", "${artifact:\(outputRole.rawValue)}"]
+        if inputRole == nil { arguments.append("--stderr") }
+        viewModel.updateSelectedLocalProcess(
+            executable: fixture.executableURL.path,
+            arguments: arguments,
+            workingDirectory: ".",
+            inheritedEnvironment: .none,
+            stdin: .nullDevice,
+            environmentAllowlist: [],
+            workspaceRoot: fixture.workspaceURL.path
+        )
+        return AuthoredStage(
+            nodeID: nodeID,
+            inputID: inputID,
+            outputID: output.id
+        )
+    }
+
+    private func connectArtifact(
+        _ source: AuthoredStage,
+        _ target: AuthoredStage,
+        viewModel: GraphWorkspaceViewModel
+    ) throws {
+        let decision = viewModel.connectNodes(
+            sourceNodeID: source.nodeID,
+            targetNodeID: target.nodeID,
+            portType: .artifact,
+            sourceOutputID: source.outputID,
+            targetInputID: try XCTUnwrap(target.inputID)
+        )
+        XCTAssertTrue(decision.isAllowed, decision.message)
+    }
+
+    private func saveCloseReopenValidate(
+        viewModel: GraphWorkspaceViewModel,
+        documentURL: URL
+    ) async throws {
+        viewModel.validateDocument()
+        XCTAssertFalse(viewModel.validationDiagnostics.contains {
+            $0.severity == .error
+        })
+        await viewModel.saveDocument(url: documentURL)
+        XCTAssertFalse(viewModel.isDirty)
+        viewModel.requestCloseDocument()
+        XCTAssertNil(viewModel.document)
+        await viewModel.openDocument(url: documentURL)
+        XCTAssertNotNil(viewModel.document)
+        await viewModel.refreshValidation()
+        XCTAssertFalse(viewModel.validationDiagnostics.contains {
+            $0.severity == .error
+        })
+    }
+
+    private func executeToCompletion(
+        viewModel: GraphWorkspaceViewModel
+    ) async throws {
+        await viewModel.prepareCreateRun()
+        XCTAssertTrue(viewModel.isShowingCreateRunSheet)
+        await viewModel.confirmCreateRun()
+        XCTAssertTrue(
+            viewModel.lastCommandResult?.accepted == true,
+            "create=\(String(describing: viewModel.lastCommandResult)) error=\(String(describing: viewModel.errorMessage))"
+        )
+        await viewModel.startRun()
+        XCTAssertTrue(
+            viewModel.lastCommandResult?.accepted == true,
+            "start=\(String(describing: viewModel.lastCommandResult)) error=\(String(describing: viewModel.errorMessage)) state=\(String(describing: viewModel.inspection?.summary.persistedState))"
+        )
+        viewModel.run()
+        await viewModel.waitForLocalOrchestration()
+        XCTAssertEqual(
+            viewModel.inspection?.summary.persistedState,
+            .completed,
+            "last=\(String(describing: viewModel.lastCommandResult)) error=\(String(describing: viewModel.errorMessage)) events=\(viewModel.history?.events.suffix(10).map(\.eventType) ?? [])"
+        )
+    }
+}
+
+private struct AuthoredStage {
+    let nodeID: String
+    let inputID: String?
+    let outputID: String
+}
+
+private struct UIAuthoredGraphFixture {
+    let rootURL: URL
+    let workspaceURL: URL
+    let runtimeURL: URL
+    let databasePath: String
+    let documentURL: URL
+    let executableURL: URL
+    let defaults: UserDefaults
+    let service: GraphWorkspaceService
+
+    init(name: String) throws {
+        rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        workspaceURL = rootURL.appendingPathComponent("workspace", isDirectory: true)
+        runtimeURL = rootURL.appendingPathComponent("runtime", isDirectory: true)
+        databasePath = rootURL.appendingPathComponent("graph.sqlite").path
+        documentURL = rootURL.appendingPathComponent("\(name).openisland-graph.json")
+        executableURL = try GraphWorkspaceBundledFixtures.fixtureExecutableURL()
+        defaults = try XCTUnwrap(
+            UserDefaults(suiteName: "UIAuthoredGraph-\(UUID().uuidString)")
+        )
+        try FileManager.default.createDirectory(
+            at: workspaceURL.appendingPathComponent("artifacts", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        let store = try SQLiteGraphExecutionStore(databasePath: databasePath)
+        let launchStore = try GraphLocalProcessLaunchStore(rootURL: runtimeURL)
+        service = GraphWorkspaceService(
+            eventStore: store,
+            readStore: store,
+            snapshotStore: store,
+            processExecutor: SupervisedLocalProcessExecutor(
+                launchStore: launchStore
+            ),
+            launchStore: launchStore
+        )
+    }
+
+    @MainActor
+    func viewModel() -> GraphWorkspaceViewModel {
+        GraphWorkspaceViewModel(service: service, defaults: defaults)
+    }
+
+    func blankRequest(name: String) -> GraphNewDocumentRequest {
+        GraphNewDocumentRequest(
+            template: .blank,
+            name: name,
+            graphID: name.lowercased().replacingOccurrences(of: " ", with: "-"),
+            definitionVersion: "1",
+            description: "Built through Graph Workspace authoring commands",
+            workspaceDirectory: workspaceURL.path
+        )
+    }
+
+    func restartedService() throws -> GraphWorkspaceService {
+        let store = try SQLiteGraphExecutionStore(databasePath: databasePath)
+        let launchStore = try GraphLocalProcessLaunchStore(rootURL: runtimeURL)
+        return GraphWorkspaceService(
+            eventStore: store,
+            readStore: store,
+            snapshotStore: store,
+            processExecutor: SupervisedLocalProcessExecutor(
+                launchStore: launchStore
+            ),
+            launchStore: launchStore
+        )
+    }
+
+    func artifactURL(_ name: String) -> URL {
+        workspaceURL.appendingPathComponent("artifacts/\(name)")
+    }
+
+    func artifactExists(_ name: String) -> Bool {
+        FileManager.default.fileExists(atPath: artifactURL(name).path)
+    }
+
+    func assertCLIState(runID: String, expectedState: String) throws {
+        let cliURL = executableURL.deletingLastPathComponent()
+            .appendingPathComponent("openisland")
+        let process = Process()
+        process.executableURL = cliURL
+        process.arguments = [
+            "graph", "inspect", runID,
+            "--include-artifacts",
+            "--output", "json",
+            "--no-color",
+        ]
+        var environment = ProcessInfo.processInfo.environment
+        environment["OPENISLAND_GRAPH_DATABASE_PATH"] = databasePath
+        process.environment = environment
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+        try process.run()
+        process.waitUntilExit()
+        let output = String(
+            decoding: stdout.fileHandleForReading.readDataToEndOfFile(),
+            as: UTF8.self
+        )
+        let error = String(
+            decoding: stderr.fileHandleForReading.readDataToEndOfFile(),
+            as: UTF8.self
+        )
+        XCTAssertEqual(process.terminationStatus, 0, error)
+        XCTAssertTrue(output.contains(runID))
+        XCTAssertTrue(output.contains(expectedState))
+    }
+}

--- a/Tests/OpenIslandCoreTests/AgentObservabilityTests.swift
+++ b/Tests/OpenIslandCoreTests/AgentObservabilityTests.swift
@@ -1,0 +1,165 @@
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+struct AgentObservabilityTests {
+    @Test
+    func reducerBuildsSessionTimelineAndMetrics() {
+        let startedAt = Date(timeIntervalSince1970: 10_000)
+        var state = SessionState()
+
+        state.apply(
+            .sessionStarted(
+                SessionStarted(
+                    sessionID: "observed-session",
+                    title: "Observed session",
+                    tool: .codex,
+                    summary: "Starting",
+                    timestamp: startedAt
+                )
+            )
+        )
+        state.apply(
+            .sessionMetadataUpdated(
+                SessionMetadataUpdated(
+                    sessionID: "observed-session",
+                    codexMetadata: CodexSessionMetadata(
+                        currentTool: "exec_command",
+                        currentCommandPreview: "swift test"
+                    ),
+                    timestamp: startedAt.addingTimeInterval(2)
+                )
+            )
+        )
+        state.apply(
+            .permissionRequested(
+                PermissionRequested(
+                    sessionID: "observed-session",
+                    request: PermissionRequest(
+                        title: "Run command",
+                        summary: "Needs permission",
+                        affectedPath: "/tmp/worktree",
+                        toolName: "exec_command"
+                    ),
+                    timestamp: startedAt.addingTimeInterval(4)
+                )
+            )
+        )
+        state.apply(
+            .actionableStateResolved(
+                ActionableStateResolved(
+                    sessionID: "observed-session",
+                    summary: "Permission handled",
+                    timestamp: startedAt.addingTimeInterval(6)
+                )
+            )
+        )
+        state.apply(
+            .sessionCompleted(
+                SessionCompleted(
+                    sessionID: "observed-session",
+                    summary: "Finished",
+                    timestamp: startedAt.addingTimeInterval(10)
+                )
+            )
+        )
+
+        let observability = state.session(id: "observed-session")?.observability
+        #expect(observability?.timeline.map(\.kind) == [
+            .lifecycle,
+            .tool,
+            .permission,
+            .status,
+            .completion,
+        ])
+        #expect(observability?.metrics.eventCount == 5)
+        #expect(observability?.metrics.toolEventCount == 1)
+        #expect(observability?.metrics.attentionEventCount == 1)
+        #expect(observability?.metrics.completionCount == 1)
+        #expect(observability?.metrics.elapsed(at: startedAt.addingTimeInterval(10)) == 10)
+    }
+
+    @Test
+    func repeatedMetadataDoesNotInflateMetrics() {
+        let startedAt = Date(timeIntervalSince1970: 20_000)
+        var state = SessionState()
+        state.apply(
+            .sessionStarted(
+                SessionStarted(
+                    sessionID: "deduplicated-session",
+                    title: "Deduplicated session",
+                    tool: .codex,
+                    summary: "Starting",
+                    timestamp: startedAt
+                )
+            )
+        )
+
+        for offset in [1.0, 2.0, 3.0] {
+            state.apply(
+                .sessionMetadataUpdated(
+                    SessionMetadataUpdated(
+                        sessionID: "deduplicated-session",
+                        codexMetadata: CodexSessionMetadata(
+                            currentTool: "exec_command",
+                            currentCommandPreview: "swift test"
+                        ),
+                        timestamp: startedAt.addingTimeInterval(offset)
+                    )
+                )
+            )
+        }
+
+        let observability = state.session(id: "deduplicated-session")?.observability
+        #expect(observability?.metrics.eventCount == 2)
+        #expect(observability?.metrics.toolEventCount == 1)
+        #expect(observability?.timeline.last?.timestamp == startedAt.addingTimeInterval(3))
+    }
+
+    @Test
+    func timelineIsBoundedWithoutLosingAggregateCount() {
+        var observability = AgentSessionObservability()
+
+        for index in 0..<4 {
+            observability.record(
+                AgentTimelineEvent(
+                    timestamp: Date(timeIntervalSince1970: TimeInterval(index)),
+                    kind: .status,
+                    title: "Status \(index)"
+                ),
+                timelineLimit: 2
+            )
+        }
+
+        #expect(observability.timeline.map(\.title) == ["Status 2", "Status 3"])
+        #expect(observability.metrics.eventCount == 4)
+    }
+
+    @Test
+    func observabilityPersistsThroughTrackedSessionRegistryRecord() throws {
+        var observability = AgentSessionObservability()
+        observability.record(
+            AgentTimelineEvent(
+                timestamp: Date(timeIntervalSince1970: 30_000),
+                kind: .tool,
+                title: "Using web scraper",
+                toolName: "web_scraper"
+            )
+        )
+        let session = AgentSession(
+            id: "persisted-session",
+            title: "Persisted session",
+            tool: .codex,
+            phase: .running,
+            summary: "Collecting sources",
+            updatedAt: Date(timeIntervalSince1970: 30_000),
+            observability: observability
+        )
+        let record = CodexTrackedSessionRecord(session: session)
+
+        let data = try JSONEncoder().encode(record)
+        let decoded = try JSONDecoder().decode(CodexTrackedSessionRecord.self, from: data)
+
+        #expect(decoded.session.observability == observability)
+    }
+}

--- a/Tests/OpenIslandCoreTests/AgentTaskGraphTests.swift
+++ b/Tests/OpenIslandCoreTests/AgentTaskGraphTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+@testable import OpenIslandCore
+
+final class AgentTaskGraphTests: XCTestCase {
+    func testRootNodesBecomeReady() {
+        let root = AgentTaskNode(
+            title: "Research",
+            instructions: "Research the problem.",
+            executionKind: .gemini
+        )
+
+        let dependent = AgentTaskNode(
+            title: "Implement",
+            instructions: "Implement the result.",
+            executionKind: .codex
+        )
+
+        var graph = AgentTaskGraph(
+            title: "Test",
+            nodes: [root, dependent],
+            edges: [
+                AgentTaskEdge(
+                    sourceNodeID: root.id,
+                    destinationNodeID: dependent.id
+                ),
+            ]
+        )
+
+        graph.refreshSchedulingStates()
+
+        XCTAssertEqual(
+            graph.node(withID: root.id)?.state,
+            .ready
+        )
+
+        XCTAssertEqual(
+            graph.node(withID: dependent.id)?.state,
+            .blocked
+        )
+    }
+
+    func testCompletedDependencyUnblocksDependentNode() {
+        var root = AgentTaskNode(
+            title: "Research",
+            instructions: "Research.",
+            executionKind: .gemini
+        )
+        root.state = .completed
+
+        let dependent = AgentTaskNode(
+            title: "Implement",
+            instructions: "Implement.",
+            executionKind: .codex
+        )
+
+        var graph = AgentTaskGraph(
+            title: "Test",
+            nodes: [root, dependent],
+            edges: [
+                AgentTaskEdge(
+                    sourceNodeID: root.id,
+                    destinationNodeID: dependent.id
+                ),
+            ]
+        )
+
+        graph.refreshSchedulingStates()
+
+        XCTAssertEqual(
+            graph.node(withID: dependent.id)?.state,
+            .ready
+        )
+    }
+
+    func testCycleDetection() {
+        let first = AgentTaskNode(
+            title: "First",
+            instructions: "",
+            executionKind: .ollama
+        )
+
+        let second = AgentTaskNode(
+            title: "Second",
+            instructions: "",
+            executionKind: .ollama
+        )
+
+        let graph = AgentTaskGraph(
+            title: "Cycle",
+            nodes: [first, second],
+            edges: [
+                AgentTaskEdge(
+                    sourceNodeID: first.id,
+                    destinationNodeID: second.id
+                ),
+                AgentTaskEdge(
+                    sourceNodeID: second.id,
+                    destinationNodeID: first.id
+                ),
+            ]
+        )
+
+        XCTAssertTrue(graph.containsCycle())
+    }
+
+    func testExecutorRunsDependencyChain() async throws {
+        let research = AgentTaskNode(
+            title: "Research",
+            instructions: "Research.",
+            executionKind: .gemini
+        )
+
+        let implementation = AgentTaskNode(
+            title: "Implementation",
+            instructions: "Implement.",
+            executionKind: .codex
+        )
+
+        let review = AgentTaskNode(
+            title: "Review",
+            instructions: "Review.",
+            executionKind: .ollama
+        )
+
+        let graph = AgentTaskGraph(
+            title: "Pipeline",
+            nodes: [research, implementation, review],
+            edges: [
+                AgentTaskEdge(
+                    sourceNodeID: research.id,
+                    destinationNodeID: implementation.id
+                ),
+                AgentTaskEdge(
+                    sourceNodeID: implementation.id,
+                    destinationNodeID: review.id
+                ),
+            ]
+        )
+
+        let executor = AgentGraphExecutor(graph: graph) {
+            node,
+            dependencies in
+
+            AgentTaskExecutionResult(
+                output: "\(node.title): \(dependencies.count) inputs"
+            )
+        }
+
+        let completed = try await executor.execute()
+
+        XCTAssertTrue(
+            completed.nodes.allSatisfy {
+                $0.state == .completed
+            }
+        )
+    }
+}

--- a/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
@@ -70,6 +70,21 @@ struct CodexSessionTrackingTests {
             phase: .running,
             updatedAt: .now
         )
+        let completedLiveRecord = CodexTrackedSessionRecord(
+            sessionID: "019f2afd-e6fd-7e11-bdd4-945caba06867",
+            title: "Codex · UHCLregistrationbot",
+            origin: .live,
+            attachmentState: .stale,
+            summary: "Turn completed.",
+            phase: .completed,
+            updatedAt: .now,
+            jumpTarget: JumpTarget(
+                terminalApp: "Codex.app",
+                workspaceName: "UHCLregistrationbot",
+                paneTitle: "Codex · UHCLregistrationbot",
+                codexThreadID: "019f2afd-e6fd-7e11-bdd4-945caba06867"
+            )
+        )
         let legacyMockRecord = CodexTrackedSessionRecord(
             sessionID: "codex-backend-server",
             title: "backend server",
@@ -89,6 +104,7 @@ struct CodexSessionTrackingTests {
 
         #expect(liveRecord.shouldRestoreToLiveState)
         #expect(!demoRecord.shouldRestoreToLiveState)
+        #expect(!completedLiveRecord.shouldRestoreToLiveState)
         #expect(!legacyMockRecord.shouldRestoreToLiveState)
         #expect(!debugScenarioRecord.shouldRestoreToLiveState)
     }

--- a/Tests/OpenIslandCoreTests/DeterministicGraphExecutorTests.swift
+++ b/Tests/OpenIslandCoreTests/DeterministicGraphExecutorTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import XCTest
+@testable import OpenIslandCore
+
+final class DeterministicGraphExecutorTests: XCTestCase {
+    func testCommittedScriptProducesDeterministicArtifacts()
+        async throws
+    {
+        let executor = DeterministicGraphExecutor(
+            script: try loadCompendiumDeterministicScript()
+        )
+        let context = try executorContext(nodeID: "architect")
+
+        let prepared = try await executor.prepare(
+            GraphExecutorPrepareRequest(context: context)
+        ).observation
+        let started = try await executor.start(
+            GraphExecutorStartRequest(context: context)
+        ).observation
+        let observed = try await executor.observe(
+            GraphExecutorObserveRequest(context: context)
+        ).observation
+        let result = try await executor.collectResult(
+            GraphExecutorCollectResultRequest(context: context)
+        ).observation
+        let repeated = try await executor.collectResult(
+            GraphExecutorCollectResultRequest(context: context)
+        ).observation
+
+        XCTAssertEqual(prepared.status, .accepted)
+        XCTAssertEqual(started.status, .started)
+        XCTAssertEqual(observed.status, .succeeded)
+        XCTAssertEqual(result.status, .succeeded)
+        XCTAssertEqual(result.artifacts.count, 1)
+        XCTAssertEqual(result, repeated)
+    }
+
+    func testLogicalPollsControlRunningWithoutSleeps() async throws {
+        let executor = DeterministicGraphExecutor(
+            script: GraphDeterministicExecutionScript(
+                attempts: [
+                    GraphDeterministicAttemptScript(
+                        nodeID: "architect",
+                        attemptOrdinal: 1,
+                        runningPollCount: 2
+                    ),
+                ]
+            )
+        )
+
+        let first = try await executor.observe(
+            GraphExecutorObserveRequest(
+                context: try executorContext(priorObservationCount: 0)
+            )
+        ).observation
+        let second = try await executor.observe(
+            GraphExecutorObserveRequest(
+                context: try executorContext(priorObservationCount: 1)
+            )
+        ).observation
+        let terminal = try await executor.observe(
+            GraphExecutorObserveRequest(
+                context: try executorContext(priorObservationCount: 2)
+            )
+        ).observation
+
+        XCTAssertEqual(first.status, .stillRunning)
+        XCTAssertEqual(second.status, .stillRunning)
+        XCTAssertEqual(terminal.status, .succeeded)
+    }
+
+    func testScriptedFailuresCancellationCrashDuplicateAndStale()
+        async throws
+    {
+        let scripts = [
+            GraphDeterministicAttemptScript(
+                nodeID: "retry",
+                attemptOrdinal: 1,
+                terminalOutcome: .retryableFailure,
+                failureCategory: "transient"
+            ),
+            GraphDeterministicAttemptScript(
+                nodeID: "cancel",
+                attemptOrdinal: 1,
+                cancellationBehavior: .acknowledge
+            ),
+            GraphDeterministicAttemptScript(
+                nodeID: "ignore",
+                attemptOrdinal: 1,
+                cancellationBehavior: .ignoreUntilTimeout
+            ),
+            GraphDeterministicAttemptScript(
+                nodeID: "crash",
+                attemptOrdinal: 1,
+                crashPoint: .afterAttemptStartPersistence
+            ),
+            GraphDeterministicAttemptScript(
+                nodeID: "stale",
+                attemptOrdinal: 1,
+                duplicateObservations: true,
+                staleLeaseGenerationOffset: -1
+            ),
+        ]
+        let executor = DeterministicGraphExecutor(
+            script: GraphDeterministicExecutionScript(attempts: scripts)
+        )
+        let retry = try await executor.observe(
+            GraphExecutorObserveRequest(
+                context: try executorContext(nodeID: "retry")
+            )
+        ).observation
+        let cancelled = try await executor.requestCancellation(
+            GraphExecutorCancellationRequest(
+                context: try executorContext(nodeID: "cancel"),
+                cancellationRequestID: "cancel"
+            )
+        ).observation
+        let ignored = try await executor.requestCancellation(
+            GraphExecutorCancellationRequest(
+                context: try executorContext(nodeID: "ignore"),
+                cancellationRequestID: "ignore"
+            )
+        ).observation
+        let staleFirst = try await executor.observe(
+            GraphExecutorObserveRequest(
+                context: try executorContext(
+                    nodeID: "stale",
+                    priorObservationCount: 0
+                )
+            )
+        ).observation
+        let staleDuplicate = try await executor.observe(
+            GraphExecutorObserveRequest(
+                context: try executorContext(
+                    nodeID: "stale",
+                    priorObservationCount: 1
+                )
+            )
+        ).observation
+
+        XCTAssertEqual(retry.failure?.retryable, true)
+        XCTAssertEqual(cancelled.status, .cancelled)
+        XCTAssertEqual(ignored.status, .stillRunning)
+        XCTAssertEqual(staleFirst.id, staleDuplicate.id)
+        XCTAssertEqual(staleFirst.identity.leaseGeneration, 0)
+        do {
+            _ = try await executor.start(
+                GraphExecutorStartRequest(
+                    context: try executorContext(nodeID: "crash")
+                )
+            )
+            XCTFail("Expected scripted crash.")
+        } catch let error as GraphExecutorAdapterError {
+            XCTAssertEqual(
+                error,
+                .simulatedCrash("after_attempt_start_persistence")
+            )
+        }
+    }
+}
+
+private func executorContext(
+    nodeID: String = "architect",
+    priorObservationCount: Int = 0
+) throws -> GraphExecutorCommandContext {
+    let definition = try loadCompendiumExecutableDefinition()
+    let execution = definition.execution(for: "architect")!
+    return GraphExecutorCommandContext(
+        identity: GraphExecutorInteractionIdentity(
+            runID: "run",
+            nodeID: nodeID,
+            attemptID: "\(nodeID)-attempt-1",
+            attemptOrdinal: 1,
+            claimID: "\(nodeID)-claim-1",
+            leaseGeneration: 1,
+            executorID: "openisland.deterministic"
+        ),
+        capabilityRequirement: execution.capabilityRequirement,
+        specification: execution.specification,
+        workspace: execution.workspace,
+        environmentAllowlist: execution.environmentAllowlist,
+        inputArtifacts: [],
+        cancellation: nil,
+        timeoutPolicy: execution.timeoutPolicy,
+        correlation: GraphExecutorCorrelationMetadata(
+            correlationID: "test"
+        ),
+        priorObservationCount: priorObservationCount,
+        logicalTime: graphTestTime
+    )
+}

--- a/Tests/OpenIslandCoreTests/Fixtures/compendium-deterministic-script.json
+++ b/Tests/OpenIslandCoreTests/Fixtures/compendium-deterministic-script.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "attempts": [
+    {
+      "nodeID": "architect",
+      "attemptOrdinal": 1,
+      "runningPollCount": 0,
+      "terminalOutcome": "succeed",
+      "cancellationBehavior": "acknowledge",
+      "artifactRoles": ["node_output"],
+      "duplicateObservations": false,
+      "staleLeaseGenerationOffset": 0
+    },
+    {
+      "nodeID": "researcher",
+      "attemptOrdinal": 1,
+      "runningPollCount": 1,
+      "terminalOutcome": "succeed",
+      "cancellationBehavior": "acknowledge",
+      "artifactRoles": ["structured_result"],
+      "duplicateObservations": false,
+      "staleLeaseGenerationOffset": 0
+    },
+    {
+      "nodeID": "graph",
+      "attemptOrdinal": 1,
+      "runningPollCount": 0,
+      "terminalOutcome": "succeed",
+      "cancellationBehavior": "acknowledge",
+      "artifactRoles": ["structured_result"],
+      "duplicateObservations": false,
+      "staleLeaseGenerationOffset": 0
+    },
+    {
+      "nodeID": "reviewer",
+      "attemptOrdinal": 1,
+      "runningPollCount": 0,
+      "terminalOutcome": "succeed",
+      "cancellationBehavior": "acknowledge",
+      "artifactRoles": ["structured_result", "diagnostic"],
+      "duplicateObservations": false,
+      "staleLeaseGenerationOffset": 0
+    }
+  ]
+}

--- a/Tests/OpenIslandCoreTests/Fixtures/compendium-execution.json
+++ b/Tests/OpenIslandCoreTests/Fixtures/compendium-execution.json
@@ -1,0 +1,121 @@
+{
+  "schemaVersion": 1,
+  "scheduling": {
+    "schemaVersion": 1,
+    "graphID": "dose-regulations-compendium",
+    "version": "execution-v1",
+    "digest": {
+      "algorithm": "sha256",
+      "value": "a84354701745e32f91f5df1df7e1e095b08a93065e986ea160d6f9c051b3cf8d"
+    },
+    "nodes": [
+      {
+        "id": "architect",
+        "title": "Compendium Architect",
+        "dependencyNodeIDs": [],
+        "requiredCapabilities": ["compendium"]
+      },
+      {
+        "id": "researcher",
+        "title": "Regulatory Researcher",
+        "dependencyNodeIDs": ["architect"],
+        "requiredCapabilities": ["compendium"]
+      },
+      {
+        "id": "graph",
+        "title": "Evidence Graph Builder",
+        "dependencyNodeIDs": ["researcher"],
+        "requiredCapabilities": ["compendium"]
+      },
+      {
+        "id": "reviewer",
+        "title": "Compendium Reviewer",
+        "dependencyNodeIDs": ["graph"],
+        "requiredCapabilities": ["compendium"]
+      }
+    ]
+  },
+  "schedulerPolicy": {
+    "schemaVersion": 1,
+    "policyID": "deterministic-compendium",
+    "version": "1",
+    "retryPolicy": {
+      "schemaVersion": 1,
+      "maximumAttempts": 2,
+      "retryableFailureCategories": ["execution_failure", "timeout", "transient"],
+      "nonRetryableFailureCategories": ["invalid_input"],
+      "initialBackoffSeconds": 10,
+      "backoffMultiplier": 2,
+      "maximumBackoffSeconds": 60,
+      "jitterBasisPoints": 0,
+      "jitterSeed": "compendium",
+      "timeoutBehavior": "retry",
+      "cancellationBehavior": "suppress",
+      "dependencyFailureBehavior": "fail_closed"
+    },
+    "defaultLeaseDurationSeconds": 60,
+    "claimAcquisitionTimeoutSeconds": 30,
+    "attemptExecutionTimeoutSeconds": 300,
+    "cancellationAcknowledgementTimeoutSeconds": 30,
+    "allowExpiredLeaseTakeover": true,
+    "schedulingEnabled": true
+  },
+  "executions": [
+    {
+      "nodeID": "architect",
+      "capabilityRequirement": ["compendium"],
+      "specification": {
+        "schemaVersion": 1,
+        "adapterKind": "deterministic",
+        "operation": "produce_section_plan",
+        "parameters": {"artifactRole": "node_output"}
+      },
+      "workspace": {"writableRelativePaths": []},
+      "environmentAllowlist": [],
+      "inputArtifactRoles": ["node_output"],
+      "timeoutPolicy": {"executionSeconds": 300, "cancellationAcknowledgementSeconds": 30}
+    },
+    {
+      "nodeID": "researcher",
+      "capabilityRequirement": ["compendium"],
+      "specification": {
+        "schemaVersion": 1,
+        "adapterKind": "deterministic",
+        "operation": "produce_researched_sections",
+        "parameters": {"artifactRole": "structured_result"}
+      },
+      "workspace": {"writableRelativePaths": []},
+      "environmentAllowlist": [],
+      "inputArtifactRoles": ["node_output"],
+      "timeoutPolicy": {"executionSeconds": 300, "cancellationAcknowledgementSeconds": 30}
+    },
+    {
+      "nodeID": "graph",
+      "capabilityRequirement": ["compendium"],
+      "specification": {
+        "schemaVersion": 1,
+        "adapterKind": "deterministic",
+        "operation": "produce_relationship_graph",
+        "parameters": {"artifactRole": "structured_result"}
+      },
+      "workspace": {"writableRelativePaths": []},
+      "environmentAllowlist": [],
+      "inputArtifactRoles": ["structured_result"],
+      "timeoutPolicy": {"executionSeconds": 300, "cancellationAcknowledgementSeconds": 30}
+    },
+    {
+      "nodeID": "reviewer",
+      "capabilityRequirement": ["compendium"],
+      "specification": {
+        "schemaVersion": 1,
+        "adapterKind": "deterministic",
+        "operation": "produce_review_verdict",
+        "parameters": {"artifactRole": "structured_result"}
+      },
+      "workspace": {"writableRelativePaths": []},
+      "environmentAllowlist": [],
+      "inputArtifactRoles": ["node_output", "structured_result"],
+      "timeoutPolicy": {"executionSeconds": 300, "cancellationAcknowledgementSeconds": 30}
+    }
+  ]
+}

--- a/Tests/OpenIslandCoreTests/Fixtures/compendium-scheduling-graph.json
+++ b/Tests/OpenIslandCoreTests/Fixtures/compendium-scheduling-graph.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": 1,
+  "graphID": "dose-regulations-compendium",
+  "version": "scheduling-v1",
+  "digest": {
+    "algorithm": "sha256",
+    "value": "d05e7e9a9ea3448b23eec56c117e715f7577be56bdc4dcb93d27289dd239d388"
+  },
+  "nodes": [
+    {
+      "id": "architect",
+      "title": "Compendium Architect",
+      "dependencyNodeIDs": [],
+      "requiredCapabilities": [
+        "compendium-architecture",
+        "web-research-planning"
+      ]
+    },
+    {
+      "id": "researcher",
+      "title": "Regulatory Web Researcher",
+      "dependencyNodeIDs": [
+        "architect"
+      ],
+      "requiredCapabilities": [
+        "source-verification",
+        "web-scraping"
+      ]
+    },
+    {
+      "id": "graph",
+      "title": "Evidence Graph Builder",
+      "dependencyNodeIDs": [
+        "researcher"
+      ],
+      "requiredCapabilities": [
+        "citation-linking",
+        "knowledge-graph"
+      ]
+    },
+    {
+      "id": "reviewer",
+      "title": "Regulatory Compendium Reviewer",
+      "dependencyNodeIDs": [
+        "graph"
+      ],
+      "requiredCapabilities": [
+        "citation-audit",
+        "regulatory-review"
+      ]
+    }
+  ]
+}

--- a/Tests/OpenIslandCoreTests/Fixtures/stale-compendium-runtime.json
+++ b/Tests/OpenIslandCoreTests/Fixtures/stale-compendium-runtime.json
@@ -1,0 +1,149 @@
+{
+  "run": {
+    "id": "dose-regulations-compendium-2026-07-20",
+    "graphID": "dose-regulations-compendium",
+    "state": "running",
+    "nodeIDs": [
+      "architect",
+      "researcher",
+      "graph",
+      "reviewer"
+    ],
+    "createdAt": "2026-07-20T04:25:30Z",
+    "updatedAt": "2026-07-20T04:25:38Z",
+    "startedAt": "2026-07-20T04:25:38Z"
+  },
+  "nodes": [
+    {
+      "id": "architect",
+      "graphRunID": "dose-regulations-compendium-2026-07-20",
+      "title": "Architect",
+      "dependencyNodeIDs": [],
+      "executorID": "local-code-agent",
+      "state": "running",
+      "activeAttemptID": "architect-attempt-1",
+      "updatedAt": "2026-07-20T04:25:38Z"
+    },
+    {
+      "id": "researcher",
+      "graphRunID": "dose-regulations-compendium-2026-07-20",
+      "title": "Researcher",
+      "dependencyNodeIDs": [],
+      "executorID": "local-research-agent",
+      "state": "running",
+      "activeAttemptID": "researcher-attempt-1",
+      "updatedAt": "2026-07-20T04:25:38Z"
+    },
+    {
+      "id": "graph",
+      "graphRunID": "dose-regulations-compendium-2026-07-20",
+      "title": "Graph Builder",
+      "dependencyNodeIDs": [
+        "architect",
+        "researcher"
+      ],
+      "executorID": "local-code-agent",
+      "state": "pending",
+      "updatedAt": "2026-07-20T04:25:38Z"
+    },
+    {
+      "id": "reviewer",
+      "graphRunID": "dose-regulations-compendium-2026-07-20",
+      "title": "Reviewer",
+      "dependencyNodeIDs": [
+        "graph"
+      ],
+      "executorID": "local-review-agent",
+      "state": "pending",
+      "updatedAt": "2026-07-20T04:25:38Z"
+    }
+  ],
+  "attempts": [
+    {
+      "id": "architect-attempt-1",
+      "graphRunID": "dose-regulations-compendium-2026-07-20",
+      "nodeID": "architect",
+      "ordinal": 1,
+      "state": "running",
+      "processIdentity": {
+        "hostID": "local-workstation",
+        "launchID": "architect-launch-1",
+        "startedAt": "2026-07-20T04:25:38Z"
+      },
+      "createdAt": "2026-07-20T04:25:38Z",
+      "updatedAt": "2026-07-20T04:25:38Z",
+      "startedAt": "2026-07-20T04:25:38Z"
+    },
+    {
+      "id": "researcher-attempt-1",
+      "graphRunID": "dose-regulations-compendium-2026-07-20",
+      "nodeID": "researcher",
+      "ordinal": 1,
+      "state": "running",
+      "processIdentity": {
+        "hostID": "local-workstation",
+        "launchID": "researcher-launch-1",
+        "startedAt": "2026-07-20T04:25:38Z"
+      },
+      "createdAt": "2026-07-20T04:25:38Z",
+      "updatedAt": "2026-07-20T04:25:38Z",
+      "startedAt": "2026-07-20T04:25:38Z"
+    }
+  ],
+  "processExits": [
+    {
+      "attemptID": "architect-attempt-1",
+      "processIdentity": {
+        "hostID": "local-workstation",
+        "launchID": "architect-launch-1",
+        "startedAt": "2026-07-20T04:25:38Z"
+      },
+      "observedAt": "2026-07-20T04:25:45Z",
+      "exitCode": 1,
+      "reason": "Execution stopped after reaching its tool-call cap."
+    }
+  ],
+  "heartbeats": [
+    {
+      "attemptID": "architect-attempt-1",
+      "processIdentity": {
+        "hostID": "local-workstation",
+        "launchID": "architect-launch-1",
+        "startedAt": "2026-07-20T04:25:38Z"
+      },
+      "observedAt": "2026-07-20T04:25:40Z",
+      "validUntil": "2026-07-20T04:27:40Z"
+    },
+    {
+      "attemptID": "researcher-attempt-1",
+      "processIdentity": {
+        "hostID": "local-workstation",
+        "launchID": "researcher-launch-1",
+        "startedAt": "2026-07-20T04:25:38Z"
+      },
+      "observedAt": "2026-07-20T04:25:40Z",
+      "validUntil": "2026-07-20T04:27:40Z"
+    }
+  ],
+  "events": [
+    {
+      "id": "event-architect-started",
+      "graphRunID": "dose-regulations-compendium-2026-07-20",
+      "nodeID": "architect",
+      "attemptID": "architect-attempt-1",
+      "sequence": 1,
+      "occurredAt": "2026-07-20T04:25:38Z",
+      "kind": "attemptStarted"
+    },
+    {
+      "id": "event-researcher-started",
+      "graphRunID": "dose-regulations-compendium-2026-07-20",
+      "nodeID": "researcher",
+      "attemptID": "researcher-attempt-1",
+      "sequence": 2,
+      "occurredAt": "2026-07-20T04:25:38Z",
+      "kind": "attemptStarted"
+    }
+  ],
+  "observedAt": "2026-07-20T05:30:00Z"
+}

--- a/Tests/OpenIslandCoreTests/GraphCLIStreamingInvariantTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphCLIStreamingInvariantTests.swift
@@ -64,7 +64,7 @@ final class GraphCLIStreamingInvariantTests: XCTestCase {
                     )
                     XCTAssertEqual(
                         object["schemaVersion"] as? Int,
-                        1
+                        GraphCLIOutputSchema.currentVersion
                     )
                 case .jsonl:
                     for line in stdout.split(separator: "\n") {
@@ -75,7 +75,7 @@ final class GraphCLIStreamingInvariantTests: XCTestCase {
                         )
                         XCTAssertEqual(
                             object["schemaVersion"] as? Int,
-                            1
+                            GraphCLIOutputSchema.currentVersion
                         )
                     }
                 }

--- a/Tests/OpenIslandCoreTests/GraphCLIStreamingInvariantTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphCLIStreamingInvariantTests.swift
@@ -1,0 +1,881 @@
+import Foundation
+import XCTest
+@testable import OpenIslandCore
+
+final class GraphCLIStreamingInvariantTests: XCTestCase {
+    func testExitCodeContractIsStable() {
+        XCTAssertEqual(GraphCLIExitCode.success.rawValue, 0)
+        XCTAssertEqual(GraphCLIExitCode.invalidArguments.rawValue, 2)
+        XCTAssertEqual(GraphCLIExitCode.notFound.rawValue, 3)
+        XCTAssertEqual(GraphCLIExitCode.incompatibleSchema.rawValue, 4)
+        XCTAssertEqual(GraphCLIExitCode.corruptHistory.rawValue, 5)
+        XCTAssertEqual(GraphCLIExitCode.persistenceFailure.rawValue, 6)
+        XCTAssertEqual(GraphCLIExitCode.evidenceUnavailable.rawValue, 7)
+        XCTAssertEqual(GraphCLIExitCode.partialResult.rawValue, 8)
+        XCTAssertEqual(GraphCLIExitCode.interrupted.rawValue, 130)
+    }
+
+    func testEveryCommandSupportsTextJSONAndJSONL() async throws {
+        let harness = try await commandHarness()
+        let commands = [
+            ["graph", "list"],
+            ["graph", "inspect", "run", "--include-artifacts"],
+            ["graph", "history", "run", "--limit", "5"],
+            ["graph", "explain", "run", "node"],
+            ["graph", "checkpoint", "list", "run"],
+            [
+                "graph",
+                "replay",
+                "run",
+                "--dry-run",
+                "--checkpoint",
+                "before-start",
+            ],
+            ["graph", "diff", "run#before-start", "run"],
+            ["graph", "export", "run", "--format", "json"],
+        ]
+
+        for command in commands {
+            for mode in GraphCLIOutputMode.allCases {
+                let arguments = command + ["--output", mode.rawValue]
+                let code = await harness.runner.run(
+                    arguments: arguments
+                )
+                let stdout = harness.stdout.consume()
+                let stderr = harness.stderr.consume()
+
+                XCTAssertEqual(
+                    code,
+                    .success,
+                    "\(arguments.joined(separator: " ")) failed: \(stderr)"
+                )
+                XCTAssertFalse(stdout.isEmpty)
+                XCTAssertTrue(stderr.isEmpty)
+                XCTAssertFalse(stdout.contains("\u{001B}["))
+
+                switch mode {
+                case .text:
+                    break
+                case .json:
+                    let object = try XCTUnwrap(
+                        JSONSerialization.jsonObject(
+                            with: Data(stdout.utf8)
+                        ) as? [String: Any]
+                    )
+                    XCTAssertEqual(
+                        object["schemaVersion"] as? Int,
+                        1
+                    )
+                case .jsonl:
+                    for line in stdout.split(separator: "\n") {
+                        let object = try XCTUnwrap(
+                            JSONSerialization.jsonObject(
+                                with: Data(line.utf8)
+                            ) as? [String: Any]
+                        )
+                        XCTAssertEqual(
+                            object["schemaVersion"] as? Int,
+                            1
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    func testCLIHistoryFilteringAndLimitAreDeterministic()
+        async throws
+    {
+        let harness = try await commandHarness()
+        let arguments = [
+            "graph",
+            "history",
+            "run",
+            "--node",
+            "node",
+            "--attempt",
+            "attempt",
+            "--event-type",
+            GraphExecutionEventType.attemptStarting.rawValue,
+            "--after-sequence",
+            "2",
+            "--since",
+            "1970-01-01T08:20:00Z",
+            "--until",
+            "1970-01-01T09:00:00Z",
+            "--limit",
+            "1",
+            "--output",
+            "json",
+        ]
+
+        let firstCode = await harness.runner.run(arguments: arguments)
+        XCTAssertEqual(firstCode, .success)
+        let first = harness.stdout.consume()
+        let secondCode = await harness.runner.run(arguments: arguments)
+        XCTAssertEqual(secondCode, .success)
+        let second = harness.stdout.consume()
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(
+                with: Data(first.utf8)
+            ) as? [String: Any]
+        )
+        let result = try XCTUnwrap(object["result"] as? [[String: Any]])
+
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(
+            result.first?["eventType"] as? String,
+            GraphExecutionEventType.attemptStarting.rawValue
+        )
+    }
+
+    func testCheckpointNotFoundUsesExitThree() async throws {
+        let harness = try await commandHarness()
+        let code = await harness.runner.run(
+            arguments: [
+                "graph",
+                "replay",
+                "run",
+                "--dry-run",
+                "--checkpoint",
+                "missing",
+                "--output",
+                "json",
+            ]
+        )
+
+        XCTAssertEqual(code, .notFound)
+        XCTAssertTrue(harness.stdout.consume().isEmpty)
+        XCTAssertTrue(
+            harness.stderr.consume().contains("error[not_found]")
+        )
+    }
+
+    func testQuietModeExecutesWithoutSuccessOutput() async throws {
+        let harness = try await commandHarness()
+        let code = await harness.runner.run(
+            arguments: [
+                "graph",
+                "inspect",
+                "run",
+                "--quiet",
+                "--output",
+                "json",
+            ]
+        )
+
+        XCTAssertEqual(code, .success)
+        XCTAssertTrue(harness.stdout.consume().isEmpty)
+        XCTAssertTrue(harness.stderr.consume().isEmpty)
+    }
+
+    func testCorruptHistoryUsesExitFiveAndKeepsStdoutClean()
+        async
+    {
+        let stdout = InvariantOutputSink()
+        let stderr = InvariantOutputSink()
+        let runner = GraphCLICommandRunner(
+            inspector: DefaultGraphTemporalInspector(
+                readStore: CorruptGraphReadStore(),
+                snapshotStore: EmptyGraphSnapshotReadStore()
+            ),
+            stdout: stdout,
+            stderr: stderr
+        )
+
+        let code = await runner.run(
+            arguments: [
+                "graph",
+                "replay",
+                "run",
+                "--dry-run",
+                "--output",
+                "json",
+            ]
+        )
+
+        XCTAssertEqual(code, .corruptHistory)
+        XCTAssertTrue(stdout.consume().isEmpty)
+        XCTAssertTrue(
+            stderr.consume().contains("error[corrupt_history]")
+        )
+    }
+
+    func testPersistenceAndRequiredEvidenceExitCategories()
+        async throws
+    {
+        let persistenceStdout = InvariantOutputSink()
+        let persistenceStderr = InvariantOutputSink()
+        let persistenceRunner = GraphCLICommandRunner(
+            inspector: DefaultGraphTemporalInspector(
+                readStore: FailingGraphReadStore(),
+                snapshotStore: EmptyGraphSnapshotReadStore()
+            ),
+            stdout: persistenceStdout,
+            stderr: persistenceStderr
+        )
+        let persistenceCode = await persistenceRunner.run(
+            arguments: ["graph", "list", "--output", "json"]
+        )
+
+        XCTAssertEqual(persistenceCode, .persistenceFailure)
+        XCTAssertTrue(persistenceStdout.consume().isEmpty)
+        XCTAssertTrue(
+            persistenceStderr.consume().contains(
+                "error[persistence_failure]"
+            )
+        )
+
+        let harness = try await commandHarness()
+        let evidenceCode = await harness.runner.run(
+            arguments: [
+                "graph",
+                "replay",
+                "run",
+                "--dry-run",
+                "--require-live-evidence",
+                "--output",
+                "json",
+            ]
+        )
+
+        XCTAssertEqual(evidenceCode, .evidenceUnavailable)
+        XCTAssertTrue(harness.stdout.consume().isEmpty)
+        XCTAssertTrue(
+            harness.stderr.consume().contains(
+                "error[evidence_unavailable]"
+            )
+        )
+    }
+
+    func testUnknownEventAndSnapshotBypassDiagnosticsReachCLI()
+        async throws
+    {
+        let events = commandEvents() + [
+            graphTestEvent(
+                id: "future-event",
+                sequence: 6,
+                payloadVersion: 7,
+                payload: .unknown(
+                    eventType: "graph.future.observed",
+                    body: .object(["mode": .string("future")])
+                )
+            ),
+        ]
+        let store = InMemoryGraphExecutionEventStore()
+        _ = try await store.append(
+            events,
+            to: "run",
+            expectedVersion: 0
+        )
+        let projection = try GraphExecutionProjector.replay(
+            runID: "run",
+            events: Array(events.prefix(3))
+        ).projection
+        let incompatible = graphTestSnapshot(
+            for: projection,
+            schemaVersion: GraphExecutionSchema.snapshotVersion + 1
+        )
+        let stdout = InvariantOutputSink()
+        let runner = GraphCLICommandRunner(
+            inspector: DefaultGraphTemporalInspector(
+                readStore: store,
+                snapshotStore: InMemoryGraphExecutionSnapshotStore(
+                    snapshots: [incompatible]
+                )
+            ),
+            stdout: stdout,
+            stderr: InvariantOutputSink()
+        )
+        let arguments = [
+            "graph",
+            "replay",
+            "run",
+            "--dry-run",
+            "--without-live-evidence",
+            "--include-diagnostics",
+            "--output",
+            "json",
+        ]
+
+        let firstCode = await runner.run(arguments: arguments)
+        XCTAssertEqual(firstCode, .success)
+        let first = stdout.consume()
+        let secondCode = await runner.run(arguments: arguments)
+        XCTAssertEqual(secondCode, .success)
+        let second = stdout.consume()
+
+        XCTAssertEqual(first, second)
+        XCTAssertTrue(
+            first.contains("\"snapshotDisposition\":\"incompatible\"")
+        )
+        XCTAssertTrue(first.contains("\"category\":\"unknownEvent\""))
+        XCTAssertTrue(first.contains("graph.future.observed"))
+    }
+
+    func testDiffOutputIsDeterministicAcrossRepeatedInvocations()
+        async throws
+    {
+        let harness = try await commandHarness()
+        let arguments = [
+            "graph",
+            "diff",
+            "run@3",
+            "run",
+            "--output",
+            "json",
+        ]
+
+        let firstCode = await harness.runner.run(arguments: arguments)
+        XCTAssertEqual(firstCode, .success)
+        let first = harness.stdout.consume()
+        let secondCode = await harness.runner.run(arguments: arguments)
+        XCTAssertEqual(secondCode, .success)
+        let second = harness.stdout.consume()
+
+        XCTAssertEqual(first, second)
+        XCTAssertTrue(first.contains("\"category\":\"attempt\""))
+        XCTAssertFalse(first.contains("updatedAt"))
+    }
+
+    func testArtifactMetadataIsSafeThroughCLI() async throws {
+        let artifact = GraphArtifactReference(
+            id: "artifact",
+            contentDigest: GraphContentDigest(
+                algorithm: "sha256",
+                value: "digest"
+            ),
+            mediaType: "text/markdown",
+            logicalRole: "compendium",
+            producingRunID: "run",
+            producingNodeID: "node",
+            producingAttemptID: "attempt",
+            createdAt: graphTestTime.addingTimeInterval(5),
+            storage: GraphArtifactStorageLocator(
+                scheme: "https",
+                opaqueReference:
+                    "https://user:password@example.invalid/private?token=secret"
+            ),
+            sensitivity: .restricted
+        )
+        let events = commandEvents() + [
+            graphTestEvent(
+                id: "artifact-event",
+                sequence: 6,
+                nodeID: "node",
+                attemptID: "attempt",
+                payload: .artifactRecorded(
+                    GraphArtifactRecordedPayload(artifact: artifact)
+                )
+            ),
+        ]
+        let harness = try await commandHarness(events: events)
+
+        let code = await harness.runner.run(
+            arguments: [
+                "graph",
+                "inspect",
+                "run",
+                "--include-artifacts",
+                "--output",
+                "json",
+            ]
+        )
+        XCTAssertEqual(code, .success)
+        let output = harness.stdout.consume()
+
+        XCTAssertTrue(output.contains("\"id\":\"artifact\""))
+        XCTAssertTrue(
+            output.contains("storage.opaqueReference")
+        )
+        XCTAssertFalse(output.contains("password"))
+        XCTAssertFalse(output.contains("token=secret"))
+        XCTAssertFalse(output.contains("/private"))
+    }
+
+    func testLargeHistoryJSONLWritesOneBoundedRecordAtATime()
+        async throws
+    {
+        let eventCount = 5_000
+        let store = InMemoryGraphExecutionEventStore()
+        _ = try await store.append(
+            largeHistoryEvents(count: eventCount),
+            to: "large-run",
+            expectedVersion: 0
+        )
+        let output = CountingGraphCLIOutputSink()
+        let runner = GraphCLICommandRunner(
+            inspector: DefaultGraphTemporalInspector(
+                readStore: store,
+                snapshotStore: InMemoryGraphExecutionSnapshotStore(),
+                pageSize: 64
+            ),
+            stdout: output,
+            stderr: InvariantOutputSink(),
+            isOutputTTY: false
+        )
+
+        let code = await runner.run(
+            arguments: [
+                "graph",
+                "history",
+                "large-run",
+                "--output",
+                "jsonl",
+                "--limit",
+                String(eventCount),
+            ]
+        )
+
+        XCTAssertEqual(code, .success)
+        XCTAssertEqual(output.writeCount, eventCount)
+        XCTAssertLessThan(output.maximumWriteSize, 4_096)
+    }
+
+    func testRealUnixPipeAndBrokenPipeBehavior() async throws {
+        let eventCount = 250
+        let fixture = try await binaryFixture(
+            events: largeHistoryEvents(count: eventCount)
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        let countResult = try runShell(
+            """
+            OPENISLAND_GRAPH_DATABASE_PATH=\(shellQuote(fixture.database.path)) \
+            \(shellQuote(fixture.binary.path)) graph history large-run --output jsonl --limit \(eventCount) \
+            | /usr/bin/wc -l
+            """
+        )
+        let brokenPipeResult = try runShell(
+            """
+            set -o pipefail
+            OPENISLAND_GRAPH_DATABASE_PATH=\(shellQuote(fixture.database.path)) \
+            \(shellQuote(fixture.binary.path)) graph history large-run --output jsonl --limit \(eventCount) \
+            | /usr/bin/head -n 1
+            """
+        )
+
+        XCTAssertEqual(countResult.status, 0, countResult.stderr)
+        XCTAssertEqual(
+            countResult.stdout
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+            String(eventCount)
+        )
+        XCTAssertEqual(
+            brokenPipeResult.status,
+            0,
+            brokenPipeResult.stderr
+        )
+        XCTAssertEqual(
+            brokenPipeResult.stdout.split(separator: "\n").count,
+            1
+        )
+    }
+
+    func testSIGINTUsesStableExit130() async throws {
+        let fixture = try await binaryFixture(
+            events: largeHistoryEvents(count: 10_000)
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let process = Process()
+        let blockedOutput = Pipe()
+        process.executableURL = fixture.binary
+        process.arguments = [
+            "graph",
+            "history",
+            "large-run",
+            "--output",
+            "jsonl",
+            "--limit",
+            "10000",
+        ]
+        process.environment = ProcessInfo.processInfo.environment.merging(
+            ["OPENISLAND_GRAPH_DATABASE_PATH": fixture.database.path]
+        ) { _, new in new }
+        process.standardOutput = blockedOutput
+        process.standardError = FileHandle.nullDevice
+
+        try process.run()
+        try await Task.sleep(for: .milliseconds(150))
+        process.interrupt()
+        process.waitUntilExit()
+
+        XCTAssertEqual(process.terminationReason, .exit)
+        XCTAssertEqual(process.terminationStatus, 130)
+    }
+
+    func testStaleCompendiumFixtureReconcilesThroughCLI()
+        async throws
+    {
+        let fixture = try loadStaleCompendiumFixture()
+        let events = staleCompendiumEvents(from: fixture)
+        let store = InMemoryGraphExecutionEventStore()
+        _ = try await store.append(
+            events,
+            to: fixture.run.id,
+            expectedVersion: 0
+        )
+        let stdout = InvariantOutputSink()
+        let runner = GraphCLICommandRunner(
+            inspector: DefaultGraphTemporalInspector(
+                readStore: store,
+                snapshotStore: InMemoryGraphExecutionSnapshotStore()
+            ),
+            stdout: stdout,
+            stderr: InvariantOutputSink()
+        )
+
+        let code = await runner.run(
+            arguments: [
+                "graph",
+                "inspect",
+                fixture.run.id,
+                "--output",
+                "json",
+            ]
+        )
+        XCTAssertEqual(code, .success)
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(
+                with: Data(stdout.consume().utf8)
+            ) as? [String: Any]
+        )
+        let result = try XCTUnwrap(object["result"] as? [String: Any])
+        let nodes = try XCTUnwrap(result["nodes"] as? [[String: Any]])
+        let states: [String: String] = Dictionary(
+            uniqueKeysWithValues: nodes.compactMap { node in
+                guard let id = node["id"] as? String,
+                      let state = node["reconciledState"] as? String
+                else {
+                    return nil
+                }
+                return (id, state)
+            }
+        )
+
+        XCTAssertEqual(states["architect"], "interrupted")
+        XCTAssertEqual(states["researcher"], "orphaned")
+        XCTAssertEqual(states["graph"], "blocked")
+        XCTAssertEqual(states["reviewer"], "blocked")
+    }
+
+    private func commandHarness(
+        events: [GraphExecutionEventEnvelope] = commandEvents()
+    ) async throws -> InvariantHarness {
+        let store = InMemoryGraphExecutionEventStore()
+        _ = try await store.append(
+            events,
+            to: "run",
+            expectedVersion: 0
+        )
+        let prefix = try GraphExecutionProjector.replay(
+            runID: "run",
+            events: Array(events.prefix(3))
+        ).projection
+        var checkpointProjection = prefix
+        checkpointProjection.namedCheckpoints = [
+            GraphCheckpointReference(
+                checkpointID: "before-start",
+                runID: "run",
+                streamVersion: 3,
+                namespace: "root"
+            ),
+        ]
+        let stdout = InvariantOutputSink()
+        let stderr = InvariantOutputSink()
+        return InvariantHarness(
+            runner: GraphCLICommandRunner(
+                inspector: DefaultGraphTemporalInspector(
+                    readStore: store,
+                    snapshotStore:
+                        InMemoryGraphExecutionSnapshotStore(
+                            snapshots: [
+                                graphTestSnapshot(
+                                    for: checkpointProjection
+                                ),
+                            ]
+                        ),
+                    pageSize: 2
+                ),
+                stdout: stdout,
+                stderr: stderr
+            ),
+            stdout: stdout,
+            stderr: stderr
+        )
+    }
+
+    private func binaryFixture(
+        events: [GraphExecutionEventEnvelope]
+    ) async throws -> BinaryFixture {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        let database = directory.appendingPathComponent("graph.sqlite")
+        let store = try SQLiteGraphExecutionStore(
+            databasePath: database.path
+        )
+        _ = try await store.append(
+            events,
+            to: "large-run",
+            expectedVersion: 0
+        )
+        return BinaryFixture(
+            directory: directory,
+            database: database,
+            binary: try locateOpenIslandBinary()
+        )
+    }
+
+    private func locateOpenIslandBinary() throws -> URL {
+        let candidates = [
+            URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+                .appendingPathComponent(".build/debug/openisland"),
+            URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+                .appendingPathComponent(
+                    ".build/arm64-apple-macosx/debug/openisland"
+                ),
+        ]
+        return try XCTUnwrap(
+            candidates.first {
+                FileManager.default.isExecutableFile(atPath: $0.path)
+            }
+        )
+    }
+
+    private func runShell(
+        _ command: String
+    ) throws -> (
+        status: Int32,
+        stdout: String,
+        stderr: String
+    ) {
+        let process = Process()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-c", command]
+        process.standardOutput = stdout
+        process.standardError = stderr
+        try process.run()
+        let outputData = stdout.fileHandleForReading.readDataToEndOfFile()
+        let errorData = stderr.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return (
+            process.terminationStatus,
+            String(decoding: outputData, as: UTF8.self),
+            String(decoding: errorData, as: UTF8.self)
+        )
+    }
+}
+
+private struct InvariantHarness {
+    let runner: GraphCLICommandRunner
+    let stdout: InvariantOutputSink
+    let stderr: InvariantOutputSink
+}
+
+private struct BinaryFixture {
+    let directory: URL
+    let database: URL
+    let binary: URL
+}
+
+private final class InvariantOutputSink:
+    GraphCLIOutputSink,
+    @unchecked Sendable
+{
+    private let lock = NSLock()
+    private var data = Data()
+
+    func write(_ data: Data) -> GraphCLIWriteResult {
+        lock.lock()
+        self.data.append(data)
+        lock.unlock()
+        return .written
+    }
+
+    func consume() -> String {
+        lock.lock()
+        let result = String(decoding: data, as: UTF8.self)
+        data.removeAll(keepingCapacity: true)
+        lock.unlock()
+        return result
+    }
+}
+
+private final class CountingGraphCLIOutputSink:
+    GraphCLIOutputSink,
+    @unchecked Sendable
+{
+    private let lock = NSLock()
+    private var count = 0
+    private var maximum = 0
+
+    var writeCount: Int {
+        lock.lock()
+        let result = count
+        lock.unlock()
+        return result
+    }
+
+    var maximumWriteSize: Int {
+        lock.lock()
+        let result = maximum
+        lock.unlock()
+        return result
+    }
+
+    func write(_ data: Data) -> GraphCLIWriteResult {
+        lock.lock()
+        count += 1
+        maximum = max(maximum, data.count)
+        lock.unlock()
+        return .written
+    }
+}
+
+private struct CorruptGraphReadStore: GraphExecutionReadStore {
+    func listStreams() async throws -> [GraphExecutionStreamDescriptor] {
+        [GraphExecutionStreamDescriptor(runID: "run", currentVersion: 3)]
+    }
+
+    func streamDescriptor(
+        runID: String
+    ) async throws -> GraphExecutionStreamDescriptor? {
+        runID == "run"
+            ? GraphExecutionStreamDescriptor(
+                runID: "run",
+                currentVersion: 3
+            )
+            : nil
+    }
+
+    func readPage(
+        runID: String,
+        afterVersion: UInt64,
+        limit: Int
+    ) async throws -> GraphExecutionEventPage {
+        GraphExecutionEventPage(
+            runID: "run",
+            afterVersion: 0,
+            currentVersion: 3,
+            events: [
+                graphTestRunCreated(),
+                graphTestNodeRegistered(sequence: 3),
+            ],
+            hasMore: false
+        )
+    }
+}
+
+private struct EmptyGraphSnapshotReadStore:
+    GraphExecutionSnapshotReadStore
+{
+    func loadLatest(
+        runID: String,
+        throughVersion: UInt64
+    ) async throws -> GraphExecutionSnapshot? {
+        nil
+    }
+}
+
+private struct FailingGraphReadStore: GraphExecutionReadStore {
+    func listStreams() async throws -> [GraphExecutionStreamDescriptor] {
+        throw GraphExecutionPersistenceError.storageFailure(
+            "fixture unavailable"
+        )
+    }
+
+    func streamDescriptor(
+        runID: String
+    ) async throws -> GraphExecutionStreamDescriptor? {
+        throw GraphExecutionPersistenceError.storageFailure(
+            "fixture unavailable"
+        )
+    }
+
+    func readPage(
+        runID: String,
+        afterVersion: UInt64,
+        limit: Int
+    ) async throws -> GraphExecutionEventPage {
+        throw GraphExecutionPersistenceError.storageFailure(
+            "fixture unavailable"
+        )
+    }
+}
+
+private func commandEvents() -> [GraphExecutionEventEnvelope] {
+    [
+        graphTestRunCreated(),
+        graphTestNodeRegistered(),
+        graphTestAttemptCreated(),
+        graphTestAttemptStarting(),
+        graphTestProcessObserved(),
+    ]
+}
+
+private func largeHistoryEvents(
+    count: Int
+) -> [GraphExecutionEventEnvelope] {
+    guard count >= 1 else {
+        return []
+    }
+    let producer = GraphExecutionProducer(
+        id: "large-history-test",
+        kind: .test
+    )
+    var events = [
+        GraphExecutionEventEnvelope(
+            id: "large-1",
+            runID: "large-run",
+            streamSequence: 1,
+            occurredAt: graphTestTime,
+            recordedAt: graphTestTime,
+            producer: producer,
+            payload: .runCreated(
+                GraphRunCreatedPayload(
+                    graphID: "large",
+                    graphDefinitionVersion: "1",
+                    graphDefinitionDigest: graphTestDigest,
+                    nodeIDs: []
+                )
+            )
+        ),
+    ]
+    guard count > 1 else {
+        return events
+    }
+    for sequence in 2...count {
+        events.append(
+            GraphExecutionEventEnvelope(
+                id: "large-\(sequence)",
+                runID: "large-run",
+                streamSequence: UInt64(sequence),
+                occurredAt: graphTestTime.addingTimeInterval(
+                    Double(sequence)
+                ),
+                recordedAt: graphTestTime.addingTimeInterval(
+                    Double(sequence)
+                ),
+                producer: producer,
+                payload: .unknown(
+                    eventType: "graph.test.stream_record",
+                    body: .object([
+                        "sequence": .number(Double(sequence)),
+                    ])
+                )
+            )
+        )
+    }
+    return events
+}
+
+private func shellQuote(_ value: String) -> String {
+    "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+}

--- a/Tests/OpenIslandCoreTests/GraphCLIStreamingInvariantTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphCLIStreamingInvariantTests.swift
@@ -12,6 +12,12 @@ final class GraphCLIStreamingInvariantTests: XCTestCase {
         XCTAssertEqual(GraphCLIExitCode.persistenceFailure.rawValue, 6)
         XCTAssertEqual(GraphCLIExitCode.evidenceUnavailable.rawValue, 7)
         XCTAssertEqual(GraphCLIExitCode.partialResult.rawValue, 8)
+        XCTAssertEqual(GraphCLIExitCode.optimisticConflict.rawValue, 9)
+        XCTAssertEqual(GraphCLIExitCode.policyDenied.rawValue, 10)
+        XCTAssertEqual(GraphCLIExitCode.staleExecutor.rawValue, 11)
+        XCTAssertEqual(GraphCLIExitCode.adapterUnavailable.rawValue, 12)
+        XCTAssertEqual(GraphCLIExitCode.executionTerminalFailure.rawValue, 13)
+        XCTAssertEqual(GraphCLIExitCode.cancellation.rawValue, 14)
         XCTAssertEqual(GraphCLIExitCode.interrupted.rawValue, 130)
     }
 

--- a/Tests/OpenIslandCoreTests/GraphCLITests.swift
+++ b/Tests/OpenIslandCoreTests/GraphCLITests.swift
@@ -64,7 +64,10 @@ final class GraphCLITests: XCTestCase {
         )
 
         XCTAssertEqual(first, second)
-        XCTAssertEqual(object["schemaVersion"] as? Int, 1)
+        XCTAssertEqual(
+            object["schemaVersion"] as? Int,
+            GraphCLIOutputSchema.currentVersion
+        )
         XCTAssertEqual(object["command"] as? String, "graph.inspect")
         XCTAssertFalse(first.contains("\u{001B}["))
         XCTAssertTrue(harness.stderr.consume().isEmpty)
@@ -243,7 +246,7 @@ final class GraphCLITests: XCTestCase {
                 "--output",
                 "json",
                 "--schema-version",
-                "2",
+                String(GraphCLIOutputSchema.currentVersion + 1),
             ]
         )
 

--- a/Tests/OpenIslandCoreTests/GraphCLITests.swift
+++ b/Tests/OpenIslandCoreTests/GraphCLITests.swift
@@ -9,6 +9,8 @@ final class GraphCLITests: XCTestCase {
             ["graph", "start", "run", "--idempotency-key", "start"],
             ["graph", "cancel", "run", "--node", "node", "--idempotency-key", "cancel"],
             ["graph", "retry", "run", "node", "--idempotency-key", "retry", "--expected-version", "9", "--dry-run"],
+            ["graph", "step", "run", "--dry-run"],
+            ["graph", "run", "run", "--cycle-limit", "20"],
         ]
 
         let invocations = try arguments.map { arguments in
@@ -22,10 +24,14 @@ final class GraphCLITests: XCTestCase {
 
         XCTAssertEqual(
             invocations.map(\.command.name),
-            ["graph.create", "graph.start", "graph.cancel", "graph.retry"]
+            [
+                "graph.create", "graph.start", "graph.cancel", "graph.retry",
+                "graph.step", "graph.run",
+            ]
         )
-        XCTAssertEqual(invocations.last?.expectedVersion, 9)
-        XCTAssertEqual(invocations.last?.dryRun, true)
+        XCTAssertEqual(invocations[3].expectedVersion, 9)
+        XCTAssertEqual(invocations[3].dryRun, true)
+        XCTAssertEqual(invocations[5].cycleLimit, 20)
     }
 
     func testMutationJSONOutputUsesSameStableEnvelope() async throws {
@@ -67,6 +73,199 @@ final class GraphCLITests: XCTestCase {
         XCTAssertEqual(code, .success)
         XCTAssertEqual(object["command"] as? String, "graph.create")
         XCTAssertEqual(object["resultCount"] as? Int, 1)
+        XCTAssertTrue(stderr.consume().isEmpty)
+    }
+
+    func testRunJSONLPreservesTerminalGraphCompatibleRecords()
+        async throws
+    {
+        let store = InMemoryGraphExecutionEventStore()
+        let stdout = LockedGraphCLISink()
+        let stderr = LockedGraphCLISink()
+        let mutator = DefaultGraphMutationService(
+            eventStore: store,
+            readStore: store
+        )
+        let orchestrator = DefaultGraphOrchestrationService(
+            eventStore: store,
+            schedulingRepository: DefaultGraphSchedulingRepository(
+                eventStore: store
+            ),
+            executorRepository: DefaultGraphExecutorRepository(
+                eventStore: store
+            ),
+            executor: DeterministicGraphExecutor(
+                script: try loadCompendiumDeterministicScript()
+            )
+        )
+        let runner = GraphCLICommandRunner(
+            inspector: DefaultGraphTemporalInspector(
+                readStore: store,
+                snapshotStore: InMemoryGraphExecutionSnapshotStore()
+            ),
+            mutator: mutator,
+            orchestrator: orchestrator,
+            definitionLoader: FixedDefinitionLoader(
+                definition: try loadCompendiumExecutableDefinition()
+            ),
+            stdout: stdout,
+            stderr: stderr,
+            isOutputTTY: false
+        )
+        let createCode = await runner.run(arguments: [
+                "graph", "create", "ignored",
+                "--run-id", "cli-execution",
+                "--idempotency-key", "create",
+                "--logical-time", "1970-01-01T08:20:00Z",
+                "--quiet",
+            ])
+        XCTAssertEqual(createCode, .success)
+        let startCode = await runner.run(arguments: [
+                "graph", "start", "cli-execution",
+                "--idempotency-key", "start",
+                "--logical-time", "1970-01-01T08:20:00Z",
+                "--quiet",
+            ])
+        XCTAssertEqual(startCode, .success)
+        let code = await runner.run(arguments: [
+            "graph", "run", "cli-execution",
+            "--cycle-limit", "30",
+            "--logical-time", "1970-01-01T08:20:00Z",
+            "--output", "jsonl",
+            "--emit-completion-record",
+            "--no-color",
+        ])
+        let lines = stdout.consume().split(separator: "\n")
+
+        XCTAssertEqual(code, .success)
+        XCTAssertGreaterThan(lines.count, 1)
+        for line in lines {
+            XCTAssertNoThrow(
+                try JSONSerialization.jsonObject(
+                    with: Data(line.utf8)
+                )
+            )
+        }
+        XCTAssertTrue(
+            lines.last?.contains("\"recordType\":\"completion\"") == true
+        )
+        XCTAssertTrue(stderr.consume().isEmpty)
+
+        let exportCode = await runner.run(arguments: [
+            "graph", "export", "cli-execution",
+            "--format", "jsonl",
+            "--output", "jsonl",
+        ])
+        let exportLines = stdout.consume().split(separator: "\n")
+        let exportRecords = try exportLines.map {
+            try XCTUnwrap(
+                JSONSerialization.jsonObject(
+                    with: Data($0.utf8)
+                ) as? [String: Any]
+            )
+        }
+        let payloads = exportRecords.compactMap {
+            $0["payload"] as? [String: Any]
+        }
+
+        XCTAssertEqual(exportCode, .success)
+        XCTAssertEqual(
+            payloads.filter { $0["kind"] as? String == "node" }.count,
+            4
+        )
+        XCTAssertEqual(
+            payloads.filter { $0["kind"] as? String == "artifact" }.count,
+            5
+        )
+    }
+
+    func testFailedRunJSONLCompletionReportsTerminalFailure()
+        async throws
+    {
+        let store = InMemoryGraphExecutionEventStore()
+        let stdout = LockedGraphCLISink()
+        let stderr = LockedGraphCLISink()
+        let mutator = DefaultGraphMutationService(
+            eventStore: store,
+            readStore: store
+        )
+        let runner = GraphCLICommandRunner(
+            inspector: DefaultGraphTemporalInspector(
+                readStore: store,
+                snapshotStore: InMemoryGraphExecutionSnapshotStore()
+            ),
+            mutator: mutator,
+            orchestrator: DefaultGraphOrchestrationService(
+                eventStore: store,
+                schedulingRepository: DefaultGraphSchedulingRepository(
+                    eventStore: store
+                ),
+                executorRepository: DefaultGraphExecutorRepository(
+                    eventStore: store
+                ),
+                executor: DeterministicGraphExecutor(
+                    script: GraphDeterministicExecutionScript(
+                        attempts: [
+                            GraphDeterministicAttemptScript(
+                                nodeID: "architect",
+                                attemptOrdinal: 1,
+                                terminalOutcome: .nonRetryableFailure,
+                                failureCategory: "invalid_input"
+                            ),
+                        ]
+                    )
+                )
+            ),
+            definitionLoader: FixedDefinitionLoader(
+                definition: try loadCompendiumExecutableDefinition()
+            ),
+            stdout: stdout,
+            stderr: stderr,
+            isOutputTTY: false
+        )
+        let createCode = await runner.run(arguments: [
+            "graph", "create", "ignored",
+            "--run-id", "failed-run",
+            "--idempotency-key", "create-failed",
+            "--logical-time", "1970-01-01T08:20:00Z",
+            "--quiet",
+        ])
+        let startCode = await runner.run(arguments: [
+            "graph", "start", "failed-run",
+            "--idempotency-key", "start-failed",
+            "--logical-time", "1970-01-01T08:20:00Z",
+            "--quiet",
+        ])
+
+        XCTAssertEqual(createCode, .success)
+        XCTAssertEqual(startCode, .success)
+
+        let code = await runner.run(arguments: [
+            "graph", "run", "failed-run",
+            "--cycle-limit", "30",
+            "--logical-time", "1970-01-01T08:20:00Z",
+            "--output", "jsonl",
+            "--emit-completion-record",
+        ])
+        let completion = try XCTUnwrap(
+            stdout.consume().split(separator: "\n").last
+        )
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(
+                with: Data(completion.utf8)
+            ) as? [String: Any]
+        )
+
+        XCTAssertEqual(code, .executionTerminalFailure)
+        XCTAssertEqual(object["recordType"] as? String, "completion")
+        XCTAssertEqual(
+            object["status"] as? String,
+            GraphCLIExitCode.executionTerminalFailure.category
+        )
+        XCTAssertEqual(
+            object["exitCode"] as? Int,
+            Int(GraphCLIExitCode.executionTerminalFailure.rawValue)
+        )
         XCTAssertTrue(stderr.consume().isEmpty)
     }
 

--- a/Tests/OpenIslandCoreTests/GraphCLITests.swift
+++ b/Tests/OpenIslandCoreTests/GraphCLITests.swift
@@ -3,6 +3,73 @@ import XCTest
 @testable import OpenIslandCore
 
 final class GraphCLITests: XCTestCase {
+    func testParserRecognizesMutationCommandsAndSafetyOptions() throws {
+        let arguments = [
+            ["graph", "create", "definition.json", "--run-id", "run", "--idempotency-key", "create"],
+            ["graph", "start", "run", "--idempotency-key", "start"],
+            ["graph", "cancel", "run", "--node", "node", "--idempotency-key", "cancel"],
+            ["graph", "retry", "run", "node", "--idempotency-key", "retry", "--expected-version", "9", "--dry-run"],
+        ]
+
+        let invocations = try arguments.map { arguments in
+            guard case let .invocation(value) = try GraphCLIParser.parse(
+                arguments
+            ) else {
+                throw GraphCLIArgumentError.invalid("expected invocation")
+            }
+            return value
+        }
+
+        XCTAssertEqual(
+            invocations.map(\.command.name),
+            ["graph.create", "graph.start", "graph.cancel", "graph.retry"]
+        )
+        XCTAssertEqual(invocations.last?.expectedVersion, 9)
+        XCTAssertEqual(invocations.last?.dryRun, true)
+    }
+
+    func testMutationJSONOutputUsesSameStableEnvelope() async throws {
+        let store = InMemoryGraphExecutionEventStore()
+        let stdout = LockedGraphCLISink()
+        let stderr = LockedGraphCLISink()
+        let runner = GraphCLICommandRunner(
+            inspector: DefaultGraphTemporalInspector(
+                readStore: store,
+                snapshotStore: InMemoryGraphExecutionSnapshotStore()
+            ),
+            mutator: DefaultGraphMutationService(
+                eventStore: store,
+                readStore: store
+            ),
+            definitionLoader: FixedDefinitionLoader(
+                definition: try loadCompendiumExecutableDefinition()
+            ),
+            stdout: stdout,
+            stderr: stderr
+        )
+
+        let code = await runner.run(
+            arguments: [
+                "graph", "create", "ignored.json",
+                "--run-id", "cli-run",
+                "--idempotency-key", "cli-create",
+                "--logical-time", "1970-01-01T08:20:00Z",
+                "--output", "json",
+                "--no-color",
+            ]
+        )
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(
+                with: Data(stdout.consume().utf8)
+            ) as? [String: Any]
+        )
+
+        XCTAssertEqual(code, .success)
+        XCTAssertEqual(object["command"] as? String, "graph.create")
+        XCTAssertEqual(object["resultCount"] as? Int, 1)
+        XCTAssertTrue(stderr.consume().isEmpty)
+    }
+
     func testParserRecognizesEveryReadOnlyCommand() throws {
         let arguments = [
             ["graph", "list"],
@@ -292,6 +359,14 @@ private struct CLIHarness {
     let runner: GraphCLICommandRunner
     let stdout: LockedGraphCLISink
     let stderr: LockedGraphCLISink
+}
+
+private struct FixedDefinitionLoader: GraphExecutableDefinitionLoading {
+    let definition: GraphExecutableDefinition
+
+    func load(path: String) throws -> GraphExecutableDefinition {
+        definition
+    }
 }
 
 private final class LockedGraphCLISink:

--- a/Tests/OpenIslandCoreTests/GraphCLITests.swift
+++ b/Tests/OpenIslandCoreTests/GraphCLITests.swift
@@ -1,0 +1,345 @@
+import Foundation
+import XCTest
+@testable import OpenIslandCore
+
+final class GraphCLITests: XCTestCase {
+    func testParserRecognizesEveryReadOnlyCommand() throws {
+        let arguments = [
+            ["graph", "list"],
+            ["graph", "inspect", "run"],
+            ["graph", "history", "run"],
+            ["graph", "explain", "run", "node"],
+            ["graph", "checkpoint", "list", "run"],
+            ["graph", "replay", "run", "--dry-run"],
+            ["graph", "diff", "run@2", "run#checkpoint"],
+            ["graph", "export", "run", "--format", "mermaid"],
+        ]
+
+        let names = try arguments.map { arguments -> String in
+            guard case let .invocation(invocation) =
+                    try GraphCLIParser.parse(arguments) else {
+                return "help"
+            }
+            return invocation.command.name
+        }
+
+        XCTAssertEqual(
+            names,
+            [
+                "graph.list",
+                "graph.inspect",
+                "graph.history",
+                "graph.explain",
+                "graph.checkpoint.list",
+                "graph.replay",
+                "graph.diff",
+                "graph.export",
+            ]
+        )
+    }
+
+    func testJSONOutputIsVersionedDeterministicAndANSIFree()
+        async throws
+    {
+        let harness = try await makeHarness()
+        let arguments = [
+            "graph",
+            "inspect",
+            "run",
+            "--output",
+            "json",
+            "--include-diagnostics",
+        ]
+
+        let firstCode = await harness.runner.run(arguments: arguments)
+        XCTAssertEqual(firstCode, .success)
+        let first = harness.stdout.consume()
+        let secondCode = await harness.runner.run(arguments: arguments)
+        XCTAssertEqual(secondCode, .success)
+        let second = harness.stdout.consume()
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(
+                with: Data(first.utf8)
+            ) as? [String: Any]
+        )
+
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(object["schemaVersion"] as? Int, 1)
+        XCTAssertEqual(object["command"] as? String, "graph.inspect")
+        XCTAssertFalse(first.contains("\u{001B}["))
+        XCTAssertTrue(harness.stderr.consume().isEmpty)
+    }
+
+    func testHistoryJSONLStreamsWithoutSkippingPageBoundary()
+        async throws
+    {
+        let harness = try await makeHarness()
+        let code = await harness.runner.run(
+            arguments: [
+                "graph",
+                "history",
+                "run",
+                "--output",
+                "jsonl",
+                "--limit",
+                "5",
+                "--emit-completion-record",
+            ]
+        )
+        let lines = harness.stdout.consume()
+            .split(separator: "\n")
+            .map(String.init)
+
+        XCTAssertEqual(code, .success)
+        XCTAssertEqual(lines.count, 6)
+        let sequences = try lines.dropLast().map { line -> Int in
+            let object = try XCTUnwrap(
+                JSONSerialization.jsonObject(
+                    with: Data(line.utf8)
+                ) as? [String: Any]
+            )
+            let payload = try XCTUnwrap(
+                object["payload"] as? [String: Any]
+            )
+            return try XCTUnwrap(payload["streamSequence"] as? Int)
+        }
+        XCTAssertEqual(sequences, [1, 2, 3, 4, 5])
+        XCTAssertTrue(lines.last?.contains("\"recordType\":\"completion\"") == true)
+    }
+
+    func testInvalidArgumentsUseStderrAndLeaveStdoutEmpty() async {
+        let stdout = LockedGraphCLISink()
+        let stderr = LockedGraphCLISink()
+        let inspector = DefaultGraphTemporalInspector(
+            readStore: InMemoryGraphExecutionEventStore(),
+            snapshotStore: InMemoryGraphExecutionSnapshotStore()
+        )
+        let runner = GraphCLICommandRunner(
+            inspector: inspector,
+            stdout: stdout,
+            stderr: stderr
+        )
+
+        let code = await runner.run(
+            arguments: ["graph", "replay", "run"]
+        )
+
+        XCTAssertEqual(code, .invalidArguments)
+        XCTAssertTrue(stdout.consume().isEmpty)
+        XCTAssertTrue(
+            stderr.consume().hasPrefix("error[invalid_arguments]:")
+        )
+    }
+
+    func testMissingRunUsesStableNotFoundExitCode() async {
+        let stdout = LockedGraphCLISink()
+        let stderr = LockedGraphCLISink()
+        let runner = GraphCLICommandRunner(
+            inspector: DefaultGraphTemporalInspector(
+                readStore: InMemoryGraphExecutionEventStore(),
+                snapshotStore: InMemoryGraphExecutionSnapshotStore()
+            ),
+            stdout: stdout,
+            stderr: stderr
+        )
+
+        let code = await runner.run(
+            arguments: [
+                "graph",
+                "inspect",
+                "missing",
+                "--output",
+                "json",
+            ]
+        )
+
+        XCTAssertEqual(code, .notFound)
+        XCTAssertTrue(stdout.consume().isEmpty)
+        XCTAssertTrue(stderr.consume().contains("error[not_found]"))
+    }
+
+    func testMermaidExportIsDeterministicAndEscapesLabels()
+        async throws
+    {
+        let store = InMemoryGraphExecutionEventStore()
+        var events = graphCLIEvents()
+        events[1] = graphTestEvent(
+            id: "event-2",
+            sequence: 2,
+            nodeID: "node",
+            payload: .nodeRegistered(
+                GraphNodeRegisteredPayload(
+                    title: "Node \"quoted\" <private>",
+                    executorID: "executor"
+                )
+            )
+        )
+        _ = try await store.append(
+            events,
+            to: "run",
+            expectedVersion: 0
+        )
+        let stdout = LockedGraphCLISink()
+        let runner = GraphCLICommandRunner(
+            inspector: DefaultGraphTemporalInspector(
+                readStore: store,
+                snapshotStore: InMemoryGraphExecutionSnapshotStore()
+            ),
+            stdout: stdout,
+            stderr: LockedGraphCLISink()
+        )
+        let arguments = [
+            "graph",
+            "export",
+            "run",
+            "--format",
+            "mermaid",
+        ]
+
+        let firstCode = await runner.run(arguments: arguments)
+        XCTAssertEqual(firstCode, .success)
+        let first = stdout.consume()
+        let secondCode = await runner.run(arguments: arguments)
+        XCTAssertEqual(secondCode, .success)
+        let second = stdout.consume()
+
+        XCTAssertEqual(first, second)
+        XCTAssertTrue(first.hasPrefix("flowchart TD\n"))
+        XCTAssertTrue(first.contains("&quot;quoted&quot;"))
+        XCTAssertTrue(first.contains("&lt;private&gt;"))
+        XCTAssertFalse(first.contains("secret"))
+    }
+
+    func testBrokenPipeStopsStructuredStreamingSuccessfully()
+        async throws
+    {
+        let harness = try await makeHarness(
+            stdout: BrokenPipeGraphCLISink(afterWrites: 2)
+        )
+
+        let code = await harness.runner.run(
+            arguments: [
+                "graph",
+                "history",
+                "run",
+                "--output",
+                "jsonl",
+                "--limit",
+                "5",
+            ]
+        )
+
+        XCTAssertEqual(code, .success)
+        XCTAssertTrue(harness.stderr.consume().isEmpty)
+    }
+
+    func testUnsupportedOutputSchemaUsesExitFour() async throws {
+        let harness = try await makeHarness()
+
+        let code = await harness.runner.run(
+            arguments: [
+                "graph",
+                "list",
+                "--output",
+                "json",
+                "--schema-version",
+                "2",
+            ]
+        )
+
+        XCTAssertEqual(code, .incompatibleSchema)
+        XCTAssertTrue(harness.stdout.consume().isEmpty)
+        XCTAssertTrue(
+            harness.stderr.consume().contains(
+                "error[incompatible_schema]"
+            )
+        )
+    }
+
+    private func makeHarness(
+        stdout: any GraphCLIOutputSink = LockedGraphCLISink()
+    ) async throws -> CLIHarness {
+        let store = InMemoryGraphExecutionEventStore()
+        _ = try await store.append(
+            graphCLIEvents(),
+            to: "run",
+            expectedVersion: 0
+        )
+        let readableStdout = stdout as? LockedGraphCLISink
+            ?? LockedGraphCLISink()
+        let stderr = LockedGraphCLISink()
+        return CLIHarness(
+            runner: GraphCLICommandRunner(
+                inspector: DefaultGraphTemporalInspector(
+                    readStore: store,
+                    snapshotStore:
+                        InMemoryGraphExecutionSnapshotStore(),
+                    pageSize: 2
+                ),
+                stdout: stdout,
+                stderr: stderr
+            ),
+            stdout: readableStdout,
+            stderr: stderr
+        )
+    }
+}
+
+private struct CLIHarness {
+    let runner: GraphCLICommandRunner
+    let stdout: LockedGraphCLISink
+    let stderr: LockedGraphCLISink
+}
+
+private final class LockedGraphCLISink:
+    GraphCLIOutputSink,
+    @unchecked Sendable
+{
+    private let lock = NSLock()
+    private var data = Data()
+
+    func write(_ data: Data) -> GraphCLIWriteResult {
+        lock.lock()
+        self.data.append(data)
+        lock.unlock()
+        return .written
+    }
+
+    func consume() -> String {
+        lock.lock()
+        let value = String(decoding: data, as: UTF8.self)
+        data.removeAll(keepingCapacity: true)
+        lock.unlock()
+        return value
+    }
+}
+
+private final class BrokenPipeGraphCLISink:
+    GraphCLIOutputSink,
+    @unchecked Sendable
+{
+    private let lock = NSLock()
+    private var writes = 0
+    private let afterWrites: Int
+
+    init(afterWrites: Int) {
+        self.afterWrites = afterWrites
+    }
+
+    func write(_ data: Data) -> GraphCLIWriteResult {
+        lock.lock()
+        defer { lock.unlock() }
+        writes += 1
+        return writes > afterWrites ? .brokenPipe : .written
+    }
+}
+
+private func graphCLIEvents() -> [GraphExecutionEventEnvelope] {
+    [
+        graphTestRunCreated(),
+        graphTestNodeRegistered(),
+        graphTestAttemptCreated(),
+        graphTestAttemptStarting(),
+        graphTestProcessObserved(),
+    ]
+}

--- a/Tests/OpenIslandCoreTests/GraphDefinitionDocumentTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphDefinitionDocumentTests.swift
@@ -1,0 +1,299 @@
+import Foundation
+import XCTest
+@testable import OpenIslandCore
+
+final class GraphDefinitionDocumentTests: XCTestCase {
+    func testRoundTripAndSerializationAreDeterministic() throws {
+        let document = try makeDocument()
+        let first = try GraphDefinitionDocumentCodec.encode(document)
+        let decoded = try GraphDefinitionDocumentCodec.decode(first)
+        let second = try GraphDefinitionDocumentCodec.encode(decoded)
+
+        XCTAssertEqual(decoded, document)
+        XCTAssertEqual(first, second)
+    }
+
+    func testRenamePreservesStableNodeIdentity() throws {
+        var document = try makeDocument()
+        let originalID = try XCTUnwrap(document.nodes.first?.id)
+        try GraphDefinitionDocumentEditor.renameNode(
+            id: originalID,
+            name: "Renamed",
+            description: "Updated",
+            in: &document,
+            modifiedAt: document.metadata.modifiedAt.addingTimeInterval(1),
+            modifiedBy: "test"
+        )
+
+        XCTAssertEqual(document.nodes.first?.id, originalID)
+        XCTAssertEqual(document.nodes.first?.name, "Renamed")
+    }
+
+    func testAddAndRemoveNodeAlsoMaintainsEdgesAndLayout() throws {
+        var document = try makeDocument()
+        let node = testNode(id: "reviewer", name: "Reviewer")
+        try GraphDefinitionDocumentEditor.addNode(
+            node,
+            to: &document,
+            position: GraphCanvasPoint(x: 500, y: 0),
+            modifiedAt: graphTestTime.addingTimeInterval(1),
+            modifiedBy: "test"
+        )
+        try GraphDefinitionDocumentEditor.addEdge(
+            GraphDefinitionEdge(
+                sourceNodeID: "researcher",
+                targetNodeID: "reviewer"
+            ),
+            to: &document,
+            modifiedAt: graphTestTime.addingTimeInterval(2),
+            modifiedBy: "test"
+        )
+        XCTAssertNotNil(document.layout.position(nodeID: "reviewer"))
+
+        try GraphDefinitionDocumentEditor.removeNode(
+            id: "reviewer",
+            from: &document,
+            modifiedAt: graphTestTime.addingTimeInterval(3),
+            modifiedBy: "test"
+        )
+        XCTAssertFalse(document.nodes.contains { $0.id == "reviewer" })
+        XCTAssertFalse(document.edges.contains {
+            $0.sourceNodeID == "reviewer" || $0.targetNodeID == "reviewer"
+        })
+        XCTAssertNil(document.layout.position(nodeID: "reviewer"))
+    }
+
+    func testDuplicateSelfUnknownAndCycleEdgesAreRejected() throws {
+        var document = try makeDocument()
+        let duplicate = document.edges[0]
+        XCTAssertThrowsError(
+            try GraphDefinitionDocumentEditor.addEdge(
+                duplicate,
+                to: &document,
+                modifiedAt: graphTestTime,
+                modifiedBy: "test"
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? GraphDefinitionDocumentError,
+                .duplicateEdge(duplicate.id)
+            )
+        }
+        XCTAssertThrowsError(
+            try GraphDefinitionDocumentEditor.addEdge(
+                GraphDefinitionEdge(
+                    sourceNodeID: "architect",
+                    targetNodeID: "architect"
+                ),
+                to: &document,
+                modifiedAt: graphTestTime,
+                modifiedBy: "test"
+            )
+        )
+        XCTAssertThrowsError(
+            try GraphDefinitionDocumentEditor.addEdge(
+                GraphDefinitionEdge(
+                    sourceNodeID: "missing",
+                    targetNodeID: "architect"
+                ),
+                to: &document,
+                modifiedAt: graphTestTime,
+                modifiedBy: "test"
+            )
+        )
+        XCTAssertThrowsError(
+            try GraphDefinitionDocumentEditor.addEdge(
+                GraphDefinitionEdge(
+                    sourceNodeID: "researcher",
+                    targetNodeID: "architect"
+                ),
+                to: &document,
+                modifiedAt: graphTestTime,
+                modifiedBy: "test"
+            )
+        ) { error in
+            XCTAssertEqual(error as? GraphDefinitionDocumentError, .cycle)
+        }
+    }
+
+    func testLayoutIsIndependentFromExecutionDigest() throws {
+        var document = try makeDocument()
+        let original = try document.semanticDigest()
+        try GraphDefinitionDocumentEditor.setPosition(
+            nodeID: "architect",
+            position: GraphCanvasPoint(x: 900, y: 450),
+            in: &document,
+            modifiedAt: graphTestTime.addingTimeInterval(10),
+            modifiedBy: "test"
+        )
+
+        XCTAssertEqual(try document.semanticDigest(), original)
+    }
+
+    func testAutomaticLayoutIsDeterministic() throws {
+        var first = try makeDocument()
+        var second = try makeDocument()
+        try GraphDefinitionDocumentEditor.applyAutomaticLayout(
+            to: &first,
+            modifiedAt: graphTestTime,
+            modifiedBy: "test"
+        )
+        try GraphDefinitionDocumentEditor.applyAutomaticLayout(
+            to: &second,
+            modifiedAt: graphTestTime,
+            modifiedBy: "test"
+        )
+        XCTAssertEqual(first.layout, second.layout)
+        XCTAssertLessThan(
+            try XCTUnwrap(first.layout.position(nodeID: "architect")?.x),
+            try XCTUnwrap(first.layout.position(nodeID: "researcher")?.x)
+        )
+    }
+
+    func testRunRetainsImmutableExecutableDefinitionAfterDocumentEdit()
+        async throws
+    {
+        var document = try makeDocument()
+        let immutable = try document.executableDefinition()
+        let store = InMemoryGraphExecutionEventStore()
+        let mutator = DefaultGraphMutationService(
+            eventStore: store,
+            readStore: store
+        )
+        _ = try await mutator.create(
+            GraphCreateRequest(
+                runID: "immutable-run",
+                definition: immutable,
+                idempotencyKey: "immutable-create",
+                occurredAt: graphTestTime,
+                producer: graphTestProducer
+            )
+        )
+        try GraphDefinitionDocumentEditor.renameNode(
+            id: "architect",
+            name: "Changed Later",
+            description: "",
+            in: &document,
+            modifiedAt: graphTestTime.addingTimeInterval(1),
+            modifiedBy: "test"
+        )
+        let stream = try await store.read(
+            runID: "immutable-run",
+            afterVersion: 0
+        )
+        let projection = try GraphExecutionProjector.replay(
+            runID: "immutable-run",
+            events: stream.events
+        ).projection
+
+        XCTAssertEqual(
+            projection.executableDefinition?.scheduling.nodes.first {
+                $0.id == "architect"
+            }?.title,
+            "Architect"
+        )
+    }
+
+    func testUnknownTopLevelFieldIsRetained() throws {
+        let data = try GraphDefinitionDocumentCodec.encode(makeDocument())
+        var json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        json["futureFeature"] = ["enabled": true]
+        let extended = try JSONSerialization.data(
+            withJSONObject: json,
+            options: [.sortedKeys]
+        )
+        let decoded = try GraphDefinitionDocumentCodec.decode(extended)
+        let encoded = try GraphDefinitionDocumentCodec.encode(decoded)
+        let roundTrip = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+
+        XCTAssertNotNil(decoded.extensionFields["futureFeature"])
+        XCTAssertNotNil(roundTrip["futureFeature"])
+    }
+
+    func testSensitiveEnvironmentValuesAreRejected() throws {
+        let process = GraphLocalProcessSpecification(
+            executable: "/usr/bin/true",
+            environment: ["API_KEY": "must-not-be-persisted"]
+        )
+        var document = try makeDocument()
+        document.nodes[0].specification = try process.immutableSpecification()
+
+        XCTAssertThrowsError(try document.validate()) { error in
+            XCTAssertEqual(
+                error as? GraphDefinitionDocumentError,
+                .embeddedSecret("API_KEY")
+            )
+        }
+    }
+}
+
+private func makeDocument() throws -> GraphDefinitionDocument {
+    let document = GraphDefinitionDocument(
+        graphID: "document-test",
+        definitionVersion: "1",
+        name: "Document Test",
+        description: "Graph document fixture",
+        nodes: [
+            testNode(id: "researcher", name: "Researcher"),
+            testNode(id: "architect", name: "Architect"),
+        ],
+        edges: [
+            GraphDefinitionEdge(
+                sourceNodeID: "architect",
+                targetNodeID: "researcher"
+            ),
+        ],
+        schedulerPolicy: GraphSchedulerPolicy(
+            policyID: "document-test-policy",
+            version: "1",
+            retryPolicy: GraphRetryPolicy(
+                maximumAttempts: 2,
+                retryableFailureCategories: ["transient"]
+            )
+        ),
+        layout: GraphLayoutMetadata(
+            nodes: [
+                GraphNodeLayoutMetadata(
+                    nodeID: "architect",
+                    position: GraphCanvasPoint(x: 0, y: 0)
+                ),
+                GraphNodeLayoutMetadata(
+                    nodeID: "researcher",
+                    position: GraphCanvasPoint(x: 280, y: 0)
+                ),
+            ]
+        ),
+        metadata: GraphDefinitionDocumentMetadata(
+            createdAt: graphTestTime,
+            modifiedAt: graphTestTime,
+            createdBy: "test",
+            modifiedBy: "test"
+        ),
+        extensionFields: ["fixture": .bool(true)]
+    )
+    try document.validate()
+    return document
+}
+
+private func testNode(
+    id: String,
+    name: String
+) -> GraphDefinitionDocumentNode {
+    GraphDefinitionDocumentNode(
+        id: id,
+        name: name,
+        requiredCapabilities: ["compendium"],
+        specification: GraphImmutableExecutionSpecification(
+            adapterKind: "deterministic",
+            operation: "test"
+        ),
+        timeoutPolicy: GraphExecutionTimeoutPolicy(
+            executionSeconds: 30,
+            cancellationAcknowledgementSeconds: 5
+        )
+    )
+}

--- a/Tests/OpenIslandCoreTests/GraphDefinitionValidatorTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphDefinitionValidatorTests.swift
@@ -223,6 +223,67 @@ final class GraphDefinitionValidatorTests: XCTestCase {
         XCTAssertTrue(codes.contains(.multipleProviders))
         XCTAssertTrue(codes.contains(.unreachableNode))
     }
+
+    func testLocalProcessArgumentTokensDistinguishInputsFromOutputs() throws {
+        let output = GraphLocalProcessArtifactDeclaration(
+            relativePath: "artifacts/result.json",
+            mediaType: "application/json",
+            role: .structuredResult
+        )
+        let invalidProcess = GraphLocalProcessSpecification(
+            executable: "/usr/bin/true",
+            arguments: [
+                "${artifact:node_output}",
+                "${artifact:structured_result}",
+            ],
+            outputArtifacts: [output]
+        )
+        var node = GraphDefinitionDocumentNode(
+            id: "transform",
+            name: "Transform",
+            nodeType: .localProcess,
+            requiredCapabilities: ["local-process"],
+            executorKind: .supervisedLocalProcess,
+            specification: try invalidProcess.immutableSpecification(),
+            workspace: .init(
+                root: "/tmp",
+                writableRelativePaths: ["artifacts"]
+            ),
+            inputArtifactRoles: [.nodeOutput],
+            outputs: [
+                GraphNodeOutputDefinition(
+                    id: "result",
+                    name: "Result",
+                    role: .structuredResult,
+                    relativePath: "artifacts/result.json",
+                    mediaType: "application/json"
+                ),
+            ],
+            timeoutPolicy: GraphExecutionTimeoutPolicy(
+                executionSeconds: 30,
+                cancellationAcknowledgementSeconds: 5
+            )
+        )
+
+        var diagnostics = GraphDefinitionValidator.validate(
+            makeDocument(nodes: [node])
+        )
+        XCTAssertTrue(diagnostics.contains { $0.code == .invalidArgumentToken })
+
+        let validProcess = GraphLocalProcessSpecification(
+            executable: "/usr/bin/true",
+            arguments: [
+                "${input:node_output}",
+                "${artifact:structured_result}",
+            ],
+            outputArtifacts: [output]
+        )
+        node.specification = try validProcess.immutableSpecification()
+        diagnostics = GraphDefinitionValidator.validate(
+            makeDocument(nodes: [node])
+        )
+        XCTAssertFalse(diagnostics.contains { $0.code == .invalidArgumentToken })
+    }
 }
 
 private func makeDocument(

--- a/Tests/OpenIslandCoreTests/GraphDefinitionValidatorTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphDefinitionValidatorTests.swift
@@ -1,0 +1,281 @@
+import Foundation
+import XCTest
+@testable import OpenIslandCore
+
+final class GraphDefinitionValidatorTests: XCTestCase {
+    func testValidExecutableGraphHasNoErrors() throws {
+        let document = makeDocument(nodes: [deterministicNode(id: "verify")])
+        let diagnostics = GraphDefinitionValidator.validate(
+            document,
+            context: GraphDefinitionValidationContext(
+                availableCapabilities: ["deterministic"]
+            )
+        )
+
+        XCTAssertFalse(diagnostics.contains { $0.severity == .error })
+    }
+
+    func testStructuralExecutionInputArtifactAndPolicyTaxonomy() throws {
+        let invalidRetry = try JSONDecoder().decode(
+            GraphRetryPolicy.self,
+            from: Data(#"""
+            {
+              "schemaVersion":1,
+              "maximumAttempts":0,
+              "retryableFailureCategories":[],
+              "nonRetryableFailureCategories":[],
+              "initialBackoffSeconds":10,
+              "backoffMultiplier":2,
+              "maximumBackoffSeconds":1,
+              "jitterBasisPoints":0,
+              "jitterSeed":"test",
+              "timeoutBehavior":"retry",
+              "cancellationBehavior":"suppress",
+              "dependencyFailureBehavior":"fail_closed"
+            }
+            """#.utf8)
+        )
+        let invalidTimeout = try JSONDecoder().decode(
+            GraphExecutionTimeoutPolicy.self,
+            from: Data(#"""
+            {
+              "executionSeconds":0,
+              "cancellationAcknowledgementSeconds":0
+            }
+            """#.utf8)
+        )
+        let process = GraphLocalProcessSpecification(
+            executable: "relative-tool",
+            workingDirectory: "../outside"
+        )
+        var first = GraphDefinitionDocumentNode(
+            id: "bad id",
+            name: "Broken",
+            nodeType: .localProcess,
+            requiredCapabilities: ["missing-capability"],
+            executorKind: .supervisedLocalProcess,
+            specification: try process.immutableSpecification(),
+            workspace: .init(),
+            inputs: [
+                GraphNodeInputDefinition(
+                    id: "required-input",
+                    name: "Required",
+                    mediaType: "application/json"
+                ),
+            ],
+            outputs: [
+                GraphNodeOutputDefinition(
+                    id: "first-output",
+                    name: "First",
+                    role: .nodeOutput,
+                    relativePath: "../escape.json",
+                    mediaType: "application/json"
+                ),
+                GraphNodeOutputDefinition(
+                    id: "second-output",
+                    name: "Second",
+                    role: .nodeOutput,
+                    relativePath: "",
+                    mediaType: "text/plain"
+                ),
+            ],
+            retryConfiguration: .init(
+                inheritsGraphDefault: false,
+                override: invalidRetry
+            ),
+            timeoutPolicy: invalidTimeout,
+            timeoutConfiguration: .init(
+                inheritsGraphDefault: false,
+                executionSeconds: 0,
+                cancellationAcknowledgementSeconds: 0,
+                claimSeconds: 0
+            )
+        )
+        first.specification = GraphImmutableExecutionSpecification(
+            adapterKind: GraphLocalProcessSpecification.adapterKind,
+            operation: GraphLocalProcessSpecification.operation,
+            parameters: first.specification.parameters
+        )
+        let generic = GraphDefinitionDocumentNode(
+            id: "generic",
+            name: "Unbound",
+            nodeType: .genericAgent,
+            requiredCapabilities: ["agent"],
+            executorKind: .unboundAgent,
+            specification: .init(adapterKind: "generic_agent", operation: "unbound"),
+            timeoutPolicy: .init(
+                executionSeconds: 30,
+                cancellationAcknowledgementSeconds: 5
+            )
+        )
+        var document = makeDocument(
+            name: "",
+            nodes: [first, generic],
+            edges: [
+                GraphDefinitionEdge(
+                    edgeID: "self",
+                    sourceNodeID: "generic",
+                    targetNodeID: "generic"
+                ),
+                GraphDefinitionEdge(
+                    edgeID: "unknown",
+                    sourceNodeID: "missing",
+                    targetNodeID: "generic"
+                ),
+            ]
+        )
+        document.graphInputs = [
+            GraphDefinitionInput(
+                id: "secret",
+                name: "Secret",
+                dataType: .text,
+                isSensitive: true,
+                defaultValue: .string("must-not-persist")
+            ),
+        ]
+        document.graphOutputs = [
+            GraphDefinitionOutput(
+                id: "dangling",
+                name: "Dangling",
+                sourceNodeID: "generic",
+                sourceOutputID: "missing"
+            ),
+        ]
+
+        let diagnostics = GraphDefinitionValidator.validate(
+            document,
+            context: GraphDefinitionValidationContext(
+                availableCapabilities: ["local-process"],
+                availableExecutablePaths: [],
+                availableDirectoryPaths: [],
+                immutableDefinitionDigest: GraphContentDigest(
+                    algorithm: "sha256",
+                    value: "immutable"
+                )
+            )
+        )
+        let codes = Set(diagnostics.map(\.code))
+
+        XCTAssertTrue(codes.isSuperset(of: [
+            .missingGraphName,
+            .invalidNodeID,
+            .selfDependency,
+            .unknownNodeReference,
+            .executableNotAbsolute,
+            .invalidWorkingDirectory,
+            .missingRequiredInput,
+            .invalidArtifactPath,
+            .artifactPathEscapesWorkspace,
+            .outputRoleCollision,
+            .invalidRetryPolicy,
+            .invalidTimeoutPolicy,
+            .unsupportedExecutorKind,
+            .impossibleCapabilityRequirements,
+            .danglingBinding,
+            .sensitiveLiteral,
+            .immutableDefinitionMutationAttempt,
+        ]))
+    }
+
+    func testCycleDuplicateTypedPortsAndDisconnectedNodesAreDiagnosed() {
+        var source = deterministicNode(id: "source")
+        source.outputs[0].mediaType = "application/json"
+        var target = deterministicNode(id: "target")
+        target.inputs = [
+            GraphNodeInputDefinition(
+                id: "target-input",
+                name: "Target",
+                mediaType: "text/plain"
+            ),
+        ]
+        let detached = deterministicNode(id: "detached")
+        let typed = GraphDefinitionEdge(
+            edgeID: "typed",
+            sourceNodeID: "source",
+            targetNodeID: "target",
+            portType: .artifact,
+            sourceOutputID: "node-output",
+            targetInputID: "target-input"
+        )
+        let document = makeDocument(
+            nodes: [source, target, detached],
+            edges: [
+                typed,
+                GraphDefinitionEdge(
+                    edgeID: "typed-copy",
+                    sourceNodeID: "source",
+                    targetNodeID: "target",
+                    portType: .artifact,
+                    sourceOutputID: "node-output",
+                    targetInputID: "target-input"
+                ),
+                GraphDefinitionEdge(
+                    sourceNodeID: "target",
+                    targetNodeID: "source"
+                ),
+            ]
+        )
+        let codes = Set(GraphDefinitionValidator.validate(document).map(\.code))
+
+        XCTAssertTrue(codes.contains(.duplicateEdge))
+        XCTAssertTrue(codes.contains(.cycle))
+        XCTAssertTrue(codes.contains(.incompatibleTypedPorts))
+        XCTAssertTrue(codes.contains(.multipleProviders))
+        XCTAssertTrue(codes.contains(.unreachableNode))
+    }
+}
+
+private func makeDocument(
+    name: String = "Validator Test",
+    nodes: [GraphDefinitionDocumentNode],
+    edges: [GraphDefinitionEdge] = []
+) -> GraphDefinitionDocument {
+    GraphDefinitionDocument(
+        graphID: "validator-test",
+        definitionVersion: "1",
+        name: name,
+        nodes: nodes,
+        edges: edges,
+        schedulerPolicy: GraphSchedulerPolicy(
+            policyID: "validator-policy",
+            version: "1",
+            retryPolicy: GraphRetryPolicy(
+                maximumAttempts: 2,
+                retryableFailureCategories: ["timeout"]
+            )
+        ),
+        metadata: GraphDefinitionDocumentMetadata(
+            createdAt: Date(timeIntervalSince1970: 1),
+            modifiedAt: Date(timeIntervalSince1970: 1),
+            createdBy: "test",
+            modifiedBy: "test"
+        )
+    )
+}
+
+private func deterministicNode(id: String) -> GraphDefinitionDocumentNode {
+    GraphDefinitionDocumentNode(
+        id: id,
+        name: id.capitalized,
+        nodeType: .deterministicTest,
+        requiredCapabilities: ["deterministic"],
+        executorKind: .deterministicTest,
+        specification: GraphImmutableExecutionSpecification(
+            adapterKind: "deterministic",
+            operation: "test"
+        ),
+        outputs: [
+            GraphNodeOutputDefinition(
+                id: "node-output",
+                name: "Node Output",
+                role: .nodeOutput,
+                relativePath: "artifacts/\(id).json",
+                mediaType: "application/json"
+            ),
+        ],
+        timeoutPolicy: GraphExecutionTimeoutPolicy(
+            executionSeconds: 30,
+            cancellationAcknowledgementSeconds: 5
+        )
+    )
+}

--- a/Tests/OpenIslandCoreTests/GraphExecutionDurabilityInvariantTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphExecutionDurabilityInvariantTests.swift
@@ -1,0 +1,982 @@
+import Foundation
+import SQLite3
+import XCTest
+@testable import OpenIslandCore
+
+final class GraphExecutionDurabilityInvariantTests: XCTestCase {
+    func testRepositoryLoadsEmptyStreamWithoutInventingState() async throws {
+        let store = InMemoryGraphExecutionEventStore()
+        let repository = DefaultGraphExecutionRepository(
+            eventStore: store,
+            snapshotStore: InMemoryGraphExecutionSnapshotStore(),
+            evidenceSource: UnavailableProcessEvidenceSource()
+        )
+
+        let result = try await repository.load(
+            runID: "empty",
+            observedAt: graphTestTime
+        )
+        let stream = try await store.read(
+            runID: "empty",
+            afterVersion: 0
+        )
+
+        XCTAssertEqual(result.streamVersion, 0)
+        XCTAssertNil(result.persistedProjection.run)
+        XCTAssertNil(result.reconciledState)
+        XCTAssertEqual(stream.events, [])
+    }
+
+    func testIncompatibleSnapshotFallsBackToFullReplay() async throws {
+        let events = baseRunningEvents()
+        let projection = try GraphExecutionProjector.replay(
+            runID: "run",
+            events: events
+        ).projection
+        let result = try await repositoryResult(
+            events: events,
+            snapshots: [
+                graphTestSnapshot(
+                    for: projection,
+                    schemaVersion: 99
+                ),
+            ]
+        )
+
+        XCTAssertEqual(result.snapshotDisposition, .incompatible)
+        XCTAssertEqual(result.persistedProjection, projection)
+    }
+
+    func testCorruptSnapshotFallsBackToFullReplay() async throws {
+        let events = baseRunningEvents()
+        let store = try await eventStore(events)
+        let repository = DefaultGraphExecutionRepository(
+            eventStore: store,
+            snapshotStore: ThrowingSnapshotStore(),
+            evidenceSource: UnavailableProcessEvidenceSource()
+        )
+
+        let result = try await repository.load(
+            runID: "run",
+            observedAt: graphTestTime.addingTimeInterval(100)
+        )
+
+        XCTAssertEqual(result.snapshotDisposition, .corrupt)
+        XCTAssertEqual(result.streamVersion, UInt64(events.count))
+    }
+
+    func testSnapshotAheadOfStreamIsBypassed() async throws {
+        let fiveEvents = baseRunningEvents()
+        let projection = try GraphExecutionProjector.replay(
+            runID: "run",
+            events: fiveEvents
+        ).projection
+        let fourEvents = Array(fiveEvents.prefix(4))
+        let result = try await repositoryResult(
+            events: fourEvents,
+            snapshots: [graphTestSnapshot(for: projection)]
+        )
+
+        XCTAssertEqual(result.snapshotDisposition, .aheadOfStream)
+        XCTAssertEqual(result.streamVersion, 4)
+        XCTAssertNil(
+            result.persistedProjection.attempts[0].processIdentity
+        )
+    }
+
+    func testSnapshotsDoNotChangeFinalProjection() async throws {
+        let events = baseRunningEvents()
+        let prefix = Array(events.prefix(3))
+        let prefixProjection = try GraphExecutionProjector.replay(
+            runID: "run",
+            events: prefix
+        ).projection
+
+        let withoutSnapshot = try await repositoryResult(events: events)
+        let withSnapshot = try await repositoryResult(
+            events: events,
+            snapshots: [graphTestSnapshot(for: prefixProjection)]
+        )
+
+        XCTAssertEqual(
+            withoutSnapshot.persistedProjection,
+            withSnapshot.persistedProjection
+        )
+        XCTAssertEqual(
+            withoutSnapshot.reconciledState,
+            withSnapshot.reconciledState
+        )
+    }
+
+    func testStaleHeartbeatDoesNotKeepAttemptRunning() async throws {
+        let stale = ExecutorHeartbeat(
+            attemptID: "attempt",
+            processIdentity: graphTestProcess,
+            observedAt: graphTestTime.addingTimeInterval(10),
+            validUntil: graphTestTime.addingTimeInterval(20)
+        )
+        let result = try await repositoryResult(
+            events: baseRunningEvents(),
+            evidence: .stale(
+                GraphProcessEvidence(heartbeats: [stale]),
+                reason: "lease expired"
+            )
+        )
+
+        XCTAssertEqual(
+            result.reconciledState?.attempts[0].state,
+            .orphaned
+        )
+    }
+
+    func testValidRetryOrdinalsRemainMonotonic() throws {
+        let events = generatedRetryEvents(attemptCount: 10)
+
+        let projection = try GraphExecutionProjector.replay(
+            runID: "run",
+            events: events
+        ).projection
+
+        XCTAssertEqual(
+            projection.attempts.map(\.ordinal),
+            Array(1...10)
+        )
+        XCTAssertEqual(
+            projection.attempts.map(\.state),
+            Array(repeating: .completed, count: 10)
+        )
+    }
+
+    func testGeneratedReplayIsDeterministicAndDuplicateIdempotent() throws {
+        for attemptCount in 1...20 {
+            let events = generatedRetryEvents(
+                attemptCount: attemptCount
+            )
+            let forward = try GraphExecutionProjector.replay(
+                runID: "run",
+                events: events
+            )
+            let reverse = try GraphExecutionProjector.replay(
+                runID: "run",
+                events: events.reversed()
+            )
+            let duplicated = try GraphExecutionProjector.replay(
+                runID: "run",
+                events: events.flatMap { [$0, $0] }
+            )
+
+            XCTAssertEqual(forward.projection, reverse.projection)
+            XCTAssertEqual(forward.projection, duplicated.projection)
+            XCTAssertEqual(
+                duplicated.duplicateEventCount,
+                events.count
+            )
+        }
+    }
+
+    func testGeneratedStreamVersionsNeverDecrease() async throws {
+        let store = InMemoryGraphExecutionEventStore()
+        let events = generatedRetryEvents(attemptCount: 8)
+        var observedVersions: [UInt64] = []
+
+        for event in events {
+            let result = try await store.append(
+                [event],
+                to: "run",
+                expectedVersion: UInt64(observedVersions.count)
+            )
+            observedVersions.append(result.newVersion)
+        }
+
+        XCTAssertEqual(
+            observedVersions,
+            Array(1...UInt64(events.count))
+        )
+    }
+
+    func testReplayFromEveryValidAttemptBoundaryMatchesFullReplay() throws {
+        let events = generatedRetryEvents(attemptCount: 8)
+        let full = try GraphExecutionProjector.replay(
+            runID: "run",
+            events: events
+        ).projection
+
+        for boundary in stride(
+            from: 2,
+            through: events.count,
+            by: 3
+        ) {
+            let prefix = Array(events.prefix(boundary))
+            let suffix = Array(events.dropFirst(boundary))
+            let initial = try GraphExecutionProjector.replay(
+                runID: "run",
+                events: prefix
+            ).projection
+            let resumed = try GraphExecutionProjector.replay(
+                runID: "run",
+                events: suffix,
+                initialProjection: initial
+            ).projection
+
+            XCTAssertEqual(resumed, full)
+        }
+    }
+
+    func testDependencyReconciliationReachesStableFixedPoint() throws {
+        let input = try loadStaleCompendiumFixture()
+        let first = GraphExecutionReconciler.reconcile(input)
+        let second = GraphExecutionReconciler.reconcile(
+            ExecutionReconciliationInput(
+                run: first.run,
+                nodes: first.nodes,
+                attempts: first.attempts,
+                observedAt: input.observedAt
+            )
+        )
+
+        XCTAssertEqual(first, second)
+    }
+
+    func testConcurrentSQLiteWritersProduceOneConflict() async throws {
+        let fixture = try SQLiteStoreFixture()
+        defer { fixture.remove() }
+        let firstStore = try SQLiteGraphExecutionStore(
+            databasePath: fixture.path
+        )
+        let secondStore = try SQLiteGraphExecutionStore(
+            databasePath: fixture.path
+        )
+        let firstEvent = graphTestRunCreated()
+        let secondEvent = GraphExecutionEventEnvelope(
+            id: "competing-event",
+            runID: "run",
+            streamSequence: 1,
+            occurredAt: graphTestTime,
+            recordedAt: graphTestTime,
+            producer: graphTestProducer,
+            payload: .runCreated(
+                GraphRunCreatedPayload(
+                    graphID: "graph",
+                    graphDefinitionVersion: "1",
+                    graphDefinitionDigest: graphTestDigest,
+                    nodeIDs: ["node"]
+                )
+            )
+        )
+        let firstTask = Task {
+            try await firstStore.append(
+                [firstEvent],
+                to: "run",
+                expectedVersion: 0
+            )
+        }
+        let secondTask = Task {
+            try await secondStore.append(
+                [secondEvent],
+                to: "run",
+                expectedVersion: 0
+            )
+        }
+        let outcomes = await [
+            appendOutcome(firstTask),
+            appendOutcome(secondTask),
+        ]
+
+        XCTAssertEqual(
+            outcomes.filter { $0 == "success" }.count,
+            1
+        )
+        XCTAssertEqual(
+            outcomes.filter { $0 == "version_conflict" }.count,
+            1
+        )
+    }
+
+    func testSQLiteReportsCorruptEventPayload() async throws {
+        let fixture = try SQLiteStoreFixture()
+        defer { fixture.remove() }
+        let store = try SQLiteGraphExecutionStore(
+            databasePath: fixture.path
+        )
+        _ = try await store.append(
+            [graphTestRunCreated()],
+            to: "run",
+            expectedVersion: 0
+        )
+        try corruptEventJSON(at: fixture.path)
+
+        await XCTAssertThrowsErrorAsync {
+            try await store.read(runID: "run", afterVersion: 0)
+        } verify: {
+            guard let persistenceError =
+                    $0 as? GraphExecutionPersistenceError else {
+                return XCTFail("Expected corrupt-record error, got \($0).")
+            }
+
+            guard case .corruptRecord = persistenceError else {
+                return XCTFail("Expected corrupt-record error, got \($0).")
+            }
+        }
+    }
+
+    func testArtifactProvenanceRoundTripsThroughSQLiteAndReplay() async throws {
+        let fixture = try SQLiteStoreFixture()
+        defer { fixture.remove() }
+        let store = try SQLiteGraphExecutionStore(
+            databasePath: fixture.path
+        )
+        let artifact = GraphArtifactReference(
+            id: "artifact",
+            contentDigest: GraphContentDigest(
+                algorithm: "sha256",
+                value: "content"
+            ),
+            mediaType: "text/markdown",
+            logicalRole: "handoff",
+            producingRunID: "run",
+            producingNodeID: "node",
+            producingAttemptID: "attempt",
+            createdAt: graphTestTime,
+            storage: GraphArtifactStorageLocator(
+                scheme: "vault",
+                opaqueReference: "artifact-reference"
+            ),
+            sensitivity: .confidential
+        )
+        var events = Array(baseRunningEvents().prefix(3))
+        events.append(
+            graphTestEvent(
+                id: "artifact-event",
+                sequence: 4,
+                nodeID: "node",
+                attemptID: "attempt",
+                payload: .artifactRecorded(
+                    GraphArtifactRecordedPayload(artifact: artifact)
+                )
+            )
+        )
+        _ = try await store.append(
+            events,
+            to: "run",
+            expectedVersion: 0
+        )
+
+        let stream = try await store.read(
+            runID: "run",
+            afterVersion: 0
+        )
+        let replay = try GraphExecutionProjector.replay(
+            runID: "run",
+            events: stream.events
+        )
+
+        XCTAssertEqual(replay.projection.artifacts, [artifact])
+    }
+
+    func testCompletedParallelWriteSurvivesSiblingFailure() throws {
+        let artifact = GraphArtifactReference(
+            id: "parallel-output",
+            contentDigest: GraphContentDigest(
+                algorithm: "sha256",
+                value: "parallel-content"
+            ),
+            mediaType: "application/json",
+            logicalRole: "worker-output",
+            producingRunID: "run",
+            producingNodeID: "worker-a",
+            producingAttemptID: "attempt-a",
+            createdAt: graphTestTime,
+            storage: GraphArtifactStorageLocator(
+                scheme: "artifact",
+                opaqueReference: "parallel-output"
+            )
+        )
+        let events: [GraphExecutionEventEnvelope] = [
+            graphTestEvent(
+                id: "parallel-1",
+                sequence: 1,
+                payload: .runCreated(
+                    GraphRunCreatedPayload(
+                        graphID: "parallel",
+                        graphDefinitionVersion: "1",
+                        graphDefinitionDigest: graphTestDigest,
+                        nodeIDs: ["worker-a", "worker-b"]
+                    )
+                )
+            ),
+            graphTestEvent(
+                id: "parallel-2",
+                sequence: 2,
+                nodeID: "worker-a",
+                payload: .nodeRegistered(
+                    GraphNodeRegisteredPayload(title: "Worker A")
+                )
+            ),
+            graphTestEvent(
+                id: "parallel-3",
+                sequence: 3,
+                nodeID: "worker-b",
+                payload: .nodeRegistered(
+                    GraphNodeRegisteredPayload(title: "Worker B")
+                )
+            ),
+            graphTestEvent(
+                id: "parallel-4",
+                sequence: 4,
+                nodeID: "worker-a",
+                attemptID: "attempt-a",
+                payload: .attemptCreated(
+                    GraphAttemptCreatedPayload(ordinal: 1)
+                )
+            ),
+            graphTestEvent(
+                id: "parallel-5",
+                sequence: 5,
+                nodeID: "worker-b",
+                attemptID: "attempt-b",
+                payload: .attemptCreated(
+                    GraphAttemptCreatedPayload(ordinal: 1)
+                )
+            ),
+            graphTestEvent(
+                id: "parallel-6",
+                sequence: 6,
+                nodeID: "worker-a",
+                attemptID: "attempt-a",
+                payload: .artifactRecorded(
+                    GraphArtifactRecordedPayload(artifact: artifact)
+                )
+            ),
+            graphTestEvent(
+                id: "parallel-7",
+                sequence: 7,
+                nodeID: "worker-a",
+                attemptID: "attempt-a",
+                payload: .attemptCompleted(
+                    GraphAttemptTerminalPayload(
+                        artifactIDs: [artifact.id]
+                    )
+                )
+            ),
+            graphTestEvent(
+                id: "parallel-8",
+                sequence: 8,
+                nodeID: "worker-b",
+                attemptID: "attempt-b",
+                payload: .attemptFailed(
+                    GraphAttemptTerminalPayload(
+                        reason: "Sibling failed."
+                    )
+                )
+            ),
+        ]
+
+        let projection = try GraphExecutionProjector.replay(
+            runID: "run",
+            events: events
+        ).projection
+        let states = Dictionary(
+            uniqueKeysWithValues: projection.attempts.map {
+                ($0.id, $0.state)
+            }
+        )
+
+        XCTAssertEqual(states["attempt-a"], .completed)
+        XCTAssertEqual(states["attempt-b"], .failed)
+        XCTAssertEqual(projection.artifacts, [artifact])
+    }
+
+    func testCheckpointForkAndHumanInterruptFactsSurviveReplay() throws {
+        let parent = GraphCheckpointReference(
+            checkpointID: "checkpoint-7",
+            runID: "parent-run",
+            streamVersion: 7,
+            namespace: "research/subgraph"
+        )
+        let request = GraphHumanInterruptRequestedPayload(
+            requestID: "approval",
+            requestSchemaID: "approval.v1",
+            requestArtifactID: "request-artifact",
+            requiredDecisionCount: 2
+        )
+        let resolution = GraphHumanInterruptResolvedPayload(
+            requestID: "approval",
+            resolution: .approved,
+            decidedBy: "operator",
+            responseArtifactID: "response-artifact"
+        )
+        let events = [
+            graphTestEvent(
+                id: "checkpoint-1",
+                sequence: 1,
+                payload: .runCreated(
+                    GraphRunCreatedPayload(
+                        graphID: "fork",
+                        graphDefinitionVersion: "2",
+                        graphDefinitionDigest: graphTestDigest,
+                        nodeIDs: [],
+                        parentRunID: "parent-run",
+                        parentCheckpoint: parent,
+                        checkpointNamespace: "research/fork"
+                    )
+                )
+            ),
+            graphTestEvent(
+                id: "checkpoint-2",
+                sequence: 2,
+                payload: .humanInterruptRequested(request)
+            ),
+            graphTestEvent(
+                id: "checkpoint-3",
+                sequence: 3,
+                payload: .humanInterruptResolved(resolution)
+            ),
+        ]
+
+        let projection = try GraphExecutionProjector.replay(
+            runID: "run",
+            events: events
+        ).projection
+
+        XCTAssertEqual(projection.parentRunID, "parent-run")
+        XCTAssertEqual(projection.parentCheckpoint, parent)
+        XCTAssertEqual(
+            projection.checkpointNamespace,
+            "research/fork"
+        )
+        XCTAssertEqual(
+            projection.humanInterrupts[0].state,
+            .resolved
+        )
+        XCTAssertEqual(
+            projection.humanInterrupts[0].resolution,
+            resolution
+        )
+    }
+
+    func testSQLiteRestartProducesIdenticalRepositoryResult() async throws {
+        let fixture = try SQLiteStoreFixture()
+        defer { fixture.remove() }
+        let firstStore = try SQLiteGraphExecutionStore(
+            databasePath: fixture.path
+        )
+        _ = try await firstStore.append(
+            baseRunningEvents(),
+            to: "run",
+            expectedVersion: 0
+        )
+        let evidence = StaticProcessEvidenceSource(
+            outcome: .unavailable(reason: "offline")
+        )
+        let firstRepository = DefaultGraphExecutionRepository(
+            eventStore: firstStore,
+            snapshotStore: firstStore,
+            evidenceSource: evidence
+        )
+        let observedAt = graphTestTime.addingTimeInterval(100)
+        let first = try await firstRepository.load(
+            runID: "run",
+            observedAt: observedAt
+        )
+        let reopened = try SQLiteGraphExecutionStore(
+            databasePath: fixture.path
+        )
+        let secondRepository = DefaultGraphExecutionRepository(
+            eventStore: reopened,
+            snapshotStore: reopened,
+            evidenceSource: evidence
+        )
+
+        let second = try await secondRepository.load(
+            runID: "run",
+            observedAt: observedAt
+        )
+
+        XCTAssertEqual(first, second)
+    }
+
+    func testInjectableSnapshotPolicyCreatesReusableCache() async throws {
+        let store = try await eventStore(baseRunningEvents())
+        let snapshotStore = InMemoryGraphExecutionSnapshotStore()
+        let evidence = StaticProcessEvidenceSource(
+            outcome: .unavailable(reason: "offline")
+        )
+        let creatingRepository = DefaultGraphExecutionRepository(
+            eventStore: store,
+            snapshotStore: snapshotStore,
+            evidenceSource: evidence,
+            snapshotPolicy: EventCountGraphExecutionSnapshotPolicy(
+                minimumReplayedEventCount: 1
+            )
+        )
+        let observedAt = graphTestTime.addingTimeInterval(100)
+
+        let created = try await creatingRepository.load(
+            runID: "run",
+            observedAt: observedAt
+        )
+        let readingRepository = DefaultGraphExecutionRepository(
+            eventStore: store,
+            snapshotStore: snapshotStore,
+            evidenceSource: evidence
+        )
+        let reloaded = try await readingRepository.load(
+            runID: "run",
+            observedAt: observedAt
+        )
+
+        XCTAssertEqual(created.snapshotDisposition, .created)
+        XCTAssertEqual(reloaded.snapshotDisposition, .current)
+        XCTAssertEqual(
+            created.persistedProjection,
+            reloaded.persistedProjection
+        )
+        XCTAssertEqual(
+            created.reconciledState,
+            reloaded.reconciledState
+        )
+    }
+
+    func testStaleCompendiumFixtureLoadsThroughRepository() async throws {
+        let input = try loadStaleCompendiumFixture()
+        let events = compendiumEvents(from: input)
+        let store = InMemoryGraphExecutionEventStore()
+        _ = try await store.append(
+            events,
+            to: input.run.id,
+            expectedVersion: 0
+        )
+        let repository = DefaultGraphExecutionRepository(
+            eventStore: store,
+            snapshotStore: InMemoryGraphExecutionSnapshotStore(),
+            evidenceSource: UnavailableProcessEvidenceSource()
+        )
+        let result = try await repository.load(
+            runID: input.run.id,
+            observedAt: input.observedAt
+        )
+        let states = Dictionary(
+            uniqueKeysWithValues: result.reconciledState!.nodes.map {
+                ($0.id, $0.state)
+            }
+        )
+
+        XCTAssertEqual(states["architect"], .interrupted)
+        XCTAssertEqual(states["researcher"], .orphaned)
+        XCTAssertEqual(states["graph"], .blocked)
+        XCTAssertEqual(states["reviewer"], .blocked)
+        XCTAssertEqual(
+            result.reconciledState?.run.state,
+            .interrupted
+        )
+    }
+
+    private func repositoryResult(
+        events: [GraphExecutionEventEnvelope],
+        snapshots: [GraphExecutionSnapshot] = [],
+        evidence: GraphProcessEvidenceOutcome =
+            .unavailable(reason: "offline"),
+        observedAt: Date = graphTestTime.addingTimeInterval(100)
+    ) async throws -> GraphExecutionRepositoryLoadResult {
+        let store = try await eventStore(events)
+        let repository = DefaultGraphExecutionRepository(
+            eventStore: store,
+            snapshotStore: InMemoryGraphExecutionSnapshotStore(
+                snapshots: snapshots
+            ),
+            evidenceSource: StaticProcessEvidenceSource(
+                outcome: evidence
+            )
+        )
+
+        return try await repository.load(
+            runID: "run",
+            observedAt: observedAt
+        )
+    }
+
+    private func eventStore(
+        _ events: [GraphExecutionEventEnvelope]
+    ) async throws -> InMemoryGraphExecutionEventStore {
+        let store = InMemoryGraphExecutionEventStore()
+        _ = try await store.append(
+            events,
+            to: "run",
+            expectedVersion: 0
+        )
+        return store
+    }
+
+    private func baseRunningEvents()
+        -> [GraphExecutionEventEnvelope]
+    {
+        [
+            graphTestRunCreated(),
+            graphTestNodeRegistered(),
+            graphTestAttemptCreated(),
+            graphTestAttemptStarting(),
+            graphTestProcessObserved(),
+        ]
+    }
+
+    private func generatedRetryEvents(
+        attemptCount: Int
+    ) -> [GraphExecutionEventEnvelope] {
+        var events = [
+            graphTestRunCreated(),
+            graphTestNodeRegistered(),
+        ]
+        var sequence: UInt64 = 3
+
+        for ordinal in 1...attemptCount {
+            let attemptID = "attempt-\(ordinal)"
+            events.append(
+                graphTestAttemptCreated(
+                    sequence: sequence,
+                    attemptID: attemptID,
+                    ordinal: ordinal
+                )
+            )
+            sequence += 1
+            events.append(
+                graphTestAttemptStarting(
+                    sequence: sequence,
+                    attemptID: attemptID
+                )
+            )
+            sequence += 1
+            events.append(
+                graphTestEvent(
+                    id: "event-\(sequence)",
+                    sequence: sequence,
+                    nodeID: "node",
+                    attemptID: attemptID,
+                    payload: .attemptCompleted(
+                        GraphAttemptTerminalPayload()
+                    )
+                )
+            )
+            sequence += 1
+        }
+
+        return events
+    }
+
+    private func compendiumEvents(
+        from input: ExecutionReconciliationInput
+    ) -> [GraphExecutionEventEnvelope] {
+        let producer = GraphExecutionProducer(
+            id: "stale-compendium-import",
+            kind: .importer
+        )
+        var sequence: UInt64 = 1
+
+        func envelope(
+            id: String,
+            nodeID: String? = nil,
+            attemptID: String? = nil,
+            occurredAt: Date,
+            payload: GraphExecutionEventPayload
+        ) -> GraphExecutionEventEnvelope {
+            defer { sequence += 1 }
+            return GraphExecutionEventEnvelope(
+                id: id,
+                runID: input.run.id,
+                nodeID: nodeID,
+                attemptID: attemptID,
+                streamSequence: sequence,
+                occurredAt: occurredAt,
+                recordedAt: input.observedAt,
+                producer: producer,
+                payload: payload
+            )
+        }
+
+        var events = [
+            envelope(
+                id: "compendium-run",
+                occurredAt: input.run.createdAt,
+                payload: .runCreated(
+                    GraphRunCreatedPayload(
+                        graphID: input.run.graphID,
+                        graphDefinitionVersion: "fixture-1",
+                        graphDefinitionDigest: GraphContentDigest(
+                            algorithm: "sha256",
+                            value: "stale-compendium-fixture"
+                        ),
+                        nodeIDs: input.run.nodeIDs
+                    )
+                )
+            ),
+        ]
+
+        for node in input.nodes {
+            events.append(
+                envelope(
+                    id: "compendium-node-\(node.id)",
+                    nodeID: node.id,
+                    occurredAt: node.updatedAt,
+                    payload: .nodeRegistered(
+                        GraphNodeRegisteredPayload(
+                            title: node.title,
+                            dependencyNodeIDs:
+                                node.dependencyNodeIDs,
+                            executorID: node.executorID
+                        )
+                    )
+                )
+            )
+        }
+
+        for attempt in input.attempts.sorted(by: {
+            $0.id < $1.id
+        }) {
+            events.append(
+                envelope(
+                    id: "compendium-attempt-\(attempt.id)",
+                    nodeID: attempt.nodeID,
+                    attemptID: attempt.id,
+                    occurredAt: attempt.createdAt,
+                    payload: .attemptCreated(
+                        GraphAttemptCreatedPayload(
+                            ordinal: attempt.ordinal
+                        )
+                    )
+                )
+            )
+            events.append(
+                envelope(
+                    id: "compendium-start-\(attempt.id)",
+                    nodeID: attempt.nodeID,
+                    attemptID: attempt.id,
+                    occurredAt: attempt.startedAt
+                        ?? attempt.createdAt,
+                    payload: .attemptStarting(
+                        GraphAttemptStartingPayload()
+                    )
+                )
+            )
+
+            if let identity = attempt.processIdentity {
+                events.append(
+                    envelope(
+                        id: "compendium-process-\(attempt.id)",
+                        nodeID: attempt.nodeID,
+                        attemptID: attempt.id,
+                        occurredAt: identity.startedAt
+                            ?? attempt.createdAt,
+                        payload: .processIdentityObserved(
+                            GraphProcessIdentityObservedPayload(
+                                processIdentity: identity
+                            )
+                        )
+                    )
+                )
+            }
+        }
+
+        for (index, heartbeat) in input.heartbeats.enumerated() {
+            let nodeID = input.attempts.first {
+                $0.id == heartbeat.attemptID
+            }!.nodeID
+            events.append(
+                envelope(
+                    id: "compendium-heartbeat-\(index)",
+                    nodeID: nodeID,
+                    attemptID: heartbeat.attemptID,
+                    occurredAt: heartbeat.observedAt,
+                    payload: .heartbeatObserved(
+                        GraphHeartbeatObservedPayload(
+                            processIdentity:
+                                heartbeat.processIdentity,
+                            validUntil: heartbeat.validUntil
+                        )
+                    )
+                )
+            )
+        }
+
+        for (index, exit) in input.processExits.enumerated() {
+            let nodeID = input.attempts.first {
+                $0.id == exit.attemptID
+            }!.nodeID
+            events.append(
+                envelope(
+                    id: "compendium-exit-\(index)",
+                    nodeID: nodeID,
+                    attemptID: exit.attemptID,
+                    occurredAt: exit.observedAt,
+                    payload: .processExitObserved(
+                        GraphProcessExitObservedPayload(
+                            processIdentity: exit.processIdentity,
+                            exitCode: exit.exitCode,
+                            signal: exit.signal,
+                            reason: exit.reason
+                        )
+                    )
+                )
+            )
+        }
+
+        return events
+    }
+
+    private func appendOutcome(
+        _ task: Task<GraphExecutionAppendResult, Error>
+    ) async -> String {
+        do {
+            _ = try await task.value
+            return "success"
+        } catch GraphExecutionPersistenceError
+            .expectedVersionConflict {
+            return "version_conflict"
+        } catch {
+            return "unexpected"
+        }
+    }
+
+    private func corruptEventJSON(at path: String) throws {
+        var database: OpaquePointer?
+
+        guard sqlite3_open_v2(
+            path,
+            &database,
+            SQLITE_OPEN_READWRITE,
+            nil
+        ) == SQLITE_OK, let database else {
+            throw GraphExecutionPersistenceError.storageFailure(
+                "Unable to open corruption fixture."
+            )
+        }
+
+        defer { sqlite3_close(database) }
+
+        guard sqlite3_exec(
+            database,
+            """
+            UPDATE graph_execution_events
+            SET event_json = x'7B'
+            WHERE event_id = 'event-1';
+            """,
+            nil,
+            nil,
+            nil
+        ) == SQLITE_OK else {
+            throw GraphExecutionPersistenceError.storageFailure(
+                "Unable to corrupt event fixture."
+            )
+        }
+    }
+}
+
+private struct ThrowingSnapshotStore: GraphExecutionSnapshotStore {
+    func loadLatest(
+        runID: String
+    ) async throws -> GraphExecutionSnapshot? {
+        throw GraphExecutionPersistenceError.corruptRecord(
+            "Injected corrupt snapshot."
+        )
+    }
+
+    func save(_ snapshot: GraphExecutionSnapshot) async throws {}
+}

--- a/Tests/OpenIslandCoreTests/GraphExecutionDurabilityInvariantTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphExecutionDurabilityInvariantTests.swift
@@ -373,6 +373,54 @@ final class GraphExecutionDurabilityInvariantTests: XCTestCase {
         XCTAssertEqual(replay.projection.artifacts, [artifact])
     }
 
+    func testArtifactWithContradictoryProvenanceIsRejected() {
+        let artifact = GraphArtifactReference(
+            id: "contradictory",
+            contentDigest: GraphContentDigest(
+                algorithm: "sha256",
+                value: "content"
+            ),
+            mediaType: "text/plain",
+            logicalRole: "result",
+            producingRunID: "run",
+            producingNodeID: "different-node",
+            producingAttemptID: "attempt",
+            createdAt: graphTestTime,
+            storage: GraphArtifactStorageLocator(
+                scheme: "artifact",
+                opaqueReference: "contradictory"
+            )
+        )
+        let events = [
+            graphTestRunCreated(),
+            graphTestNodeRegistered(),
+            graphTestAttemptCreated(),
+            graphTestEvent(
+                id: "artifact-event",
+                sequence: 4,
+                nodeID: "node",
+                attemptID: "attempt",
+                payload: .artifactRecorded(
+                    GraphArtifactRecordedPayload(artifact: artifact)
+                )
+            ),
+        ]
+
+        XCTAssertThrowsError(
+            try GraphExecutionProjector.replay(
+                runID: "run",
+                events: events
+            )
+        ) {
+            XCTAssertEqual(
+                $0 as? GraphExecutionReplayError,
+                .artifactProvenanceMismatch(
+                    artifactID: "contradictory"
+                )
+            )
+        }
+    }
+
     func testCompletedParallelWriteSurvivesSiblingFailure() throws {
         let artifact = GraphArtifactReference(
             id: "parallel-output",
@@ -634,6 +682,41 @@ final class GraphExecutionDurabilityInvariantTests: XCTestCase {
         XCTAssertEqual(
             created.reconciledState,
             reloaded.reconciledState
+        )
+    }
+
+    func testRepositoryEmitsPrivacyBoundedTelemetryOperations() async throws {
+        let store = try await eventStore(baseRunningEvents())
+        let telemetry = RecordingGraphTelemetrySink()
+        let repository = DefaultGraphExecutionRepository(
+            eventStore: store,
+            snapshotStore: InMemoryGraphExecutionSnapshotStore(),
+            evidenceSource: UnavailableProcessEvidenceSource(),
+            telemetry: telemetry
+        )
+
+        _ = try await repository.load(
+            runID: "run",
+            observedAt: graphTestTime.addingTimeInterval(100)
+        )
+        let records = await telemetry.snapshot()
+        let operations = Set(records.map(\.operation))
+        let allowedKeys = Set([
+            GraphTelemetryAttribute.runID,
+            GraphTelemetryAttribute.streamVersion,
+            GraphTelemetryAttribute.replayCount,
+            GraphTelemetryAttribute.reconciliationResult,
+        ])
+
+        XCTAssertTrue(operations.contains(.repositoryLoad))
+        XCTAssertTrue(operations.contains(.snapshotLoad))
+        XCTAssertTrue(operations.contains(.eventReplay))
+        XCTAssertTrue(operations.contains(.processEvidenceQuery))
+        XCTAssertTrue(operations.contains(.reconciliation))
+        XCTAssertTrue(
+            records.allSatisfy {
+                Set($0.attributes.keys).isSubset(of: allowedKeys)
+            }
         )
     }
 
@@ -979,4 +1062,18 @@ private struct ThrowingSnapshotStore: GraphExecutionSnapshotStore {
     }
 
     func save(_ snapshot: GraphExecutionSnapshot) async throws {}
+}
+
+private actor RecordingGraphTelemetrySink:
+    GraphExecutionTelemetrySink
+{
+    private var records: [GraphTelemetryRecord] = []
+
+    func record(_ record: GraphTelemetryRecord) {
+        records.append(record)
+    }
+
+    func snapshot() -> [GraphTelemetryRecord] {
+        records
+    }
 }

--- a/Tests/OpenIslandCoreTests/GraphExecutionEventStoreTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphExecutionEventStoreTests.swift
@@ -165,6 +165,54 @@ final class GraphExecutionEventStoreTests: XCTestCase {
         )
     }
 
+    func testEventTaxonomyDistinguishesCommandsObservationsAndDeclarations() {
+        XCTAssertEqual(
+            GraphExecutionEventPayload.attemptStarting(
+                GraphAttemptStartingPayload()
+            ).factClass,
+            .command
+        )
+        XCTAssertEqual(
+            GraphExecutionEventPayload.heartbeatObserved(
+                GraphHeartbeatObservedPayload(
+                    processIdentity: graphTestProcess,
+                    validUntil: timestamp
+                )
+            ).factClass,
+            .observation
+        )
+        XCTAssertEqual(
+            GraphExecutionEventPayload.attemptCompleted(
+                GraphAttemptTerminalPayload()
+            ).factClass,
+            .declaration
+        )
+        XCTAssertEqual(
+            GraphExecutionEventPayload.artifactRecorded(
+                GraphArtifactRecordedPayload(
+                    artifact: GraphArtifactReference(
+                        id: "artifact",
+                        contentDigest: GraphContentDigest(
+                            algorithm: "sha256",
+                            value: "digest"
+                        ),
+                        mediaType: "text/plain",
+                        logicalRole: "result",
+                        producingRunID: "run",
+                        producingNodeID: "node",
+                        producingAttemptID: "attempt",
+                        createdAt: timestamp,
+                        storage: GraphArtifactStorageLocator(
+                            scheme: "artifact",
+                            opaqueReference: "artifact"
+                        )
+                    )
+                )
+            ).factClass,
+            .metadata
+        )
+    }
+
     private func event(
         id: String,
         sequence: UInt64,

--- a/Tests/OpenIslandCoreTests/GraphExecutionEventStoreTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphExecutionEventStoreTests.swift
@@ -1,0 +1,210 @@
+import Foundation
+import XCTest
+@testable import OpenIslandCore
+
+final class GraphExecutionEventStoreTests: XCTestCase {
+    private let timestamp = Date(timeIntervalSince1970: 20_000)
+
+    func testEmptyStreamStartsAtVersionZero() async throws {
+        let store = InMemoryGraphExecutionEventStore()
+
+        let stream = try await store.read(
+            runID: "run",
+            afterVersion: 0
+        )
+
+        XCTAssertEqual(stream.currentVersion, 0)
+        XCTAssertEqual(stream.events, [])
+    }
+
+    func testAppendAndOrderedReadUseStreamSequence() async throws {
+        let store = InMemoryGraphExecutionEventStore()
+        let first = event(id: "one", sequence: 1)
+        let second = event(id: "two", sequence: 2)
+
+        let result = try await store.append(
+            [second, first],
+            to: "run",
+            expectedVersion: 0
+        )
+        let stream = try await store.read(
+            runID: "run",
+            afterVersion: 0
+        )
+
+        XCTAssertEqual(result.newVersion, 2)
+        XCTAssertEqual(stream.events.map(\.id), ["one", "two"])
+    }
+
+    func testExactDuplicateDeliveryIsIdempotent() async throws {
+        let store = InMemoryGraphExecutionEventStore()
+        let value = event(id: "one", sequence: 1)
+        _ = try await store.append(
+            [value],
+            to: "run",
+            expectedVersion: 0
+        )
+
+        let result = try await store.append(
+            [value, value],
+            to: "run",
+            expectedVersion: 0
+        )
+        let stream = try await store.read(
+            runID: "run",
+            afterVersion: 0
+        )
+
+        XCTAssertEqual(result.appendedCount, 0)
+        XCTAssertEqual(result.deduplicatedCount, 2)
+        XCTAssertEqual(stream.events, [value])
+    }
+
+    func testEventIDReuseWithDifferentContentIsRejected() async throws {
+        let store = InMemoryGraphExecutionEventStore()
+        _ = try await store.append(
+            [event(id: "same", sequence: 1)],
+            to: "run",
+            expectedVersion: 0
+        )
+
+        await XCTAssertThrowsErrorAsync {
+            try await store.append(
+                [
+                    self.event(
+                        id: "same",
+                        sequence: 2,
+                        payload: .attemptStarting(
+                            GraphAttemptStartingPayload()
+                        )
+                    ),
+                ],
+                to: "run",
+                expectedVersion: 1
+            )
+        } verify: {
+            XCTAssertEqual(
+                $0 as? GraphExecutionPersistenceError,
+                .eventIDCollision(eventID: "same")
+            )
+        }
+    }
+
+    func testExpectedVersionConflictRejectsConcurrentWriter() async throws {
+        let store = InMemoryGraphExecutionEventStore()
+        _ = try await store.append(
+            [event(id: "one", sequence: 1)],
+            to: "run",
+            expectedVersion: 0
+        )
+
+        await XCTAssertThrowsErrorAsync {
+            try await store.append(
+                [self.event(id: "two", sequence: 2)],
+                to: "run",
+                expectedVersion: 0
+            )
+        } verify: {
+            XCTAssertEqual(
+                $0 as? GraphExecutionPersistenceError,
+                .expectedVersionConflict(
+                    runID: "run",
+                    expected: 0,
+                    actual: 1
+                )
+            )
+        }
+    }
+
+    func testSequenceGapIsRejected() async {
+        let store = InMemoryGraphExecutionEventStore()
+
+        await XCTAssertThrowsErrorAsync {
+            try await store.append(
+                [self.event(id: "two", sequence: 2)],
+                to: "run",
+                expectedVersion: 0
+            )
+        } verify: {
+            XCTAssertEqual(
+                $0 as? GraphExecutionPersistenceError,
+                .sequenceGap(expected: 1, actual: 2)
+            )
+        }
+    }
+
+    func testEnvelopeRoundTripPreservesUnknownFutureEvent() throws {
+        let original = event(
+            id: "future",
+            sequence: 1,
+            payloadVersion: 9,
+            payload: .unknown(
+                eventType: "graph.future.quantum_checkpoint",
+                body: .object([
+                    "partition": .string("alpha"),
+                    "writes": .number(3),
+                ])
+            )
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        encoder.dateEncodingStrategy = .millisecondsSince1970
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .millisecondsSince1970
+
+        let data = try encoder.encode(original)
+        let decoded = try decoder.decode(
+            GraphExecutionEventEnvelope.self,
+            from: data
+        )
+
+        XCTAssertEqual(decoded, original)
+        XCTAssertEqual(
+            decoded.eventType,
+            "graph.future.quantum_checkpoint"
+        )
+    }
+
+    private func event(
+        id: String,
+        sequence: UInt64,
+        payloadVersion: Int = 1,
+        payload: GraphExecutionEventPayload = .attemptCreated(
+            GraphAttemptCreatedPayload(ordinal: 1)
+        )
+    ) -> GraphExecutionEventEnvelope {
+        GraphExecutionEventEnvelope(
+            id: id,
+            runID: "run",
+            nodeID: "node",
+            attemptID: "attempt",
+            streamSequence: sequence,
+            occurredAt: timestamp,
+            recordedAt: timestamp.addingTimeInterval(1),
+            producer: GraphExecutionProducer(
+                id: "test",
+                kind: .test
+            ),
+            correlationID: "correlation",
+            causationID: sequence == 1 ? nil : "one",
+            telemetryContext: GraphExecutionTelemetryContext(
+                traceID: "trace",
+                spanID: "span"
+            ),
+            payloadVersion: payloadVersion,
+            payload: payload
+        )
+    }
+}
+
+private func XCTAssertThrowsErrorAsync<T>(
+    _ expression: () async throws -> T,
+    verify: (Error) -> Void = { _ in }
+) async {
+    do {
+        _ = try await expression()
+        XCTFail("Expected expression to throw.")
+    } catch {
+        verify(error)
+    }
+}

--- a/Tests/OpenIslandCoreTests/GraphExecutionEventStoreTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphExecutionEventStoreTests.swift
@@ -196,15 +196,3 @@ final class GraphExecutionEventStoreTests: XCTestCase {
         )
     }
 }
-
-private func XCTAssertThrowsErrorAsync<T>(
-    _ expression: () async throws -> T,
-    verify: (Error) -> Void = { _ in }
-) async {
-    do {
-        _ = try await expression()
-        XCTFail("Expected expression to throw.")
-    } catch {
-        verify(error)
-    }
-}

--- a/Tests/OpenIslandCoreTests/GraphExecutionReplayTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphExecutionReplayTests.swift
@@ -1,0 +1,213 @@
+import Foundation
+import XCTest
+@testable import OpenIslandCore
+
+final class GraphExecutionReplayTests: XCTestCase {
+    func testNormalReplayBuildsRunNodeAttemptAndArtifact() throws {
+        let artifact = GraphArtifactReference(
+            id: "artifact",
+            contentDigest: GraphContentDigest(
+                algorithm: "sha256",
+                value: "artifact-digest"
+            ),
+            mediaType: "application/json",
+            logicalRole: "result",
+            producingRunID: "run",
+            producingNodeID: "node",
+            producingAttemptID: "attempt",
+            createdAt: graphTestTime.addingTimeInterval(6),
+            storage: GraphArtifactStorageLocator(
+                scheme: "openisland-artifact",
+                opaqueReference: "artifact"
+            ),
+            sensitivity: .internalUse
+        )
+        let events = [
+            graphTestRunCreated(),
+            graphTestNodeRegistered(),
+            graphTestAttemptCreated(),
+            graphTestAttemptStarting(),
+            graphTestProcessObserved(),
+            graphTestEvent(
+                id: "event-6",
+                sequence: 6,
+                nodeID: "node",
+                attemptID: "attempt",
+                payload: .artifactRecorded(
+                    GraphArtifactRecordedPayload(artifact: artifact)
+                )
+            ),
+            graphTestEvent(
+                id: "event-7",
+                sequence: 7,
+                nodeID: "node",
+                attemptID: "attempt",
+                payload: .attemptCompleted(
+                    GraphAttemptTerminalPayload(
+                        artifactIDs: ["artifact"]
+                    )
+                )
+            ),
+        ]
+
+        let result = try GraphExecutionProjector.replay(
+            runID: "run",
+            events: events.reversed()
+        )
+
+        XCTAssertEqual(result.projection.streamVersion, 7)
+        XCTAssertEqual(result.projection.run?.graphID, "graph")
+        XCTAssertEqual(result.projection.nodes[0].state, .completed)
+        XCTAssertEqual(result.projection.attempts[0].state, .completed)
+        XCTAssertEqual(result.projection.artifacts, [artifact])
+        XCTAssertEqual(result.replayedEventCount, 7)
+    }
+
+    func testExactDuplicateReplayIsIdempotent() throws {
+        let events = [
+            graphTestRunCreated(),
+            graphTestNodeRegistered(),
+            graphTestNodeRegistered(),
+        ]
+
+        let result = try GraphExecutionProjector.replay(
+            runID: "run",
+            events: events
+        )
+
+        XCTAssertEqual(result.projection.streamVersion, 2)
+        XCTAssertEqual(result.projection.nodes.count, 1)
+        XCTAssertEqual(result.duplicateEventCount, 1)
+    }
+
+    func testAttemptOrdinalRegressionIsRejected() throws {
+        let events = [
+            graphTestRunCreated(),
+            graphTestNodeRegistered(),
+            graphTestAttemptCreated(),
+            graphTestAttemptCreated(
+                sequence: 4,
+                attemptID: "retry",
+                ordinal: 1
+            ),
+        ]
+
+        XCTAssertThrowsError(
+            try GraphExecutionProjector.replay(
+                runID: "run",
+                events: events
+            )
+        ) {
+            XCTAssertEqual(
+                $0 as? GraphExecutionReplayError,
+                .attemptOrdinalRegression(
+                    nodeID: "node",
+                    previous: 1,
+                    proposed: 1
+                )
+            )
+        }
+    }
+
+    func testProcessIdentityChangeIsRejected() throws {
+        let changed = ProcessIdentity(
+            hostID: "test-host",
+            launchID: "different-launch",
+            processID: 43,
+            startedAt: graphTestTime.addingTimeInterval(5)
+        )
+        let events = [
+            graphTestRunCreated(),
+            graphTestNodeRegistered(),
+            graphTestAttemptCreated(),
+            graphTestProcessObserved(sequence: 4),
+            graphTestProcessObserved(
+                sequence: 5,
+                process: changed
+            ),
+        ]
+
+        XCTAssertThrowsError(
+            try GraphExecutionProjector.replay(
+                runID: "run",
+                events: events
+            )
+        ) {
+            XCTAssertEqual(
+                $0 as? GraphExecutionReplayError,
+                .processIdentityChanged(attemptID: "attempt")
+            )
+        }
+    }
+
+    func testTerminalAttemptCannotRegress() throws {
+        let events = [
+            graphTestRunCreated(),
+            graphTestNodeRegistered(),
+            graphTestAttemptCreated(),
+            graphTestEvent(
+                id: "event-4",
+                sequence: 4,
+                nodeID: "node",
+                attemptID: "attempt",
+                payload: .attemptCompleted(
+                    GraphAttemptTerminalPayload()
+                )
+            ),
+            graphTestAttemptStarting(sequence: 5),
+        ]
+
+        XCTAssertThrowsError(
+            try GraphExecutionProjector.replay(
+                runID: "run",
+                events: events
+            )
+        ) {
+            XCTAssertEqual(
+                $0 as? GraphExecutionReplayError,
+                .terminalAttemptRegression(attemptID: "attempt")
+            )
+        }
+    }
+
+    func testUnknownFutureEventIsRetainedAndAdvancesVersion() throws {
+        let future = graphTestEvent(
+            id: "future",
+            sequence: 2,
+            payloadVersion: 99,
+            payload: .unknown(
+                eventType: "graph.future.event",
+                body: .object(["value": .string("preserved")])
+            )
+        )
+
+        let result = try GraphExecutionProjector.replay(
+            runID: "run",
+            events: [graphTestRunCreated(), future]
+        )
+
+        XCTAssertEqual(result.projection.streamVersion, 2)
+        XCTAssertEqual(result.projection.unknownEvents, [future])
+        XCTAssertEqual(
+            result.diagnostics.map(\.category),
+            [.unknownEvent]
+        )
+    }
+
+    func testSequenceGapIsRejectedByProjector() {
+        XCTAssertThrowsError(
+            try GraphExecutionProjector.replay(
+                runID: "run",
+                events: [
+                    graphTestRunCreated(),
+                    graphTestNodeRegistered(sequence: 3),
+                ]
+            )
+        ) {
+            XCTAssertEqual(
+                $0 as? GraphExecutionReplayError,
+                .sequenceGap(expected: 2, actual: 3)
+            )
+        }
+    }
+}

--- a/Tests/OpenIslandCoreTests/GraphExecutionRepositoryTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphExecutionRepositoryTests.swift
@@ -1,0 +1,229 @@
+import Foundation
+import XCTest
+@testable import OpenIslandCore
+
+final class GraphExecutionRepositoryTests: XCTestCase {
+    func testStaleSnapshotReplaysSubsequentEvents() async throws {
+        let store = InMemoryGraphExecutionEventStore()
+        let firstThree = [
+            graphTestRunCreated(),
+            graphTestNodeRegistered(),
+            graphTestAttemptCreated(),
+        ]
+        _ = try await store.append(
+            firstThree,
+            to: "run",
+            expectedVersion: 0
+        )
+        let snapshotProjection = try GraphExecutionProjector.replay(
+            runID: "run",
+            events: firstThree
+        ).projection
+        let snapshotStore = InMemoryGraphExecutionSnapshotStore(
+            snapshots: [snapshot(for: snapshotProjection)]
+        )
+        _ = try await store.append(
+            [graphTestAttemptStarting()],
+            to: "run",
+            expectedVersion: 3
+        )
+        let repository = DefaultGraphExecutionRepository(
+            eventStore: store,
+            snapshotStore: snapshotStore,
+            evidenceSource: UnavailableProcessEvidenceSource()
+        )
+
+        let result = try await repository.load(
+            runID: "run",
+            observedAt: graphTestTime.addingTimeInterval(100)
+        )
+
+        XCTAssertEqual(result.snapshotDisposition, .stale)
+        XCTAssertEqual(result.streamVersion, 4)
+        XCTAssertEqual(
+            result.persistedProjection.attempts[0].state,
+            .running
+        )
+        XCTAssertEqual(
+            result.reconciledState?.attempts[0].state,
+            .interrupted
+        )
+    }
+
+    func testUnavailableEvidenceReturnsProjectionAndConservativeState() async throws {
+        let result = try await loadRunningRepository(
+            evidence: .unavailable(reason: "offline")
+        )
+
+        XCTAssertEqual(
+            result.persistedProjection.attempts[0].state,
+            .running
+        )
+        XCTAssertEqual(
+            result.reconciledState?.attempts[0].state,
+            .orphaned
+        )
+        XCTAssertEqual(
+            result.evidenceOutcome,
+            .unavailable(reason: "offline")
+        )
+    }
+
+    func testAdapterFailureDoesNotMutateHistory() async throws {
+        let result = try await loadRunningRepository(
+            evidence: .adapterFailed(reason: "probe crashed")
+        )
+
+        XCTAssertEqual(result.streamVersion, 5)
+        XCTAssertEqual(
+            result.persistedProjection.attempts[0].state,
+            .running
+        )
+        XCTAssertEqual(
+            result.reconciledState?.attempts[0].state,
+            .orphaned
+        )
+    }
+
+    func testIdentityMismatchIsNotAcceptedAsLiveEvidence() async throws {
+        let mismatch = ExecutorHeartbeat(
+            attemptID: "attempt",
+            processIdentity: ProcessIdentity(
+                hostID: "test-host",
+                launchID: "other",
+                processID: 99,
+                startedAt: graphTestTime
+            ),
+            observedAt: graphTestTime.addingTimeInterval(50),
+            validUntil: graphTestTime.addingTimeInterval(200)
+        )
+        let result = try await loadRunningRepository(
+            evidence: .identityMismatch(
+                GraphProcessEvidence(heartbeats: [mismatch]),
+                reason: "launch identity differs"
+            )
+        )
+
+        XCTAssertEqual(
+            result.reconciledState?.attempts[0].state,
+            .orphaned
+        )
+    }
+
+    func testAvailableHeartbeatKeepsMatchingAttemptRunning() async throws {
+        let heartbeat = ExecutorHeartbeat(
+            attemptID: "attempt",
+            processIdentity: graphTestProcess,
+            observedAt: graphTestTime.addingTimeInterval(50),
+            validUntil: graphTestTime.addingTimeInterval(200)
+        )
+        let result = try await loadRunningRepository(
+            evidence: .available(
+                GraphProcessEvidence(heartbeats: [heartbeat])
+            )
+        )
+
+        XCTAssertEqual(
+            result.reconciledState?.attempts[0].state,
+            .running
+        )
+    }
+
+    func testMatchingProcessExitInterruptsAttempt() async throws {
+        let exit = ProcessExit(
+            attemptID: "attempt",
+            processIdentity: graphTestProcess,
+            observedAt: graphTestTime.addingTimeInterval(50),
+            exitCode: 0
+        )
+        let result = try await loadRunningRepository(
+            evidence: .available(
+                GraphProcessEvidence(processExits: [exit])
+            )
+        )
+
+        XCTAssertEqual(
+            result.reconciledState?.attempts[0].state,
+            .interrupted
+        )
+    }
+
+    func testRepeatedLoadsAreIdenticalAndDoNotAppendEvents() async throws {
+        let store = try await runningStore()
+        let repository = DefaultGraphExecutionRepository(
+            eventStore: store,
+            snapshotStore: InMemoryGraphExecutionSnapshotStore(),
+            evidenceSource: StaticProcessEvidenceSource(
+                outcome: .unavailable(reason: "offline")
+            )
+        )
+        let observedAt = graphTestTime.addingTimeInterval(100)
+
+        let first = try await repository.load(
+            runID: "run",
+            observedAt: observedAt
+        )
+        let second = try await repository.load(
+            runID: "run",
+            observedAt: observedAt
+        )
+        let stream = try await store.read(
+            runID: "run",
+            afterVersion: 0
+        )
+
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(stream.currentVersion, 5)
+    }
+
+    private func loadRunningRepository(
+        evidence: GraphProcessEvidenceOutcome
+    ) async throws -> GraphExecutionRepositoryLoadResult {
+        let repository = DefaultGraphExecutionRepository(
+            eventStore: try await runningStore(),
+            snapshotStore: InMemoryGraphExecutionSnapshotStore(),
+            evidenceSource: StaticProcessEvidenceSource(
+                outcome: evidence
+            )
+        )
+
+        return try await repository.load(
+            runID: "run",
+            observedAt: graphTestTime.addingTimeInterval(100)
+        )
+    }
+
+    private func runningStore() async throws
+        -> InMemoryGraphExecutionEventStore
+    {
+        let store = InMemoryGraphExecutionEventStore()
+        _ = try await store.append(
+            [
+                graphTestRunCreated(),
+                graphTestNodeRegistered(),
+                graphTestAttemptCreated(),
+                graphTestAttemptStarting(),
+                graphTestProcessObserved(),
+            ],
+            to: "run",
+            expectedVersion: 0
+        )
+        return store
+    }
+
+    private func snapshot(
+        for projection: GraphExecutionProjection
+    ) -> GraphExecutionSnapshot {
+        GraphExecutionSnapshot(
+            runID: projection.runID,
+            streamVersion: projection.streamVersion,
+            graphDefinitionVersion: projection
+                .graphDefinitionVersion!,
+            graphDefinitionDigest: projection.graphDefinitionDigest!,
+            projectedState: projection,
+            createdAt: graphTestTime.addingTimeInterval(10),
+            createdBy: graphTestProducer,
+            checkpointNamespace: projection.checkpointNamespace
+        )
+    }
+}

--- a/Tests/OpenIslandCoreTests/GraphExecutionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphExecutionStateTests.swift
@@ -109,6 +109,44 @@ final class GraphExecutionStateTests: XCTestCase {
         )
     }
 
+    func testEqualTimestampProcessExitsHaveDeterministicTieBreaker() {
+        let process = processIdentity()
+        let attempt = makeAttempt(processIdentity: process)
+        let firstExit = ProcessExit(
+            attemptID: attempt.id,
+            processIdentity: process,
+            observedAt: observedAt,
+            exitCode: 1,
+            reason: "First reason."
+        )
+        let secondExit = ProcessExit(
+            attemptID: attempt.id,
+            processIdentity: process,
+            observedAt: observedAt,
+            exitCode: 1,
+            reason: "Second reason."
+        )
+
+        let forward = GraphExecutionReconciler.reconcile(
+            makeInput(
+                attempts: [attempt],
+                processExits: [firstExit, secondExit]
+            )
+        )
+        let reversed = GraphExecutionReconciler.reconcile(
+            makeInput(
+                attempts: [attempt],
+                processExits: [secondExit, firstExit]
+            )
+        )
+
+        XCTAssertEqual(forward, reversed)
+        XCTAssertEqual(
+            forward.attempts[0].statusReason,
+            "Second reason."
+        )
+    }
+
     func testUnsupportedRunningClaimsBecomeInterruptedOrOrphaned() {
         let unidentified = makeAttempt(id: "unidentified", nodeID: "one")
         let identified = makeAttempt(
@@ -133,6 +171,28 @@ final class GraphExecutionStateTests: XCTestCase {
 
         XCTAssertEqual(states["unidentified"], .interrupted)
         XCTAssertEqual(states["identified"], .orphaned)
+    }
+
+    func testNodeTimestampTracksAttemptStateReconciliation() {
+        let originalUpdatedAt = observedAt.addingTimeInterval(-50)
+        let input = makeInput(
+            nodes: [
+                GraphNode(
+                    id: "node",
+                    graphRunID: "run",
+                    title: "node",
+                    state: .running,
+                    activeAttemptID: "attempt",
+                    updatedAt: originalUpdatedAt
+                ),
+            ],
+            attempts: [makeAttempt()]
+        )
+
+        let result = GraphExecutionReconciler.reconcile(input)
+
+        XCTAssertEqual(result.nodes[0].state, .interrupted)
+        XCTAssertEqual(result.nodes[0].updatedAt, observedAt)
     }
 
     func testEventOrderingIsDeterministicAcrossInputOrder() {

--- a/Tests/OpenIslandCoreTests/GraphExecutionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphExecutionStateTests.swift
@@ -1,0 +1,235 @@
+import Foundation
+import XCTest
+@testable import OpenIslandCore
+
+final class GraphExecutionStateTests: XCTestCase {
+    private let observedAt = Date(timeIntervalSince1970: 10_000)
+
+    func testValidHeartbeatKeepsAttemptRunning() {
+        let process = processIdentity()
+        let attempt = makeAttempt(
+            state: .running,
+            processIdentity: process
+        )
+        let input = makeInput(
+            attempts: [attempt],
+            heartbeats: [
+                ExecutorHeartbeat(
+                    attemptID: attempt.id,
+                    processIdentity: process,
+                    observedAt: observedAt.addingTimeInterval(-10),
+                    validUntil: observedAt.addingTimeInterval(10)
+                ),
+            ]
+        )
+
+        let result = GraphExecutionReconciler.reconcile(input)
+
+        XCTAssertEqual(result.attempts[0].state, .running)
+        XCTAssertEqual(result.nodes[0].state, .running)
+        XCTAssertEqual(result.run.state, .running)
+    }
+
+    func testTerminalEventOutranksExitAndHeartbeat() {
+        let process = processIdentity()
+        let attempt = makeAttempt(
+            state: .running,
+            processIdentity: process
+        )
+        let input = makeInput(
+            attempts: [attempt],
+            processExits: [
+                ProcessExit(
+                    attemptID: attempt.id,
+                    processIdentity: process,
+                    observedAt: observedAt.addingTimeInterval(-2),
+                    exitCode: 1
+                ),
+            ],
+            heartbeats: [
+                ExecutorHeartbeat(
+                    attemptID: attempt.id,
+                    processIdentity: process,
+                    observedAt: observedAt.addingTimeInterval(-1),
+                    validUntil: observedAt.addingTimeInterval(10)
+                ),
+            ],
+            events: [
+                ExecutionEvent(
+                    id: "event-completed",
+                    graphRunID: "run",
+                    nodeID: "node",
+                    attemptID: attempt.id,
+                    sequence: 2,
+                    occurredAt: observedAt.addingTimeInterval(-3),
+                    kind: .attemptCompleted
+                ),
+            ]
+        )
+
+        let result = GraphExecutionReconciler.reconcile(input)
+
+        XCTAssertEqual(result.attempts[0].state, .completed)
+        XCTAssertEqual(result.nodes[0].state, .completed)
+        XCTAssertEqual(result.run.state, .completed)
+    }
+
+    func testProcessExitOutranksLiveHeartbeatAndRequiresTerminalEventForSuccess() {
+        let process = processIdentity()
+        let attempt = makeAttempt(
+            state: .running,
+            processIdentity: process
+        )
+        let input = makeInput(
+            attempts: [attempt],
+            processExits: [
+                ProcessExit(
+                    attemptID: attempt.id,
+                    processIdentity: process,
+                    observedAt: observedAt.addingTimeInterval(-4),
+                    exitCode: 0
+                ),
+            ],
+            heartbeats: [
+                ExecutorHeartbeat(
+                    attemptID: attempt.id,
+                    processIdentity: process,
+                    observedAt: observedAt.addingTimeInterval(-5),
+                    validUntil: observedAt.addingTimeInterval(30)
+                ),
+            ]
+        )
+
+        let result = GraphExecutionReconciler.reconcile(input)
+
+        XCTAssertEqual(result.attempts[0].state, .interrupted)
+        XCTAssertEqual(
+            result.attempts[0].statusReason,
+            "Process exited with code 0 without a terminal execution event."
+        )
+    }
+
+    func testUnsupportedRunningClaimsBecomeInterruptedOrOrphaned() {
+        let unidentified = makeAttempt(id: "unidentified", nodeID: "one")
+        let identified = makeAttempt(
+            id: "identified",
+            nodeID: "two",
+            processIdentity: processIdentity()
+        )
+        let input = makeInput(
+            nodes: [
+                makeNode(id: "one"),
+                makeNode(id: "two"),
+            ],
+            attempts: [unidentified, identified]
+        )
+
+        let result = GraphExecutionReconciler.reconcile(input)
+        let states = Dictionary(
+            uniqueKeysWithValues: result.attempts.map {
+                ($0.id, $0.state)
+            }
+        )
+
+        XCTAssertEqual(states["unidentified"], .interrupted)
+        XCTAssertEqual(states["identified"], .orphaned)
+    }
+
+    func testEventOrderingIsDeterministicAcrossInputOrder() {
+        let attempt = makeAttempt()
+        let completed = ExecutionEvent(
+            id: "event-a",
+            graphRunID: "run",
+            nodeID: "node",
+            attemptID: attempt.id,
+            sequence: 2,
+            occurredAt: observedAt,
+            kind: .attemptCompleted
+        )
+        let failed = ExecutionEvent(
+            id: "event-b",
+            graphRunID: "run",
+            nodeID: "node",
+            attemptID: attempt.id,
+            sequence: 2,
+            occurredAt: observedAt,
+            kind: .attemptFailed
+        )
+
+        let forward = GraphExecutionReconciler.reconcile(
+            makeInput(attempts: [attempt], events: [completed, failed])
+        )
+        let reversed = GraphExecutionReconciler.reconcile(
+            makeInput(attempts: [attempt], events: [failed, completed])
+        )
+
+        XCTAssertEqual(forward, reversed)
+        XCTAssertEqual(forward.attempts[0].state, .failed)
+    }
+
+    private func makeInput(
+        nodes: [GraphNode]? = nil,
+        attempts: [ExecutionAttempt],
+        processExits: [ProcessExit] = [],
+        heartbeats: [ExecutorHeartbeat] = [],
+        events: [ExecutionEvent] = []
+    ) -> ExecutionReconciliationInput {
+        let resolvedNodes = nodes ?? [makeNode()]
+
+        return ExecutionReconciliationInput(
+            run: GraphRun(
+                id: "run",
+                graphID: "graph",
+                state: .running,
+                nodeIDs: resolvedNodes.map(\.id),
+                createdAt: observedAt.addingTimeInterval(-100),
+                updatedAt: observedAt.addingTimeInterval(-50),
+                startedAt: observedAt.addingTimeInterval(-100)
+            ),
+            nodes: resolvedNodes,
+            attempts: attempts,
+            processExits: processExits,
+            heartbeats: heartbeats,
+            events: events,
+            observedAt: observedAt
+        )
+    }
+
+    private func makeNode(id: String = "node") -> GraphNode {
+        GraphNode(
+            id: id,
+            graphRunID: "run",
+            title: id,
+            state: .running,
+            updatedAt: observedAt.addingTimeInterval(-50)
+        )
+    }
+
+    private func makeAttempt(
+        id: String = "attempt",
+        nodeID: String = "node",
+        state: ReconciledExecutionState = .running,
+        processIdentity: ProcessIdentity? = nil
+    ) -> ExecutionAttempt {
+        ExecutionAttempt(
+            id: id,
+            graphRunID: "run",
+            nodeID: nodeID,
+            ordinal: 1,
+            state: state,
+            processIdentity: processIdentity,
+            createdAt: observedAt.addingTimeInterval(-100),
+            updatedAt: observedAt.addingTimeInterval(-50),
+            startedAt: observedAt.addingTimeInterval(-100)
+        )
+    }
+
+    private func processIdentity() -> ProcessIdentity {
+        ProcessIdentity(
+            hostID: "host",
+            launchID: "launch",
+            processID: 42,
+            startedAt: observedAt.addingTimeInterval(-100)
+        )
+    }
+}

--- a/Tests/OpenIslandCoreTests/GraphExecutionTestSupport.swift
+++ b/Tests/OpenIslandCoreTests/GraphExecutionTestSupport.swift
@@ -1,4 +1,5 @@
 import Foundation
+import XCTest
 @testable import OpenIslandCore
 
 let graphTestTime = Date(timeIntervalSince1970: 30_000)
@@ -138,5 +139,17 @@ struct StaticProcessEvidenceSource: ProcessEvidenceSource {
         for request: GraphProcessEvidenceRequest
     ) async -> GraphProcessEvidenceOutcome {
         outcome
+    }
+}
+
+func XCTAssertThrowsErrorAsync<T>(
+    _ expression: () async throws -> T,
+    verify: (Error) -> Void = { _ in }
+) async {
+    do {
+        _ = try await expression()
+        XCTFail("Expected expression to throw.")
+    } catch {
+        verify(error)
     }
 }

--- a/Tests/OpenIslandCoreTests/GraphExecutionTestSupport.swift
+++ b/Tests/OpenIslandCoreTests/GraphExecutionTestSupport.swift
@@ -172,6 +172,109 @@ func loadStaleCompendiumFixture()
     )
 }
 
+func loadCompendiumSchedulingDefinition()
+    throws -> GraphSchedulingDefinition
+{
+    let url = try XCTUnwrap(
+        Bundle.module.url(
+            forResource: "compendium-scheduling-graph",
+            withExtension: "json",
+            subdirectory: "Fixtures"
+        )
+    )
+    return try JSONDecoder().decode(
+        GraphSchedulingDefinition.self,
+        from: Data(contentsOf: url)
+    )
+}
+
+func compendiumSchedulingBaseEvents(
+    definition: GraphSchedulingDefinition,
+    runID: String,
+    occurredAt: Date
+) -> [GraphExecutionEventEnvelope] {
+    var sequence: UInt64 = 1
+    var events = [
+        GraphExecutionEventEnvelope(
+            id: "\(runID)-created",
+            runID: runID,
+            streamSequence: sequence,
+            occurredAt: occurredAt,
+            recordedAt: occurredAt,
+            producer: graphTestProducer,
+            payload: .runCreated(
+                GraphRunCreatedPayload(
+                    graphID: definition.graphID,
+                    graphDefinitionVersion: definition.version,
+                    graphDefinitionDigest: definition.digest,
+                    nodeIDs: definition.nodes.map(\.id)
+                )
+            )
+        ),
+    ]
+    for node in definition.nodes {
+        sequence += 1
+        events.append(
+            GraphExecutionEventEnvelope(
+                id: "\(runID)-node-\(node.id)",
+                runID: runID,
+                nodeID: node.id,
+                streamSequence: sequence,
+                occurredAt: occurredAt,
+                recordedAt: occurredAt,
+                producer: graphTestProducer,
+                payload: .nodeRegistered(
+                    GraphNodeRegisteredPayload(
+                        title: node.title,
+                        dependencyNodeIDs: node.dependencyNodeIDs,
+                        definitionVersion: definition.version
+                    )
+                )
+            )
+        )
+    }
+    return events
+}
+
+func compendiumExecutorCapabilities()
+    -> [GraphExecutorCapabilities]
+{
+    [
+        GraphExecutorCapabilities(
+            executorID: "architect-worker",
+            capabilityIdentity: "compendium-architect-v1",
+            capabilities: [
+                "compendium-architecture",
+                "web-research-planning",
+            ]
+        ),
+        GraphExecutorCapabilities(
+            executorID: "research-worker",
+            capabilityIdentity: "regulatory-research-v1",
+            capabilities: [
+                "source-verification",
+                "web-scraping",
+            ]
+        ),
+        GraphExecutorCapabilities(
+            executorID: "graph-worker",
+            capabilityIdentity: "evidence-graph-v1",
+            capabilities: [
+                "citation-linking",
+                "knowledge-graph",
+            ]
+        ),
+        GraphExecutorCapabilities(
+            executorID: "review-worker",
+            capabilityIdentity: "regulatory-review-v1",
+            capabilities: [
+                "citation-audit",
+                "regulatory-review",
+            ]
+        ),
+    ]
+}
+
 func staleCompendiumEvents(
     from input: ExecutionReconciliationInput
 ) -> [GraphExecutionEventEnvelope] {

--- a/Tests/OpenIslandCoreTests/GraphExecutionTestSupport.swift
+++ b/Tests/OpenIslandCoreTests/GraphExecutionTestSupport.swift
@@ -1,0 +1,142 @@
+import Foundation
+@testable import OpenIslandCore
+
+let graphTestTime = Date(timeIntervalSince1970: 30_000)
+let graphTestProducer = GraphExecutionProducer(
+    id: "graph-tests",
+    kind: .test,
+    instanceID: "test-process"
+)
+let graphTestDigest = GraphContentDigest(
+    algorithm: "sha256",
+    value: "graph-digest"
+)
+let graphTestProcess = ProcessIdentity(
+    hostID: "test-host",
+    launchID: "test-launch",
+    processID: 42,
+    startedAt: graphTestTime.addingTimeInterval(3)
+)
+
+func graphTestEvent(
+    id: String,
+    sequence: UInt64,
+    nodeID: String? = nil,
+    attemptID: String? = nil,
+    occurredAt: Date? = nil,
+    payloadVersion: Int = 1,
+    payload: GraphExecutionEventPayload
+) -> GraphExecutionEventEnvelope {
+    GraphExecutionEventEnvelope(
+        id: id,
+        runID: "run",
+        nodeID: nodeID,
+        attemptID: attemptID,
+        streamSequence: sequence,
+        occurredAt: occurredAt
+            ?? graphTestTime.addingTimeInterval(Double(sequence)),
+        recordedAt: graphTestTime.addingTimeInterval(
+            Double(sequence) + 0.5
+        ),
+        producer: graphTestProducer,
+        correlationID: "run-correlation",
+        causationID: sequence > 1 ? "event-\(sequence - 1)" : nil,
+        payloadVersion: payloadVersion,
+        payload: payload
+    )
+}
+
+func graphTestRunCreated(
+    sequence: UInt64 = 1
+) -> GraphExecutionEventEnvelope {
+    graphTestEvent(
+        id: "event-\(sequence)",
+        sequence: sequence,
+        payload: .runCreated(
+            GraphRunCreatedPayload(
+                graphID: "graph",
+                graphDefinitionVersion: "1",
+                graphDefinitionDigest: graphTestDigest,
+                nodeIDs: ["node"]
+            )
+        )
+    )
+}
+
+func graphTestNodeRegistered(
+    sequence: UInt64 = 2
+) -> GraphExecutionEventEnvelope {
+    graphTestEvent(
+        id: "event-\(sequence)",
+        sequence: sequence,
+        nodeID: "node",
+        payload: .nodeRegistered(
+            GraphNodeRegisteredPayload(
+                title: "Node",
+                executorID: "executor"
+            )
+        )
+    )
+}
+
+func graphTestAttemptCreated(
+    sequence: UInt64 = 3,
+    attemptID: String = "attempt",
+    ordinal: Int = 1
+) -> GraphExecutionEventEnvelope {
+    graphTestEvent(
+        id: "event-\(sequence)",
+        sequence: sequence,
+        nodeID: "node",
+        attemptID: attemptID,
+        payload: .attemptCreated(
+            GraphAttemptCreatedPayload(
+                ordinal: ordinal,
+                executorID: "executor"
+            )
+        )
+    )
+}
+
+func graphTestAttemptStarting(
+    sequence: UInt64 = 4,
+    attemptID: String = "attempt"
+) -> GraphExecutionEventEnvelope {
+    graphTestEvent(
+        id: "event-\(sequence)",
+        sequence: sequence,
+        nodeID: "node",
+        attemptID: attemptID,
+        payload: .attemptStarting(
+            GraphAttemptStartingPayload()
+        )
+    )
+}
+
+func graphTestProcessObserved(
+    sequence: UInt64 = 5,
+    attemptID: String = "attempt",
+    process: ProcessIdentity = graphTestProcess
+) -> GraphExecutionEventEnvelope {
+    graphTestEvent(
+        id: "event-\(sequence)",
+        sequence: sequence,
+        nodeID: "node",
+        attemptID: attemptID,
+        payload: .processIdentityObserved(
+            GraphProcessIdentityObservedPayload(
+                processIdentity: process
+            )
+        )
+    )
+}
+
+struct StaticProcessEvidenceSource: ProcessEvidenceSource {
+    let outcome: GraphProcessEvidenceOutcome
+
+    func evidence(
+        for request: GraphProcessEvidenceRequest
+    ) async -> GraphProcessEvidenceOutcome {
+        outcome
+    }
+}

--- a/Tests/OpenIslandCoreTests/GraphExecutionTestSupport.swift
+++ b/Tests/OpenIslandCoreTests/GraphExecutionTestSupport.swift
@@ -188,6 +188,24 @@ func loadCompendiumSchedulingDefinition()
     )
 }
 
+func loadCompendiumExecutableDefinition()
+    throws -> GraphExecutableDefinition
+{
+    let url = try XCTUnwrap(
+        Bundle.module.url(
+            forResource: "compendium-execution",
+            withExtension: "json",
+            subdirectory: "Fixtures"
+        )
+    )
+    let definition = try JSONDecoder().decode(
+        GraphExecutableDefinition.self,
+        from: Data(contentsOf: url)
+    )
+    try definition.validate()
+    return definition
+}
+
 func compendiumSchedulingBaseEvents(
     definition: GraphSchedulingDefinition,
     runID: String,

--- a/Tests/OpenIslandCoreTests/GraphExecutionTestSupport.swift
+++ b/Tests/OpenIslandCoreTests/GraphExecutionTestSupport.swift
@@ -206,6 +206,22 @@ func loadCompendiumExecutableDefinition()
     return definition
 }
 
+func loadCompendiumDeterministicScript()
+    throws -> GraphDeterministicExecutionScript
+{
+    let url = try XCTUnwrap(
+        Bundle.module.url(
+            forResource: "compendium-deterministic-script",
+            withExtension: "json",
+            subdirectory: "Fixtures"
+        )
+    )
+    return try JSONDecoder().decode(
+        GraphDeterministicExecutionScript.self,
+        from: Data(contentsOf: url)
+    )
+}
+
 func compendiumSchedulingBaseEvents(
     definition: GraphSchedulingDefinition,
     runID: String,

--- a/Tests/OpenIslandCoreTests/GraphExecutionTestSupport.swift
+++ b/Tests/OpenIslandCoreTests/GraphExecutionTestSupport.swift
@@ -132,6 +132,46 @@ func graphTestProcessObserved(
     )
 }
 
+func graphTestSnapshot(
+    for projection: GraphExecutionProjection,
+    schemaVersion: Int = GraphExecutionSchema.snapshotVersion,
+    streamVersion: UInt64? = nil,
+    graphDefinitionDigest: GraphContentDigest? = nil
+) -> GraphExecutionSnapshot {
+    GraphExecutionSnapshot(
+        schemaVersion: schemaVersion,
+        runID: projection.runID,
+        streamVersion: streamVersion ?? projection.streamVersion,
+        graphDefinitionVersion: projection.graphDefinitionVersion!,
+        graphDefinitionDigest: graphDefinitionDigest
+            ?? projection.graphDefinitionDigest!,
+        projectedState: projection,
+        createdAt: graphTestTime.addingTimeInterval(100),
+        createdBy: graphTestProducer,
+        checkpointNamespace: projection.checkpointNamespace,
+        namedCheckpoints: projection.namedCheckpoints
+    )
+}
+
+func loadStaleCompendiumFixture()
+    throws -> ExecutionReconciliationInput
+{
+    let url = try XCTUnwrap(
+        Bundle.module.url(
+            forResource: "stale-compendium-runtime",
+            withExtension: "json",
+            subdirectory: "Fixtures"
+        )
+    )
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+
+    return try decoder.decode(
+        ExecutionReconciliationInput.self,
+        from: Data(contentsOf: url)
+    )
+}
+
 struct StaticProcessEvidenceSource: ProcessEvidenceSource {
     let outcome: GraphProcessEvidenceOutcome
 

--- a/Tests/OpenIslandCoreTests/GraphExecutionTestSupport.swift
+++ b/Tests/OpenIslandCoreTests/GraphExecutionTestSupport.swift
@@ -172,6 +172,165 @@ func loadStaleCompendiumFixture()
     )
 }
 
+func staleCompendiumEvents(
+    from input: ExecutionReconciliationInput
+) -> [GraphExecutionEventEnvelope] {
+    let producer = GraphExecutionProducer(
+        id: "stale-compendium-import",
+        kind: .importer
+    )
+    let nodeByAttempt = Dictionary(
+        uniqueKeysWithValues: input.attempts.map {
+            ($0.id, $0.nodeID)
+        }
+    )
+    var sequence: UInt64 = 1
+
+    func envelope(
+        id: String,
+        nodeID: String? = nil,
+        attemptID: String? = nil,
+        occurredAt: Date,
+        payload: GraphExecutionEventPayload
+    ) -> GraphExecutionEventEnvelope {
+        defer { sequence += 1 }
+        return GraphExecutionEventEnvelope(
+            id: id,
+            runID: input.run.id,
+            nodeID: nodeID,
+            attemptID: attemptID,
+            streamSequence: sequence,
+            occurredAt: occurredAt,
+            recordedAt: input.observedAt,
+            producer: producer,
+            payload: payload
+        )
+    }
+
+    var events = [
+        envelope(
+            id: "compendium-run",
+            occurredAt: input.run.createdAt,
+            payload: .runCreated(
+                GraphRunCreatedPayload(
+                    graphID: input.run.graphID,
+                    graphDefinitionVersion: "fixture-1",
+                    graphDefinitionDigest: GraphContentDigest(
+                        algorithm: "sha256",
+                        value: "stale-compendium-fixture"
+                    ),
+                    nodeIDs: input.run.nodeIDs
+                )
+            )
+        ),
+    ]
+
+    for node in input.nodes {
+        events.append(
+            envelope(
+                id: "compendium-node-\(node.id)",
+                nodeID: node.id,
+                occurredAt: node.updatedAt,
+                payload: .nodeRegistered(
+                    GraphNodeRegisteredPayload(
+                        title: node.title,
+                        dependencyNodeIDs: node.dependencyNodeIDs,
+                        executorID: node.executorID
+                    )
+                )
+            )
+        )
+    }
+
+    for attempt in input.attempts.sorted(by: { $0.id < $1.id }) {
+        events.append(
+            envelope(
+                id: "compendium-attempt-\(attempt.id)",
+                nodeID: attempt.nodeID,
+                attemptID: attempt.id,
+                occurredAt: attempt.createdAt,
+                payload: .attemptCreated(
+                    GraphAttemptCreatedPayload(
+                        ordinal: attempt.ordinal
+                    )
+                )
+            )
+        )
+        events.append(
+            envelope(
+                id: "compendium-start-\(attempt.id)",
+                nodeID: attempt.nodeID,
+                attemptID: attempt.id,
+                occurredAt: attempt.startedAt ?? attempt.createdAt,
+                payload: .attemptStarting(
+                    GraphAttemptStartingPayload()
+                )
+            )
+        )
+
+        if let identity = attempt.processIdentity {
+            events.append(
+                envelope(
+                    id: "compendium-process-\(attempt.id)",
+                    nodeID: attempt.nodeID,
+                    attemptID: attempt.id,
+                    occurredAt:
+                        identity.startedAt ?? attempt.createdAt,
+                    payload: .processIdentityObserved(
+                        GraphProcessIdentityObservedPayload(
+                            processIdentity: identity
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    for (index, heartbeat) in input.heartbeats.enumerated() {
+        guard let nodeID = nodeByAttempt[heartbeat.attemptID] else {
+            continue
+        }
+        events.append(
+            envelope(
+                id: "compendium-heartbeat-\(index)",
+                nodeID: nodeID,
+                attemptID: heartbeat.attemptID,
+                occurredAt: heartbeat.observedAt,
+                payload: .heartbeatObserved(
+                    GraphHeartbeatObservedPayload(
+                        processIdentity: heartbeat.processIdentity,
+                        validUntil: heartbeat.validUntil
+                    )
+                )
+            )
+        )
+    }
+
+    for (index, exit) in input.processExits.enumerated() {
+        guard let nodeID = nodeByAttempt[exit.attemptID] else {
+            continue
+        }
+        events.append(
+            envelope(
+                id: "compendium-exit-\(index)",
+                nodeID: nodeID,
+                attemptID: exit.attemptID,
+                occurredAt: exit.observedAt,
+                payload: .processExitObserved(
+                    GraphProcessExitObservedPayload(
+                        processIdentity: exit.processIdentity,
+                        exitCode: exit.exitCode,
+                        signal: exit.signal,
+                        reason: exit.reason
+                    )
+                )
+            )
+        )
+    }
+
+    return events
+}
+
 struct StaticProcessEvidenceSource: ProcessEvidenceSource {
     let outcome: GraphProcessEvidenceOutcome
 

--- a/Tests/OpenIslandCoreTests/GraphExecutorRepositoryTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphExecutorRepositoryTests.swift
@@ -135,6 +135,47 @@ final class GraphExecutorRepositoryTests: XCTestCase {
         }
     }
 
+    func testAcceptedProcessIdentityBecomesAuthoritativeHistory() async throws {
+        let context = try await ExecutorRepositoryContext.make()
+        let started = try await context.repository.recordStartRequest(
+            context.startCommand()
+        )
+        let process = ProcessIdentity(
+            hostID: "test-host",
+            launchID: "durable-launch",
+            processID: 812,
+            startedAt: context.time
+        )
+        let observation = context.observation(
+            status: .started,
+            operation: .start,
+            observedAt: context.time.addingTimeInterval(1),
+            processIdentity: process
+        )
+        let recorded = try await context.repository.recordObservation(
+            GraphExecutorObservationCommand(
+                observation: observation,
+                expectedVersion: started.appendResult.newVersion,
+                producer: graphTestProducer,
+                correlationID: "execute"
+            )
+        )
+
+        XCTAssertEqual(recorded.appendResult.appendedCount, 2)
+        XCTAssertEqual(
+            recorded.projection.attempts.first?.processIdentity,
+            process
+        )
+        let stream = try await context.store.read(
+            runID: "run",
+            afterVersion: 0
+        )
+        XCTAssertTrue(stream.events.contains {
+            $0.eventType == GraphExecutionEventType
+                .processIdentityObserved.rawValue
+        })
+    }
+
     func testStaleClaimCannotPublishAfterLeaseTakeover() async throws {
         let context = try await ExecutorRepositoryContext.make(
             leaseDuration: 5
@@ -313,6 +354,7 @@ private struct ExecutorRepositoryContext {
         status: GraphExecutorResponseStatus,
         operation: GraphExecutorOperation,
         observedAt: Date,
+        processIdentity: ProcessIdentity? = nil,
         artifacts: [GraphExecutorProducedArtifact] = []
     ) -> GraphExecutorObservation {
         GraphExecutorObservation(
@@ -321,6 +363,7 @@ private struct ExecutorRepositoryContext {
             identity: identity,
             status: status,
             observedAt: observedAt,
+            processIdentity: processIdentity,
             artifacts: artifacts
         )
     }

--- a/Tests/OpenIslandCoreTests/GraphExecutorRepositoryTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphExecutorRepositoryTests.swift
@@ -1,0 +1,393 @@
+import Foundation
+import XCTest
+@testable import OpenIslandCore
+
+final class GraphExecutorRepositoryTests: XCTestCase {
+    func testFencedStartObservationArtifactAndTerminalDeclaration()
+        async throws
+    {
+        let context = try await ExecutorRepositoryContext.make()
+        let started = try await context.repository.recordStartRequest(
+            context.startCommand()
+        )
+        let observation = context.observation(
+            status: .succeeded,
+            operation: .collectResult,
+            observedAt: context.time.addingTimeInterval(1),
+            artifacts: [context.outputArtifact]
+        )
+        let observed = try await context.repository.recordObservation(
+            GraphExecutorObservationCommand(
+                observation: observation,
+                expectedVersion: started.appendResult.newVersion,
+                producer: graphTestProducer,
+                correlationID: "execute"
+            )
+        )
+        let terminal = try await context.repository.declareTerminal(
+            GraphExecutorTerminalDeclaration(
+                identity: context.identity,
+                observationID: observation.id,
+                state: .completed,
+                expectedVersion: observed.appendResult.newVersion,
+                logicalTime: context.time.addingTimeInterval(2),
+                producer: graphTestProducer,
+                correlationID: "execute"
+            )
+        )
+
+        XCTAssertEqual(terminal.projection.run?.state, .ready)
+        XCTAssertEqual(
+            terminal.projection.attempts.first?.state,
+            .completed
+        )
+        XCTAssertEqual(terminal.projection.artifacts.count, 1)
+        XCTAssertEqual(
+            terminal.projection.artifacts.first?.producingClaimID,
+            context.identity.claimID
+        )
+        XCTAssertEqual(
+            terminal.projection.scheduling.claims.first?.status,
+            .released
+        )
+    }
+
+    func testCompletionBeforeDurableStartIsRejected() async throws {
+        let context = try await ExecutorRepositoryContext.make()
+        let observation = context.observation(
+            status: .succeeded,
+            operation: .collectResult,
+            observedAt: context.time.addingTimeInterval(1)
+        )
+        let observed = try await context.repository.recordObservation(
+            GraphExecutorObservationCommand(
+                observation: observation,
+                expectedVersion: context.version,
+                producer: graphTestProducer,
+                correlationID: "execute"
+            )
+        )
+
+        await assertExecutorError(.completionBeforeStart) {
+            try await context.repository.declareTerminal(
+                GraphExecutorTerminalDeclaration(
+                    identity: context.identity,
+                    observationID: observation.id,
+                    state: .completed,
+                    expectedVersion: observed.appendResult.newVersion,
+                    logicalTime: context.time.addingTimeInterval(2),
+                    producer: graphTestProducer,
+                    correlationID: "execute"
+                )
+            )
+        }
+    }
+
+    func testDuplicateObservationIsIdempotent() async throws {
+        let context = try await ExecutorRepositoryContext.make()
+        let started = try await context.repository.recordStartRequest(
+            context.startCommand()
+        )
+        let observation = context.observation(
+            status: .stillRunning,
+            operation: .observe,
+            observedAt: context.time.addingTimeInterval(1)
+        )
+        let command = GraphExecutorObservationCommand(
+            observation: observation,
+            expectedVersion: started.appendResult.newVersion,
+            producer: graphTestProducer,
+            correlationID: "execute"
+        )
+        let first = try await context.repository.recordObservation(command)
+        let duplicate = try await context.repository.recordObservation(
+            GraphExecutorObservationCommand(
+                observation: observation,
+                expectedVersion: first.appendResult.newVersion,
+                producer: graphTestProducer,
+                correlationID: "execute"
+            )
+        )
+
+        XCTAssertEqual(first.appendResult.appendedCount, 1)
+        XCTAssertEqual(duplicate.appendResult.appendedCount, 0)
+        XCTAssertEqual(duplicate.appendResult.deduplicatedCount, 1)
+    }
+
+    func testWrongLeaseGenerationAndExecutorAreRejected()
+        async throws
+    {
+        let context = try await ExecutorRepositoryContext.make()
+        let wrongGeneration = context.identity(
+            generation: context.identity.leaseGeneration + 1
+        )
+        let wrongExecutor = context.identity(executorID: "other")
+
+        await assertExecutorError(.leaseGenerationMismatch) {
+            try await context.repository.recordStartRequest(
+                context.startCommand(identity: wrongGeneration)
+            )
+        }
+        await assertExecutorError(.executorMismatch) {
+            try await context.repository.recordStartRequest(
+                context.startCommand(identity: wrongExecutor)
+            )
+        }
+    }
+
+    func testStaleClaimCannotPublishAfterLeaseTakeover() async throws {
+        let context = try await ExecutorRepositoryContext.make(
+            leaseDuration: 5
+        )
+        let takeoverTime = context.time.addingTimeInterval(6)
+        let replacement = try await context.takeOver(at: takeoverTime)
+        let staleObservation = context.observation(
+            status: .succeeded,
+            operation: .collectResult,
+            observedAt: takeoverTime
+        )
+
+        await assertExecutorError(.claimInactive) {
+            try await context.repository.recordObservation(
+                GraphExecutorObservationCommand(
+                    observation: staleObservation,
+                    expectedVersion: replacement.version,
+                    producer: graphTestProducer,
+                    correlationID: "stale"
+                )
+            )
+        }
+        XCTAssertNotEqual(replacement.claim.id, context.identity.claimID)
+    }
+}
+
+private struct ExecutorRepositoryContext {
+    let store: InMemoryGraphExecutionEventStore
+    let schedulingRepository: DefaultGraphSchedulingRepository
+    let repository: DefaultGraphExecutorRepository
+    let definition: GraphExecutableDefinition
+    let executor: GraphExecutorCapabilities
+    let identity: GraphExecutorInteractionIdentity
+    let version: UInt64
+    let time: Date
+    let leaseDuration: UInt64
+
+    static func make(
+        leaseDuration: UInt64 = 60
+    ) async throws -> ExecutorRepositoryContext {
+        let store = InMemoryGraphExecutionEventStore()
+        let definition = try loadCompendiumExecutableDefinition()
+        let mutator = DefaultGraphMutationService(
+            eventStore: store,
+            readStore: store
+        )
+        _ = try await mutator.create(
+            GraphCreateRequest(
+                runID: "run",
+                definition: definition,
+                idempotencyKey: "create",
+                occurredAt: graphTestTime,
+                producer: graphTestProducer
+            )
+        )
+        _ = try await mutator.start(
+            GraphStartRequest(
+                runID: "run",
+                idempotencyKey: "start",
+                requestedBy: "test",
+                occurredAt: graphTestTime,
+                producer: graphTestProducer
+            )
+        )
+        let scheduling = DefaultGraphSchedulingRepository(
+            eventStore: store
+        )
+        let executor = GraphExecutorCapabilities(
+            executorID: "deterministic",
+            capabilityIdentity: "deterministic-v1",
+            capabilities: ["compendium"]
+        )
+        let evaluated = try await scheduling.evaluateAndAppend(
+            GraphSchedulerEvaluationRequest(
+                runID: "run",
+                expectedVersion: 6,
+                definition: definition.scheduling,
+                policy: definition.schedulerPolicy,
+                logicalTime: graphTestTime,
+                availableExecutors: [executor],
+                producer: graphTestProducer,
+                recordedAt: graphTestTime
+            )
+        )
+        let evaluationID = try XCTUnwrap(
+            evaluated.projection.scheduling.records.last(where: {
+                $0.eventType == GraphExecutionEventType
+                    .schedulerCycleCompleted.rawValue
+            })?.evaluationID
+        )
+        let claimed = try await scheduling.attemptClaim(
+            GraphExecutorClaimRequest(
+                runID: "run",
+                nodeID: "architect",
+                claimID: "claim-1",
+                executor: executor,
+                evaluationID: evaluationID,
+                expectedVersion: evaluated.appendResult.newVersion,
+                logicalTime: graphTestTime,
+                leaseDurationSeconds: leaseDuration,
+                producer: graphTestProducer,
+                recordedAt: graphTestTime
+            )
+        )
+        let claim = try XCTUnwrap(claimed.claim)
+        let projection = try await Self.projection(store)
+        let attempt = try XCTUnwrap(
+            projection.attempts.first { $0.nodeID == "architect" }
+        )
+        return ExecutorRepositoryContext(
+            store: store,
+            schedulingRepository: scheduling,
+            repository: DefaultGraphExecutorRepository(
+                eventStore: store
+            ),
+            definition: definition,
+            executor: executor,
+            identity: GraphExecutorInteractionIdentity(
+                runID: "run",
+                nodeID: "architect",
+                attemptID: attempt.id,
+                attemptOrdinal: attempt.ordinal,
+                claimID: claim.id,
+                leaseGeneration: claim.leaseGeneration,
+                executorID: claim.executorID
+            ),
+            version: claimed.appendResult.newVersion,
+            time: graphTestTime,
+            leaseDuration: leaseDuration
+        )
+    }
+
+    var outputArtifact: GraphExecutorProducedArtifact {
+        GraphExecutorProducedArtifact(
+            contentDigest: GraphContentDigest(
+                algorithm: "sha256",
+                value: "artifact-digest"
+            ),
+            mediaType: "application/json",
+            role: .nodeOutput,
+            storage: GraphArtifactStorageLocator(
+                scheme: "deterministic",
+                opaqueReference: "artifact-digest"
+            )
+        )
+    }
+
+    func identity(
+        generation: UInt64? = nil,
+        executorID: String? = nil
+    ) -> GraphExecutorInteractionIdentity {
+        GraphExecutorInteractionIdentity(
+            runID: identity.runID,
+            nodeID: identity.nodeID,
+            attemptID: identity.attemptID,
+            attemptOrdinal: identity.attemptOrdinal,
+            claimID: identity.claimID,
+            leaseGeneration: generation ?? identity.leaseGeneration,
+            executorID: executorID ?? identity.executorID
+        )
+    }
+
+    func startCommand(
+        identity: GraphExecutorInteractionIdentity? = nil
+    ) -> GraphExecutorStartCommand {
+        GraphExecutorStartCommand(
+            identity: identity ?? self.identity,
+            expectedVersion: version,
+            logicalTime: time,
+            producer: graphTestProducer,
+            correlationID: "execute"
+        )
+    }
+
+    func observation(
+        status: GraphExecutorResponseStatus,
+        operation: GraphExecutorOperation,
+        observedAt: Date,
+        artifacts: [GraphExecutorProducedArtifact] = []
+    ) -> GraphExecutorObservation {
+        GraphExecutorObservation(
+            id: "observation-\(operation.rawValue)-\(status.rawValue)",
+            operation: operation,
+            identity: identity,
+            status: status,
+            observedAt: observedAt,
+            artifacts: artifacts
+        )
+    }
+
+    func takeOver(
+        at logicalTime: Date
+    ) async throws -> (claim: GraphExecutorClaim, version: UInt64) {
+        let projected = try await Self.projection(store)
+        let evaluated = try await schedulingRepository.evaluateAndAppend(
+            GraphSchedulerEvaluationRequest(
+                runID: "run",
+                expectedVersion: projected.streamVersion,
+                definition: definition.scheduling,
+                policy: definition.schedulerPolicy,
+                logicalTime: logicalTime,
+                availableExecutors: [executor],
+                producer: graphTestProducer,
+                recordedAt: logicalTime
+            )
+        )
+        let evaluationID = try XCTUnwrap(
+            evaluated.projection.scheduling.records.last(where: {
+                $0.eventType == GraphExecutionEventType
+                    .schedulerCycleCompleted.rawValue
+            })?.evaluationID
+        )
+        let result = try await schedulingRepository.attemptClaim(
+            GraphExecutorClaimRequest(
+                runID: "run",
+                nodeID: "architect",
+                claimID: "claim-2",
+                executor: executor,
+                evaluationID: evaluationID,
+                expectedVersion: evaluated.appendResult.newVersion,
+                logicalTime: logicalTime,
+                leaseDurationSeconds: leaseDuration,
+                producer: graphTestProducer,
+                recordedAt: logicalTime
+            )
+        )
+        return (try XCTUnwrap(result.claim), result.appendResult.newVersion)
+    }
+
+    private static func projection(
+        _ store: InMemoryGraphExecutionEventStore
+    ) async throws -> GraphExecutionProjection {
+        let stream = try await store.read(runID: "run", afterVersion: 0)
+        return try GraphExecutionProjector.replay(
+            runID: "run",
+            events: stream.events
+        ).projection
+    }
+}
+
+private func assertExecutorError<T>(
+    _ expected: GraphExecutorFencingReason,
+    operation: () async throws -> T
+) async {
+    do {
+        _ = try await operation()
+        XCTFail("Expected executor fencing rejection.")
+    } catch let error as GraphExecutorRepositoryError {
+        guard case let .rejected(reason, _) = error else {
+            return XCTFail("Expected rejection, found \(error).")
+        }
+        XCTAssertEqual(reason, expected)
+    } catch {
+        XCTFail("Unexpected error: \(error)")
+    }
+}

--- a/Tests/OpenIslandCoreTests/GraphMutationServiceTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphMutationServiceTests.swift
@@ -1,0 +1,262 @@
+import Foundation
+import XCTest
+@testable import OpenIslandCore
+
+final class GraphMutationServiceTests: XCTestCase {
+    func testCreateIsInactiveDurableAndIdempotent() async throws {
+        let context = try MutationContext()
+
+        let first = try await context.service.create(context.createRequest)
+        let second = try await context.service.create(context.createRequest)
+        let projection = try await context.projection()
+
+        XCTAssertEqual(first.status, .applied)
+        XCTAssertEqual(first.streamVersion, 5)
+        XCTAssertEqual(second.status, .deduplicated)
+        XCTAssertEqual(projection.run?.state, .pending)
+        XCTAssertNil(projection.runStartRequestedAt)
+        XCTAssertEqual(projection.executableDefinition, context.definition)
+    }
+
+    func testCreateRejectsConflictingIdempotencyReuse() async throws {
+        let context = try MutationContext()
+        _ = try await context.service.create(context.createRequest)
+        let other = GraphCreateRequest(
+            runID: "other-run",
+            definition: context.definition,
+            idempotencyKey: "create-key",
+            occurredAt: graphTestTime,
+            producer: graphTestProducer
+        )
+
+        await XCTAssertThrowsErrorAsync(
+            try await context.service.create(other)
+        ) { error in
+            XCTAssertEqual(
+                error as? GraphMutationError,
+                .idempotencyConflict("create-key")
+            )
+        }
+    }
+
+    func testStartMakesArchitectSchedulableAndIsIdempotent()
+        async throws
+    {
+        let context = try MutationContext()
+        _ = try await context.service.create(context.createRequest)
+        let request = context.startRequest
+
+        let first = try await context.service.start(request)
+        let second = try await context.service.start(request)
+        let projection = try await context.projection()
+        let reconciled = try XCTUnwrap(
+            GraphExecutionProjectionReconciler.reconcile(
+                projection: projection,
+                evidenceOutcome: .available(GraphProcessEvidence()),
+                observedAt: graphTestTime
+            )
+        )
+        let decision = GraphScheduler.evaluate(
+            GraphSchedulingInput(
+                definition: context.definition.scheduling,
+                projectedState: projection,
+                reconciledState: reconciled,
+                policy: context.definition.schedulerPolicy,
+                logicalTime: graphTestTime,
+                availableExecutors: [context.executor]
+            )
+        )
+
+        XCTAssertEqual(first.status, .applied)
+        XCTAssertEqual(second.status, .deduplicated)
+        XCTAssertEqual(projection.run?.state, .ready)
+        XCTAssertEqual(decision.phasesByNodeID["architect"], .claimable)
+        XCTAssertEqual(decision.phasesByNodeID["researcher"], .pending)
+    }
+
+    func testDryRunWritesNothing() async throws {
+        let context = try MutationContext()
+        let request = GraphCreateRequest(
+            runID: "run",
+            definition: context.definition,
+            idempotencyKey: "create-key",
+            dryRun: true,
+            occurredAt: graphTestTime,
+            producer: graphTestProducer
+        )
+
+        let report = try await context.service.create(request)
+        let descriptor = await context.store.streamDescriptor(
+            runID: "run"
+        )
+
+        XCTAssertEqual(report.status, .proposed)
+        XCTAssertEqual(report.eventTypes.count, 5)
+        XCTAssertNil(descriptor)
+    }
+
+    func testExpectedVersionConflictIsStable() async throws {
+        let context = try MutationContext()
+        _ = try await context.service.create(context.createRequest)
+        let request = GraphStartRequest(
+            runID: "run",
+            idempotencyKey: "start-key",
+            expectedVersion: 4,
+            requestedBy: "test",
+            occurredAt: graphTestTime,
+            producer: graphTestProducer
+        )
+
+        await XCTAssertThrowsErrorAsync(
+            try await context.service.start(request)
+        ) { error in
+            XCTAssertEqual(
+                error as? GraphMutationError,
+                .optimisticConflict(expected: 4, actual: 5)
+            )
+        }
+    }
+
+    func testRetryPolicyAndCancellationRequestsAreDurable()
+        async throws
+    {
+        let context = try MutationContext()
+        _ = try await context.service.create(context.createRequest)
+        _ = try await context.service.start(context.startRequest)
+        try await context.appendFailedArchitect(category: "transient")
+        let version = try await context.currentVersion()
+
+        let retry = try await context.service.retry(
+            GraphRetryMutationRequest(
+                runID: "run",
+                nodeID: "architect",
+                idempotencyKey: "retry-key",
+                expectedVersion: version,
+                requestedBy: "test",
+                occurredAt: graphTestTime.addingTimeInterval(2),
+                producer: graphTestProducer
+            )
+        )
+        let cancel = try await context.service.cancel(
+            GraphCancelMutationRequest(
+                runID: "run",
+                nodeID: "researcher",
+                idempotencyKey: "cancel-key",
+                requestedBy: "test",
+                occurredAt: graphTestTime.addingTimeInterval(3),
+                producer: graphTestProducer
+            )
+        )
+        let projection = try await context.projection()
+
+        XCTAssertEqual(retry.status, .applied)
+        XCTAssertEqual(cancel.status, .applied)
+        XCTAssertEqual(projection.retryRequestIDs.count, 1)
+        XCTAssertEqual(
+            projection.scheduling.cancellations.map(\.nodeID),
+            ["researcher"]
+        )
+    }
+}
+
+private struct MutationContext {
+    let store = InMemoryGraphExecutionEventStore()
+    let service: DefaultGraphMutationService
+    let definition: GraphExecutableDefinition
+    let executor = GraphExecutorCapabilities(
+        executorID: "deterministic",
+        capabilityIdentity: "deterministic-v1",
+        capabilities: ["compendium"]
+    )
+
+    init() throws {
+        definition = try loadCompendiumExecutableDefinition()
+        service = DefaultGraphMutationService(
+            eventStore: store,
+            readStore: store
+        )
+    }
+
+    var createRequest: GraphCreateRequest {
+        GraphCreateRequest(
+            runID: "run",
+            definition: definition,
+            idempotencyKey: "create-key",
+            occurredAt: graphTestTime,
+            producer: graphTestProducer
+        )
+    }
+
+    var startRequest: GraphStartRequest {
+        GraphStartRequest(
+            runID: "run",
+            idempotencyKey: "start-key",
+            requestedBy: "test",
+            occurredAt: graphTestTime,
+            producer: graphTestProducer
+        )
+    }
+
+    func currentVersion() async throws -> UInt64 {
+        try await store.read(runID: "run", afterVersion: 0)
+            .currentVersion
+    }
+
+    func projection() async throws -> GraphExecutionProjection {
+        let stream = try await store.read(runID: "run", afterVersion: 0)
+        return try GraphExecutionProjector.replay(
+            runID: "run",
+            events: stream.events
+        ).projection
+    }
+
+    func appendFailedArchitect(category: String) async throws {
+        let version = try await currentVersion()
+        let attemptID = "architect-attempt-1"
+        let events = [
+            GraphExecutionEventEnvelope(
+                id: attemptID,
+                runID: "run",
+                nodeID: "architect",
+                attemptID: attemptID,
+                streamSequence: version + 1,
+                occurredAt: graphTestTime,
+                recordedAt: graphTestTime,
+                producer: graphTestProducer,
+                payload: .attemptCreated(
+                    GraphAttemptCreatedPayload(ordinal: 1)
+                )
+            ),
+            GraphExecutionEventEnvelope(
+                id: "architect-failed",
+                runID: "run",
+                nodeID: "architect",
+                attemptID: attemptID,
+                streamSequence: version + 2,
+                occurredAt: graphTestTime.addingTimeInterval(1),
+                recordedAt: graphTestTime.addingTimeInterval(1),
+                producer: graphTestProducer,
+                payload: .attemptFailed(
+                    GraphAttemptTerminalPayload(reason: category)
+                )
+            ),
+        ]
+        _ = try await store.append(
+            events,
+            to: "run",
+            expectedVersion: version
+        )
+    }
+}
+
+private func XCTAssertThrowsErrorAsync<T>(
+    _ expression: @autoclosure () async throws -> T,
+    _ errorHandler: (Error) -> Void
+) async {
+    do {
+        _ = try await expression()
+        XCTFail("Expected expression to throw.")
+    } catch {
+        errorHandler(error)
+    }
+}

--- a/Tests/OpenIslandCoreTests/GraphOrchestrationServiceTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphOrchestrationServiceTests.swift
@@ -1,0 +1,724 @@
+import Foundation
+import XCTest
+@testable import OpenIslandCore
+
+final class GraphOrchestrationServiceTests: XCTestCase {
+    func testCompendiumRunsAllFourNodesAndPropagatesArtifacts()
+        async throws
+    {
+        let context = try await OrchestrationContext.make()
+
+        let result = try await context.service.run(
+            GraphOrchestrationRunRequest(
+                runID: "run",
+                cycleLimit: 30,
+                logicalTime: graphTestTime
+            )
+        )
+        let projection = try await context.projection()
+
+        XCTAssertEqual(result.status, .terminal)
+        XCTAssertEqual(result.finalState, .completed)
+        XCTAssertEqual(
+            projection.attempts.map { "\($0.nodeID):\($0.state.rawValue)" },
+            [
+                "architect:completed",
+                "graph:completed",
+                "researcher:completed",
+                "reviewer:completed",
+            ]
+        )
+        XCTAssertEqual(projection.artifacts.count, 5)
+        let reviewerInputs = try GraphArtifactInputResolver.resolve(
+            nodeID: "reviewer",
+            definition: context.definition,
+            projection: projection
+        )
+        XCTAssertEqual(
+            Set(reviewerInputs.map(\.producingNodeID)),
+            Set(["architect", "researcher", "graph"])
+        )
+        XCTAssertTrue(
+            projection.scheduling.claims.allSatisfy {
+                $0.status == .released
+            }
+        )
+    }
+
+    func testRepeatedRunDoesNotDuplicateTerminalWork() async throws {
+        let context = try await OrchestrationContext.make()
+        _ = try await context.service.run(
+            GraphOrchestrationRunRequest(
+                runID: "run",
+                cycleLimit: 30,
+                logicalTime: graphTestTime
+            )
+        )
+        let version = try await context.currentVersion()
+
+        let repeated = try await context.service.run(
+            GraphOrchestrationRunRequest(
+                runID: "run",
+                cycleLimit: 30,
+                logicalTime: graphTestTime
+            )
+        )
+
+        XCTAssertEqual(repeated.cycles.count, 1)
+        XCTAssertEqual(repeated.cycles[0].persistedEventCount, 0)
+        XCTAssertEqual(repeated.finalVersion, version)
+    }
+
+    func testStepIsBoundedAndDryRunHasNoWritesOrInvocations()
+        async throws
+    {
+        let context = try await OrchestrationContext.make()
+        let initialVersion = try await context.currentVersion()
+        let dryRun = try await context.service.step(
+            GraphOrchestrationStepRequest(
+                runID: "run",
+                logicalTime: graphTestTime,
+                dryRun: true
+            )
+        )
+        let afterDryRun = try await context.currentVersion()
+        let step = try await context.service.step(
+            GraphOrchestrationStepRequest(
+                runID: "run",
+                logicalTime: graphTestTime
+            )
+        )
+        let projection = try await context.projection()
+
+        XCTAssertEqual(dryRun.status, .proposed)
+        XCTAssertEqual(dryRun.claimedNodeID, "architect")
+        XCTAssertEqual(dryRun.executorInvocationCount, 0)
+        XCTAssertEqual(initialVersion, afterDryRun)
+        XCTAssertEqual(step.claimedNodeID, "architect")
+        XCTAssertEqual(step.executorOperation, .start)
+        XCTAssertEqual(step.executorInvocationCount, 2)
+        XCTAssertEqual(projection.attempts.count, 1)
+        XCTAssertEqual(projection.attempts.first?.state, .running)
+    }
+
+    func testRetryDelaySurvivesServiceRestart() async throws {
+        let script = GraphDeterministicExecutionScript(
+            attempts: [
+                GraphDeterministicAttemptScript(
+                    nodeID: "researcher",
+                    attemptOrdinal: 1,
+                    terminalOutcome: .retryableFailure,
+                    failureCategory: "transient"
+                ),
+                GraphDeterministicAttemptScript(
+                    nodeID: "researcher",
+                    attemptOrdinal: 2,
+                    terminalOutcome: .succeed,
+                    artifactRoles: [.structuredResult]
+                ),
+            ]
+        )
+        let context = try await OrchestrationContext.make(script: script)
+        let first = try await context.service.run(
+            GraphOrchestrationRunRequest(
+                runID: "run",
+                cycleLimit: 30,
+                logicalTime: graphTestTime
+            )
+        )
+        let waiting = try await context.projection()
+        let retry = try XCTUnwrap(
+            waiting.scheduling.retries.first {
+                $0.nodeID == "researcher"
+            }
+        )
+        let restarted = context.makeService(script: script)
+        let completed = try await restarted.run(
+            GraphOrchestrationRunRequest(
+                runID: "run",
+                cycleLimit: 30,
+                logicalTime: retry.eligibleAt
+            )
+        )
+        let projection = try await context.projection()
+
+        XCTAssertEqual(first.status, .stalled)
+        XCTAssertEqual(retry.delaySeconds, 10)
+        XCTAssertEqual(completed.finalState, .completed)
+        XCTAssertEqual(
+            projection.attempts.filter {
+                $0.nodeID == "researcher"
+            }.map(\.ordinal),
+            [1, 2]
+        )
+    }
+
+    func testNonRetryableFailureBlocksDownstreamAndFailsRun()
+        async throws
+    {
+        let script = GraphDeterministicExecutionScript(
+            attempts: [
+                GraphDeterministicAttemptScript(
+                    nodeID: "researcher",
+                    attemptOrdinal: 1,
+                    terminalOutcome: .nonRetryableFailure,
+                    failureCategory: "invalid_input"
+                ),
+            ]
+        )
+        let context = try await OrchestrationContext.make(script: script)
+
+        let result = try await context.service.run(
+            GraphOrchestrationRunRequest(
+                runID: "run",
+                cycleLimit: 30,
+                logicalTime: graphTestTime
+            )
+        )
+        let projection = try await context.projection()
+        let reconciled = try XCTUnwrap(
+            GraphExecutionProjectionReconciler.reconcile(
+                projection: projection,
+                evidenceOutcome: .available(GraphProcessEvidence()),
+                observedAt: graphTestTime
+            )
+        )
+
+        XCTAssertEqual(result.finalState, .failed)
+        XCTAssertEqual(
+            reconciled.nodes.first { $0.id == "graph" }?.state,
+            .blocked
+        )
+        XCTAssertEqual(
+            reconciled.nodes.first { $0.id == "reviewer" }?.state,
+            .blocked
+        )
+        XCTAssertTrue(
+            projection.scheduling.records.contains {
+                $0.eventType == GraphExecutionEventType
+                    .retrySuppressed.rawValue
+            }
+        )
+    }
+
+    func testCancellationBeforeClaimDoesNotInvokeExecutor()
+        async throws
+    {
+        let context = try await OrchestrationContext.make()
+        _ = try await context.mutator.cancel(
+            GraphCancelMutationRequest(
+                runID: "run",
+                nodeID: "architect",
+                idempotencyKey: "cancel-before-claim",
+                requestedBy: "test",
+                occurredAt: graphTestTime,
+                producer: graphTestProducer
+            )
+        )
+
+        let cycle = try await context.service.step(
+            GraphOrchestrationStepRequest(
+                runID: "run",
+                logicalTime: graphTestTime
+            )
+        )
+        let projection = try await context.projection()
+
+        XCTAssertEqual(cycle.executorInvocationCount, 0)
+        XCTAssertEqual(
+            projection.attempts.first?.state,
+            .cancelled
+        )
+        XCTAssertTrue(projection.scheduling.claims.isEmpty)
+    }
+
+    func testCancellationAcknowledgementAndTimeoutAreDurable()
+        async throws
+    {
+        let acknowledge = try await OrchestrationContext.make()
+        _ = try await acknowledge.service.step(
+            GraphOrchestrationStepRequest(
+                runID: "run",
+                logicalTime: graphTestTime
+            )
+        )
+        _ = try await acknowledge.mutator.cancel(
+            GraphCancelMutationRequest(
+                runID: "run",
+                nodeID: "architect",
+                idempotencyKey: "cancel-running",
+                requestedBy: "test",
+                occurredAt: graphTestTime.addingTimeInterval(1),
+                producer: graphTestProducer
+            )
+        )
+        let cancelled = try await acknowledge.service.step(
+            GraphOrchestrationStepRequest(
+                runID: "run",
+                logicalTime: graphTestTime.addingTimeInterval(1)
+            )
+        )
+        let cancelledProjection = try await acknowledge.projection()
+
+        XCTAssertEqual(cancelled.executorStatus, .cancelled)
+        XCTAssertEqual(
+            cancelledProjection.attempts.first?.state,
+            .cancelled
+        )
+        XCTAssertEqual(
+            cancelledProjection.scheduling.cancellations.first?.state,
+            .acknowledged
+        )
+
+        let ignoreScript = GraphDeterministicExecutionScript(
+            attempts: [
+                GraphDeterministicAttemptScript(
+                    nodeID: "architect",
+                    attemptOrdinal: 1,
+                    cancellationBehavior: .ignoreUntilTimeout
+                ),
+            ]
+        )
+        let ignore = try await OrchestrationContext.make(
+            runID: "ignore",
+            script: ignoreScript
+        )
+        _ = try await ignore.service.step(
+            GraphOrchestrationStepRequest(
+                runID: "ignore",
+                logicalTime: graphTestTime
+            )
+        )
+        _ = try await ignore.mutator.cancel(
+            GraphCancelMutationRequest(
+                runID: "ignore",
+                nodeID: "architect",
+                idempotencyKey: "cancel-ignore",
+                requestedBy: "test",
+                occurredAt: graphTestTime.addingTimeInterval(1),
+                producer: graphTestProducer
+            )
+        )
+        let waiting = try await ignore.service.step(
+            GraphOrchestrationStepRequest(
+                runID: "ignore",
+                logicalTime: graphTestTime.addingTimeInterval(1)
+            )
+        )
+        _ = try await ignore.service.step(
+            GraphOrchestrationStepRequest(
+                runID: "ignore",
+                logicalTime: graphTestTime.addingTimeInterval(31)
+            )
+        )
+        let timedOut = try await ignore.projection(runID: "ignore")
+
+        XCTAssertEqual(waiting.status, .waitingForCancellation)
+        XCTAssertTrue(
+            timedOut.scheduling.timeouts.contains {
+                $0.kind == .cancellationAcknowledgement
+            }
+        )
+        XCTAssertEqual(timedOut.attempts.first?.state, .interrupted)
+    }
+
+    func testCrashAfterStartRequestRecoversWithoutDuplicateStart()
+        async throws
+    {
+        let script = GraphDeterministicExecutionScript(
+            attempts: [
+                GraphDeterministicAttemptScript(
+                    nodeID: "architect",
+                    attemptOrdinal: 1,
+                    crashPoint: .afterAttemptStartPersistence
+                ),
+            ]
+        )
+        let context = try await OrchestrationContext.make(script: script)
+        let crashed = try await context.service.step(
+            GraphOrchestrationStepRequest(
+                runID: "run",
+                logicalTime: graphTestTime
+            )
+        )
+        let restarted = context.makeService(script: script)
+        let recovered = try await restarted.step(
+            GraphOrchestrationStepRequest(
+                runID: "run",
+                logicalTime: graphTestTime.addingTimeInterval(1)
+            )
+        )
+        let stream = try await context.store.read(
+            runID: "run",
+            afterVersion: 0
+        )
+
+        XCTAssertEqual(crashed.status, .adapterUnavailable)
+        XCTAssertEqual(recovered.executorOperation, .recover)
+        XCTAssertEqual(
+            stream.events.filter {
+                $0.eventType == GraphExecutionEventType
+                    .attemptStarting.rawValue
+            }.count,
+            1
+        )
+    }
+
+    func testCrashAfterAdapterAcceptanceRecoversConservatively()
+        async throws
+    {
+        let script = GraphDeterministicExecutionScript(
+            attempts: [
+                GraphDeterministicAttemptScript(
+                    nodeID: "architect",
+                    attemptOrdinal: 1,
+                    crashPoint: .afterAcceptingStart
+                ),
+            ]
+        )
+        let context = try await OrchestrationContext.make(script: script)
+
+        let accepted = try await context.service.step(
+            GraphOrchestrationStepRequest(
+                runID: "run",
+                logicalTime: graphTestTime
+            )
+        )
+        let restarted = context.makeService(script: script)
+        let recovered = try await restarted.step(
+            GraphOrchestrationStepRequest(
+                runID: "run",
+                logicalTime: graphTestTime.addingTimeInterval(1)
+            )
+        )
+        let completed = try await restarted.run(
+            GraphOrchestrationRunRequest(
+                runID: "run",
+                cycleLimit: 30,
+                logicalTime: graphTestTime.addingTimeInterval(2)
+            )
+        )
+        let stream = try await context.store.read(
+            runID: "run",
+            afterVersion: 0
+        )
+
+        XCTAssertEqual(accepted.executorStatus, .accepted)
+        XCTAssertEqual(recovered.executorOperation, .recover)
+        XCTAssertEqual(completed.finalState, .completed)
+        XCTAssertEqual(
+            stream.events.filter {
+                $0.eventType == GraphExecutionEventType
+                    .attemptStarting.rawValue
+                    && $0.nodeID == "architect"
+            }.count,
+            1
+        )
+    }
+
+    func testStaleExecutorObservationIsRejectedWithoutArtifacts()
+        async throws
+    {
+        let script = GraphDeterministicExecutionScript(
+            attempts: [
+                GraphDeterministicAttemptScript(
+                    nodeID: "architect",
+                    attemptOrdinal: 1,
+                    staleLeaseGenerationOffset: -1
+                ),
+            ]
+        )
+        let context = try await OrchestrationContext.make(script: script)
+
+        await XCTAssertThrowsErrorAsync {
+            try await context.service.step(
+                GraphOrchestrationStepRequest(
+                    runID: "run",
+                    logicalTime: graphTestTime
+                )
+            )
+        } verify: { error in
+            XCTAssertEqual(
+                error as? GraphOrchestrationError,
+                .staleExecutor(.leaseGenerationMismatch)
+            )
+        }
+        let projection = try await context.projection()
+
+        XCTAssertTrue(projection.artifacts.isEmpty)
+        XCTAssertTrue(
+            projection.attempts.allSatisfy { !$0.state.isTerminal }
+        )
+    }
+
+    func testStepRejectsOptimisticConcurrencyConflict() async throws {
+        let context = try await OrchestrationContext.make()
+        let version = try await context.currentVersion()
+
+        await XCTAssertThrowsErrorAsync {
+            try await context.service.step(
+                GraphOrchestrationStepRequest(
+                    runID: "run",
+                    logicalTime: graphTestTime,
+                    expectedVersion: version - 1
+                )
+            )
+        } verify: { error in
+            XCTAssertEqual(
+                error as? GraphOrchestrationError,
+                .optimisticConflict(
+                    expected: version - 1,
+                    actual: version
+                )
+            )
+        }
+    }
+
+    func testSQLiteProcessRestartResumesSameGraphWithoutDuplicateStart()
+        async throws
+    {
+        let fixture = try SQLiteStoreFixture()
+        defer { fixture.remove() }
+        let definition = try loadCompendiumExecutableDefinition()
+        let script = try loadCompendiumDeterministicScript()
+        let firstStore = try SQLiteGraphExecutionStore(
+            databasePath: fixture.path
+        )
+        let mutator = DefaultGraphMutationService(
+            eventStore: firstStore,
+            readStore: firstStore
+        )
+        _ = try await mutator.create(
+            GraphCreateRequest(
+                runID: "sqlite-run",
+                definition: definition,
+                idempotencyKey: "sqlite-create",
+                occurredAt: graphTestTime,
+                producer: graphTestProducer
+            )
+        )
+        _ = try await mutator.start(
+            GraphStartRequest(
+                runID: "sqlite-run",
+                idempotencyKey: "sqlite-start",
+                requestedBy: "test",
+                occurredAt: graphTestTime,
+                producer: graphTestProducer
+            )
+        )
+        let firstService = makeOrchestrationService(
+            store: firstStore,
+            script: script
+        )
+        _ = try await firstService.step(
+            GraphOrchestrationStepRequest(
+                runID: "sqlite-run",
+                logicalTime: graphTestTime
+            )
+        )
+
+        let reopenedStore = try SQLiteGraphExecutionStore(
+            databasePath: fixture.path
+        )
+        let restartedService = makeOrchestrationService(
+            store: reopenedStore,
+            script: script
+        )
+        let completed = try await restartedService.run(
+            GraphOrchestrationRunRequest(
+                runID: "sqlite-run",
+                cycleLimit: 30,
+                logicalTime: graphTestTime.addingTimeInterval(1)
+            )
+        )
+        let stream = try await reopenedStore.read(
+            runID: "sqlite-run",
+            afterVersion: 0
+        )
+
+        XCTAssertEqual(completed.finalState, .completed)
+        XCTAssertEqual(
+            stream.events.filter {
+                $0.eventType == GraphExecutionEventType
+                    .attemptStarting.rawValue
+                    && $0.nodeID == "architect"
+            }.count,
+            1
+        )
+    }
+
+    func testSuccessfulExecutionReplaysByteIdenticallyAndDiffExplainsRun()
+        async throws
+    {
+        let context = try await OrchestrationContext.make()
+        let initialStream = try await context.store.read(
+            runID: "run",
+            afterVersion: 0
+        )
+        let initialBoundary = try XCTUnwrap(
+            initialStream.events.last?.streamSequence
+        )
+        _ = try await context.service.run(
+            GraphOrchestrationRunRequest(
+                runID: "run",
+                cycleLimit: 30,
+                logicalTime: graphTestTime
+            )
+        )
+        let terminalStream = try await context.store.read(
+            runID: "run",
+            afterVersion: 0
+        )
+        let first = try GraphExecutionProjector.replay(
+            runID: "run",
+            events: terminalStream.events
+        ).projection
+        let second = try GraphExecutionProjector.replay(
+            runID: "run",
+            events: terminalStream.events
+        ).projection
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        let firstBytes = try encoder.encode(first)
+        let secondBytes = try encoder.encode(second)
+        let inspector = DefaultGraphTemporalInspector(
+            readStore: context.store,
+            snapshotStore: InMemoryGraphExecutionSnapshotStore()
+        )
+        let diff = try await inspector.diff(
+            left: GraphTemporalReference(
+                runID: "run",
+                boundary: .sequence(initialBoundary)
+            ),
+            right: GraphTemporalReference(runID: "run")
+        )
+        let completedNodes = Set(
+            diff.changes.filter {
+                $0.category == .node
+                    && $0.field == "persisted_state"
+                    && $0.right == ReconciledExecutionState.completed.rawValue
+            }.map(\.entityID)
+        )
+
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(firstBytes, secondBytes)
+        XCTAssertEqual(
+            completedNodes,
+            Set(["architect", "researcher", "graph", "reviewer"])
+        )
+        XCTAssertTrue(
+            diff.changes.contains {
+                $0.category == .run
+                    && $0.field == "persisted_state"
+                    && $0.right == ReconciledExecutionState.completed.rawValue
+            }
+        )
+        XCTAssertTrue(
+            diff.changes.contains { $0.category == .artifact }
+        )
+        XCTAssertTrue(
+            diff.changes.contains { $0.category == .eventRange }
+        )
+    }
+}
+
+private struct OrchestrationContext {
+    let runID: String
+    let store: InMemoryGraphExecutionEventStore
+    let definition: GraphExecutableDefinition
+    let mutator: DefaultGraphMutationService
+    let service: DefaultGraphOrchestrationService
+
+    static func make(
+        runID: String = "run",
+        script: GraphDeterministicExecutionScript? = nil
+    ) async throws -> OrchestrationContext {
+        let store = InMemoryGraphExecutionEventStore()
+        let definition = try loadCompendiumExecutableDefinition()
+        let mutator = DefaultGraphMutationService(
+            eventStore: store,
+            readStore: store
+        )
+        _ = try await mutator.create(
+            GraphCreateRequest(
+                runID: runID,
+                definition: definition,
+                idempotencyKey: "create-\(runID)",
+                occurredAt: graphTestTime,
+                producer: graphTestProducer
+            )
+        )
+        _ = try await mutator.start(
+            GraphStartRequest(
+                runID: runID,
+                idempotencyKey: "start-\(runID)",
+                requestedBy: "test",
+                occurredAt: graphTestTime,
+                producer: graphTestProducer
+            )
+        )
+        let selectedScript = try script
+            ?? loadCompendiumDeterministicScript()
+        let context = OrchestrationContext(
+            runID: runID,
+            store: store,
+            definition: definition,
+            mutator: mutator,
+            service: makeService(
+                store: store,
+                script: selectedScript
+            )
+        )
+        return context
+    }
+
+    func makeService(
+        script: GraphDeterministicExecutionScript
+    ) -> DefaultGraphOrchestrationService {
+        Self.makeService(store: store, script: script)
+    }
+
+    func currentVersion() async throws -> UInt64 {
+        try await store.read(runID: runID, afterVersion: 0)
+            .currentVersion
+    }
+
+    func projection(
+        runID: String? = nil
+    ) async throws -> GraphExecutionProjection {
+        let selectedRunID = runID ?? self.runID
+        let stream = try await store.read(
+            runID: selectedRunID,
+            afterVersion: 0
+        )
+        return try GraphExecutionProjector.replay(
+            runID: selectedRunID,
+            events: stream.events
+        ).projection
+    }
+
+    private static func makeService(
+        store: InMemoryGraphExecutionEventStore,
+        script: GraphDeterministicExecutionScript
+    ) -> DefaultGraphOrchestrationService {
+        makeOrchestrationService(store: store, script: script)
+    }
+}
+
+private func makeOrchestrationService(
+    store: any GraphExecutionEventStore,
+    script: GraphDeterministicExecutionScript
+) -> DefaultGraphOrchestrationService {
+    DefaultGraphOrchestrationService(
+        eventStore: store,
+        schedulingRepository: DefaultGraphSchedulingRepository(
+            eventStore: store
+        ),
+        executorRepository: DefaultGraphExecutorRepository(
+            eventStore: store
+        ),
+        executor: DeterministicGraphExecutor(script: script),
+        producer: graphTestProducer
+    )
+}

--- a/Tests/OpenIslandCoreTests/GraphOrchestrationServiceTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphOrchestrationServiceTests.swift
@@ -474,6 +474,51 @@ final class GraphOrchestrationServiceTests: XCTestCase {
         }
     }
 
+    func testLongRunningAttemptRenewsLeaseWithNextFencingGeneration()
+        async throws
+    {
+        let script = GraphDeterministicExecutionScript(
+            attempts: [
+                GraphDeterministicAttemptScript(
+                    nodeID: "architect",
+                    attemptOrdinal: 1,
+                    terminalOutcome: .remainRunning
+                ),
+            ]
+        )
+        let context = try await OrchestrationContext.make(script: script)
+        _ = try await context.service.step(
+            GraphOrchestrationStepRequest(
+                runID: "run",
+                logicalTime: graphTestTime
+            )
+        )
+
+        let renewed = try await context.service.step(
+            GraphOrchestrationStepRequest(
+                runID: "run",
+                logicalTime: graphTestTime.addingTimeInterval(31)
+            )
+        )
+        let projection = try await context.projection()
+        let claim = try XCTUnwrap(
+            projection.scheduling.activeClaim(
+                nodeID: "architect",
+                at: graphTestTime.addingTimeInterval(31)
+            )
+        )
+
+        XCTAssertEqual(renewed.executorOperation, .observe)
+        XCTAssertEqual(renewed.executorStatus, .stillRunning)
+        XCTAssertEqual(claim.leaseGeneration, 2)
+        XCTAssertTrue(
+            projection.scheduling.records.contains {
+                $0.eventType == GraphExecutionEventType
+                    .executorLeaseRenewed.rawValue
+            }
+        )
+    }
+
     func testSQLiteProcessRestartResumesSameGraphWithoutDuplicateStart()
         async throws
     {

--- a/Tests/OpenIslandCoreTests/GraphSchedulerTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphSchedulerTests.swift
@@ -1,0 +1,383 @@
+import XCTest
+@testable import OpenIslandCore
+
+final class GraphSchedulerTests: XCTestCase {
+    func testSchedulerIsDeterministicAndSelectsOnlyRootNode() {
+        let fixture = schedulingFixture()
+        let first = GraphScheduler.evaluate(fixture.input)
+        let second = GraphScheduler.evaluate(fixture.input)
+
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(first.phasesByNodeID["architect"], .claimable)
+        XCTAssertEqual(first.reasonsByNodeID["architect"], .dependenciesSatisfied)
+        XCTAssertEqual(first.phasesByNodeID["researcher"], .pending)
+        XCTAssertEqual(first.phasesByNodeID["graph"], .pending)
+        XCTAssertEqual(first.phasesByNodeID["reviewer"], .pending)
+        XCTAssertEqual(
+            first.reasonsByNodeID["reviewer"],
+            .dependencyIncomplete
+        )
+    }
+
+    func testSchedulerUsesFixedPointFailurePropagation() {
+        var fixture = schedulingFixture()
+        fixture.projection.nodes[0].state = .failed
+        fixture.reconciled.nodes[0].state = .failed
+        fixture.reconciled.nodes[1].state = .blocked
+        fixture.reconciled.nodes[2].state = .blocked
+        fixture.reconciled.nodes[3].state = .blocked
+        fixture.projection.attempts = [
+            ExecutionAttempt(
+                id: "architect-attempt-1",
+                graphRunID: "compendium-run",
+                nodeID: "architect",
+                ordinal: 1,
+                state: .failed,
+                createdAt: fixture.time,
+                updatedAt: fixture.time,
+                finishedAt: fixture.time,
+                statusReason: "fatal"
+            ),
+        ]
+        fixture.reconciled.attempts = fixture.projection.attempts
+        fixture.policy = GraphSchedulerPolicy(
+            policyID: "compendium-policy",
+            version: "1",
+            retryPolicy: GraphRetryPolicy(
+                maximumAttempts: 1,
+                retryableFailureCategories: ["execution_failure"]
+            )
+        )
+
+        let result = GraphScheduler.evaluate(fixture.input)
+
+        XCTAssertEqual(result.phasesByNodeID["architect"], .terminal)
+        XCTAssertEqual(result.phasesByNodeID["researcher"], .blocked)
+        XCTAssertEqual(result.phasesByNodeID["graph"], .blocked)
+        XCTAssertEqual(result.phasesByNodeID["reviewer"], .blocked)
+        XCTAssertEqual(
+            result.reasonsByNodeID["reviewer"],
+            .dependencyFailed
+        )
+        XCTAssertEqual(
+            result.proposedEvents.filter {
+                $0.payload.eventType
+                    == GraphExecutionEventType
+                        .dependencyFailurePropagated.rawValue
+            }.count,
+            3
+        )
+    }
+
+    func testRetryBackoffIsDurableAndDeterministic() throws {
+        var fixture = schedulingFixture()
+        let failed = ExecutionAttempt(
+            id: "architect-attempt-1",
+            graphRunID: "compendium-run",
+            nodeID: "architect",
+            ordinal: 1,
+            state: .failed,
+            createdAt: fixture.time,
+            updatedAt: fixture.time,
+            finishedAt: fixture.time,
+            statusReason: "temporary"
+        )
+        fixture.projection.attempts = [failed]
+        fixture.reconciled.attempts = [failed]
+        fixture.projection.nodes[0].state = .failed
+        fixture.reconciled.nodes[0].state = .failed
+        fixture.failureCategories = [failed.id: "transient"]
+        fixture.policy = GraphSchedulerPolicy(
+            policyID: "compendium-policy",
+            version: "1",
+            retryPolicy: GraphRetryPolicy(
+                maximumAttempts: 3,
+                retryableFailureCategories: ["transient"],
+                initialBackoffSeconds: 10,
+                jitterBasisPoints: 1_000,
+                jitterSeed: "fixture-seed"
+            )
+        )
+
+        let first = GraphScheduler.evaluate(fixture.input)
+        let second = GraphScheduler.evaluate(fixture.input)
+        let payload = try XCTUnwrap(
+            first.proposedEvents.compactMap { event -> GraphRetryRecord? in
+                guard case let .retryScheduled(value) = event.payload else {
+                    return nil
+                }
+                return value.retry
+            }.first
+        )
+
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(first.phasesByNodeID["architect"], .retryWaiting)
+        XCTAssertEqual(payload.nextAttemptOrdinal, 2)
+        XCTAssertGreaterThanOrEqual(payload.delaySeconds, 10)
+        XCTAssertEqual(
+            payload.eligibleAt,
+            fixture.time.addingTimeInterval(
+                TimeInterval(payload.delaySeconds)
+            )
+        )
+    }
+
+    func testCapabilityAndDefinitionMismatchesAreExplicit() {
+        var fixture = schedulingFixture()
+        fixture.executors = []
+        let unavailable = GraphScheduler.evaluate(fixture.input)
+        XCTAssertEqual(unavailable.phasesByNodeID["architect"], .ready)
+        XCTAssertEqual(
+            unavailable.reasonsByNodeID["architect"],
+            .executorCapabilityUnavailable
+        )
+
+        fixture.definition = GraphSchedulingDefinition(
+            graphID: "dose-compendium",
+            version: "different",
+            digest: fixture.digest,
+            nodes: fixture.definition.nodes
+        )
+        let mismatch = GraphScheduler.evaluate(fixture.input)
+        XCTAssertEqual(mismatch.phasesByNodeID["architect"], .blocked)
+        XCTAssertEqual(
+            mismatch.reasonsByNodeID["architect"],
+            .graphDefinitionMismatch
+        )
+    }
+
+    func testCompletedEvaluationMakesSchedulerIdempotent() {
+        var fixture = schedulingFixture()
+        let first = GraphScheduler.evaluate(fixture.input)
+        fixture.projection.scheduling.completedEvaluationIDs = [
+            first.evaluationID,
+        ]
+
+        let repeated = GraphScheduler.evaluate(fixture.input)
+
+        XCTAssertTrue(repeated.proposedEvents.isEmpty)
+        XCTAssertTrue(repeated.phasesByNodeID.isEmpty)
+    }
+
+    func testSchedulingEventsReplayAndSurviveSnapshotRoundTrip()
+        throws
+    {
+        let fixture = schedulingFixture(nodeIDs: ["architect"])
+        let base = baseHistory(fixture: fixture)
+        let baseReplay = try GraphExecutionProjector.replay(
+            runID: "compendium-run",
+            events: base
+        )
+        let input = GraphSchedulingInput(
+            definition: fixture.definition,
+            projectedState: baseReplay.projection,
+            reconciledState: fixture.reconciled,
+            policy: fixture.policy,
+            logicalTime: fixture.time,
+            availableExecutors: fixture.executors
+        )
+        let decision = GraphScheduler.evaluate(input)
+        let events = base + decision.proposedEvents.enumerated().map {
+            index, proposal in
+            GraphExecutionEventEnvelope(
+                id: proposal.id,
+                runID: "compendium-run",
+                nodeID: proposal.nodeID,
+                attemptID: proposal.attemptID,
+                streamSequence: UInt64(base.count + index + 1),
+                occurredAt: proposal.occurredAt,
+                recordedAt: proposal.occurredAt,
+                producer: graphTestProducer,
+                payload: proposal.payload
+            )
+        }
+
+        let replay = try GraphExecutionProjector.replay(
+            runID: "compendium-run",
+            events: events
+        )
+        let data = try JSONEncoder().encode(replay.projection)
+        let decoded = try JSONDecoder().decode(
+            GraphExecutionProjection.self,
+            from: data
+        )
+
+        XCTAssertEqual(decoded, replay.projection)
+        XCTAssertEqual(
+            replay.projection.scheduling.completedEvaluationIDs,
+            [decision.evaluationID]
+        )
+        XCTAssertEqual(
+            replay.projection.scheduling.records.last?.eventType,
+            GraphExecutionEventType.schedulerCycleCompleted.rawValue
+        )
+        XCTAssertEqual(
+            replay.projection.scheduling.records.first?.factClass,
+            .decision
+        )
+    }
+}
+
+private struct SchedulingFixture {
+    var definition: GraphSchedulingDefinition
+    var projection: GraphExecutionProjection
+    var reconciled: ExecutionReconciliationResult
+    var policy: GraphSchedulerPolicy
+    var executors: [GraphExecutorCapabilities]
+    var failureCategories: [String: String]
+    let time: Date
+    let digest: GraphContentDigest
+
+    var input: GraphSchedulingInput {
+        GraphSchedulingInput(
+            definition: definition,
+            projectedState: projection,
+            reconciledState: reconciled,
+            policy: policy,
+            logicalTime: time,
+            availableExecutors: executors,
+            failureCategoriesByAttemptID: failureCategories
+        )
+    }
+}
+
+private func schedulingFixture(
+    nodeIDs: [String] = [
+        "architect",
+        "researcher",
+        "graph",
+        "reviewer",
+    ]
+) -> SchedulingFixture {
+    let time = Date(timeIntervalSince1970: 100_000)
+    let digest = GraphContentDigest(
+        algorithm: "sha256",
+        value: "compendium-scheduling-v1"
+    )
+    let allDefinitions = [
+        GraphSchedulingDefinitionNode(
+            id: "architect",
+            title: "Architect",
+            requiredCapabilities: ["research-planning"]
+        ),
+        GraphSchedulingDefinitionNode(
+            id: "researcher",
+            title: "Researcher",
+            dependencyNodeIDs: ["architect"],
+            requiredCapabilities: ["web-research"]
+        ),
+        GraphSchedulingDefinitionNode(
+            id: "graph",
+            title: "Graph Engineer",
+            dependencyNodeIDs: ["researcher"],
+            requiredCapabilities: ["swift-graph"]
+        ),
+        GraphSchedulingDefinitionNode(
+            id: "reviewer",
+            title: "Reviewer",
+            dependencyNodeIDs: ["graph"],
+            requiredCapabilities: ["independent-review"]
+        ),
+    ]
+    let definitions = allDefinitions.filter { nodeIDs.contains($0.id) }
+    let nodes = definitions.map {
+        GraphNode(
+            id: $0.id,
+            graphRunID: "compendium-run",
+            title: $0.title,
+            dependencyNodeIDs: $0.dependencyNodeIDs,
+            state: $0.dependencyNodeIDs.isEmpty ? .ready : .pending,
+            updatedAt: time
+        )
+    }
+    let run = GraphRun(
+        id: "compendium-run",
+        graphID: "dose-compendium",
+        nodeIDs: nodeIDs,
+        createdAt: time,
+        updatedAt: time
+    )
+    let projection = GraphExecutionProjection(
+        runID: run.id,
+        streamVersion: UInt64(1 + definitions.count),
+        run: run,
+        nodes: nodes,
+        graphDefinitionVersion: "1",
+        graphDefinitionDigest: digest
+    )
+    return SchedulingFixture(
+        definition: GraphSchedulingDefinition(
+            graphID: run.graphID,
+            version: "1",
+            digest: digest,
+            nodes: definitions
+        ),
+        projection: projection,
+        reconciled: ExecutionReconciliationResult(
+            run: run,
+            nodes: nodes,
+            attempts: []
+        ),
+        policy: GraphSchedulerPolicy(
+            policyID: "compendium-policy",
+            version: "1",
+            retryPolicy: GraphRetryPolicy(
+                maximumAttempts: 3,
+                retryableFailureCategories: ["execution_failure"]
+            )
+        ),
+        executors: definitions.map {
+            GraphExecutorCapabilities(
+                executorID: "executor-\($0.id)",
+                capabilityIdentity: "capability-\($0.id)",
+                capabilities: $0.requiredCapabilities
+            )
+        },
+        failureCategories: [:],
+        time: time,
+        digest: digest
+    )
+}
+
+private func baseHistory(
+    fixture: SchedulingFixture
+) -> [GraphExecutionEventEnvelope] {
+    var events = [
+        GraphExecutionEventEnvelope(
+            id: "compendium-run-created",
+            runID: "compendium-run",
+            streamSequence: 1,
+            occurredAt: fixture.time,
+            recordedAt: fixture.time,
+            producer: graphTestProducer,
+            payload: .runCreated(
+                GraphRunCreatedPayload(
+                    graphID: fixture.definition.graphID,
+                    graphDefinitionVersion: fixture.definition.version,
+                    graphDefinitionDigest: fixture.digest,
+                    nodeIDs: fixture.definition.nodes.map(\.id)
+                )
+            )
+        ),
+    ]
+    for (index, node) in fixture.definition.nodes.enumerated() {
+        events.append(
+            GraphExecutionEventEnvelope(
+                id: "compendium-node-\(node.id)",
+                runID: "compendium-run",
+                nodeID: node.id,
+                streamSequence: UInt64(index + 2),
+                occurredAt: fixture.time,
+                recordedAt: fixture.time,
+                producer: graphTestProducer,
+                payload: .nodeRegistered(
+                    GraphNodeRegisteredPayload(
+                        title: node.title,
+                        dependencyNodeIDs: node.dependencyNodeIDs
+                    )
+                )
+            )
+        )
+    }
+    return events
+}

--- a/Tests/OpenIslandCoreTests/GraphSchedulingDurabilityInvariantTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphSchedulingDurabilityInvariantTests.swift
@@ -1,0 +1,1197 @@
+import Foundation
+import XCTest
+@testable import OpenIslandCore
+
+final class GraphSchedulingDurabilityInvariantTests: XCTestCase {
+    func testCompendiumFixtureAdvancesExactlyOneRunnableNodeAtATime()
+        async throws
+    {
+        let definition = try loadCompendiumSchedulingDefinition()
+        let store = InMemoryGraphExecutionEventStore()
+        let runID = "compendium-success"
+        let time = Date(timeIntervalSince1970: 400_000)
+        let base = compendiumSchedulingBaseEvents(
+            definition: definition,
+            runID: runID,
+            occurredAt: time
+        )
+        _ = try await store.append(base, to: runID, expectedVersion: 0)
+        let repository = DefaultGraphSchedulingRepository(eventStore: store)
+        let executors = compendiumExecutorCapabilities()
+        let nodeOrder = ["architect", "researcher", "graph", "reviewer"]
+        var version = UInt64(base.count)
+
+        for (index, nodeID) in nodeOrder.enumerated() {
+            let logicalTime = time.addingTimeInterval(Double(index * 10))
+            let evaluationExpectedVersion = version
+            let evaluation = try await repository.evaluateAndAppend(
+                evaluationRequest(
+                    runID: runID,
+                    expectedVersion: evaluationExpectedVersion,
+                    definition: definition,
+                    logicalTime: logicalTime,
+                    executors: executors
+                )
+            )
+            version = evaluation.appendResult.newVersion
+            XCTAssertEqual(
+                runnableNodeIDs(evaluation.projection),
+                [nodeID]
+            )
+            for blockedNodeID in nodeOrder.dropFirst(index + 1) {
+                XCTAssertFalse(
+                    runnableNodeIDs(evaluation.projection)
+                        .contains(blockedNodeID)
+                )
+            }
+
+            let duplicate = try await repository.evaluateAndAppend(
+                evaluationRequest(
+                    runID: runID,
+                    expectedVersion: evaluationExpectedVersion,
+                    definition: definition,
+                    logicalTime: logicalTime,
+                    executors: executors
+                )
+            )
+            XCTAssertEqual(duplicate.appendResult.appendedCount, 0)
+
+            let evaluationID = try latestEvaluationID(
+                evaluation.projection
+            )
+            let executor = try XCTUnwrap(
+                executors.first {
+                    $0.satisfies(
+                        definition.nodes.first { $0.id == nodeID }!
+                            .requiredCapabilities
+                    )
+                }
+            )
+            let claimed = try await repository.attemptClaim(
+                GraphExecutorClaimRequest(
+                    runID: runID,
+                    nodeID: nodeID,
+                    claimID: "claim-\(nodeID)",
+                    executor: executor,
+                    evaluationID: evaluationID,
+                    expectedVersion: version,
+                    logicalTime: logicalTime,
+                    leaseDurationSeconds: 60,
+                    producer: graphTestProducer,
+                    recordedAt: logicalTime
+                )
+            )
+            version = claimed.appendResult.newVersion
+            let claimedProjection = try await projection(
+                store,
+                runID: runID
+            )
+            let attempt = try XCTUnwrap(
+                claimedProjection.attempts.first { $0.nodeID == nodeID }
+            )
+            let completion = try await appendAttemptTerminal(
+                store: store,
+                runID: runID,
+                nodeID: nodeID,
+                attemptID: attempt.id,
+                expectedVersion: version,
+                time: logicalTime.addingTimeInterval(1),
+                payload: .attemptCompleted(
+                    GraphAttemptTerminalPayload(reason: "fixture complete")
+                )
+            )
+            version = completion.newVersion
+            let claim = try XCTUnwrap(claimed.claim)
+            let released = try await repository.releaseClaim(
+                GraphExecutorClaimReleaseRequest(
+                    runID: runID,
+                    claimID: claim.id,
+                    executorID: claim.executorID,
+                    expectedGeneration: claim.leaseGeneration,
+                    expectedVersion: version,
+                    logicalTime: logicalTime.addingTimeInterval(2),
+                    producer: graphTestProducer,
+                    recordedAt: logicalTime.addingTimeInterval(2)
+                )
+            )
+            version = released.appendResult.newVersion
+        }
+
+        let projected = try await projection(store, runID: runID)
+        let reconciled = try XCTUnwrap(
+            GraphExecutionProjectionReconciler.reconcile(
+                projection: projected,
+                evidenceOutcome: .available(GraphProcessEvidence()),
+                observedAt: time.addingTimeInterval(100)
+            )
+        )
+        XCTAssertEqual(reconciled.run.state, .completed)
+        XCTAssertTrue(reconciled.nodes.allSatisfy { $0.state == .completed })
+        XCTAssertEqual(
+            projected.scheduling.claims.map(\.status),
+            [.released, .released, .released, .released]
+        )
+    }
+
+    func testRetryExhaustionAndCancellationBlockDownstreamFixedPoint()
+        async throws
+    {
+        let definition = try loadCompendiumSchedulingDefinition()
+        let time = Date(timeIntervalSince1970: 410_000)
+        let failure = try await makeCompendiumContext(
+            runID: "compendium-failure",
+            definition: definition,
+            time: time
+        )
+        let evaluation = try await failure.repository.evaluateAndAppend(
+            evaluationRequest(
+                runID: failure.runID,
+                expectedVersion: failure.version,
+                definition: definition,
+                logicalTime: time,
+                executors: failure.executors,
+                maximumAttempts: 1
+            )
+        )
+        let architect = try XCTUnwrap(
+            failure.executors.first { $0.executorID == "architect-worker" }
+        )
+        let claimed = try await failure.repository.attemptClaim(
+            GraphExecutorClaimRequest(
+                runID: failure.runID,
+                nodeID: "architect",
+                claimID: "failed-architect-claim",
+                executor: architect,
+                evaluationID: try latestEvaluationID(evaluation.projection),
+                expectedVersion: evaluation.appendResult.newVersion,
+                logicalTime: time,
+                leaseDurationSeconds: 60,
+                producer: graphTestProducer,
+                recordedAt: time
+            )
+        )
+        let claimedProjection = try await projection(
+            failure.store,
+            runID: failure.runID
+        )
+        let failedAttempt = try XCTUnwrap(claimedProjection.attempts.first)
+        let terminal = try await appendAttemptTerminal(
+            store: failure.store,
+            runID: failure.runID,
+            nodeID: "architect",
+            attemptID: failedAttempt.id,
+            expectedVersion: claimed.appendResult.newVersion,
+            time: time.addingTimeInterval(1),
+            payload: .attemptFailed(
+                GraphAttemptTerminalPayload(reason: "non-retryable")
+            )
+        )
+        let exhausted = try await failure.repository.evaluateAndAppend(
+            evaluationRequest(
+                runID: failure.runID,
+                expectedVersion: terminal.newVersion,
+                definition: definition,
+                logicalTime: time.addingTimeInterval(2),
+                executors: failure.executors,
+                maximumAttempts: 1,
+                failures: [failedAttempt.id: "transient"]
+            )
+        )
+        XCTAssertTrue(exhausted.projection.scheduling.retries.isEmpty)
+        XCTAssertEqual(
+            exhausted.projection.scheduling.records.filter {
+                $0.eventType
+                    == GraphExecutionEventType
+                        .dependencyFailurePropagated.rawValue
+            }.count,
+            3
+        )
+        XCTAssertTrue(
+            exhausted.projection.scheduling.records.contains {
+                $0.nodeID == "architect" && $0.reason == .retryExhausted
+            }
+        )
+        let failedReconciliation = try XCTUnwrap(
+            GraphExecutionProjectionReconciler.reconcile(
+                projection: exhausted.projection,
+                evidenceOutcome: .available(GraphProcessEvidence()),
+                observedAt: time.addingTimeInterval(2)
+            )
+        )
+        XCTAssertEqual(
+            Dictionary(
+                uniqueKeysWithValues: failedReconciliation.nodes.map {
+                    ($0.id, $0.state)
+                }
+            ),
+            [
+                "architect": .failed,
+                "researcher": .blocked,
+                "graph": .blocked,
+                "reviewer": .blocked,
+            ]
+        )
+
+        let cancelled = try await makeCompendiumContext(
+            runID: "compendium-cancelled",
+            definition: definition,
+            time: time
+        )
+        let cancellation = try await cancelled.repository
+            .requestCancellation(
+                GraphCancellationCommandRequest(
+                    runID: cancelled.runID,
+                    nodeID: "architect",
+                    requestID: "cancel-compendium",
+                    requestedBy: "operator",
+                    expectedVersion: cancelled.version,
+                    logicalTime: time,
+                    producer: graphTestProducer,
+                    recordedAt: time
+                )
+            )
+        let terminalCancellation = try await cancelled.repository
+            .declareCancellationTerminal(
+                GraphCancellationTerminalRequest(
+                    runID: cancelled.runID,
+                    requestID: "cancel-compendium",
+                    expectedVersion: cancellation.appendResult.newVersion,
+                    logicalTime: time.addingTimeInterval(1),
+                    producer: graphTestProducer,
+                    recordedAt: time.addingTimeInterval(1)
+                )
+            )
+        let afterCancellation = try await cancelled.repository
+            .evaluateAndAppend(
+                evaluationRequest(
+                    runID: cancelled.runID,
+                    expectedVersion:
+                        terminalCancellation.appendResult.newVersion,
+                    definition: definition,
+                    logicalTime: time.addingTimeInterval(2),
+                    executors: cancelled.executors
+                )
+            )
+        XCTAssertTrue(runnableNodeIDs(afterCancellation.projection).isEmpty)
+        let cancelledReconciliation = try XCTUnwrap(
+            GraphExecutionProjectionReconciler.reconcile(
+                projection: afterCancellation.projection,
+                evidenceOutcome: .available(GraphProcessEvidence()),
+                observedAt: time.addingTimeInterval(2)
+            )
+        )
+        XCTAssertEqual(
+            cancelledReconciliation.nodes.first {
+                $0.id == "architect"
+            }?.state,
+            .cancelled
+        )
+        XCTAssertTrue(
+            cancelledReconciliation.nodes.filter {
+                $0.id != "architect"
+            }.allSatisfy { $0.state == .blocked }
+        )
+    }
+
+    func testSQLiteCompetingClaimsAndRestartPreserveOwnershipAndRetry()
+        async throws
+    {
+        let database = try TemporarySchedulingDatabase()
+        defer { database.remove() }
+        let definition = try loadCompendiumSchedulingDefinition()
+        let runID = "compendium-sqlite"
+        let time = Date(timeIntervalSince1970: 420_000)
+        let firstStore = try SQLiteGraphExecutionStore(
+            databasePath: database.path
+        )
+        let base = compendiumSchedulingBaseEvents(
+            definition: definition,
+            runID: runID,
+            occurredAt: time
+        )
+        _ = try await firstStore.append(
+            base,
+            to: runID,
+            expectedVersion: 0
+        )
+        let firstRepository = DefaultGraphSchedulingRepository(
+            eventStore: firstStore
+        )
+        let evaluation = try await firstRepository.evaluateAndAppend(
+            evaluationRequest(
+                runID: runID,
+                expectedVersion: UInt64(base.count),
+                definition: definition,
+                logicalTime: time,
+                executors: compendiumExecutorCapabilities(),
+                initialBackoff: 30
+            )
+        )
+        let evaluationID = try latestEvaluationID(evaluation.projection)
+        let expectedVersion = evaluation.appendResult.newVersion
+        let secondStore = try SQLiteGraphExecutionStore(
+            databasePath: database.path
+        )
+        let repositories = [
+            DefaultGraphSchedulingRepository(eventStore: firstStore),
+            DefaultGraphSchedulingRepository(eventStore: secondStore),
+        ]
+        let owners = [
+            GraphExecutorCapabilities(
+                executorID: "worker-a",
+                capabilityIdentity: "compendium-architect-v1",
+                capabilities: [
+                    "compendium-architecture",
+                    "web-research-planning",
+                ],
+                hostID: "host-a"
+            ),
+            GraphExecutorCapabilities(
+                executorID: "worker-b",
+                capabilityIdentity: "compendium-architect-v1",
+                capabilities: [
+                    "compendium-architecture",
+                    "web-research-planning",
+                ],
+                hostID: "host-b"
+            ),
+        ]
+
+        let outcomes = await withTaskGroup(
+            of: Result<GraphExecutorClaimResult, Error>.self
+        ) { group in
+            for index in repositories.indices {
+                group.addTask {
+                    do {
+                        return .success(
+                            try await repositories[index].attemptClaim(
+                                GraphExecutorClaimRequest(
+                                    runID: runID,
+                                    nodeID: "architect",
+                                    claimID: "sqlite-claim-\(index)",
+                                    executor: owners[index],
+                                    evaluationID: evaluationID,
+                                    expectedVersion: expectedVersion,
+                                    logicalTime: time,
+                                    leaseDurationSeconds: 20,
+                                    producer: graphTestProducer,
+                                    recordedAt: time
+                                )
+                            )
+                        )
+                    } catch {
+                        return .failure(error)
+                    }
+                }
+            }
+            var results: [Result<GraphExecutorClaimResult, Error>] = []
+            for await result in group { results.append(result) }
+            return results
+        }
+        let winners = outcomes.compactMap { try? $0.get() }
+            .filter { $0.outcome == .granted }
+        XCTAssertEqual(winners.count, 1)
+        let winner = try XCTUnwrap(winners.first)
+        let winnerClaim = try XCTUnwrap(winner.claim)
+
+        let restartedStore = try SQLiteGraphExecutionStore(
+            databasePath: database.path
+        )
+        let restartedProjection = try await projection(
+            restartedStore,
+            runID: runID
+        )
+        XCTAssertEqual(
+            restartedProjection.scheduling.activeClaim(
+                nodeID: "architect",
+                at: time.addingTimeInterval(1)
+            ),
+            winnerClaim
+        )
+
+        let restartedRepository = DefaultGraphSchedulingRepository(
+            eventStore: restartedStore
+        )
+        let renewed = try await restartedRepository.renewLease(
+            GraphExecutorLeaseRenewalRequest(
+                runID: runID,
+                claimID: winnerClaim.id,
+                executorID: winnerClaim.executorID,
+                expectedGeneration: 1,
+                expectedVersion: winner.appendResult.newVersion,
+                logicalTime: time.addingTimeInterval(5),
+                leaseDurationSeconds: 20,
+                producer: graphTestProducer,
+                recordedAt: time.addingTimeInterval(5)
+            )
+        )
+        let renewedClaim = try XCTUnwrap(
+            renewed.projection.scheduling.claims.first {
+                $0.claim.id == winnerClaim.id
+            }?.claim
+        )
+        XCTAssertEqual(renewedClaim.leaseGeneration, 2)
+
+        let takeoverOwner = GraphExecutorCapabilities(
+            executorID: "worker-takeover",
+            capabilityIdentity: "compendium-architect-v1",
+            capabilities: [
+                "compendium-architecture",
+                "web-research-planning",
+            ],
+            hostID: "host-takeover"
+        )
+        let takeover = try await restartedRepository.attemptClaim(
+            GraphExecutorClaimRequest(
+                runID: runID,
+                nodeID: "architect",
+                claimID: "sqlite-takeover",
+                executor: takeoverOwner,
+                evaluationID: evaluationID,
+                expectedVersion: renewed.appendResult.newVersion,
+                logicalTime: time.addingTimeInterval(30),
+                leaseDurationSeconds: 20,
+                producer: graphTestProducer,
+                recordedAt: time.addingTimeInterval(30)
+            )
+        )
+        XCTAssertEqual(takeover.claim?.attemptOrdinal, 1)
+
+        await XCTAssertThrowsErrorAsync {
+            try await restartedRepository.renewLease(
+                GraphExecutorLeaseRenewalRequest(
+                    runID: runID,
+                    claimID: winnerClaim.id,
+                    executorID: winnerClaim.executorID,
+                    expectedGeneration: 2,
+                    expectedVersion: takeover.appendResult.newVersion,
+                    logicalTime: time.addingTimeInterval(31),
+                    leaseDurationSeconds: 20,
+                    producer: graphTestProducer,
+                    recordedAt: time.addingTimeInterval(31)
+                )
+            )
+        } verify: { error in
+            guard case let GraphSchedulingRepositoryError.conflict(
+                reason,
+                _,
+                _,
+                _
+            ) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(reason, .claimAlreadyReleased)
+        }
+
+        let takeoverClaim = try XCTUnwrap(takeover.claim)
+        let released = try await restartedRepository.releaseClaim(
+            GraphExecutorClaimReleaseRequest(
+                runID: runID,
+                claimID: takeoverClaim.id,
+                executorID: takeoverClaim.executorID,
+                expectedGeneration: 1,
+                expectedVersion: takeover.appendResult.newVersion,
+                logicalTime: time.addingTimeInterval(32),
+                producer: graphTestProducer,
+                recordedAt: time.addingTimeInterval(32)
+            )
+        )
+        let attempt = try XCTUnwrap(
+            released.projection.attempts.first {
+                $0.nodeID == "architect"
+            }
+        )
+        let failed = try await appendAttemptTerminal(
+            store: restartedStore,
+            runID: runID,
+            nodeID: "architect",
+            attemptID: attempt.id,
+            expectedVersion: released.appendResult.newVersion,
+            time: time.addingTimeInterval(33),
+            payload: .attemptFailed(
+                GraphAttemptTerminalPayload(reason: "transient")
+            )
+        )
+        let retry = try await restartedRepository.evaluateAndAppend(
+            evaluationRequest(
+                runID: runID,
+                expectedVersion: failed.newVersion,
+                definition: definition,
+                logicalTime: time.addingTimeInterval(34),
+                executors: compendiumExecutorCapabilities(),
+                initialBackoff: 30,
+                failures: [attempt.id: "transient"]
+            )
+        )
+        let recordedRetry = try XCTUnwrap(
+            retry.projection.scheduling.retries.first
+        )
+        XCTAssertEqual(recordedRetry.nextAttemptOrdinal, 2)
+
+        let retryRestart = try SQLiteGraphExecutionStore(
+            databasePath: database.path
+        )
+        let restartedRetryProjection = try await projection(
+            retryRestart,
+            runID: runID
+        )
+        XCTAssertEqual(
+            restartedRetryProjection.scheduling.retries.first,
+            recordedRetry
+        )
+        XCTAssertEqual(
+            restartedRetryProjection.scheduling.activeClaim(
+                nodeID: "architect",
+                at: time.addingTimeInterval(34)
+            ),
+            nil
+        )
+    }
+
+    func testClaimCrashBoundariesLatestEvaluationAndGeneratedCollisions()
+        async throws
+    {
+        let definition = try loadCompendiumSchedulingDefinition()
+        let context = try await makeCompendiumContext(
+            runID: "compendium-claim-boundaries",
+            definition: definition,
+            time: Date(timeIntervalSince1970: 425_000)
+        )
+        let firstEvaluation = try await context.repository.evaluateAndAppend(
+            evaluationRequest(
+                runID: context.runID,
+                expectedVersion: context.version,
+                definition: definition,
+                logicalTime: context.time,
+                executors: context.executors
+            )
+        )
+        let firstEvaluationID = try latestEvaluationID(
+            firstEvaluation.projection
+        )
+        let secondEvaluation = try await context.repository.evaluateAndAppend(
+            evaluationRequest(
+                runID: context.runID,
+                expectedVersion: firstEvaluation.appendResult.newVersion,
+                definition: definition,
+                logicalTime: context.time.addingTimeInterval(1),
+                executors: context.executors
+            )
+        )
+        XCTAssertTrue(
+            secondEvaluation.projection.scheduling.claims.isEmpty,
+            "A crash before the claim append leaves no ownership fact."
+        )
+        let owner = try XCTUnwrap(
+            context.executors.first {
+                $0.executorID == "architect-worker"
+            }
+        )
+        let restarted = DefaultGraphSchedulingRepository(
+            eventStore: context.store
+        )
+
+        await XCTAssertThrowsErrorAsync {
+            try await restarted.attemptClaim(
+                GraphExecutorClaimRequest(
+                    runID: context.runID,
+                    nodeID: "architect",
+                    claimID: "stale-evaluation-claim",
+                    executor: owner,
+                    evaluationID: firstEvaluationID,
+                    expectedVersion:
+                        secondEvaluation.appendResult.newVersion,
+                    logicalTime: context.time.addingTimeInterval(1),
+                    leaseDurationSeconds: 60,
+                    producer: graphTestProducer,
+                    recordedAt: context.time.addingTimeInterval(1)
+                )
+            )
+        } verify: { error in
+            assertSchedulingRepositoryConflict(
+                error,
+                .schedulerEvaluationMissing
+            )
+        }
+
+        let request = GraphExecutorClaimRequest(
+            runID: context.runID,
+            nodeID: "architect",
+            claimID: "durable-claim",
+            executor: owner,
+            evaluationID: try latestEvaluationID(
+                secondEvaluation.projection
+            ),
+            expectedVersion: secondEvaluation.appendResult.newVersion,
+            logicalTime: context.time.addingTimeInterval(1),
+            leaseDurationSeconds: 60,
+            producer: graphTestProducer,
+            recordedAt: context.time.addingTimeInterval(1)
+        )
+        let claimed = try await restarted.attemptClaim(request)
+        let afterCrash = DefaultGraphSchedulingRepository(
+            eventStore: context.store
+        )
+        let redelivery = try await afterCrash.attemptClaim(request)
+        XCTAssertEqual(redelivery.outcome, .deduplicated)
+        XCTAssertEqual(redelivery.claim, claimed.claim)
+
+        let mutations: [GraphExecutorClaimRequest] = [
+            GraphExecutorClaimRequest(
+                runID: context.runID,
+                nodeID: "architect",
+                claimID: "durable-claim",
+                executor: GraphExecutorCapabilities(
+                    executorID: owner.executorID,
+                    capabilityIdentity: "different-capability",
+                    capabilities: owner.capabilities,
+                    hostID: owner.hostID
+                ),
+                evaluationID: request.evaluationID,
+                expectedVersion: claimed.appendResult.newVersion,
+                logicalTime: request.logicalTime,
+                leaseDurationSeconds: 60,
+                producer: graphTestProducer,
+                recordedAt: request.recordedAt
+            ),
+            GraphExecutorClaimRequest(
+                runID: context.runID,
+                nodeID: "architect",
+                claimID: "durable-claim",
+                executor: GraphExecutorCapabilities(
+                    executorID: owner.executorID,
+                    capabilityIdentity: owner.capabilityIdentity,
+                    capabilities: owner.capabilities,
+                    hostID: "different-host"
+                ),
+                evaluationID: request.evaluationID,
+                expectedVersion: claimed.appendResult.newVersion,
+                logicalTime: request.logicalTime,
+                leaseDurationSeconds: 60,
+                producer: graphTestProducer,
+                recordedAt: request.recordedAt
+            ),
+            GraphExecutorClaimRequest(
+                runID: context.runID,
+                nodeID: "architect",
+                claimID: "durable-claim",
+                executor: owner,
+                evaluationID: request.evaluationID,
+                expectedVersion: claimed.appendResult.newVersion,
+                logicalTime: request.logicalTime.addingTimeInterval(1),
+                leaseDurationSeconds: 60,
+                producer: graphTestProducer,
+                recordedAt: request.recordedAt
+            ),
+            GraphExecutorClaimRequest(
+                runID: context.runID,
+                nodeID: "architect",
+                claimID: "durable-claim",
+                executor: owner,
+                evaluationID: request.evaluationID,
+                expectedVersion: claimed.appendResult.newVersion,
+                logicalTime: request.logicalTime,
+                leaseDurationSeconds: 61,
+                producer: graphTestProducer,
+                recordedAt: request.recordedAt
+            ),
+        ]
+        for mutation in mutations {
+            await XCTAssertThrowsErrorAsync {
+                try await afterCrash.attemptClaim(mutation)
+            } verify: { error in
+                assertSchedulingRepositoryConflict(
+                    error,
+                    .claimIdentityCollision
+                )
+            }
+        }
+    }
+
+    func testFutureSchedulingEventsSnapshotsAndStaleFixtureRemainCompatible()
+        async throws
+    {
+        let definition = try loadCompendiumSchedulingDefinition()
+        let time = Date(timeIntervalSince1970: 430_000)
+        let runID = "future-scheduling"
+        var events = compendiumSchedulingBaseEvents(
+            definition: definition,
+            runID: runID,
+            occurredAt: time
+        )
+        events.append(
+            GraphExecutionEventEnvelope(
+                id: "future-scheduler-event",
+                runID: runID,
+                streamSequence: UInt64(events.count + 1),
+                occurredAt: time,
+                recordedAt: time,
+                producer: graphTestProducer,
+                payloadVersion: 99,
+                payload: .unknown(
+                    eventType: "graph.scheduler.quantum.reserved",
+                    body: .object(["reservation": .string("future")])
+                )
+            )
+        )
+        let futureProjection = try GraphExecutionProjector.replay(
+            runID: runID,
+            events: events
+        ).projection
+        XCTAssertEqual(futureProjection.unknownEvents.count, 1)
+        XCTAssertTrue(futureProjection.scheduling.records.isEmpty)
+
+        let encoded = try JSONEncoder().encode(futureProjection)
+        var object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoded)
+                as? [String: Any]
+        )
+        object.removeValue(forKey: "scheduling")
+        let legacyData = try JSONSerialization.data(withJSONObject: object)
+        let legacyProjection = try JSONDecoder().decode(
+            GraphExecutionProjection.self,
+            from: legacyData
+        )
+        XCTAssertEqual(
+            legacyProjection.scheduling,
+            GraphSchedulingProjection()
+        )
+
+        let stale = try loadStaleCompendiumFixture()
+        let staleProjection = try GraphExecutionProjector.replay(
+            runID: stale.run.id,
+            events: staleCompendiumEvents(from: stale)
+        ).projection
+        let staleReconciled = try XCTUnwrap(
+            GraphExecutionProjectionReconciler.reconcile(
+                projection: staleProjection,
+                evidenceOutcome: .available(GraphProcessEvidence()),
+                observedAt: stale.observedAt
+            )
+        )
+        let decision = GraphScheduler.evaluate(
+            GraphSchedulingInput(
+                definition: definition,
+                projectedState: staleProjection,
+                reconciledState: staleReconciled,
+                policy: schedulingPolicy(),
+                logicalTime: stale.observedAt,
+                availableExecutors: compendiumExecutorCapabilities()
+            )
+        )
+        XCTAssertTrue(
+            decision.reasonsByNodeID.values.allSatisfy {
+                $0 == .graphDefinitionMismatch
+            }
+        )
+    }
+
+    func testStructuredSchedulingInspectionIsByteStableAndVersioned()
+        async throws
+    {
+        let definition = try loadCompendiumSchedulingDefinition()
+        let context = try await makeCompendiumContext(
+            runID: "compendium-inspection",
+            definition: definition,
+            time: Date(timeIntervalSince1970: 440_000)
+        )
+        let evaluation = try await context.repository.evaluateAndAppend(
+            evaluationRequest(
+                runID: context.runID,
+                expectedVersion: context.version,
+                definition: definition,
+                logicalTime: context.time,
+                executors: context.executors
+            )
+        )
+        let owner = try XCTUnwrap(
+            context.executors.first {
+                $0.executorID == "architect-worker"
+            }
+        )
+        let claim = try await context.repository.attemptClaim(
+            GraphExecutorClaimRequest(
+                runID: context.runID,
+                nodeID: "architect",
+                claimID: "inspection-claim",
+                executor: owner,
+                evaluationID: try latestEvaluationID(
+                    evaluation.projection
+                ),
+                expectedVersion: evaluation.appendResult.newVersion,
+                logicalTime: context.time,
+                leaseDurationSeconds: 60,
+                producer: graphTestProducer,
+                recordedAt: context.time
+            )
+        )
+        let cancellation = try await context.repository.requestCancellation(
+            GraphCancellationCommandRequest(
+                runID: context.runID,
+                nodeID: "architect",
+                requestID: "inspection-cancellation",
+                requestedBy: "operator",
+                expectedVersion: claim.appendResult.newVersion,
+                logicalTime: context.time.addingTimeInterval(1),
+                producer: graphTestProducer,
+                recordedAt: context.time.addingTimeInterval(1)
+            )
+        )
+        _ = try await context.repository.recordTimeout(
+            GraphTimeoutCommandRequest(
+                decision: GraphTimeoutDecision(
+                    timeoutID: "inspection-timeout",
+                    runID: context.runID,
+                    nodeID: "graph",
+                    attemptID: nil,
+                    claimID: nil,
+                    kind: .claimAcquisition,
+                    deadline: context.time.addingTimeInterval(2),
+                    declaredAt: context.time.addingTimeInterval(2)
+                ),
+                expectedVersion: cancellation.appendResult.newVersion,
+                producer: graphTestProducer,
+                recordedAt: context.time.addingTimeInterval(2)
+            )
+        )
+        let stdout = SchedulingCLISink()
+        let stderr = SchedulingCLISink()
+        let runner = GraphCLICommandRunner(
+            inspector: DefaultGraphTemporalInspector(
+                readStore: context.store,
+                snapshotStore: InMemoryGraphExecutionSnapshotStore()
+            ),
+            stdout: stdout,
+            stderr: stderr
+        )
+        let currentArguments = [
+            "graph",
+            "inspect",
+            context.runID,
+            "--output",
+            "json",
+            "--schema-version",
+            "2",
+        ]
+        let firstCode = await runner.run(arguments: currentArguments)
+        XCTAssertEqual(firstCode, .success)
+        let first = stdout.consume()
+        let secondCode = await runner.run(arguments: currentArguments)
+        XCTAssertEqual(secondCode, .success)
+        let second = stdout.consume()
+        XCTAssertEqual(first, second)
+        let current = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(first.utf8))
+                as? [String: Any]
+        )
+        XCTAssertEqual(current["schemaVersion"] as? Int, 2)
+        let currentResult = try XCTUnwrap(
+            current["result"] as? [String: Any]
+        )
+        let scheduling = try XCTUnwrap(
+            currentResult["scheduling"] as? [String: Any]
+        )
+        XCTAssertNotNil(scheduling["currentPolicy"])
+        XCTAssertNotNil(scheduling["reasonCodes"])
+        XCTAssertEqual(
+            (scheduling["activeClaims"] as? [[String: Any]])?.count,
+            1
+        )
+        XCTAssertEqual(
+            (scheduling["claimHistory"] as? [[String: Any]])?.count,
+            1
+        )
+        XCTAssertEqual(
+            (scheduling["pendingCancellations"]
+                as? [[String: Any]])?.count,
+            1
+        )
+        XCTAssertEqual(
+            (scheduling["timeouts"] as? [[String: Any]])?.count,
+            1
+        )
+
+        let explainCode = await runner.run(
+            arguments: [
+                "graph",
+                "explain",
+                context.runID,
+                "architect",
+                "--output",
+                "json",
+                "--schema-version",
+                "2",
+            ]
+        )
+        XCTAssertEqual(explainCode, .success)
+        let explanation = try XCTUnwrap(
+            JSONSerialization.jsonObject(
+                with: Data(stdout.consume().utf8)
+            ) as? [String: Any]
+        )
+        let explanationResult = try XCTUnwrap(
+            explanation["result"] as? [String: Any]
+        )
+        XCTAssertEqual(
+            explanationResult["schedulerReasons"] as? [String],
+            [
+                "cancellation_pending",
+                "claim_granted",
+                "dependencies_satisfied",
+            ]
+        )
+
+        let legacyCode = await runner.run(
+            arguments: [
+                "graph",
+                "inspect",
+                context.runID,
+                "--output",
+                "json",
+                "--schema-version",
+                "1",
+            ]
+        )
+        XCTAssertEqual(legacyCode, .success)
+        let legacy = try XCTUnwrap(
+            JSONSerialization.jsonObject(
+                with: Data(stdout.consume().utf8)
+            ) as? [String: Any]
+        )
+        XCTAssertEqual(legacy["schemaVersion"] as? Int, 1)
+        let legacyResult = try XCTUnwrap(
+            legacy["result"] as? [String: Any]
+        )
+        XCTAssertNil(legacyResult["scheduling"])
+        XCTAssertTrue(stderr.consume().isEmpty)
+    }
+}
+
+private struct CompendiumTestContext {
+    let runID: String
+    let time: Date
+    let version: UInt64
+    let store: InMemoryGraphExecutionEventStore
+    let repository: DefaultGraphSchedulingRepository
+    let executors: [GraphExecutorCapabilities]
+}
+
+private func makeCompendiumContext(
+    runID: String,
+    definition: GraphSchedulingDefinition,
+    time: Date
+) async throws -> CompendiumTestContext {
+    let store = InMemoryGraphExecutionEventStore()
+    let events = compendiumSchedulingBaseEvents(
+        definition: definition,
+        runID: runID,
+        occurredAt: time
+    )
+    let appended = try await store.append(
+        events,
+        to: runID,
+        expectedVersion: 0
+    )
+    return CompendiumTestContext(
+        runID: runID,
+        time: time,
+        version: appended.newVersion,
+        store: store,
+        repository: DefaultGraphSchedulingRepository(eventStore: store),
+        executors: compendiumExecutorCapabilities()
+    )
+}
+
+private func schedulingPolicy(
+    maximumAttempts: Int = 3,
+    initialBackoff: UInt64 = 0
+) -> GraphSchedulerPolicy {
+    GraphSchedulerPolicy(
+        policyID: "compendium-scheduling-policy",
+        version: "1",
+        retryPolicy: GraphRetryPolicy(
+            maximumAttempts: maximumAttempts,
+            retryableFailureCategories: ["transient"],
+            nonRetryableFailureCategories: ["invalid_output"],
+            initialBackoffSeconds: initialBackoff,
+            backoffMultiplier: 2,
+            maximumBackoffSeconds: 300,
+            jitterBasisPoints: 500,
+            jitterSeed: "compendium-fixture"
+        ),
+        defaultLeaseDurationSeconds: 60,
+        claimAcquisitionTimeoutSeconds: 30,
+        attemptExecutionTimeoutSeconds: 3_600,
+        cancellationAcknowledgementTimeoutSeconds: 30
+    )
+}
+
+private func evaluationRequest(
+    runID: String,
+    expectedVersion: UInt64,
+    definition: GraphSchedulingDefinition,
+    logicalTime: Date,
+    executors: [GraphExecutorCapabilities],
+    maximumAttempts: Int = 3,
+    initialBackoff: UInt64 = 0,
+    failures: [String: String] = [:]
+) -> GraphSchedulerEvaluationRequest {
+    GraphSchedulerEvaluationRequest(
+        runID: runID,
+        expectedVersion: expectedVersion,
+        definition: definition,
+        policy: schedulingPolicy(
+            maximumAttempts: maximumAttempts,
+            initialBackoff: initialBackoff
+        ),
+        logicalTime: logicalTime,
+        availableExecutors: executors,
+        failureCategoriesByAttemptID: failures,
+        producer: graphTestProducer,
+        recordedAt: logicalTime
+    )
+}
+
+private func latestEvaluationID(
+    _ projection: GraphExecutionProjection
+) throws -> String {
+    try XCTUnwrap(
+        projection.scheduling.records.last {
+            $0.eventType
+                == GraphExecutionEventType.schedulerCycleCompleted.rawValue
+        }?.evaluationID
+    )
+}
+
+private func runnableNodeIDs(
+    _ projection: GraphExecutionProjection
+) -> [String] {
+    guard let evaluationID = projection.scheduling.records.last(where: {
+        $0.eventType
+            == GraphExecutionEventType.schedulerCycleCompleted.rawValue
+    })?.evaluationID else {
+        return []
+    }
+    return projection.scheduling.records.filter {
+        $0.evaluationID == evaluationID
+            && $0.eventType
+                == GraphExecutionEventType.nodeBecameRunnable.rawValue
+    }.compactMap(\.nodeID).sorted()
+}
+
+private func projection(
+    _ store: any GraphExecutionEventStore,
+    runID: String
+) async throws -> GraphExecutionProjection {
+    let stream = try await store.read(runID: runID, afterVersion: 0)
+    return try GraphExecutionProjector.replay(
+        runID: runID,
+        events: stream.events
+    ).projection
+}
+
+private func appendAttemptTerminal(
+    store: any GraphExecutionEventStore,
+    runID: String,
+    nodeID: String,
+    attemptID: String,
+    expectedVersion: UInt64,
+    time: Date,
+    payload: GraphExecutionEventPayload
+) async throws -> GraphExecutionAppendResult {
+    let events = [
+        GraphExecutionEventEnvelope(
+            id: "\(attemptID)-starting-\(expectedVersion)",
+            runID: runID,
+            nodeID: nodeID,
+            attemptID: attemptID,
+            streamSequence: expectedVersion + 1,
+            occurredAt: time,
+            recordedAt: time,
+            producer: graphTestProducer,
+            payload: .attemptStarting(GraphAttemptStartingPayload())
+        ),
+        GraphExecutionEventEnvelope(
+            id: "\(attemptID)-terminal-\(expectedVersion)",
+            runID: runID,
+            nodeID: nodeID,
+            attemptID: attemptID,
+            streamSequence: expectedVersion + 2,
+            occurredAt: time,
+            recordedAt: time,
+            producer: graphTestProducer,
+            payload: payload
+        ),
+    ]
+    return try await store.append(
+        events,
+        to: runID,
+        expectedVersion: expectedVersion
+    )
+}
+
+private final class TemporarySchedulingDatabase {
+    let directory: URL
+    let path: String
+
+    init() throws {
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "openisland-scheduling-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        path = directory.appendingPathComponent("history.sqlite").path
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: directory)
+    }
+}
+
+private final class SchedulingCLISink:
+    GraphCLIOutputSink,
+    @unchecked Sendable
+{
+    private let lock = NSLock()
+    private var data = Data()
+
+    func write(_ value: Data) -> GraphCLIWriteResult {
+        lock.lock()
+        data.append(value)
+        lock.unlock()
+        return .written
+    }
+
+    func consume() -> String {
+        lock.lock()
+        let value = String(decoding: data, as: UTF8.self)
+        data.removeAll(keepingCapacity: true)
+        lock.unlock()
+        return value
+    }
+}
+
+private func assertSchedulingRepositoryConflict(
+    _ error: Error,
+    _ expected: GraphSchedulingConflictReason,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    guard case let GraphSchedulingRepositoryError.conflict(
+        reason,
+        _,
+        _,
+        _
+    ) = error else {
+        return XCTFail(
+            "Unexpected error: \(error)",
+            file: file,
+            line: line
+        )
+    }
+    XCTAssertEqual(reason, expected, file: file, line: line)
+}

--- a/Tests/OpenIslandCoreTests/GraphSchedulingProtocolTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphSchedulingProtocolTests.swift
@@ -177,6 +177,44 @@ final class GraphSchedulingProtocolTests: XCTestCase {
         }
     }
 
+    func testExpiredOwnerDoesNotPreventTerminalCancellation()
+        async throws
+    {
+        let owned = try await claimedContext(leaseDuration: 2)
+        let cancellation = try await owned.context.repository
+            .requestCancellation(
+                GraphCancellationCommandRequest(
+                    runID: owned.context.runID,
+                    nodeID: "architect",
+                    attemptID: owned.attemptID,
+                    requestID: "cancel-expired-owner",
+                    requestedBy: "operator",
+                    expectedVersion: owned.version,
+                    logicalTime: owned.context.time.addingTimeInterval(1),
+                    producer: graphTestProducer,
+                    recordedAt: owned.context.time.addingTimeInterval(1)
+                )
+            )
+        let terminal = try await owned.context.repository
+            .declareCancellationTerminal(
+                GraphCancellationTerminalRequest(
+                    runID: owned.context.runID,
+                    requestID: "cancel-expired-owner",
+                    expectedVersion: cancellation.appendResult.newVersion,
+                    logicalTime: owned.context.time.addingTimeInterval(3),
+                    reason: "owner unavailable after lease expiry",
+                    producer: graphTestProducer,
+                    recordedAt: owned.context.time.addingTimeInterval(3)
+                )
+            )
+
+        XCTAssertEqual(terminal.projection.attempts.first?.state, .cancelled)
+        XCTAssertEqual(
+            terminal.projection.scheduling.claims.first?.status,
+            .expired
+        )
+    }
+
     func testTimeoutKindsAreDurableAndLeaseTimeoutDoesNotEndAttempt()
         async throws
     {

--- a/Tests/OpenIslandCoreTests/GraphSchedulingProtocolTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphSchedulingProtocolTests.swift
@@ -1,0 +1,498 @@
+import XCTest
+@testable import OpenIslandCore
+
+final class GraphSchedulingProtocolTests: XCTestCase {
+    func testCancellationBeforeClaimIsIdempotentAndTerminal()
+        async throws
+    {
+        let context = try await schedulingRepositoryContext()
+        let request = GraphCancellationCommandRequest(
+            runID: context.runID,
+            nodeID: "architect",
+            requestID: "cancel-before-claim",
+            requestedBy: "operator",
+            reason: "No longer needed",
+            expectedVersion: 2,
+            logicalTime: context.time,
+            producer: graphTestProducer,
+            recordedAt: context.time
+        )
+
+        let requested = try await context.repository.requestCancellation(
+            request
+        )
+        let duplicate = try await context.repository.requestCancellation(
+            request
+        )
+        XCTAssertEqual(duplicate.appendResult.appendedCount, 0)
+        XCTAssertEqual(
+            requested.projection.scheduling.cancellations.first?.state,
+            .requested
+        )
+
+        let terminal = try await context.repository
+            .declareCancellationTerminal(
+                GraphCancellationTerminalRequest(
+                    runID: context.runID,
+                    requestID: request.requestID,
+                    expectedVersion: requested.appendResult.newVersion,
+                    logicalTime: context.time.addingTimeInterval(1),
+                    reason: "Cancelled before ownership",
+                    producer: graphTestProducer,
+                    recordedAt: context.time.addingTimeInterval(1)
+                )
+            )
+        XCTAssertEqual(terminal.projection.attempts.count, 1)
+        XCTAssertEqual(terminal.projection.attempts.first?.ordinal, 1)
+        XCTAssertEqual(terminal.projection.attempts.first?.state, .cancelled)
+
+        let repeated = try await context.repository
+            .declareCancellationTerminal(
+                GraphCancellationTerminalRequest(
+                    runID: context.runID,
+                    requestID: request.requestID,
+                    expectedVersion: requested.appendResult.newVersion,
+                    logicalTime: context.time.addingTimeInterval(1),
+                    reason: "Cancelled before ownership",
+                    producer: graphTestProducer,
+                    recordedAt: context.time.addingTimeInterval(1)
+                )
+            )
+        XCTAssertEqual(repeated.appendResult.appendedCount, 0)
+    }
+
+    func testClaimedCancellationRequiresOwnerAcknowledgement()
+        async throws
+    {
+        let owned = try await claimedContext(leaseDuration: 30)
+        let cancellation = try await owned.context.repository
+            .requestCancellation(
+                GraphCancellationCommandRequest(
+                    runID: owned.context.runID,
+                    nodeID: "architect",
+                    attemptID: owned.attemptID,
+                    requestID: "cancel-owned",
+                    requestedBy: "operator",
+                    expectedVersion: owned.version,
+                    logicalTime: owned.context.time.addingTimeInterval(1),
+                    producer: graphTestProducer,
+                    recordedAt: owned.context.time.addingTimeInterval(1)
+                )
+            )
+        let acknowledged = try await owned.context.repository
+            .acknowledgeCancellation(
+                GraphCancellationAcknowledgementRequest(
+                    runID: owned.context.runID,
+                    requestID: "cancel-owned",
+                    claimID: owned.claim.id,
+                    executorID: owned.claim.executorID,
+                    expectedVersion: cancellation.appendResult.newVersion,
+                    logicalTime: owned.context.time.addingTimeInterval(2),
+                    producer: graphTestProducer,
+                    recordedAt: owned.context.time.addingTimeInterval(2)
+                )
+            )
+        XCTAssertEqual(
+            acknowledged.projection.scheduling.cancellations.first?.state,
+            .acknowledged
+        )
+        let duplicateAcknowledgement = try await owned.context.repository
+            .acknowledgeCancellation(
+                GraphCancellationAcknowledgementRequest(
+                    runID: owned.context.runID,
+                    requestID: "cancel-owned",
+                    claimID: owned.claim.id,
+                    executorID: owned.claim.executorID,
+                    expectedVersion: cancellation.appendResult.newVersion,
+                    logicalTime: owned.context.time.addingTimeInterval(2),
+                    producer: graphTestProducer,
+                    recordedAt: owned.context.time.addingTimeInterval(2)
+                )
+            )
+        XCTAssertEqual(
+            duplicateAcknowledgement.appendResult.appendedCount,
+            0
+        )
+
+        let terminal = try await owned.context.repository
+            .declareCancellationTerminal(
+                GraphCancellationTerminalRequest(
+                    runID: owned.context.runID,
+                    requestID: "cancel-owned",
+                    expectedVersion: acknowledged.appendResult.newVersion,
+                    logicalTime: owned.context.time.addingTimeInterval(3),
+                    producer: graphTestProducer,
+                    recordedAt: owned.context.time.addingTimeInterval(3)
+                )
+            )
+        XCTAssertEqual(terminal.projection.attempts.first?.state, .cancelled)
+        XCTAssertEqual(
+            terminal.projection.scheduling.claims.first?.status,
+            .released
+        )
+    }
+
+    func testStaleOwnerCannotAcknowledgeAfterLeaseExpiry()
+        async throws
+    {
+        let owned = try await claimedContext(leaseDuration: 2)
+        let cancellation = try await owned.context.repository
+            .requestCancellation(
+                GraphCancellationCommandRequest(
+                    runID: owned.context.runID,
+                    nodeID: "architect",
+                    attemptID: owned.attemptID,
+                    requestID: "cancel-stale",
+                    requestedBy: "operator",
+                    expectedVersion: owned.version,
+                    logicalTime: owned.context.time.addingTimeInterval(1),
+                    producer: graphTestProducer,
+                    recordedAt: owned.context.time.addingTimeInterval(1)
+                )
+            )
+
+        await XCTAssertThrowsErrorAsync {
+            try await owned.context.repository.acknowledgeCancellation(
+                GraphCancellationAcknowledgementRequest(
+                    runID: owned.context.runID,
+                    requestID: "cancel-stale",
+                    claimID: owned.claim.id,
+                    executorID: owned.claim.executorID,
+                    expectedVersion: cancellation.appendResult.newVersion,
+                    logicalTime: owned.context.time.addingTimeInterval(3),
+                    producer: graphTestProducer,
+                    recordedAt: owned.context.time.addingTimeInterval(3)
+                )
+            )
+        } verify: { error in
+            guard case let GraphSchedulingRepositoryError.conflict(
+                reason,
+                _,
+                _,
+                _
+            ) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(reason, .staleCancellationAcknowledgement)
+        }
+    }
+
+    func testTimeoutKindsAreDurableAndLeaseTimeoutDoesNotEndAttempt()
+        async throws
+    {
+        let owned = try await claimedContext(leaseDuration: 2)
+        let deadline = owned.context.time.addingTimeInterval(2)
+        let decision = GraphTimeoutDecision(
+            timeoutID: "lease-timeout",
+            runID: owned.context.runID,
+            nodeID: "architect",
+            attemptID: owned.attemptID,
+            claimID: owned.claim.id,
+            kind: .lease,
+            deadline: deadline,
+            declaredAt: deadline,
+            reason: .timeoutRecorded
+        )
+        let timedOut = try await owned.context.repository.recordTimeout(
+            GraphTimeoutCommandRequest(
+                decision: decision,
+                expectedVersion: owned.version,
+                producer: graphTestProducer,
+                recordedAt: deadline
+            )
+        )
+
+        XCTAssertEqual(
+            timedOut.projection.scheduling.timeouts,
+            [decision]
+        )
+        XCTAssertEqual(
+            timedOut.projection.scheduling.claims.first?.status,
+            .expired
+        )
+        XCTAssertEqual(timedOut.projection.attempts.first?.state, .pending)
+
+        let duplicate = try await owned.context.repository.recordTimeout(
+            GraphTimeoutCommandRequest(
+                decision: decision,
+                expectedVersion: owned.version,
+                producer: graphTestProducer,
+                recordedAt: deadline
+            )
+        )
+        XCTAssertEqual(duplicate.appendResult.appendedCount, 0)
+    }
+
+    func testEveryTimeoutCategoryIsRecordedAsAnExplicitDecision()
+        async throws
+    {
+        let context = try await schedulingRepositoryContext()
+        var expectedVersion: UInt64 = 2
+        let kinds: [GraphTimeoutKind] = [
+            .claimAcquisition,
+            .attemptExecution,
+            .cancellationAcknowledgement,
+            .retryDelay,
+        ]
+
+        for (offset, kind) in kinds.enumerated() {
+            let deadline = context.time.addingTimeInterval(
+                Double(offset + 1)
+            )
+            let result = try await context.repository.recordTimeout(
+                GraphTimeoutCommandRequest(
+                    decision: GraphTimeoutDecision(
+                        timeoutID: "timeout-\(kind.rawValue)",
+                        runID: context.runID,
+                        nodeID: "architect",
+                        attemptID: nil,
+                        claimID: nil,
+                        kind: kind,
+                        deadline: deadline,
+                        declaredAt: deadline,
+                        reason: .timeoutRecorded
+                    ),
+                    expectedVersion: expectedVersion,
+                    producer: graphTestProducer,
+                    recordedAt: deadline
+                )
+            )
+            expectedVersion = result.appendResult.newVersion
+        }
+
+        let stream = try await context.store.read(
+            runID: context.runID,
+            afterVersion: 0
+        )
+        let projection = try GraphExecutionProjector.replay(
+            runID: context.runID,
+            events: stream.events
+        ).projection
+        XCTAssertEqual(
+            Set(projection.scheduling.timeouts.map(\.kind)),
+            Set(kinds)
+        )
+    }
+
+    func testCancellationAfterProcessExitBeforeTerminalEventIsAccepted()
+        async throws
+    {
+        let owned = try await claimedContext(leaseDuration: 30)
+        let identity = ProcessIdentity(
+            hostID: "host-worker-a",
+            launchID: "launch-after-claim",
+            processID: 551,
+            startedAt: owned.context.time.addingTimeInterval(2)
+        )
+        let facts = [
+            GraphExecutionEventEnvelope(
+                id: "attempt-starting-before-cancel",
+                runID: owned.context.runID,
+                nodeID: "architect",
+                attemptID: owned.attemptID,
+                streamSequence: owned.version + 1,
+                occurredAt: owned.context.time.addingTimeInterval(2),
+                recordedAt: owned.context.time.addingTimeInterval(2),
+                producer: graphTestProducer,
+                payload: .attemptStarting(GraphAttemptStartingPayload())
+            ),
+            GraphExecutionEventEnvelope(
+                id: "process-observed-before-cancel",
+                runID: owned.context.runID,
+                nodeID: "architect",
+                attemptID: owned.attemptID,
+                streamSequence: owned.version + 2,
+                occurredAt: owned.context.time.addingTimeInterval(3),
+                recordedAt: owned.context.time.addingTimeInterval(3),
+                producer: graphTestProducer,
+                payload: .processIdentityObserved(
+                    GraphProcessIdentityObservedPayload(
+                        processIdentity: identity
+                    )
+                )
+            ),
+            GraphExecutionEventEnvelope(
+                id: "process-exit-before-cancel",
+                runID: owned.context.runID,
+                nodeID: "architect",
+                attemptID: owned.attemptID,
+                streamSequence: owned.version + 3,
+                occurredAt: owned.context.time.addingTimeInterval(4),
+                recordedAt: owned.context.time.addingTimeInterval(4),
+                producer: graphTestProducer,
+                payload: .processExitObserved(
+                    GraphProcessExitObservedPayload(
+                        processIdentity: identity,
+                        exitCode: 143,
+                        reason: "owner exited before terminal declaration"
+                    )
+                )
+            ),
+        ]
+        let appended = try await owned.context.store.append(
+            facts,
+            to: owned.context.runID,
+            expectedVersion: owned.version
+        )
+        let cancelled = try await owned.context.repository
+            .requestCancellation(
+                GraphCancellationCommandRequest(
+                    runID: owned.context.runID,
+                    nodeID: "architect",
+                    attemptID: owned.attemptID,
+                    requestID: "cancel-after-process-exit",
+                    requestedBy: "operator",
+                    expectedVersion: appended.newVersion,
+                    logicalTime: owned.context.time.addingTimeInterval(5),
+                    producer: graphTestProducer,
+                    recordedAt: owned.context.time.addingTimeInterval(5)
+                )
+            )
+
+        XCTAssertEqual(
+            cancelled.projection.scheduling.cancellations.first?.state,
+            .requested
+        )
+        XCTAssertEqual(
+            cancelled.projection.attempts.first?.state,
+            .running
+        )
+    }
+
+    func testRetryDecisionCreatesStrictlyMonotonicAttemptOrdinal()
+        async throws
+    {
+        let owned = try await claimedContext(leaseDuration: 30)
+        let released = try await owned.context.repository.releaseClaim(
+            GraphExecutorClaimReleaseRequest(
+                runID: owned.context.runID,
+                claimID: owned.claim.id,
+                executorID: owned.claim.executorID,
+                expectedGeneration: 1,
+                expectedVersion: owned.version,
+                logicalTime: owned.context.time.addingTimeInterval(1),
+                producer: graphTestProducer,
+                recordedAt: owned.context.time.addingTimeInterval(1)
+            )
+        )
+        let failure = GraphExecutionEventEnvelope(
+            id: "attempt-one-failed",
+            runID: owned.context.runID,
+            nodeID: "architect",
+            attemptID: owned.attemptID,
+            streamSequence: released.appendResult.newVersion + 1,
+            occurredAt: owned.context.time.addingTimeInterval(2),
+            recordedAt: owned.context.time.addingTimeInterval(2),
+            producer: graphTestProducer,
+            payload: .attemptFailed(
+                GraphAttemptTerminalPayload(reason: "transient")
+            )
+        )
+        _ = try await owned.context.store.append(
+            [failure],
+            to: owned.context.runID,
+            expectedVersion: released.appendResult.newVersion
+        )
+        let failedVersion = failure.streamSequence
+        let retryEvaluation = try await owned.context.repository
+            .evaluateAndAppend(
+                GraphSchedulerEvaluationRequest(
+                    runID: owned.context.runID,
+                    expectedVersion: failedVersion,
+                    definition: owned.context.definition,
+                    policy: owned.context.policy,
+                    logicalTime: owned.context.time.addingTimeInterval(3),
+                    availableExecutors: [owned.executor],
+                    failureCategoriesByAttemptID: [
+                        owned.attemptID: "transient",
+                    ],
+                    producer: graphTestProducer,
+                    recordedAt: owned.context.time.addingTimeInterval(3)
+                )
+            )
+        let evaluationID = try XCTUnwrap(
+            retryEvaluation.projection.scheduling
+                .completedEvaluationIDs.last
+        )
+        let retryClaim = try await owned.context.repository.attemptClaim(
+            GraphExecutorClaimRequest(
+                runID: owned.context.runID,
+                nodeID: "architect",
+                claimID: "claim-retry",
+                executor: owned.executor,
+                evaluationID: evaluationID,
+                expectedVersion: retryEvaluation.appendResult.newVersion,
+                logicalTime: owned.context.time.addingTimeInterval(3),
+                leaseDurationSeconds: 30,
+                producer: graphTestProducer,
+                recordedAt: owned.context.time.addingTimeInterval(3)
+            )
+        )
+
+        XCTAssertEqual(retryClaim.claim?.attemptOrdinal, 2)
+        let stream = try await owned.context.store.read(
+            runID: owned.context.runID,
+            afterVersion: 0
+        )
+        let projection = try GraphExecutionProjector.replay(
+            runID: owned.context.runID,
+            events: stream.events
+        ).projection
+        XCTAssertEqual(projection.attempts.map(\.ordinal), [1, 2])
+        XCTAssertEqual(
+            projection.scheduling.retries.map(\.nextAttemptOrdinal),
+            [2]
+        )
+    }
+}
+
+private struct ClaimedSchedulingContext {
+    let context: SchedulingRepositoryContext
+    let claim: GraphExecutorClaim
+    let attemptID: String
+    let version: UInt64
+    let executor: GraphExecutorCapabilities
+}
+
+private func claimedContext(
+    leaseDuration: UInt64
+) async throws -> ClaimedSchedulingContext {
+    let context = try await schedulingRepositoryContext()
+    let executor = GraphExecutorCapabilities(
+        executorID: "worker-a",
+        capabilityIdentity: "research-worker",
+        capabilities: ["research-planning"],
+        hostID: "host-worker-a"
+    )
+    let evaluation = try await context.repository.evaluateAndAppend(
+        context.evaluationRequest(expectedVersion: 2)
+    )
+    let evaluationID = try XCTUnwrap(
+        evaluation.projection.scheduling.completedEvaluationIDs.first
+    )
+    let claimed = try await context.repository.attemptClaim(
+        context.claimRequest(
+            claimID: "claim-a",
+            evaluationID: evaluationID,
+            expectedVersion: evaluation.appendResult.newVersion,
+            executorID: executor.executorID,
+            leaseDurationSeconds: leaseDuration
+        )
+    )
+    let claim = try XCTUnwrap(claimed.claim)
+    let stream = try await context.store.read(
+        runID: context.runID,
+        afterVersion: 0
+    )
+    let projection = try GraphExecutionProjector.replay(
+        runID: context.runID,
+        events: stream.events
+    ).projection
+    return ClaimedSchedulingContext(
+        context: context,
+        claim: claim,
+        attemptID: try XCTUnwrap(projection.attempts.first?.id),
+        version: claimed.appendResult.newVersion,
+        executor: executor
+    )
+}

--- a/Tests/OpenIslandCoreTests/GraphSchedulingRepositoryTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphSchedulingRepositoryTests.swift
@@ -310,7 +310,7 @@ final class GraphSchedulingRepositoryTests: XCTestCase {
     }
 }
 
-private struct SchedulingRepositoryContext {
+struct SchedulingRepositoryContext {
     let runID = "claim-run"
     let time = Date(timeIntervalSince1970: 200_000)
     let digest = GraphContentDigest(
@@ -393,7 +393,7 @@ private struct SchedulingRepositoryContext {
     }
 }
 
-private func schedulingRepositoryContext()
+func schedulingRepositoryContext()
     async throws -> SchedulingRepositoryContext
 {
     let store = InMemoryGraphExecutionEventStore()

--- a/Tests/OpenIslandCoreTests/GraphSchedulingRepositoryTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphSchedulingRepositoryTests.swift
@@ -1,0 +1,457 @@
+import XCTest
+@testable import OpenIslandCore
+
+final class GraphSchedulingRepositoryTests: XCTestCase {
+    func testEvaluationClaimRenewalAndReleaseAreDurable()
+        async throws
+    {
+        let context = try await schedulingRepositoryContext()
+        let evaluation = try await context.repository.evaluateAndAppend(
+            context.evaluationRequest(expectedVersion: 2)
+        )
+        let evaluationID = try XCTUnwrap(
+            evaluation.projection.scheduling.completedEvaluationIDs.first
+        )
+        let claimRequest = context.claimRequest(
+            claimID: "claim-a",
+            evaluationID: evaluationID,
+            expectedVersion: evaluation.appendResult.newVersion,
+            executorID: "worker-a"
+        )
+
+        let claimed = try await context.repository.attemptClaim(
+            claimRequest
+        )
+        let claim = try XCTUnwrap(claimed.claim)
+        XCTAssertEqual(claimed.outcome, .granted)
+        XCTAssertEqual(claim.attemptOrdinal, 1)
+        XCTAssertEqual(claim.leaseGeneration, 1)
+
+        let repeated = try await context.repository.attemptClaim(
+            claimRequest
+        )
+        XCTAssertEqual(repeated.outcome, .deduplicated)
+        XCTAssertEqual(repeated.claim, claim)
+
+        let renewed = try await context.repository.renewLease(
+            GraphExecutorLeaseRenewalRequest(
+                runID: context.runID,
+                claimID: claim.id,
+                executorID: claim.executorID,
+                expectedGeneration: 1,
+                expectedVersion: claimed.appendResult.newVersion,
+                logicalTime: context.time.addingTimeInterval(10),
+                leaseDurationSeconds: 60,
+                producer: graphTestProducer,
+                recordedAt: context.time.addingTimeInterval(10)
+            )
+        )
+        let renewedClaim = try XCTUnwrap(
+            renewed.projection.scheduling.claims.first?.claim
+        )
+        XCTAssertEqual(renewedClaim.leaseGeneration, 2)
+
+        let released = try await context.repository.releaseClaim(
+            GraphExecutorClaimReleaseRequest(
+                runID: context.runID,
+                claimID: claim.id,
+                executorID: claim.executorID,
+                expectedGeneration: 2,
+                expectedVersion: renewed.appendResult.newVersion,
+                logicalTime: context.time.addingTimeInterval(20),
+                producer: graphTestProducer,
+                recordedAt: context.time.addingTimeInterval(20)
+            )
+        )
+        XCTAssertEqual(
+            released.projection.scheduling.claims.first?.status,
+            .released
+        )
+
+        let repeatedRelease = try await context.repository.releaseClaim(
+            GraphExecutorClaimReleaseRequest(
+                runID: context.runID,
+                claimID: claim.id,
+                executorID: claim.executorID,
+                expectedGeneration: 2,
+                expectedVersion: renewed.appendResult.newVersion,
+                logicalTime: context.time.addingTimeInterval(20),
+                producer: graphTestProducer,
+                recordedAt: context.time.addingTimeInterval(20)
+            )
+        )
+        XCTAssertEqual(repeatedRelease.appendResult.appendedCount, 0)
+    }
+
+    func testCompetingClaimsProduceExactlyOneWinner() async throws {
+        let context = try await schedulingRepositoryContext()
+        let evaluation = try await context.repository.evaluateAndAppend(
+            context.evaluationRequest(expectedVersion: 2)
+        )
+        let evaluationID = try XCTUnwrap(
+            evaluation.projection.scheduling.completedEvaluationIDs.first
+        )
+        let expected = evaluation.appendResult.newVersion
+        let repository = context.repository
+        let first = context.claimRequest(
+            claimID: "claim-a",
+            evaluationID: evaluationID,
+            expectedVersion: expected,
+            executorID: "worker-a"
+        )
+        let second = context.claimRequest(
+            claimID: "claim-b",
+            evaluationID: evaluationID,
+            expectedVersion: expected,
+            executorID: "worker-b"
+        )
+
+        let outcomes = await withTaskGroup(
+            of: Result<GraphExecutorClaimResult, Error>.self
+        ) { group in
+            group.addTask {
+                do {
+                    return .success(
+                        try await repository.attemptClaim(first)
+                    )
+                } catch {
+                    return .failure(error)
+                }
+            }
+            group.addTask {
+                do {
+                    return .success(
+                        try await repository.attemptClaim(second)
+                    )
+                } catch {
+                    return .failure(error)
+                }
+            }
+            var results: [Result<GraphExecutorClaimResult, Error>] = []
+            for await result in group { results.append(result) }
+            return results
+        }
+        let winners = outcomes.compactMap { try? $0.get() }.filter {
+            $0.outcome == .granted
+        }
+        let conflicts = outcomes.compactMap { result -> GraphSchedulingConflictReason? in
+            switch result {
+            case let .success(value):
+                return value.conflictReason
+            case let .failure(error):
+                guard case let GraphSchedulingRepositoryError.conflict(
+                    reason,
+                    _,
+                    _,
+                    _
+                ) = error else {
+                    return nil
+                }
+                return reason
+            }
+        }
+        let stream = try await context.store.read(
+            runID: context.runID,
+            afterVersion: 0
+        )
+        let projection = try GraphExecutionProjector.replay(
+            runID: context.runID,
+            events: stream.events
+        ).projection
+
+        XCTAssertEqual(winners.count, 1)
+        XCTAssertEqual(
+            conflicts.count,
+            1
+        )
+        if let reason = conflicts.first {
+            XCTAssertTrue(
+                reason == .expectedVersionConflict
+                    || reason == .existingActiveClaim
+            )
+        }
+        XCTAssertEqual(
+            projection.scheduling.claims.filter { $0.status == .active }.count,
+            1
+        )
+    }
+
+    func testExpiredLeaseAllowsTakeoverAndRejectsStaleRenewal()
+        async throws
+    {
+        let context = try await schedulingRepositoryContext()
+        let evaluation = try await context.repository.evaluateAndAppend(
+            context.evaluationRequest(expectedVersion: 2)
+        )
+        let evaluationID = try XCTUnwrap(
+            evaluation.projection.scheduling.completedEvaluationIDs.first
+        )
+        let first = try await context.repository.attemptClaim(
+            context.claimRequest(
+                claimID: "claim-a",
+                evaluationID: evaluationID,
+                expectedVersion: evaluation.appendResult.newVersion,
+                executorID: "worker-a",
+                leaseDurationSeconds: 5
+            )
+        )
+        let firstClaim = try XCTUnwrap(first.claim)
+
+        await XCTAssertThrowsErrorAsync {
+            try await context.repository.renewLease(
+                GraphExecutorLeaseRenewalRequest(
+                    runID: context.runID,
+                    claimID: firstClaim.id,
+                    executorID: firstClaim.executorID,
+                    expectedGeneration: 1,
+                    expectedVersion: first.appendResult.newVersion,
+                    logicalTime: context.time.addingTimeInterval(6),
+                    leaseDurationSeconds: 30,
+                    producer: graphTestProducer,
+                    recordedAt: context.time.addingTimeInterval(6)
+                )
+            )
+        } verify: { error in
+            guard case let GraphSchedulingRepositoryError.conflict(
+                reason,
+                _,
+                _,
+                _
+            ) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(reason, .leaseExpired)
+        }
+
+        let takeover = try await context.repository.attemptClaim(
+            context.claimRequest(
+                claimID: "claim-b",
+                evaluationID: evaluationID,
+                expectedVersion: first.appendResult.newVersion,
+                executorID: "worker-b",
+                logicalTime: context.time.addingTimeInterval(6)
+            )
+        )
+        XCTAssertEqual(takeover.outcome, .granted)
+        XCTAssertEqual(takeover.claim?.attemptOrdinal, 1)
+
+        let stream = try await context.store.read(
+            runID: context.runID,
+            afterVersion: 0
+        )
+        let projection = try GraphExecutionProjector.replay(
+            runID: context.runID,
+            events: stream.events
+        ).projection
+        XCTAssertEqual(
+            projection.scheduling.claims.first {
+                $0.claim.id == firstClaim.id
+            }?.status,
+            .expired
+        )
+        XCTAssertEqual(
+            projection.scheduling.activeClaim(
+                nodeID: "architect",
+                at: context.time.addingTimeInterval(6)
+            )?.id,
+            "claim-b"
+        )
+    }
+
+    func testContradictoryClaimIdentityAndLeaseGenerationFail()
+        async throws
+    {
+        let context = try await schedulingRepositoryContext()
+        let evaluation = try await context.repository.evaluateAndAppend(
+            context.evaluationRequest(expectedVersion: 2)
+        )
+        let evaluationID = try XCTUnwrap(
+            evaluation.projection.scheduling.completedEvaluationIDs.first
+        )
+        let first = try await context.repository.attemptClaim(
+            context.claimRequest(
+                claimID: "claim-a",
+                evaluationID: evaluationID,
+                expectedVersion: evaluation.appendResult.newVersion,
+                executorID: "worker-a"
+            )
+        )
+
+        await XCTAssertThrowsErrorAsync {
+            try await context.repository.attemptClaim(
+                context.claimRequest(
+                    claimID: "claim-a",
+                    evaluationID: evaluationID,
+                    expectedVersion: first.appendResult.newVersion,
+                    executorID: "worker-b"
+                )
+            )
+        } verify: { error in
+            assertSchedulingConflict(error, .claimIdentityCollision)
+        }
+
+        await XCTAssertThrowsErrorAsync {
+            try await context.repository.renewLease(
+                GraphExecutorLeaseRenewalRequest(
+                    runID: context.runID,
+                    claimID: "claim-a",
+                    executorID: "worker-a",
+                    expectedGeneration: 9,
+                    expectedVersion: first.appendResult.newVersion,
+                    logicalTime: context.time.addingTimeInterval(1),
+                    leaseDurationSeconds: 60,
+                    producer: graphTestProducer,
+                    recordedAt: context.time.addingTimeInterval(1)
+                )
+            )
+        } verify: { error in
+            assertSchedulingConflict(error, .leaseGenerationMismatch)
+        }
+    }
+}
+
+private struct SchedulingRepositoryContext {
+    let runID = "claim-run"
+    let time = Date(timeIntervalSince1970: 200_000)
+    let digest = GraphContentDigest(
+        algorithm: "sha256",
+        value: "claim-graph-v1"
+    )
+    let store: InMemoryGraphExecutionEventStore
+    let repository: DefaultGraphSchedulingRepository
+
+    var definition: GraphSchedulingDefinition {
+        GraphSchedulingDefinition(
+            graphID: "claim-graph",
+            version: "1",
+            digest: digest,
+            nodes: [
+                GraphSchedulingDefinitionNode(
+                    id: "architect",
+                    title: "Architect",
+                    requiredCapabilities: ["research-planning"]
+                ),
+            ]
+        )
+    }
+
+    var policy: GraphSchedulerPolicy {
+        GraphSchedulerPolicy(
+            policyID: "claim-policy",
+            version: "1",
+            retryPolicy: GraphRetryPolicy(
+                maximumAttempts: 3,
+                retryableFailureCategories: ["transient"]
+            )
+        )
+    }
+
+    func evaluationRequest(
+        expectedVersion: UInt64
+    ) -> GraphSchedulerEvaluationRequest {
+        GraphSchedulerEvaluationRequest(
+            runID: runID,
+            expectedVersion: expectedVersion,
+            definition: definition,
+            policy: policy,
+            logicalTime: time,
+            availableExecutors: [executor("worker-a")],
+            producer: graphTestProducer,
+            recordedAt: time
+        )
+    }
+
+    func claimRequest(
+        claimID: String,
+        evaluationID: String,
+        expectedVersion: UInt64,
+        executorID: String,
+        leaseDurationSeconds: UInt64 = 60,
+        logicalTime: Date? = nil
+    ) -> GraphExecutorClaimRequest {
+        GraphExecutorClaimRequest(
+            runID: runID,
+            nodeID: "architect",
+            claimID: claimID,
+            executor: executor(executorID),
+            evaluationID: evaluationID,
+            expectedVersion: expectedVersion,
+            logicalTime: logicalTime ?? time,
+            leaseDurationSeconds: leaseDurationSeconds,
+            producer: graphTestProducer,
+            recordedAt: logicalTime ?? time
+        )
+    }
+
+    private func executor(_ id: String) -> GraphExecutorCapabilities {
+        GraphExecutorCapabilities(
+            executorID: id,
+            capabilityIdentity: "research-worker",
+            capabilities: ["research-planning"],
+            hostID: "host-\(id)"
+        )
+    }
+}
+
+private func schedulingRepositoryContext()
+    async throws -> SchedulingRepositoryContext
+{
+    let store = InMemoryGraphExecutionEventStore()
+    let context = SchedulingRepositoryContext(
+        store: store,
+        repository: DefaultGraphSchedulingRepository(eventStore: store)
+    )
+    let events = [
+        GraphExecutionEventEnvelope(
+            id: "claim-run-created",
+            runID: context.runID,
+            streamSequence: 1,
+            occurredAt: context.time,
+            recordedAt: context.time,
+            producer: graphTestProducer,
+            payload: .runCreated(
+                GraphRunCreatedPayload(
+                    graphID: context.definition.graphID,
+                    graphDefinitionVersion: context.definition.version,
+                    graphDefinitionDigest: context.digest,
+                    nodeIDs: ["architect"]
+                )
+            )
+        ),
+        GraphExecutionEventEnvelope(
+            id: "claim-node-created",
+            runID: context.runID,
+            nodeID: "architect",
+            streamSequence: 2,
+            occurredAt: context.time,
+            recordedAt: context.time,
+            producer: graphTestProducer,
+            payload: .nodeRegistered(
+                GraphNodeRegisteredPayload(title: "Architect")
+            )
+        ),
+    ]
+    _ = try await store.append(
+        events,
+        to: context.runID,
+        expectedVersion: 0
+    )
+    return context
+}
+
+private func assertSchedulingConflict(
+    _ error: Error,
+    _ expected: GraphSchedulingConflictReason,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    guard case let GraphSchedulingRepositoryError.conflict(
+        reason,
+        _,
+        _,
+        _
+    ) = error else {
+        return XCTFail("Unexpected error: \(error)", file: file, line: line)
+    }
+    XCTAssertEqual(reason, expected, file: file, line: line)
+}

--- a/Tests/OpenIslandCoreTests/GraphTemporalInspectionTests.swift
+++ b/Tests/OpenIslandCoreTests/GraphTemporalInspectionTests.swift
@@ -1,0 +1,475 @@
+import Foundation
+import XCTest
+@testable import OpenIslandCore
+
+final class GraphTemporalInspectionTests: XCTestCase {
+    func testListAndInspectUseDeterministicReconciledState() async throws {
+        let events = [
+            graphTestRunCreated(),
+            graphTestNodeRegistered(),
+            graphTestAttemptCreated(),
+            graphTestAttemptStarting(),
+        ]
+        let store = try await populatedStore(events)
+        let inspector = makeInspector(store: store)
+
+        let first = try await inspector.listRuns(state: nil, limit: 10)
+        let second = try await inspector.listRuns(state: nil, limit: 10)
+        let inspection = try await inspector.inspect(
+            runID: "run",
+            includeArtifacts: false,
+            includeDiagnostics: true
+        )
+
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(first.map(\.runID), ["run"])
+        XCTAssertEqual(first.first?.reconciledState, .interrupted)
+        XCTAssertEqual(inspection.nodes.first?.reconciledState, .interrupted)
+        XCTAssertEqual(
+            inspection.attempts.first?.statusReason,
+            "The attempt was running without recoverable process identity."
+        )
+    }
+
+    func testEventPagesFilterAndAdvanceThroughRawHistory() async throws {
+        let events = [
+            graphTestRunCreated(),
+            graphTestNodeRegistered(),
+            graphTestAttemptCreated(),
+            graphTestAttemptStarting(),
+            graphTestProcessObserved(),
+        ]
+        let store = try await populatedStore(events)
+        let inspector = makeInspector(store: store, pageSize: 2)
+        let page = try await inspector.eventPage(
+            runID: "run",
+            filter: GraphInspectionEventFilter(
+                nodeID: "node",
+                eventTypes: [
+                    GraphExecutionEventType.attemptCreated.rawValue,
+                    GraphExecutionEventType.processIdentityObserved.rawValue,
+                ],
+                limit: 2
+            )
+        )
+
+        XCTAssertEqual(
+            page.events.map(\.eventType),
+            [
+                GraphExecutionEventType.attemptCreated.rawValue,
+                GraphExecutionEventType.processIdentityObserved.rawValue,
+            ]
+        )
+        XCTAssertEqual(page.scannedThroughSequence, 5)
+        XCTAssertFalse(page.hasMore)
+    }
+
+    func testEventPageCursorStopsAtLastExaminedMatch() async throws {
+        let events = [
+            graphTestRunCreated(),
+            graphTestNodeRegistered(),
+            graphTestAttemptCreated(),
+            graphTestAttemptStarting(),
+            graphTestProcessObserved(),
+        ]
+        let store = try await populatedStore(events)
+        let inspector = makeInspector(store: store, pageSize: 5)
+
+        let first = try await inspector.eventPage(
+            runID: "run",
+            filter: GraphInspectionEventFilter(limit: 2)
+        )
+        let second = try await inspector.eventPage(
+            runID: "run",
+            filter: GraphInspectionEventFilter(
+                afterSequence: first.scannedThroughSequence,
+                limit: 10
+            )
+        )
+
+        XCTAssertEqual(first.events.map(\.streamSequence), [1, 2])
+        XCTAssertEqual(first.scannedThroughSequence, 2)
+        XCTAssertTrue(first.hasMore)
+        XCTAssertEqual(second.events.map(\.streamSequence), [3, 4, 5])
+    }
+
+    func testReplayToSequenceIsIdempotentAndDoesNotWriteSnapshot()
+        async throws
+    {
+        let events = [
+            graphTestRunCreated(),
+            graphTestNodeRegistered(),
+            graphTestAttemptCreated(),
+            graphTestAttemptStarting(),
+        ]
+        let store = try await populatedStore(events)
+        let snapshots = InMemoryGraphExecutionSnapshotStore()
+        let inspector = DefaultGraphTemporalInspector(
+            readStore: store,
+            snapshotStore: snapshots
+        )
+        let reference = GraphTemporalReference(
+            runID: "run",
+            boundary: .sequence(3)
+        )
+
+        let first = try await inspector.replay(
+            reference: reference,
+            evidenceMode: .withoutLiveEvidence
+        )
+        let second = try await inspector.replay(
+            reference: reference,
+            evidenceMode: .withoutLiveEvidence
+        )
+
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(first.boundary, 3)
+        XCTAssertEqual(first.projected.attempts.first?.state, .pending)
+        let persistedSnapshot = await snapshots.loadLatest(
+            runID: "run"
+        )
+        XCTAssertNil(persistedSnapshot)
+    }
+
+    func testNamedCheckpointResolvesToHistoricalBoundary() async throws {
+        let events = [
+            graphTestRunCreated(),
+            graphTestNodeRegistered(),
+            graphTestAttemptCreated(),
+            graphTestAttemptStarting(),
+        ]
+        let projection = try GraphExecutionProjector.replay(
+            runID: "run",
+            events: Array(events.prefix(3))
+        ).projection
+        var checkpointProjection = projection
+        checkpointProjection.namedCheckpoints = [
+            GraphCheckpointReference(
+                checkpointID: "before-start",
+                runID: "run",
+                streamVersion: 3,
+                namespace: "root"
+            ),
+        ]
+        let snapshot = graphTestSnapshot(for: checkpointProjection)
+        let store = try await populatedStore(events)
+        let inspector = DefaultGraphTemporalInspector(
+            readStore: store,
+            snapshotStore: InMemoryGraphExecutionSnapshotStore(
+                snapshots: [snapshot]
+            )
+        )
+
+        let checkpoints = try await inspector.checkpoints(runID: "run")
+        let replay = try await inspector.replay(
+            reference: GraphTemporalReference(
+                runID: "run",
+                boundary: .checkpoint("before-start")
+            ),
+            evidenceMode: .withoutLiveEvidence
+        )
+
+        XCTAssertEqual(checkpoints.map(\.checkpointID), ["before-start"])
+        XCTAssertEqual(replay.boundary, 3)
+        XCTAssertEqual(replay.snapshotDisposition, .current)
+        XCTAssertEqual(replay.projected.attempts.first?.state, .pending)
+    }
+
+    func testIncompatibleSnapshotIsBypassed() async throws {
+        let events = [
+            graphTestRunCreated(),
+            graphTestNodeRegistered(),
+        ]
+        let projection = try GraphExecutionProjector.replay(
+            runID: "run",
+            events: events
+        ).projection
+        let snapshot = graphTestSnapshot(
+            for: projection,
+            schemaVersion: GraphExecutionSchema.snapshotVersion + 1
+        )
+        let store = try await populatedStore(events)
+        let inspector = DefaultGraphTemporalInspector(
+            readStore: store,
+            snapshotStore: InMemoryGraphExecutionSnapshotStore(
+                snapshots: [snapshot]
+            )
+        )
+
+        let replay = try await inspector.replay(
+            reference: GraphTemporalReference(runID: "run"),
+            evidenceMode: .withoutLiveEvidence
+        )
+
+        XCTAssertEqual(replay.snapshotDisposition, .incompatible)
+        XCTAssertEqual(replay.replayedEventCount, 2)
+        XCTAssertEqual(replay.projected.nodes.map(\.id), ["node"])
+    }
+
+    func testDiffIgnoresTimestampsAsStandaloneChanges() async throws {
+        let events = [
+            graphTestRunCreated(),
+            graphTestNodeRegistered(),
+            graphTestAttemptCreated(),
+            graphTestAttemptStarting(),
+        ]
+        let store = try await populatedStore(events)
+        let inspector = makeInspector(store: store)
+        let diff = try await inspector.diff(
+            left: GraphTemporalReference(
+                runID: "run",
+                boundary: .sequence(3)
+            ),
+            right: GraphTemporalReference(runID: "run")
+        )
+
+        XCTAssertTrue(
+            diff.changes.contains {
+                $0.category == .attempt
+                    && $0.field == "persisted_state"
+                    && $0.left == "pending"
+                    && $0.right == "running"
+            }
+        )
+        XCTAssertFalse(
+            diff.changes.contains {
+                $0.field.localizedCaseInsensitiveContains("time")
+                    || $0.field.localizedCaseInsensitiveContains("date")
+            }
+        )
+        XCTAssertEqual(
+            diff.changes,
+            diff.changes.sorted(by: temporalChangeOrder)
+        )
+    }
+
+    func testArtifactInspectionAlwaysRedactsStorageLocator()
+        async throws
+    {
+        let artifact = GraphArtifactReference(
+            id: "artifact",
+            contentDigest: GraphContentDigest(
+                algorithm: "sha256",
+                value: "content"
+            ),
+            mediaType: "application/json",
+            logicalRole: "research-output",
+            producingRunID: "run",
+            producingNodeID: "node",
+            producingAttemptID: "attempt",
+            createdAt: graphTestTime.addingTimeInterval(4),
+            storage: GraphArtifactStorageLocator(
+                scheme: "file",
+                opaqueReference: "/private/research/secret.json"
+            ),
+            sensitivity: .confidential
+        )
+        let events = [
+            graphTestRunCreated(),
+            graphTestNodeRegistered(),
+            graphTestAttemptCreated(),
+            graphTestEvent(
+                id: "artifact-event",
+                sequence: 4,
+                nodeID: "node",
+                attemptID: "attempt",
+                payload: .artifactRecorded(
+                    GraphArtifactRecordedPayload(artifact: artifact)
+                )
+            ),
+        ]
+        let store = try await populatedStore(events)
+        let inspector = makeInspector(store: store)
+
+        let artifacts = try await inspector.artifacts(runID: "run")
+        let encoded = try JSONEncoder().encode(artifacts)
+        let output = String(decoding: encoded, as: UTF8.self)
+
+        XCTAssertEqual(artifacts.first?.storageScheme, "file")
+        XCTAssertEqual(
+            artifacts.first?.redactions.first?.field,
+            "storage.opaqueReference"
+        )
+        XCTAssertFalse(output.contains("/private/research"))
+    }
+
+    func testCausalExplanationFindsTransitiveBlockingChain()
+        async throws
+    {
+        let events = blockingGraphEvents()
+        let store = InMemoryGraphExecutionEventStore()
+        _ = try await store.append(
+            events,
+            to: "blocked-run",
+            expectedVersion: 0
+        )
+        let inspector = makeInspector(store: store)
+
+        let explanation = try await inspector.explain(
+            runID: "blocked-run",
+            nodeID: "reviewer"
+        )
+
+        XCTAssertEqual(explanation.state, .blocked)
+        XCTAssertEqual(
+            explanation.causalPredecessorNodeIDs,
+            ["architect", "graph"]
+        )
+        XCTAssertEqual(
+            explanation.blockingDependencyNodeIDs,
+            ["architect", "graph"]
+        )
+        XCTAssertTrue(
+            explanation.reasons.contains {
+                $0.code == .dependencyInterrupted
+                    && $0.subjectID == "architect"
+            }
+        )
+        XCTAssertEqual(explanation.shortestCausalChain.count, 3)
+        XCTAssertEqual(
+            explanation.readinessRequirements,
+            ["Dependency graph must reach completed state."]
+        )
+    }
+
+    private func makeInspector(
+        store: InMemoryGraphExecutionEventStore,
+        pageSize: Int = 500
+    ) -> DefaultGraphTemporalInspector {
+        DefaultGraphTemporalInspector(
+            readStore: store,
+            snapshotStore: InMemoryGraphExecutionSnapshotStore(),
+            pageSize: pageSize
+        )
+    }
+
+    private func populatedStore(
+        _ events: [GraphExecutionEventEnvelope]
+    ) async throws -> InMemoryGraphExecutionEventStore {
+        let store = InMemoryGraphExecutionEventStore()
+        _ = try await store.append(
+            events,
+            to: "run",
+            expectedVersion: 0
+        )
+        return store
+    }
+
+    private func blockingGraphEvents()
+        -> [GraphExecutionEventEnvelope]
+    {
+        let producer = GraphExecutionProducer(
+            id: "inspection-tests",
+            kind: .test
+        )
+
+        func event(
+            id: String,
+            sequence: UInt64,
+            nodeID: String? = nil,
+            attemptID: String? = nil,
+            payload: GraphExecutionEventPayload
+        ) -> GraphExecutionEventEnvelope {
+            GraphExecutionEventEnvelope(
+                id: id,
+                runID: "blocked-run",
+                nodeID: nodeID,
+                attemptID: attemptID,
+                streamSequence: sequence,
+                occurredAt: graphTestTime.addingTimeInterval(
+                    Double(sequence)
+                ),
+                recordedAt: graphTestTime.addingTimeInterval(
+                    Double(sequence)
+                ),
+                producer: producer,
+                payload: payload
+            )
+        }
+
+        return [
+            event(
+                id: "run",
+                sequence: 1,
+                payload: .runCreated(
+                    GraphRunCreatedPayload(
+                        graphID: "blocked-graph",
+                        graphDefinitionVersion: "1",
+                        graphDefinitionDigest: graphTestDigest,
+                        nodeIDs: ["architect", "graph", "reviewer"]
+                    )
+                )
+            ),
+            event(
+                id: "architect-node",
+                sequence: 2,
+                nodeID: "architect",
+                payload: .nodeRegistered(
+                    GraphNodeRegisteredPayload(title: "Architect")
+                )
+            ),
+            event(
+                id: "graph-node",
+                sequence: 3,
+                nodeID: "graph",
+                payload: .nodeRegistered(
+                    GraphNodeRegisteredPayload(
+                        title: "Graph",
+                        dependencyNodeIDs: ["architect"]
+                    )
+                )
+            ),
+            event(
+                id: "reviewer-node",
+                sequence: 4,
+                nodeID: "reviewer",
+                payload: .nodeRegistered(
+                    GraphNodeRegisteredPayload(
+                        title: "Reviewer",
+                        dependencyNodeIDs: ["graph"]
+                    )
+                )
+            ),
+            event(
+                id: "architect-attempt",
+                sequence: 5,
+                nodeID: "architect",
+                attemptID: "architect-1",
+                payload: .attemptCreated(
+                    GraphAttemptCreatedPayload(ordinal: 1)
+                )
+            ),
+            event(
+                id: "architect-start",
+                sequence: 6,
+                nodeID: "architect",
+                attemptID: "architect-1",
+                payload: .attemptStarting(
+                    GraphAttemptStartingPayload()
+                )
+            ),
+            event(
+                id: "architect-stop",
+                sequence: 7,
+                nodeID: "architect",
+                attemptID: "architect-1",
+                payload: .attemptInterrupted(
+                    GraphAttemptTerminalPayload(reason: "stopped")
+                )
+            ),
+        ]
+    }
+}
+
+private func temporalChangeOrder(
+    _ lhs: GraphTemporalChange,
+    _ rhs: GraphTemporalChange
+) -> Bool {
+    if lhs.category != rhs.category {
+        return lhs.category.rawValue < rhs.category.rawValue
+    }
+    if lhs.entityID != rhs.entityID {
+        return lhs.entityID < rhs.entityID
+    }
+    return lhs.field < rhs.field
+}

--- a/Tests/OpenIslandCoreTests/SQLiteGraphExecutionStoreTests.swift
+++ b/Tests/OpenIslandCoreTests/SQLiteGraphExecutionStoreTests.swift
@@ -1,0 +1,160 @@
+import Foundation
+import XCTest
+@testable import OpenIslandCore
+
+final class SQLiteGraphExecutionStoreTests: XCTestCase {
+    func testMigrationCreatesCurrentSchema() async throws {
+        let fixture = try SQLiteStoreFixture()
+        defer { fixture.remove() }
+        let store = try SQLiteGraphExecutionStore(
+            databasePath: fixture.path
+        )
+
+        let version = try await store.databaseSchemaVersion()
+
+        XCTAssertEqual(
+            version,
+            SQLiteGraphExecutionStore.currentDatabaseSchemaVersion
+        )
+    }
+
+    func testEventsPersistAcrossStoreRestart() async throws {
+        let fixture = try SQLiteStoreFixture()
+        defer { fixture.remove() }
+        let firstStore = try SQLiteGraphExecutionStore(
+            databasePath: fixture.path
+        )
+        let events = [
+            graphTestRunCreated(),
+            graphTestNodeRegistered(),
+        ]
+        _ = try await firstStore.append(
+            events,
+            to: "run",
+            expectedVersion: 0
+        )
+        let reopened = try SQLiteGraphExecutionStore(
+            databasePath: fixture.path
+        )
+
+        let stream = try await reopened.read(
+            runID: "run",
+            afterVersion: 0
+        )
+
+        XCTAssertEqual(stream.currentVersion, 2)
+        XCTAssertEqual(stream.events, events)
+    }
+
+    func testSQLiteAppendEnforcesExpectedVersion() async throws {
+        let fixture = try SQLiteStoreFixture()
+        defer { fixture.remove() }
+        let store = try SQLiteGraphExecutionStore(
+            databasePath: fixture.path
+        )
+        _ = try await store.append(
+            [graphTestRunCreated()],
+            to: "run",
+            expectedVersion: 0
+        )
+
+        await XCTAssertThrowsErrorAsync {
+            try await store.append(
+                [graphTestNodeRegistered()],
+                to: "run",
+                expectedVersion: 0
+            )
+        } verify: {
+            XCTAssertEqual(
+                $0 as? GraphExecutionPersistenceError,
+                .expectedVersionConflict(
+                    runID: "run",
+                    expected: 0,
+                    actual: 1
+                )
+            )
+        }
+    }
+
+    func testSQLiteExactDuplicateIsIdempotent() async throws {
+        let fixture = try SQLiteStoreFixture()
+        defer { fixture.remove() }
+        let store = try SQLiteGraphExecutionStore(
+            databasePath: fixture.path
+        )
+        let event = graphTestRunCreated()
+        _ = try await store.append(
+            [event],
+            to: "run",
+            expectedVersion: 0
+        )
+
+        let result = try await store.append(
+            [event],
+            to: "run",
+            expectedVersion: 0
+        )
+
+        XCTAssertEqual(result.appendedCount, 0)
+        XCTAssertEqual(result.deduplicatedCount, 1)
+        XCTAssertEqual(result.newVersion, 1)
+    }
+
+    func testSnapshotPersistsAcrossStoreRestart() async throws {
+        let fixture = try SQLiteStoreFixture()
+        defer { fixture.remove() }
+        let firstStore = try SQLiteGraphExecutionStore(
+            databasePath: fixture.path
+        )
+        let events = [
+            graphTestRunCreated(),
+            graphTestNodeRegistered(),
+        ]
+        let projection = try GraphExecutionProjector.replay(
+            runID: "run",
+            events: events
+        ).projection
+        let snapshot = GraphExecutionSnapshot(
+            runID: "run",
+            streamVersion: 2,
+            graphDefinitionVersion: "1",
+            graphDefinitionDigest: graphTestDigest,
+            projectedState: projection,
+            createdAt: graphTestTime.addingTimeInterval(10),
+            createdBy: graphTestProducer,
+            checkpointNamespace: "root"
+        )
+        try await firstStore.save(snapshot)
+        let reopened = try SQLiteGraphExecutionStore(
+            databasePath: fixture.path
+        )
+
+        let loaded = try await reopened.loadLatest(runID: "run")
+
+        XCTAssertEqual(loaded, snapshot)
+    }
+}
+
+struct SQLiteStoreFixture {
+    let directory: URL
+    let path: String
+
+    init() throws {
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "openisland-graph-store-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        path = directory.appendingPathComponent(
+            "graph-execution.sqlite"
+        ).path
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: directory)
+    }
+}

--- a/Tests/OpenIslandCoreTests/StaleCompendiumRuntimeFixtureTests.swift
+++ b/Tests/OpenIslandCoreTests/StaleCompendiumRuntimeFixtureTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import XCTest
+@testable import OpenIslandCore
+
+final class StaleCompendiumRuntimeFixtureTests: XCTestCase {
+    func testStaleCompendiumRunReconcilesWithoutLiveProcessClaims() throws {
+        let input = try loadFixture()
+
+        let result = GraphExecutionReconciler.reconcile(input)
+        let attemptStates = Dictionary(
+            uniqueKeysWithValues: result.attempts.map {
+                ($0.id, $0.state)
+            }
+        )
+        let nodeStates = Dictionary(
+            uniqueKeysWithValues: result.nodes.map {
+                ($0.id, $0.state)
+            }
+        )
+
+        XCTAssertEqual(
+            attemptStates["architect-attempt-1"],
+            .interrupted
+        )
+        XCTAssertEqual(
+            attemptStates["researcher-attempt-1"],
+            .orphaned
+        )
+        XCTAssertEqual(nodeStates["architect"], .interrupted)
+        XCTAssertEqual(nodeStates["researcher"], .orphaned)
+        XCTAssertEqual(nodeStates["graph"], .blocked)
+        XCTAssertEqual(nodeStates["reviewer"], .blocked)
+        XCTAssertEqual(result.run.state, .interrupted)
+        XCTAssertFalse(result.nodes.contains { $0.state == .running })
+    }
+
+    private func loadFixture() throws -> ExecutionReconciliationInput {
+        let url = try XCTUnwrap(
+            Bundle.module.url(
+                forResource: "stale-compendium-runtime",
+                withExtension: "json",
+                subdirectory: "Fixtures"
+            )
+        )
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        return try decoder.decode(
+            ExecutionReconciliationInput.self,
+            from: Data(contentsOf: url)
+        )
+    }
+}

--- a/Tests/OpenIslandCoreTests/StaleCompendiumRuntimeFixtureTests.swift
+++ b/Tests/OpenIslandCoreTests/StaleCompendiumRuntimeFixtureTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 final class StaleCompendiumRuntimeFixtureTests: XCTestCase {
     func testStaleCompendiumRunReconcilesWithoutLiveProcessClaims() throws {
-        let input = try loadFixture()
+        let input = try loadStaleCompendiumFixture()
 
         let result = GraphExecutionReconciler.reconcile(input)
         let attemptStates = Dictionary(
@@ -32,22 +32,5 @@ final class StaleCompendiumRuntimeFixtureTests: XCTestCase {
         XCTAssertEqual(nodeStates["reviewer"], .blocked)
         XCTAssertEqual(result.run.state, .interrupted)
         XCTAssertFalse(result.nodes.contains { $0.state == .running })
-    }
-
-    private func loadFixture() throws -> ExecutionReconciliationInput {
-        let url = try XCTUnwrap(
-            Bundle.module.url(
-                forResource: "stale-compendium-runtime",
-                withExtension: "json",
-                subdirectory: "Fixtures"
-            )
-        )
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-
-        return try decoder.decode(
-            ExecutionReconciliationInput.self,
-            from: Data(contentsOf: url)
-        )
     }
 }

--- a/Tests/OpenIslandCoreTests/SupervisedLocalProcessExecutorTests.swift
+++ b/Tests/OpenIslandCoreTests/SupervisedLocalProcessExecutorTests.swift
@@ -1,0 +1,440 @@
+import Foundation
+import XCTest
+@testable import OpenIslandCore
+
+final class SupervisedLocalProcessExecutorTests: XCTestCase {
+    func testSuccessfulExecutionCapturesBothStreamsAndDeclaredArtifact() async throws {
+        let fixture = try LocalProcessTestFixture()
+        let context = try fixture.context(
+            arguments: [
+                "--role", "architect",
+                "--output", "${artifact:node_output}",
+                "--stderr",
+            ],
+            outputs: [fixture.output(role: .nodeOutput)]
+        )
+        let executor = fixture.executor()
+        let prepared = try await executor.prepare(.init(context: context))
+        XCTAssertEqual(prepared.observation.status, .accepted)
+        let started = try await executor.start(.init(context: context))
+            .observation
+        XCTAssertEqual(started.status, .started)
+        let launchID = try XCTUnwrap(started.processIdentity?.launchID)
+        await executor.waitForExit(launchRecordID: launchID)
+        let observed = try await executor.observe(.init(context: context))
+            .observation
+        XCTAssertEqual(observed.status, .succeeded)
+        let collected = try await executor.collectResult(.init(context: context))
+            .observation
+        XCTAssertEqual(collected.status, .succeeded)
+        XCTAssertEqual(
+            Set(collected.artifacts.map(\.role)),
+            Set([.nodeOutput, .executionLog])
+        )
+        let logs = try await executor.logs(launchRecordID: launchID)
+        XCTAssertTrue(logs.entries.contains { $0.channel == .stdout })
+        XCTAssertTrue(logs.entries.contains { $0.channel == .stderr })
+        XCTAssertTrue(logs.entries.map(\.text).joined().contains("architect"))
+        let output = try Data(
+            contentsOf: fixture.workspace
+                .appendingPathComponent("artifacts/output.json")
+        )
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: output) as? [String: Any]
+        )
+        XCTAssertEqual(json["agent"] as? String, "architect")
+    }
+
+    func testNonzeroExitIsClassifiedByRetryPolicy() async throws {
+        let fixture = try LocalProcessTestFixture()
+        let context = try fixture.context(
+            arguments: ["--failure-code", "23"],
+            retryableExitCodes: [23]
+        )
+        let executor = fixture.executor()
+        _ = try await executor.prepare(.init(context: context))
+        let started = try await executor.start(.init(context: context)).observation
+        await executor.waitForExit(
+            launchRecordID: try XCTUnwrap(started.processIdentity?.launchID)
+        )
+        let observed = try await executor.observe(.init(context: context))
+            .observation
+        XCTAssertEqual(observed.status, .failed)
+        XCTAssertEqual(observed.failure?.category, "process_exit_23")
+        XCTAssertEqual(observed.failure?.retryable, true)
+    }
+
+    func testCancellationSignalsOnlyMatchingProcessAndCleanupIsIdempotent() async throws {
+        let fixture = try LocalProcessTestFixture()
+        let context = try fixture.context(
+            arguments: ["--wait-for-cancellation"]
+        )
+        let executor = fixture.executor()
+        _ = try await executor.prepare(.init(context: context))
+        let started = try await executor.start(.init(context: context)).observation
+        let launchID = try XCTUnwrap(started.processIdentity?.launchID)
+        let first = try await executor.requestCancellation(
+            .init(context: context, cancellationRequestID: "cancel")
+        ).observation
+        XCTAssertTrue([.stillRunning, .cancelled].contains(first.status))
+        await executor.waitForExit(launchRecordID: launchID)
+        let second = try await executor.requestCancellation(
+            .init(context: context, cancellationRequestID: "cancel")
+        ).observation
+        XCTAssertEqual(second.status, .cancelled)
+        let firstCleanup = try await executor.cleanup(.init(context: context))
+        XCTAssertEqual(firstCleanup.observation.status, .accepted)
+        let secondCleanup = try await executor.cleanup(.init(context: context))
+        XCTAssertEqual(secondCleanup.observation.status, .accepted)
+    }
+
+    func testCancellationEscalatesAtLogicalDeadline() async throws {
+        let fixture = try LocalProcessTestFixture()
+        var context = try fixture.context(
+            arguments: ["--wait-for-cancellation", "--ignore-term"],
+            cancellationAcknowledgementSeconds: 1
+        )
+        let executor = fixture.executor()
+        _ = try await executor.prepare(.init(context: context))
+        let started = try await executor.start(.init(context: context)).observation
+        let launchID = try XCTUnwrap(started.processIdentity?.launchID)
+        let becameReady = try await executor.waitForLog(
+            launchRecordID: launchID,
+            containing: "waiting for cancellation"
+        )
+        XCTAssertTrue(becameReady)
+        _ = try await executor.requestCancellation(
+            .init(context: context, cancellationRequestID: "cancel")
+        )
+        context = fixture.replacingTime(
+            context,
+            with: context.logicalTime.addingTimeInterval(2)
+        )
+        let response = try await executor.requestCancellation(
+            .init(context: context, cancellationRequestID: "cancel")
+        ).observation
+        XCTAssertTrue([.stillRunning, .cancelled].contains(response.status))
+        await executor.waitForExit(launchRecordID: launchID)
+        let stored = try await executor.launchRecord(
+            id: launchID
+        )
+        let record = try XCTUnwrap(stored)
+        XCTAssertNotNil(record.cancellationEscalatedAt)
+    }
+
+    func testDuplicateStartReturnsSameDurableProcess() async throws {
+        let fixture = try LocalProcessTestFixture()
+        let context = try fixture.context(
+            arguments: ["--wait-for-cancellation"]
+        )
+        let executor = fixture.executor()
+        _ = try await executor.prepare(.init(context: context))
+        let first = try await executor.start(.init(context: context)).observation
+        let second = try await executor.start(.init(context: context)).observation
+        XCTAssertEqual(first.processIdentity, second.processIdentity)
+        _ = try await executor.cleanup(.init(context: context))
+    }
+
+    func testRecoveryAfterAcceptedSpawnUsesDurableIdentity() async throws {
+        let fixture = try LocalProcessTestFixture()
+        let context = try fixture.context(
+            arguments: ["--wait-for-cancellation"]
+        )
+        let crashing = fixture.executor(crashPoint: .afterSpawnAcceptance)
+        _ = try await crashing.prepare(.init(context: context))
+        do {
+            _ = try await crashing.start(.init(context: context))
+            XCTFail("Expected the injected crash boundary")
+        } catch GraphExecutorAdapterError.simulatedCrash {
+        }
+        let restarted = fixture.executor()
+        let recovered = try await restarted.recover(.init(context: context))
+            .observation
+        XCTAssertEqual(recovered.status, .started)
+        XCTAssertNotNil(recovered.processIdentity?.processID)
+        _ = try await restarted.cleanup(.init(context: context))
+    }
+
+    func testCrashBeforeSpawnRecoversByLaunchingExactlyOnce() async throws {
+        let fixture = try LocalProcessTestFixture()
+        let context = try fixture.context()
+        let crashing = fixture.executor(crashPoint: .beforeSpawn)
+        _ = try await crashing.prepare(.init(context: context))
+        do {
+            _ = try await crashing.start(.init(context: context))
+            XCTFail("Expected the injected crash boundary")
+        } catch GraphExecutorAdapterError.simulatedCrash {
+        }
+        let restarted = fixture.executor()
+        let recovered = try await restarted.recover(.init(context: context))
+            .observation
+        XCTAssertEqual(recovered.status, .started)
+        await restarted.waitForExit(
+            launchRecordID: try XCTUnwrap(recovered.processIdentity?.launchID)
+        )
+    }
+
+    func testRecoveryAfterProcessExitDoesNotRelaunch() async throws {
+        let fixture = try LocalProcessTestFixture()
+        let context = try fixture.context(arguments: ["--role", "architect"])
+        let original = fixture.executor()
+        _ = try await original.prepare(.init(context: context))
+        let started = try await original.start(.init(context: context))
+            .observation
+        let launchID = try XCTUnwrap(started.processIdentity?.launchID)
+        await original.waitForExit(launchRecordID: launchID)
+
+        let restarted = fixture.executor()
+        let recovered = try await restarted.recover(.init(context: context))
+            .observation
+        let records = try await fixture.store.records()
+
+        XCTAssertEqual(recovered.status, .succeeded)
+        XCTAssertEqual(recovered.processIdentity?.launchID, launchID)
+        XCTAssertEqual(records.count, 1)
+    }
+
+    func testStaleLeaseGenerationIsRejected() async throws {
+        let fixture = try LocalProcessTestFixture()
+        let generationTwo = try fixture.context(leaseGeneration: 2)
+        let generationOne = try fixture.context(leaseGeneration: 1)
+        let executor = fixture.executor()
+        _ = try await executor.prepare(.init(context: generationTwo))
+        let response = try await executor.observe(.init(context: generationOne))
+            .observation
+        XCTAssertEqual(response.status, .staleClaim)
+    }
+
+    func testIdentityMismatchSimulationIsConservative() async throws {
+        let fixture = try LocalProcessTestFixture()
+        let context = try fixture.context(
+            arguments: ["--wait-for-cancellation"]
+        )
+        let executor = fixture.executor(
+            inspector: FixedProcessInspector(.identityMismatch)
+        )
+        _ = try await executor.prepare(.init(context: context))
+        let response = try await executor.start(.init(context: context))
+            .observation
+        XCTAssertEqual(response.status, .started)
+        let observed = try await executor.observe(.init(context: context))
+            .observation
+        XCTAssertEqual(observed.status, .identityMismatch)
+        let pid = try XCTUnwrap(response.processIdentity?.processID)
+        Darwin.kill(pid, SIGKILL)
+    }
+
+    func testLargeAndInvalidUTF8OutputUsesBoundedFallbackLog() async throws {
+        let fixture = try LocalProcessTestFixture()
+        let context = try fixture.context(
+            arguments: ["--large-output", "65536", "--invalid-utf8"],
+            maximumLogBytes: 4_096
+        )
+        let executor = fixture.executor()
+        _ = try await executor.prepare(.init(context: context))
+        let started = try await executor.start(.init(context: context)).observation
+        let launchID = try XCTUnwrap(started.processIdentity?.launchID)
+        await executor.waitForExit(launchRecordID: launchID)
+        let logs = try await executor.logs(launchRecordID: launchID)
+        XCTAssertTrue(logs.truncatedChannels.contains(.stdout))
+        XCTAssertLessThanOrEqual(
+            logs.entries.filter { $0.channel == .stdout }.reduce(0) {
+                $0 + $1.data.count
+            },
+            4_096
+        )
+        XCTAssertTrue(logs.entries.contains { $0.usedUTF8Fallback })
+    }
+
+    func testUndeclaredOutputFileIsNotCollectedAsArtifact() async throws {
+        let fixture = try LocalProcessTestFixture()
+        let undeclared = fixture.workspace
+            .appendingPathComponent("artifacts/undeclared.json")
+        let context = try fixture.context(arguments: [
+            "--role", "architect", "--output", undeclared.path,
+        ])
+        let executor = fixture.executor()
+        _ = try await executor.prepare(.init(context: context))
+        let started = try await executor.start(.init(context: context))
+            .observation
+        await executor.waitForExit(
+            launchRecordID: try XCTUnwrap(started.processIdentity?.launchID)
+        )
+        let collected = try await executor.collectResult(
+            .init(context: context)
+        ).observation
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: undeclared.path))
+        XCTAssertEqual(collected.artifacts.map(\.role), [.executionLog])
+    }
+
+    func testSpecificationRejectsUnsafeWorkspaceEnvironmentAndArtifacts() throws {
+        let fixture = try LocalProcessTestFixture()
+        XCTAssertThrowsError(
+            try fixture.context(
+                workingDirectory: "../outside"
+            ).resolvedSpecification()
+        )
+        XCTAssertThrowsError(
+            try fixture.context(
+                environment: ["NOT_ALLOWED": "value"]
+            ).resolvedSpecification()
+        )
+        XCTAssertThrowsError(
+            try fixture.context(
+                outputs: [
+                    .init(
+                        relativePath: "../outside.json",
+                        mediaType: "application/json",
+                        role: .nodeOutput
+                    ),
+                ]
+            ).resolvedSpecification()
+        )
+    }
+}
+
+private struct FixedProcessInspector: GraphProcessInspecting {
+    let classification: GraphProcessRecoveryClassification
+
+    init(_ classification: GraphProcessRecoveryClassification) {
+        self.classification = classification
+    }
+
+    func classify(
+        _ identity: GraphDurableProcessIdentity
+    ) -> GraphProcessRecoveryClassification {
+        classification
+    }
+}
+
+private struct LocalProcessTestFixture {
+    let root: URL
+    let workspace: URL
+    let runtime: URL
+    let store: GraphLocalProcessLaunchStore
+    let executable: String
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        workspace = root.appendingPathComponent("workspace", isDirectory: true)
+        runtime = root.appendingPathComponent("runtime", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: workspace.appendingPathComponent("artifacts", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        store = try GraphLocalProcessLaunchStore(rootURL: runtime)
+        executable = URL(
+            fileURLWithPath: FileManager.default.currentDirectoryPath
+        ).appendingPathComponent(
+            ".build/debug/OpenIslandProcessFixtureAgent"
+        ).path
+    }
+
+    func executor(
+        inspector: any GraphProcessInspecting = DarwinGraphProcessInspector(),
+        crashPoint: GraphLocalProcessCrashPoint? = nil
+    ) -> SupervisedLocalProcessExecutor {
+        SupervisedLocalProcessExecutor(
+            executorInstanceID: UUID().uuidString,
+            launchStore: store,
+            inspector: inspector,
+            crashPoint: crashPoint
+        )
+    }
+
+    func output(
+        role: GraphArtifactRole
+    ) -> GraphLocalProcessArtifactDeclaration {
+        GraphLocalProcessArtifactDeclaration(
+            relativePath: "artifacts/output.json",
+            mediaType: "application/json",
+            role: role,
+            maximumBytes: 1_024 * 1_024
+        )
+    }
+
+    func context(
+        arguments: [String] = [],
+        workingDirectory: String = ".",
+        environment: [String: String] = [:],
+        outputs: [GraphLocalProcessArtifactDeclaration] = [],
+        retryableExitCodes: [Int32] = [],
+        maximumLogBytes: Int = 1_024 * 1_024,
+        cancellationAcknowledgementSeconds: UInt64 = 1,
+        leaseGeneration: UInt64 = 1
+    ) throws -> GraphExecutorCommandContext {
+        let specification = GraphLocalProcessSpecification(
+            executable: executable,
+            arguments: arguments,
+            workingDirectory: workingDirectory,
+            environment: environment,
+            outputArtifacts: outputs,
+            retryableExitCodes: retryableExitCodes,
+            logPolicy: GraphLocalProcessLogPolicy(
+                maximumBytesPerStream: maximumLogBytes
+            )
+        )
+        return GraphExecutorCommandContext(
+            identity: GraphExecutorInteractionIdentity(
+                runID: "run",
+                nodeID: "node",
+                attemptID: "attempt",
+                attemptOrdinal: 1,
+                claimID: "claim",
+                leaseGeneration: leaseGeneration,
+                executorID: "openisland.local-process"
+            ),
+            capabilityRequirement: ["local-process"],
+            specification: try specification.immutableSpecification(),
+            workspace: GraphExecutionWorkspaceContext(
+                root: workspace.path,
+                writableRelativePaths: ["artifacts"]
+            ),
+            environmentAllowlist: ["ALLOWED"],
+            inputArtifacts: [],
+            cancellation: nil,
+            timeoutPolicy: GraphExecutionTimeoutPolicy(
+                executionSeconds: 30,
+                cancellationAcknowledgementSeconds:
+                    cancellationAcknowledgementSeconds
+            ),
+            correlation: GraphExecutorCorrelationMetadata(
+                correlationID: "correlation"
+            ),
+            priorObservationCount: 0,
+            logicalTime: Date(timeIntervalSince1970: 50_000)
+        )
+    }
+
+    func replacingTime(
+        _ context: GraphExecutorCommandContext,
+        with time: Date
+    ) -> GraphExecutorCommandContext {
+        GraphExecutorCommandContext(
+            identity: context.identity,
+            capabilityRequirement: context.capabilityRequirement,
+            specification: context.specification,
+            workspace: context.workspace,
+            environmentAllowlist: context.environmentAllowlist,
+            inputArtifacts: context.inputArtifacts,
+            cancellation: context.cancellation,
+            timeoutPolicy: context.timeoutPolicy,
+            correlation: context.correlation,
+            priorObservationCount: context.priorObservationCount,
+            logicalTime: time
+        )
+    }
+}
+
+private extension GraphExecutorCommandContext {
+    func resolvedSpecification() throws -> GraphResolvedLocalProcessSpecification {
+        try GraphLocalProcessSpecificationResolver.resolve(
+            GraphLocalProcessSpecification(
+                immutableSpecification: specification
+            ),
+            context: self
+        )
+    }
+}

--- a/Tests/OpenIslandCoreTests/TerminalGraphCompatibilityTests.swift
+++ b/Tests/OpenIslandCoreTests/TerminalGraphCompatibilityTests.swift
@@ -1,0 +1,427 @@
+import Foundation
+import XCTest
+@testable import OpenIslandCore
+
+final class TerminalGraphCompatibilityTests: XCTestCase {
+    func testAbsentTerminalGraphEnvironmentIsOptional() {
+        let context = TerminalGraphEnvironmentDiscovery.discover(
+            environment: ["PATH": "/usr/bin"]
+        )
+
+        XCTAssertFalse(context.detected)
+        XCTAssertNil(context.nodeID)
+        XCTAssertTrue(context.values.isEmpty)
+    }
+
+    func testRepresentativeEnvironmentIsSanitizedAndPreserved() {
+        let context = TerminalGraphEnvironmentDiscovery.discover(
+            environment: [
+                "TG_NODE_ID": "node-7",
+                "TG_WORKSPACE_ID": "workspace",
+                "TG_PROJECT_ROOT": "/tmp/project/../project",
+                "TG_MCP_URL": "http://user:password@127.0.0.1:4317/api?token=secret",
+                "TG_FUTURE_MODE": "spatial",
+                "TG_API_TOKEN": "must-not-escape",
+            ]
+        )
+        let values = Dictionary(
+            uniqueKeysWithValues: context.values.map {
+                ($0.name, $0)
+            }
+        )
+
+        XCTAssertTrue(context.detected)
+        XCTAssertEqual(context.nodeID, "node-7")
+        XCTAssertEqual(context.workspaceID, "workspace")
+        XCTAssertEqual(context.projectRoot, "/tmp/project")
+        XCTAssertEqual(
+            values["TG_MCP_URL"]?.value,
+            "http://127.0.0.1:4317/api"
+        )
+        XCTAssertEqual(values["TG_FUTURE_MODE"]?.value, "spatial")
+        XCTAssertNil(values["TG_API_TOKEN"]?.value)
+        XCTAssertTrue(values["TG_API_TOKEN"]?.redacted == true)
+    }
+
+    func testMalformedEnvironmentValuesAreBoundedWithoutFailure() {
+        let context = TerminalGraphEnvironmentDiscovery.discover(
+            environment: [
+                "TG_MCP_URL": "not a URL with credentials",
+                "TG_FUTURE_VALUE": String(repeating: "x", count: 2_000),
+                "TG_GROUP_ID": "group\nwith-control",
+            ]
+        )
+        let values = Dictionary(
+            uniqueKeysWithValues: context.values.map {
+                ($0.name, $0)
+            }
+        )
+
+        XCTAssertTrue(context.detected)
+        XCTAssertNil(values["TG_MCP_URL"]?.value)
+        XCTAssertNil(values["TG_FUTURE_VALUE"]?.value)
+        XCTAssertEqual(values["TG_GROUP_ID"]?.value, "group with-control")
+    }
+
+    func testGitContextDistinguishesIdentityAndRedactedPaths() {
+        let resolver = GitGraphRepositoryContextResolver()
+        let directory = FileManager.default.currentDirectoryPath
+        let visible = resolver.resolve(
+            workingDirectory: directory,
+            exposePaths: true,
+            externalContextID: "workspace",
+            sourceProjectAssociation: "project"
+        )
+        let redacted = resolver.resolve(
+            workingDirectory: directory,
+            exposePaths: false,
+            externalContextID: "workspace",
+            sourceProjectAssociation: "project"
+        )
+
+        XCTAssertNotNil(visible)
+        XCTAssertEqual(
+            visible?.repositoryIdentity,
+            redacted?.repositoryIdentity
+        )
+        XCTAssertNotNil(visible?.canonicalProjectRoot.value)
+        XCTAssertNotNil(visible?.worktreeRoot.value)
+        XCTAssertNil(redacted?.canonicalProjectRoot.value)
+        XCTAssertTrue(redacted?.canonicalProjectRoot.redacted == true)
+        XCTAssertFalse(visible?.commit?.isEmpty ?? true)
+    }
+
+    func testMultiProjectWorkspaceRepresentationIsDeterministic() {
+        let first = repositoryContext(
+            identity: "repository-b",
+            path: "/tmp/b"
+        )
+        let second = repositoryContext(
+            identity: "repository-a",
+            path: "/tmp/a"
+        )
+        let workspace = GraphWorkspaceContext(
+            workspaceID: "workspace",
+            externalContextID: "external",
+            selectedRepositoryIdentity: "repository-b",
+            repositories: [first, second]
+        )
+
+        XCTAssertEqual(
+            workspace.repositories.map(\.repositoryIdentity),
+            ["repository-a", "repository-b"]
+        )
+        XCTAssertEqual(
+            workspace.selectedRepositoryIdentity,
+            "repository-b"
+        )
+    }
+
+    func testWorkspacePlanUsesStableMappingsAndNeutralPorts()
+        async throws
+    {
+        let inspection = try await inspectionFixture()
+        let workspace = GraphWorkspaceContext(
+            workspaceID: "workspace",
+            externalContextID: "external",
+            selectedRepositoryIdentity: "repository",
+            repositories: [
+                repositoryContext(
+                    identity: "repository",
+                    path: "/tmp/worktree"
+                ),
+            ]
+        )
+
+        let first = GraphTerminalWorkspacePlanBuilder.build(
+            inspection: inspection,
+            workspaceContext: workspace
+        )
+        let second = GraphTerminalWorkspacePlanBuilder.build(
+            inspection: inspection,
+            workspaceContext: workspace
+        )
+
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(first.authority, "openisland")
+        XCTAssertEqual(first.terminals.count, 1)
+        XCTAssertEqual(
+            first.terminals.first?.command,
+            [
+                "openisland",
+                "graph",
+                "inspect",
+                "run",
+                "--node",
+                "node",
+                "--output",
+                "json",
+            ]
+        )
+        XCTAssertTrue(
+            first.terminals.first?.ports.contains {
+                $0.kind == .stream
+                    && $0.semanticType == .eventHistory
+            } == true
+        )
+        XCTAssertFalse(
+            first.terminals.first?.ports.contains {
+                $0.id.contains("/tmp")
+            } == true
+        )
+    }
+
+    func testSynchronizationRequestSortsExternalMappings() async throws {
+        let plan = GraphTerminalWorkspacePlanBuilder.build(
+            inspection: try await inspectionFixture(),
+            workspaceContext: nil
+        )
+        let request = GraphVisualizationSynchronizationRequest(
+            plan: plan,
+            existingMappings: [
+                GraphExternalEntityMapping(
+                    openIslandMappingKey: "z",
+                    externalEntityID: "external-z"
+                ),
+                GraphExternalEntityMapping(
+                    openIslandMappingKey: "a",
+                    externalEntityID: "external-a"
+                ),
+            ]
+        )
+
+        XCTAssertEqual(
+            request.existingMappings.map(\.openIslandMappingKey),
+            ["a", "z"]
+        )
+        XCTAssertEqual(
+            request.plan.graphRunID,
+            "run"
+        )
+    }
+
+    func testTerminalWorkspacePlanExportIncludesContextAndNoSecrets()
+        async throws
+    {
+        let store = InMemoryGraphExecutionEventStore()
+        _ = try await store.append(
+            terminalGraphEvents(),
+            to: "run",
+            expectedVersion: 0
+        )
+        let stdout = CompatibilityOutputSink()
+        let context = GraphCLIExecutionContext(
+            terminalGraph: TerminalGraphEnvironmentDiscovery.discover(
+                environment: [
+                    "TG_NODE_ID": "terminal-node",
+                    "TG_API_TOKEN": "private-token",
+                ]
+            ),
+            workspace: nil
+        )
+        let runner = GraphCLICommandRunner(
+            inspector: DefaultGraphTemporalInspector(
+                readStore: store,
+                snapshotStore: InMemoryGraphExecutionSnapshotStore()
+            ),
+            stdout: stdout,
+            stderr: CompatibilityOutputSink(),
+            context: context
+        )
+
+        let code = await runner.run(
+            arguments: [
+                "graph",
+                "export",
+                "run",
+                "--format",
+                "terminal-workspace-plan",
+            ]
+        )
+        let output = stdout.consume()
+
+        XCTAssertEqual(code, .success)
+        XCTAssertTrue(
+            output.contains("\"authority\":\"openisland\"")
+        )
+        XCTAssertTrue(
+            output.contains("\"recordType\"") == false
+        )
+        XCTAssertTrue(
+            output.contains("\"terminalGraph\"")
+        )
+        XCTAssertFalse(output.contains("private-token"))
+    }
+
+    func testCLITelemetryIsBoundedAndPrivacySafe() async throws {
+        let store = InMemoryGraphExecutionEventStore()
+        _ = try await store.append(
+            terminalGraphEvents(),
+            to: "run",
+            expectedVersion: 0
+        )
+        let telemetry = CapturingGraphCLITelemetrySink()
+        let context = GraphCLIExecutionContext(
+            terminalGraph: TerminalGraphEnvironmentDiscovery.discover(
+                environment: [
+                    "TG_NODE_ID": "node",
+                    "TG_PROJECT_ROOT": "/private/project",
+                    "TG_API_TOKEN": "private-token",
+                ]
+            ),
+            workspace: nil
+        )
+        let runner = GraphCLICommandRunner(
+            inspector: DefaultGraphTemporalInspector(
+                readStore: store,
+                snapshotStore: InMemoryGraphExecutionSnapshotStore()
+            ),
+            stdout: CompatibilityOutputSink(),
+            stderr: CompatibilityOutputSink(),
+            context: context,
+            telemetry: telemetry,
+            clock: SequenceGraphCLIClock(
+                values: [1_000_000, 6_000_000]
+            ),
+            isOutputTTY: false
+        )
+
+        let code = await runner.run(
+            arguments: [
+                "graph",
+                "history",
+                "run",
+                "--output",
+                "jsonl",
+                "--limit",
+                "2",
+            ]
+        )
+        let record = try XCTUnwrap(telemetry.records().first)
+        let encoded = String(
+            decoding: try JSONEncoder().encode(record),
+            as: UTF8.self
+        )
+
+        XCTAssertEqual(code, .success)
+        XCTAssertEqual(record.command, "graph.history")
+        XCTAssertEqual(record.outputMode, .jsonl)
+        XCTAssertEqual(record.durationMilliseconds, 5)
+        XCTAssertEqual(record.eventCount, 2)
+        XCTAssertTrue(record.terminalGraphDetected)
+        XCTAssertTrue(record.pipedOutput)
+        XCTAssertFalse(encoded.contains("private-token"))
+        XCTAssertFalse(encoded.contains("/private/project"))
+        XCTAssertFalse(encoded.contains("--limit"))
+    }
+
+    private func inspectionFixture() async throws -> GraphRunInspection {
+        let store = InMemoryGraphExecutionEventStore()
+        _ = try await store.append(
+            terminalGraphEvents(),
+            to: "run",
+            expectedVersion: 0
+        )
+        return try await DefaultGraphTemporalInspector(
+            readStore: store,
+            snapshotStore: InMemoryGraphExecutionSnapshotStore()
+        ).inspect(
+            runID: "run",
+            includeArtifacts: true,
+            includeDiagnostics: false
+        )
+    }
+
+    private func repositoryContext(
+        identity: String,
+        path: String
+    ) -> GraphRepositoryContext {
+        GraphRepositoryContext(
+            repositoryIdentity: identity,
+            canonicalProjectRoot: GraphRepositoryPath(
+                value: path,
+                redacted: false
+            ),
+            worktreeRoot: GraphRepositoryPath(
+                value: path,
+                redacted: false
+            ),
+            branch: "feature",
+            commit: "abc",
+            isDirty: false,
+            externalContextID: "external",
+            sourceProjectAssociation: identity
+        )
+    }
+}
+
+private final class CompatibilityOutputSink:
+    GraphCLIOutputSink,
+    @unchecked Sendable
+{
+    private let lock = NSLock()
+    private var data = Data()
+
+    func write(_ data: Data) -> GraphCLIWriteResult {
+        lock.lock()
+        self.data.append(data)
+        lock.unlock()
+        return .written
+    }
+
+    func consume() -> String {
+        lock.lock()
+        let result = String(decoding: data, as: UTF8.self)
+        data.removeAll()
+        lock.unlock()
+        return result
+    }
+}
+
+private final class CapturingGraphCLITelemetrySink:
+    GraphCLITelemetrySink,
+    @unchecked Sendable
+{
+    private let lock = NSLock()
+    private var storage: [GraphCLITelemetryRecord] = []
+
+    func record(_ record: GraphCLITelemetryRecord) {
+        lock.lock()
+        storage.append(record)
+        lock.unlock()
+    }
+
+    func records() -> [GraphCLITelemetryRecord] {
+        lock.lock()
+        let result = storage
+        lock.unlock()
+        return result
+    }
+}
+
+private final class SequenceGraphCLIClock:
+    GraphCLIMonotonicClock,
+    @unchecked Sendable
+{
+    private let lock = NSLock()
+    private var values: [UInt64]
+
+    init(values: [UInt64]) {
+        self.values = values
+    }
+
+    func nowNanoseconds() -> UInt64 {
+        lock.lock()
+        defer { lock.unlock() }
+        return values.isEmpty ? 0 : values.removeFirst()
+    }
+}
+
+private func terminalGraphEvents() -> [GraphExecutionEventEnvelope] {
+    [
+        graphTestRunCreated(),
+        graphTestNodeRegistered(),
+        graphTestAttemptCreated(),
+        graphTestAttemptStarting(),
+    ]
+}

--- a/docs/architecture-decisions/001-durable-graph-history.md
+++ b/docs/architecture-decisions/001-durable-graph-history.md
@@ -4,6 +4,11 @@
 **Date:** 2026-07-20
 **Scope:** Native graph execution history, replay, snapshots, reconciliation, local persistence, artifacts, and telemetry vocabulary
 
+**Follow-on:** [ADR 002](./002-durable-graph-scheduling.md) now adds scheduling,
+claims, leases, retry, cancellation, and timeout decisions on this history
+boundary. Statements below that scheduling is absent describe this ADR's
+original scope, not the current repository capability.
+
 ## Context
 
 Open Island needs durable graph execution before it can safely add model launchers,
@@ -271,9 +276,8 @@ performance policy can evolve without changing replay semantics.
 ## Framework Interoperability
 
 - **Temporal-style durable execution:** this foundation supplies immutable history,
-  optimistic concurrency, replay, and version boundaries, but it does not implement task
-  queues, durable timers, scheduling, or workflow workers. A future executor can append to
-  this contract or bridge it to a durable workflow backend.
+  optimistic concurrency, replay, and version boundaries. ADR 002 adds local scheduler and
+  timeout decisions; task queues, workflow workers, and distributed transport remain absent.
 - **LangGraph-style checkpoints and time travel:** snapshots, named stream boundaries,
   parent checkpoint references, subgraph namespaces, human interrupts, and replay from a
   projection boundary provide the required data model. User-facing state mutation and fork
@@ -302,8 +306,9 @@ Costs and consciously deferred work:
 
 - event history grows without a retention/archival implementation
 - integrity metadata is stored but cryptographic verification policy is not yet selected
-- durable timers, dynamic graphs, scheduling, executor claiming, fencing tokens, and
-  distributed networking are not implemented
+- dynamic graphs, provider executors, resource reservation, and distributed networking are
+  not implemented; ADR 002 supplies scheduling, claiming, lease-generation fencing, and
+  explicit timeout decisions
 - no execution mutation commands or user-facing temporal debugger exist yet
 
 ## Requirement Audit
@@ -323,8 +328,9 @@ Costs and consciously deferred work:
 | 11. Required tests | complete | all listed cases are covered across `GraphExecutionEventStoreTests`, `GraphExecutionReplayTests`, `GraphExecutionRepositoryTests`, `SQLiteGraphExecutionStoreTests`, and `GraphExecutionDurabilityInvariantTests` |
 | 12. Property/model validation | complete | generated 1-20 attempt streams, duplicate/reverse replay equivalence, monotonic stream versions and ordinals, snapshot-boundary equivalence, fixed-point reconciliation, and no-manufactured-event reload tests |
 
-Architectural principles 1-10 are complete in the implemented boundaries: definition remains
-separate, history is immutable, projection and reconciliation are pure, scheduling is absent,
+Architectural principles 1-10 are complete in this ADR's implemented boundaries: definition remains
+separate, history is immutable, projection and reconciliation are pure, scheduling was kept
+outside this history layer and is now defined separately by ADR 002,
 attempt/process identity is distinct, artifacts are durable references, core has no
 provider/terminal/UI coupling, storage is accessed through protocols with SQLite confined to
 the local adapter, and every persisted public format is schema-versioned.

--- a/docs/architecture-decisions/001-durable-graph-history.md
+++ b/docs/architecture-decisions/001-durable-graph-history.md
@@ -1,0 +1,330 @@
+# Durable Graph History And Replay
+
+**Status:** Accepted
+**Date:** 2026-07-20
+**Scope:** Native graph execution history, replay, snapshots, reconciliation, local persistence, artifacts, and telemetry vocabulary
+
+## Context
+
+Open Island needs durable graph execution before it can safely add model launchers,
+scheduling, mutation commands, time travel, or distributed executors. The prior runtime
+could describe a DAG and execute an in-memory simulation, but it could not prove what
+happened after restart, distinguish a workflow from an operating-system process, reject
+concurrent writers, or reconstruct state at a historical stream boundary.
+
+The design separates five concerns:
+
+1. **Definition** describes intended graph work.
+2. **History** records immutable commands, observations, declarations, and metadata.
+3. **Projection** deterministically folds history into persisted logical state.
+4. **Reconciliation** compares projected state with current external process evidence.
+5. **Decision** determines what should execute next and remains out of scope.
+
+A snapshot is not history. A process is not a workflow. A reconciled state is not written
+back as though it were an external fact. A UI is not a scheduler.
+
+## Decision
+
+### Event-sourced authority
+
+`GraphExecutionEventEnvelope` is the durable unit of history. Every envelope carries:
+
+- envelope and payload schema versions
+- globally stable event ID
+- run, optional node, and optional attempt identity
+- monotonically increasing run-stream sequence
+- separate occurrence and recording timestamps
+- event type and typed payload
+- producer identity
+- correlation and causation IDs
+- extensible trace context
+- optional integrity metadata
+
+The stream sequence is authoritative ordering. Timestamps are descriptive and are never the
+sole ordering mechanism.
+
+Known payload types are strongly typed. Unknown event types remain
+`GraphExecutionEventPayload.unknown` with a JSON value body. Replay advances the stream
+version, retains the envelope, emits a warning diagnostic, and does not invent semantics.
+A newer envelope schema is rejected because its structural invariants cannot be assumed.
+
+### Event taxonomy
+
+The initial taxonomy distinguishes metadata, commands, observations, and authoritative
+declarations:
+
+| Class | Events |
+|---|---|
+| Metadata | run created, node registered, attempt created, artifact recorded |
+| Command | attempt starting, human interrupt requested |
+| Observation | process identity observed, heartbeat observed, process exit observed |
+| Declaration | attempt completed, failed, interrupted, orphaned, or cancelled; human interrupt resolved; run terminal state recorded |
+
+Process exit is only an observation. Without an explicit terminal attempt declaration,
+reconciliation classifies the attempt as interrupted rather than completed, including when
+the process exit code is zero.
+
+### Ordering, duplicates, and concurrency
+
+Each run starts at stream version zero. A successful append requires:
+
+1. every envelope names the target run;
+2. every new event ID is globally unique;
+3. an existing event ID has byte-equivalent semantic content;
+4. the caller's expected version equals the persisted stream head;
+5. new sequences are contiguous from `head + 1`.
+
+An exact redelivery is idempotent, including a retry made with the pre-append expected
+version. Event-ID reuse with different content, contradictory stream sequences, and gaps are
+errors. No update, replacement, or deletion API exists.
+
+SQLite uses `BEGIN IMMEDIATE` to serialize writers. The expected-version check and all event
+inserts occur in one transaction. Two writers starting from the same version therefore
+produce one commit and one explicit version conflict. WAL mode supports concurrent readers,
+and deterministic queries order by `(run_id, stream_sequence, event_id)`.
+
+### Replay projection
+
+`GraphExecutionProjector` is side-effect-free. It does not read clocks, generate identifiers,
+access files, query processes, open storage, or perform network operations.
+
+Replay:
+
+1. validates an optional initial projection boundary;
+2. orders input by stream sequence and event ID;
+3. removes only exact duplicate delivery;
+4. rejects ID collisions, sequence conflicts, and gaps;
+5. validates envelope and payload compatibility;
+6. applies each typed event;
+7. advances stream version only after successful application;
+8. retains unknown events and diagnostics;
+9. normalizes collection ordering for stable equality and encoding.
+
+Attempt ordinals must be exactly monotonic per logical node. An attempt cannot change
+process identity unless a future explicit migration event defines that behavior. Terminal
+attempts and terminal runs cannot regress. A committed successful sibling attempt and its
+artifacts remain materialized when another sibling fails.
+
+### Snapshots and checkpoints
+
+`GraphExecutionSnapshot` contains:
+
+- snapshot schema and run ID
+- stream version covered by the snapshot
+- graph-definition version and digest
+- complete projected state
+- creation time and producer
+- optional integrity metadata
+- checkpoint namespace and named checkpoint references
+
+A snapshot is a replay cache. The repository bypasses incompatible, corrupt, internally
+inconsistent, or ahead-of-stream snapshots. A stale compatible snapshot is accepted only as
+an initial projection, followed by replay of every subsequent event. Snapshot creation
+frequency is controlled by `GraphExecutionSnapshotPolicy`; the default never writes one.
+
+Checkpoint-ready fields preserve:
+
+- named stream boundaries
+- parent run and parent checkpoint for future forks
+- explicit subgraph checkpoint namespace
+- completed sibling writes
+- durable human interrupt request and resolution facts
+
+This task does not expose time travel or forks to users. Future replay APIs can select a
+stream boundary without changing the event or snapshot schemas.
+
+### Reconciliation and evidence isolation
+
+`DefaultGraphExecutionRepository.load` follows this order:
+
+1. load and validate the latest snapshot;
+2. read subsequent events, or the complete stream when bypassing a snapshot;
+3. replay deterministically;
+4. request external evidence through `ProcessEvidenceSource`;
+5. invoke `GraphExecutionReconciler`;
+6. return persisted projection, reconciled state, snapshot disposition, evidence outcome,
+   replay diagnostics, and repository diagnostics.
+
+Evidence outcomes are explicit: available, unavailable, stale, permission denied, adapter
+failed, or identity mismatch. Evidence failures never append history and never masquerade
+as workflow terminal events. Identity-mismatched evidence is not passed to reconciliation.
+Unavailable evidence conservatively turns unsupported running claims into interrupted or
+orphaned projections while preserving the persisted history unchanged.
+
+### Local persistence
+
+`SQLiteGraphExecutionStore` is the production local event and snapshot store. Its default
+location is:
+
+```text
+~/Library/Application Support/OpenIsland/graph-execution.sqlite
+```
+
+Database schema version 1 contains:
+
+```text
+graph_schema_migrations
+  version PRIMARY KEY
+  applied_at
+
+graph_execution_streams
+  run_id PRIMARY KEY
+  current_version
+
+graph_execution_events
+  event_id PRIMARY KEY
+  run_id
+  stream_sequence
+  envelope_schema_version
+  event_type
+  payload_version
+  occurred_at
+  recorded_at
+  event_json
+  UNIQUE(run_id, stream_sequence)
+  INDEX(run_id, stream_sequence)
+
+graph_execution_snapshots
+  run_id
+  stream_version
+  snapshot_schema_version
+  graph_definition_version
+  graph_definition_digest
+  created_at
+  snapshot_json
+  PRIMARY KEY(run_id, stream_version)
+  INDEX(run_id, stream_version DESC)
+```
+
+Migrations run transactionally and are recorded in both `graph_schema_migrations` and
+SQLite `user_version`. Indexed columns are cross-checked against decoded envelopes and
+snapshots so malformed or tampered JSON produces a corruption error.
+
+### Artifact lineage
+
+`GraphArtifactReference` stores metadata, not artifact contents:
+
+- schema version and artifact ID
+- content digest
+- media type and logical role
+- producing run, node, and attempt
+- creation timestamp
+- abstract storage scheme and opaque locator
+- sensitivity/redaction classification
+
+The projector rejects artifact provenance that disagrees with its event envelope and rejects
+artifact-ID reuse with different metadata. This provides the future handoff, lineage,
+selective-backfill, integrity, and redaction boundary without embedding large outputs in
+events.
+
+### Observability and privacy
+
+The internal vocabulary uses OpenTelemetry-compatible operation and attribute naming without
+adding an SDK:
+
+Operations:
+
+- `openisland.graph.repository.load`
+- `openisland.graph.event.append`
+- `openisland.graph.event.replay`
+- `openisland.graph.snapshot.load`
+- `openisland.graph.reconciliation`
+- `openisland.graph.process_evidence.query`
+
+Stable attributes:
+
+- `openisland.graph.run.id`
+- `openisland.graph.node.id`
+- `openisland.graph.attempt.id`
+- `openisland.graph.executor.id`
+- `openisland.graph.event.type`
+- `openisland.graph.stream.version`
+- `openisland.graph.replay.count`
+- `openisland.graph.reconciliation.result`
+- `error.type`
+
+These are trace/log attributes, not unbounded metric dimensions. Prompts, secrets, file
+contents, artifact contents, and unrestricted command arguments are prohibited. Telemetry is
+local and no export dependency is installed.
+
+### Schema evolution
+
+- Database changes use ordered transactional migrations and increment `user_version`.
+- Envelope structural changes increment the envelope schema.
+- Payload changes increment the payload version independently.
+- Additive optional payload fields may remain compatible within a payload version only when
+  old decoders preserve the same meaning.
+- Unknown event types within the current envelope schema are retained but not interpreted.
+- Incompatible known payloads and future envelope schemas fail replay explicitly.
+- Snapshot schema changes do not rewrite history; incompatible snapshots are bypassed.
+- Graph-definition versions and digests are immutable per run.
+- Process-identity migration requires a future explicit event type.
+
+### Retention and compaction
+
+No retention or deletion API is implemented. This is intentional: compaction policy cannot
+silently turn snapshots into authority. A future archival design must preserve immutable
+event identity, stream sequence, integrity metadata, checkpoint references, and a verifiable
+archive boundary before local history can be removed. Snapshot cadence is injectable now so
+performance policy can evolve without changing replay semantics.
+
+## Framework Interoperability
+
+- **Temporal-style durable execution:** this foundation supplies immutable history,
+  optimistic concurrency, replay, and version boundaries, but it does not implement task
+  queues, durable timers, scheduling, or workflow workers. A future executor can append to
+  this contract or bridge it to a durable workflow backend.
+- **LangGraph-style checkpoints and time travel:** snapshots, named stream boundaries,
+  parent checkpoint references, subgraph namespaces, human interrupts, and replay from a
+  projection boundary provide the required data model. User-facing state mutation and fork
+  APIs remain deferred.
+- **Dagster-style lineage and backfills:** content-addressed artifacts and explicit producer
+  provenance provide the asset boundary. Partitions, selective backfills, and materialization
+  policies are future scheduling features.
+- **OpenTelemetry-style observability:** operation and attribute names align with traces,
+  spans, links, logs, and resources without binding core code to an exporter or SDK.
+
+Open Island does not copy or depend on these frameworks. Interoperability must occur through
+versioned events, artifacts, checkpoints, telemetry context, or adapter protocols.
+
+## Consequences
+
+Benefits:
+
+- restart-safe and deterministic logical history
+- explicit corruption and concurrent-writer failure
+- conservative degradation when process evidence is missing
+- future-safe boundaries for checkpoints, forks, nested graphs, human interrupts, lineage,
+  and telemetry
+- a local production store with no cloud dependency
+
+Costs and consciously deferred work:
+
+- event history grows without a retention/archival implementation
+- integrity metadata is stored but cryptographic verification policy is not yet selected
+- durable timers, dynamic graphs, scheduling, executor claiming, fencing tokens, and
+  distributed networking are not implemented
+- no execution mutation commands or user-facing temporal debugger exist yet
+
+## Requirement Audit
+
+| # | Status | Implementation and test evidence |
+|---|---|---|
+| 1. Persistence protocols | complete | `GraphExecutionEventStore`, `GraphExecutionSnapshotStore`, `ProcessEvidenceSource`, and `GraphExecutionRepository`; event-store and repository test suites |
+| 2. Canonical event envelope | complete | `GraphExecutionEventEnvelope`, producer, correlation/causation, telemetry, integrity, separate timestamps, typed payloads; envelope round-trip and ordering tests |
+| 3. Event taxonomy | complete | `GraphExecutionEventType`, typed payload structs, and `GraphExecutionEventFactClass`; normal replay, process, artifact, and interrupt tests |
+| 4. Replay projector | complete | `GraphExecutionProjector` and replay diagnostics/errors; duplicate, collision, gap, ordinal, identity, terminal-regression, unknown-event, generated determinism tests |
+| 5. Snapshot boundary | complete | versioned snapshots, protocol, in-memory and SQLite stores, injectable policy; stale, incompatible, corrupt, ahead, restart, and result-equivalence tests |
+| 6. Checkpoint-ready model | complete | checkpoint references, parent run/checkpoint, namespace, named boundaries, durable interrupts, independent sibling writes; checkpoint/interrupt and sibling-failure tests |
+| 7. Local persistence | complete | SQLite WAL store, transactions, unique constraints, indexes, migrations, deterministic reads, default macOS path; migration, restart, corruption, and concurrent-writer tests |
+| 8. Evidence failure isolation | complete | six explicit evidence outcomes and repository diagnostics; unavailable, stale, failure, mismatch, heartbeat, and exit tests |
+| 9. Artifact provenance | complete | content-addressed metadata reference and storage abstraction; provenance rejection and SQLite/replay round-trip tests |
+| 10. Observability preparation | complete | operation, phase, sink, record, and stable attribute vocabulary; repository emits load/replay/snapshot/evidence/reconciliation records without sensitive payloads |
+| 11. Required tests | complete | all listed cases are covered across `GraphExecutionEventStoreTests`, `GraphExecutionReplayTests`, `GraphExecutionRepositoryTests`, `SQLiteGraphExecutionStoreTests`, and `GraphExecutionDurabilityInvariantTests` |
+| 12. Property/model validation | complete | generated 1-20 attempt streams, duplicate/reverse replay equivalence, monotonic stream versions and ordinals, snapshot-boundary equivalence, fixed-point reconciliation, and no-manufactured-event reload tests |
+
+Architectural principles 1-10 are complete in the implemented boundaries: definition remains
+separate, history is immutable, projection and reconciliation are pure, scheduling is absent,
+attempt/process identity is distinct, artifacts are durable references, core has no
+provider/terminal/UI coupling, storage is accessed through protocols with SQLite confined to
+the local adapter, and every persisted public format is schema-versioned.

--- a/docs/architecture-decisions/002-durable-graph-scheduling.md
+++ b/docs/architecture-decisions/002-durable-graph-scheduling.md
@@ -1,0 +1,315 @@
+# Durable Graph Scheduling And Executor Ownership
+
+**Status:** Accepted
+**Date:** 2026-07-21
+**Scope:** Scheduler decisions, runnable selection, claims, leases, retry,
+cancellation, timeout declarations, restart recovery, and read-only inspection
+
+## Context
+
+Durable graph history established what happened, but history alone did not decide
+what may run next or which executor owns that work. Launching an agent before
+these decisions are durable would allow duplicate execution, lost retries,
+ambiguous cancellation, and different recovery results after restart.
+
+The scheduling boundary preserves this order:
+
+```text
+Definition
+-> History
+-> Projection
+-> Reconciliation
+-> Scheduling decision
+-> Claim
+-> Execution
+```
+
+No layer mutates the output of the preceding layer. The scheduler proposes
+events. A repository appends them with optimistic concurrency. Replay alone
+reconstructs the same scheduling and ownership state.
+
+## Decision
+
+### Pure scheduler
+
+`GraphScheduler.evaluate(_:)` accepts a versioned graph definition, projected
+state, reconciled state, scheduler policy, logical evaluation time, available
+executor capabilities, claims, leases, and failure categories. It returns a
+`GraphSchedulingDecision` containing proposed events, node phases, and reason
+codes. It performs no I/O and has no clock, process, model, tmux, marker-file,
+SQLite, or Terminal Graph dependency.
+
+The evaluation ID hashes the durable semantic inputs: definition and policy
+identity, logical time, capability identities, run/node/attempt state, claim
+generations and expiry, retries, cancellations, timeouts, and failure
+categories. Input ordering is normalized. Identical input produces identical
+events and IDs.
+
+The repository recognizes exact redelivery from the original expected stream
+head by replaying that boundary and matching its completed evaluation ID.
+Changed input receives a different ID and still requires the current head.
+
+### Scheduling event taxonomy
+
+| Event type | Fact class | Meaning |
+|---|---|---|
+| `graph.scheduler.evaluation.recorded` | decision | Captures definition, policy, logical time, and available capability identities |
+| `graph.scheduler.node.runnable` | decision | Declares a node claimable for that evaluation |
+| `graph.scheduler.node.deferred` | decision | Declares a non-claimable phase and reason |
+| `graph.executor.claim.requested` | command | Records the ownership request |
+| `graph.executor.claim.granted` | declaration | Establishes exclusive ownership |
+| `graph.executor.claim.rejected` | declaration | Records a competing valid request that lost |
+| `graph.executor.lease.renewed` | declaration | Replaces the claim with its next generation |
+| `graph.executor.lease.expired` | declaration | Ends ownership without ending the attempt |
+| `graph.executor.claim.released` | declaration | Explicitly relinquishes ownership |
+| `graph.scheduler.retry.scheduled` | decision | Records ordinal, delay, eligibility, category, and policy |
+| `graph.scheduler.retry.suppressed` | decision | Records why no retry may occur |
+| `graph.scheduler.cancellation.requested` | command | Starts the cancellation protocol |
+| `graph.scheduler.cancellation.acknowledged` | declaration | Records observation by the current owner |
+| `graph.scheduler.timeout.declared` | decision | Records that a named deadline elapsed |
+| `graph.scheduler.dependency_failure.propagated` | decision | Records fail-closed transitive blocking |
+| `graph.scheduler.cycle.completed` | declaration | Makes an evaluation atomically complete and reusable |
+
+All events use the existing versioned envelope. Unknown future scheduling
+events are retained as unknown metadata and do not acquire invented semantics.
+
+### Node phase transition table
+
+| Phase | Entry condition | Claimable | Exit |
+|---|---|---:|---|
+| `pending` | A required dependency is incomplete, or policy is disabled | no | Dependency or policy changes in a later durable evaluation |
+| `blocked` | Definition mismatch or fail-closed dependency failure/cancellation | no | A later definition/run or retry history changes the input |
+| `ready` | Dependencies are complete but capability is unavailable, or running ownership expired | no | A matching executor appears or a takeover evaluation is recorded |
+| `claimable` | Dependencies complete, policy allows, capability exists, no cancellation/terminal attempt/valid claim/backoff | yes | Claim or any newer scheduling input |
+| `claimed` | A valid claim owns a non-running, non-terminal attempt | no | Attempt starts, claim releases, or lease expires |
+| `running` | Reconciled attempt is running with a valid claim | no | Terminal declaration, cancellation, release, or expiry |
+| `retry_waiting` | A durable retry exists and its recorded eligibility time is later than logical time | no | Logical time reaches the recorded eligibility boundary |
+| `cancellation_pending` | A cancellation request exists and the attempt is not terminal | no | Terminal cancellation or another authoritative terminal declaration |
+| `terminal` | Run is terminal, attempt completed/cancelled, or retry is exhausted | no | No transition within that attempt/run history |
+
+An incomplete dependency is `pending`; `blocked` is reserved for a condition
+that prevents execution under current fail-closed semantics. Both are
+non-claimable.
+
+### Reconciliation and scheduling precedence
+
+Node evaluation applies this deterministic precedence:
+
+1. definition identity must match the persisted version and digest;
+2. scheduling policy must be enabled;
+3. a terminal run is terminal for every node;
+4. completed or cancelled attempts are terminal;
+5. pending cancellation prevents a claim;
+6. dependencies are evaluated to a fixed point; terminal failure or
+   cancellation propagates transitively;
+7. a running attempt with a valid claim remains running; expired ownership is
+   ready for recovery;
+8. a valid claim owns only a non-terminal attempt;
+9. a recorded retry delay prevents early execution;
+10. failed, interrupted, or orphaned attempts apply retry allow/exhaust rules;
+11. required capabilities must be available;
+12. otherwise the node is claimable because dependencies are satisfied.
+
+An authoritative terminal attempt outranks a lease. A lease never proves that
+an attempt is running and never converts expiry into failure, interruption, or
+cancellation.
+
+### Reason-code taxonomy
+
+| Category | Stable reason codes |
+|---|---|
+| Dependency and readiness | `dependencies_satisfied`, `dependency_failed`, `dependency_cancelled`, `dependency_incomplete` |
+| Ownership | `existing_active_claim`, `lease_expired`, `claim_granted`, `claim_rejected`, `claim_released`, `lease_renewed` |
+| Retry | `retry_allowed`, `retry_exhausted`, `retry_backoff_active`, `retry_not_applicable` |
+| Cancellation and timeout | `cancellation_pending`, `cancellation_acknowledged`, `timeout_recorded` |
+| Terminal and policy gates | `terminal_attempt_exists`, `run_terminal`, `executor_capability_unavailable`, `graph_definition_mismatch`, `scheduler_policy_denied` |
+
+Every node decision has one typed reason. Consumers never parse prose to decide
+whether work is claimable.
+
+### Claims and renewable leases
+
+`GraphExecutorClaim` records schema version, run, node, attempt ordinal, claim
+ID, executor ID, capability identity, grant sequence, lease start and expiry,
+lease generation, and optional host identity. Claim grant is one append with
+attempt creation when needed, request, and grant events.
+
+The event store's expected-head transaction is the exclusion mechanism. There
+is no correctness dependency on an in-memory lock. Exactly one competing
+writer wins. Exact claim redelivery compares owner, capability identity, host,
+lease start, and lease expiry. Contradictory reuse is a structured
+`claim_identity_collision`.
+
+Renewal requires the current claim, executor, generation, current stream head,
+and an unexpired lease. It writes generation `n + 1`. Stale generations and
+expired renewals fail. Takeover records expiry before granting a new claim.
+Release is explicit and exact-redelivery idempotent.
+
+### Retry policy
+
+`GraphRetryPolicy` versions maximum attempts, retryable and non-retryable
+categories, exponential bounded backoff, optional bounded jitter, timeout
+behavior, cancellation behavior, and dependency-failure behavior. Jitter is a
+SHA-256-derived function of durable seed, run, node, and next ordinal.
+
+`retryScheduled` records the policy, failed and next ordinals, category,
+scheduled time, delay, and eligibility time. A restart during the delay reads
+that value; it does not recalculate historical time. Ordinals increase
+strictly and are never reused. Exhaustion emits `retrySuppressed` and causes
+fail-closed dependency propagation.
+
+### Cancellation protocol
+
+Cancellation is:
+
+```text
+request -> owner observation -> acknowledgement -> terminal declaration
+```
+
+Before a claim, terminal declaration creates a first cancelled attempt. During
+valid ownership, only the matching owner may acknowledge and terminal
+declaration requires acknowledgement. After process exit, the request remains
+valid because process observation is not terminal workflow state. If the owner
+is unavailable and its lease expires, terminal declaration first records lease
+expiry, then cancellation. Duplicate requests, acknowledgements, and terminal
+declarations are idempotent only when their content matches. Cancellation stays
+distinct from failure and interruption.
+
+### Timeout decisions
+
+`GraphTimeoutDecision` supports claim acquisition, lease, attempt execution,
+cancellation acknowledgement, and retry delay. Declaration before the deadline
+is rejected. Replay reads the recorded declaration and never infers a past
+timeout from the current clock. Lease timeout also records explicit lease
+expiry but does not end the attempt.
+
+### Repository transactions and restart
+
+`GraphSchedulingRepository` exposes evaluate-and-append, claim, renew, release,
+request cancellation, acknowledge cancellation, terminal cancellation, and
+timeout declaration. Each operation uses an expected stream head, emits one
+atomic append, returns structured conflict reasons, and has exact-redelivery
+handling. Domain APIs expose no SQLite type.
+
+Restart recovery opens the same event stream and replays evaluations, claims,
+lease generations/status, retries and eligibility, cancellations, and timeout
+decisions. Logical time determines whether a currently active lease is still
+valid; it does not rewrite history. SQLite contention and restart tests use
+separate store instances against one database.
+
+### Read-only inspection and migration
+
+CLI schema version 2 adds scheduling inspection to `graph inspect`, scheduler
+reason codes to `graph explain`, scheduling categories to `graph diff`, and the
+new events to `graph history`. Inspection includes policy, active claims,
+expiry, claim history, retries and eligibility, pending cancellation, timeout
+decisions, and scheduling records. Host identity is exposed only as a Boolean.
+
+Schema version 1 remains selectable and omits version 2 fields. JSON/JSONL
+envelopes report the selected version. Snapshot decoding defaults a missing
+`scheduling` projection to empty. Evaluation payloads decode older records with
+no embedded policy. No SQLite schema migration is required because scheduling
+uses the existing typed event envelope and snapshot document.
+
+## Compendium fixture result
+
+`compendium-scheduling-graph.json` defines the realistic chain:
+
+```text
+architect -> researcher -> graph -> reviewer
+```
+
+Each node has distinct capability requirements. Tests prove only architect is
+initially claimable; each successor remains non-claimable until its predecessor
+completes; renewal preserves ownership; expiry allows takeover; stale renewal
+fails; retry uses ordinal two; exhaustion and cancellation block all downstream
+nodes; SQLite restart preserves claim and retry state; exact repeated evaluation
+adds nothing; and all four completions reconcile the run to successful terminal
+state.
+
+## Deferred boundary and next-slice readiness
+
+This decision does not launch a process or model and adds no mutation CLI, UI,
+network transport, Terminal Graph MCP call, or provider adapter.
+
+The next slice is ready because scheduler output is deterministic, ownership is
+exclusive and restartable, retry/cancellation/timeout state is durable, every
+operation is version checked and idempotent, the complete compendium path is a
+fixture, schema v1 compatibility is retained, and SQLite contention is proven.
+
+The next task is exactly:
+
+> Implement graph mutation commands and an executor adapter boundary, then use a no-op or deterministic test executor to create, claim, start, complete, retry, and cancel the four-node compendium graph end to end before introducing real tmux, Codex, Qwen, Ollama, or Terminal Graph MCP adapters.
+
+## Requirement audit
+
+All requested scheduling requirements are complete. No requirement is blocked
+or partially complete.
+
+### Domain capabilities
+
+| # | Status | Evidence |
+|---:|---|---|
+| 1 | complete | Scheduler events in `GraphExecutionHistory.swift`; replay test in `GraphSchedulerTests` |
+| 2 | complete | Pure phase selection in `GraphScheduling.swift`; compendium progression invariant |
+| 3 | complete | `attemptClaim`; in-memory and SQLite competing-claim tests |
+| 4 | complete | `renewLease`; renewal and restart tests |
+| 5 | complete | Expiry event, timeout, takeover, and stale-owner tests |
+| 6 | complete | Exact-redelivery-safe `releaseClaim` and repository test |
+| 7 | complete | Versioned `GraphRetryPolicy` and deterministic backoff test |
+| 8 | complete | Stable attempt IDs and monotonic ordinal tests |
+| 9 | complete | Durable delay and eligibility in retry records and SQLite restart test |
+| 10 | complete | Versioned cancellation request record and pre-claim/claimed tests |
+| 11 | complete | Owner-validated acknowledgement and stale acknowledgement test |
+| 12 | complete | Five timeout kinds and explicit-decision tests |
+| 13 | complete | Fixed-point scheduler and reconciler failure propagation tests |
+| 14 | complete | Crash-boundary, snapshot, and SQLite reopen tests |
+| 15 | complete | Stable input identity and exact original-head redelivery tests |
+| 16 | complete | Expected-head exclusion in in-memory and SQLite competing writers |
+
+### Numbered compendium fixture scenarios
+
+| # | Status | Evidence |
+|---:|---|---|
+| 1 | complete | Initial evaluation makes only architect runnable |
+| 2 | complete | Researcher is non-claimable until architect completion |
+| 3 | complete | Graph is non-claimable until researcher completion |
+| 4 | complete | Reviewer is non-claimable until graph completion |
+| 5 | complete | In-memory and SQLite contention each produce one architect owner |
+| 6 | complete | Renewal advances generation and preserves the same claim owner |
+| 7 | complete | Expiry is recorded before takeover grants a new claim |
+| 8 | complete | Prior executor renewal fails after takeover |
+| 9 | complete | Retry claim creates ordinal two and never reuses ordinal one |
+| 10 | complete | Maximum-attempt exhaustion emits suppression and blocks descendants |
+| 11 | complete | Architect cancellation reconciles researcher, graph, and reviewer blocked |
+| 12 | complete | SQLite reopen reconstructs identical active claim and retry eligibility |
+| 13 | complete | Original-head evaluation redelivery appends zero events |
+| 14 | complete | Four completed attempts reconcile every node and run to `completed` |
+
+### Claims, protocols, repository, CLI, and fixture
+
+| Area | Status | Evidence |
+|---|---|---|
+| Claim field model and one-valid-owner rule | complete | `GraphExecutorClaim`, replay validation, generated collision variants |
+| Renewal identity/generation and stale behavior | complete | Repository conflict tests and SQLite takeover invariant |
+| Lease is not terminal attempt state | complete | Lease timeout protocol test |
+| Retry categories, bounds, jitter, timeout/cancel/dependency behavior | complete | `GraphRetryPolicy` and scheduler tests |
+| Cancellation before/while claim, while running, after exit, duplicate, stale, unavailable owner, expiry | complete | `GraphSchedulingProtocolTests` |
+| Claim, lease, execution, cancellation, and retry-delay timeout kinds | complete | Timeout category test and durable timeout projection |
+| Transactionality, expected head, idempotency, conflicts, no partial writes | complete | `GraphSchedulingRepository.swift`, event-store tests, SQLite invariants |
+| Read-only inspect/explain/history/diff with stable output/redaction | complete | CLI schema v1/v2 and byte-identical output tests |
+| Four-node fixture scenarios 1-14 | complete | `GraphSchedulingDurabilityInvariantTests` |
+| Unknown future event, snapshot replay, stale fixture compatibility | complete | Future/snapshot/stale compatibility invariant |
+| Model-generated coverage where practical | complete | Table-driven contradictory claim mutation test |
+| No mutation CLI, launcher, MCP, networking, or UI | complete | Core-only adapter-neutral implementation and documented boundary |
+
+## Consequences
+
+- Open Island can now determine and persist who may execute a node without
+  executing it.
+- Operators can inspect the exact policy, ownership, retry, cancellation, and
+  timeout history through a stable read-only interface.
+- Executors must treat the claim generation as a fencing value and append
+  terminal workflow facts explicitly.
+- Dynamic graph mutation, typed handoff validation, resource reservations, and
+  real provider launch adapters remain later capabilities.

--- a/docs/architecture-decisions/003-graph-mutation-and-executor-boundary.md
+++ b/docs/architecture-decisions/003-graph-mutation-and-executor-boundary.md
@@ -1,0 +1,299 @@
+# Graph Mutation And Executor Boundary
+
+**Status:** Accepted
+**Date:** 2026-07-22
+**Scope:** Mutation commands, fenced executor operations, bounded orchestration,
+artifact handoffs, crash recovery, and deterministic compendium execution
+
+## Context
+
+Durable history, replay, reconciliation, scheduling decisions, claims, leases,
+retry, cancellation, and timeout policy existed before graph execution. The next
+boundary had to execute work without allowing a CLI process or provider adapter
+to become a second source of truth.
+
+The required authority chain is:
+
+```text
+Definition
+-> History
+-> Projection
+-> Reconciliation
+-> Scheduling decision
+-> Claim
+-> Executor command
+-> Executor observation
+-> Durable terminal declaration
+```
+
+Real Codex, Qwen, Ollama, tmux, and Terminal Graph MCP adapters remain out of
+scope. This decision establishes the contract they must implement.
+
+## Decision
+
+### Mutation command semantics
+
+`GraphMutationService` owns `create`, `start`, `cancel`, and `retry` requests.
+Every accepted mutation is represented by versioned append-only events and
+supports expected-head concurrency. Client idempotency keys make exact
+redelivery safe and reject conflicting reuse.
+
+- `create` persists the validated executable definition and content digest but
+  does not start it.
+- `start` persists scheduling intent but cannot claim or execute a node.
+- `cancel` persists run- or node-scoped intent. It cannot fabricate adapter
+  acknowledgement or terminal cancellation.
+- `retry` persists operator intent only when policy permits. The scheduler still
+  owns retry delay and the next attempt ordinal.
+- `step` and `run` call the orchestration service; they do not append internal
+  lifecycle events directly.
+
+Dry-run is side-effect-free. Structured stdout uses the existing versioned JSON
+and JSONL envelopes; diagnostics remain on stderr.
+
+### Executor adapter boundary
+
+`GraphExecutorAdapter` is provider-neutral and has seven typed operations:
+
+| Operation | Purpose |
+|---|---|
+| `prepare` | Validate capability and create adapter-local prerequisites |
+| `start` | Start or attach to the claimed execution identity |
+| `observe` | Return current execution evidence |
+| `requestCancellation` | Deliver durable cancellation intent to the owner |
+| `collectResult` | Return terminal status and content-addressed references |
+| `cleanup` | Release adapter-local resources without changing graph truth |
+| `recover` | Conservatively reattach after a persisted start intent or restart |
+
+Every request carries run, node, attempt ID and ordinal, claim ID, lease
+generation, executor ID, capability requirements, immutable execution
+specification, workspace context, environment-name allowlist, input artifact
+references, cancellation state, timeout policy, correlation metadata, prior
+observation count, and logical time.
+
+Responses use the closed `GraphExecutorResponseStatus` vocabulary:
+`accepted`, `started`, `still_running`, `succeeded`, `failed`, `cancelled`,
+`interrupted`, `unavailable`, `rejected`, `identity_mismatch`, `stale_claim`, and
+`transient_adapter_failure`. Free-form strings cannot drive transitions.
+
+### Intent versus observation
+
+Intent and evidence remain distinct:
+
+1. claim grant establishes exclusive ownership;
+2. `attemptStarting` persists start intent and the full fenced identity;
+3. adapter work happens outside the event-store transaction;
+4. `executorObservationRecorded` persists the typed result;
+5. artifact-reference events are appended with that observation;
+6. a repository validates the observation before a terminal declaration;
+7. terminal declaration and claim release are appended together.
+
+An adapter return value alone never completes an attempt. Cleanup acceptance is
+also not completion evidence.
+
+### Fencing and stale executors
+
+Every repository mutation validates all of:
+
+- run ID;
+- node ID;
+- attempt ID and monotonic ordinal;
+- claim ID and active status;
+- executor ID;
+- current lease generation;
+- unexpired logical lease time.
+
+Lease generation is the fencing token. Renewal increments it. An operation
+using an old token cannot start, observe, publish artifacts, acknowledge
+cancellation, declare terminal state, or clean up as current owner. Stable
+reason codes distinguish run, node, attempt, ordinal, claim, executor,
+generation, expiry, inactive-claim, provenance, and version failures.
+
+### Orchestration-cycle transactions
+
+`DefaultGraphOrchestrationService.step` performs one bounded cycle:
+
+1. load and replay the complete run;
+2. validate expected head and executable definition;
+3. reconcile state and append one deterministic scheduler evaluation;
+4. acquire the first eligible claim in stable node order;
+5. renew an active lease when no more than half its policy duration remains;
+6. persist start intent before invoking external work;
+7. call one adapter path outside database transactions;
+8. append the observation at the current expected head;
+9. collect reference-only results and request cleanup when terminal;
+10. append terminal declaration and claim release when justified;
+11. aggregate a terminal run only from durable node outcomes;
+12. return a versioned cycle report.
+
+`run` repeats this bounded operation until the run is terminal, cancellation
+needs external acknowledgement, no progress is possible, the adapter is
+unavailable, the process is interrupted, or the cycle limit is reached.
+Reinvocation resumes from history.
+
+No transaction is held across an adapter call. Any optimistic conflict is
+visible and retryable by rereading history.
+
+### Attempt lifecycle
+
+The projected lifecycle is explicit:
+
+| Current | Input | Next |
+|---|---|---|
+| `created` | valid claim grant | `claimed` |
+| `claimed` | durable start intent | `startRequested` |
+| `startRequested` | `started` observation or recovery | `started` |
+| `started` | running observation | `running` |
+| `running` | cancellation request | `cancellationRequested` |
+| active phase | validated terminal observation and declaration | `terminal` |
+| `terminal` | atomic release declaration | `claimReleased` |
+
+Exact duplicate events are idempotent. Terminal-to-running regression,
+different-identity duplicate start, completion without durable start, stale
+generation results, wrong-attempt artifacts, non-owner cancellation
+acknowledgement, and terminal ordinal reuse are rejected.
+
+### Crash boundaries
+
+| Boundary | Durable evidence | Recovery behavior |
+|---|---|---|
+| before claim append | scheduler decision only | another cycle may claim |
+| after claim append | active claim and created attempt | same owner continues while lease is valid |
+| after start-intent append, before adapter acceptance | `startRequested` | call `recover`, never blind-start |
+| after adapter acceptance, before process certainty | accepted observation | call `recover` conservatively |
+| after terminal observation, before declaration | terminal observation | validate, collect/cleanup as required, then declare once |
+| after terminal declaration | terminal attempt and released claim | replay returns terminal; no adapter call |
+
+The deterministic executor injects both start crash boundaries without sleeps or
+randomness. SQLite reopen tests prove process restart resumes the same stream.
+
+### Artifact input and output resolution
+
+Executor outputs are content-addressed `GraphArtifactReference` records. Event
+history never stores bodies. Each reference validates digest, media type, role,
+sensitivity, producer run/node/attempt/ordinal/claim, and non-inline storage
+locator.
+
+`GraphArtifactInputResolver` computes all ancestors from the immutable DAG,
+filters by the consumer's declared input roles, validates completed-attempt and
+claim provenance, and returns stable ID order. Adapters receive references only.
+
+Supported roles are node output, execution log, structured result, and
+diagnostic artifact.
+
+### Deterministic compendium execution
+
+The committed fixture executes:
+
+```text
+architect -> researcher -> graph -> reviewer
+```
+
+Architect emits a section-plan reference. Researcher consumes it and emits
+researched sections. Graph consumes researcher output and emits a relationship
+graph. Reviewer resolves all matching upstream artifacts and emits a review
+verdict. The fixture contains no regulatory claims or model prompts.
+
+The executor script supports immediate success, logical running polls,
+retryable and non-retryable failure, indefinite running for timeout tests,
+cancellation acknowledge/ignore, both crash boundaries, artifact emission,
+duplicate observations, and stale-generation observations.
+
+## Consequences
+
+- Real adapters can be added without changing history, scheduling, CLI, or
+  terminal declaration semantics.
+- Adapter-local process state is recoverable evidence, not graph authority.
+- Execution is deliberately single-cycle and bounded; throughput optimization
+  comes after correctness and observability.
+- Dynamic graph mutation, remote leases, distributed transport, and production
+  model execution remain separate future decisions.
+
+## Readiness Criteria For A Real Adapter
+
+A local adapter is ready only when it:
+
+1. persists durable process identity and can reject PID/session reuse;
+2. captures bounded logs and content-addressed artifacts without event bodies;
+3. implements all seven operations and typed statuses;
+4. accepts renewed lease generations and rejects stale commands;
+5. recovers both start crash windows without duplicate launch;
+6. honors cancellation and execution deadlines using logical durable decisions;
+7. passes the deterministic repository, SQLite restart, pipe, replay, diff, and
+   full application regression suites;
+8. exposes no prompts, secrets, unrestricted environment, or artifact contents
+   through graph events or structured CLI output.
+
+The first real adapter should be a supervised direct-process or tmux adapter.
+Only one compendium node should use it initially; provider-specific Codex, Qwen,
+Ollama, and Terminal Graph MCP adapters follow after that boundary is proven.
+
+## Numbered Requirement Audit
+
+All numbered requirements are complete. No numbered item is partially complete
+or blocked.
+
+### Primary objective
+
+| # | Status | Evidence |
+|---:|---|---|
+| 1 | complete | `GraphMutationService.create`; `GraphMutationServiceTests.testCreateIsInactiveDurableAndIdempotent` |
+| 2 | complete | `GraphMutationService.start`; `testStartMakesArchitectSchedulableAndIsIdempotent` |
+| 3 | complete | `GraphOrchestrationService.step`; `testStepIsBoundedAndDryRunHasNoWritesOrInvocations` |
+| 4 | complete | `GraphExecutorRepository.recordStartRequest`; `testFencedStartObservationArtifactAndTerminalDeclaration` |
+| 5 | complete | Typed observation and terminal declaration; `testCompendiumRunsAllFourNodesAndPropagatesArtifacts` |
+| 6 | complete | Recorded retry eligibility and new ordinal; `testRetryDelaySurvivesServiceRestart` |
+| 7 | complete | Cancellation request/acknowledgement; `testCancellationAcknowledgementAndTimeoutAreDurable` |
+| 8 | complete | Pure scheduler dependency propagation; compendium and non-retryable failure tests |
+| 9 | complete | Durable run terminal aggregation; successful and failed compendium tests |
+| 10 | complete | Recover operation and SQLite reopen; both crash tests and SQLite restart test |
+
+### Orchestration service responsibilities
+
+| # | Status | Evidence |
+|---:|---|---|
+| 1 | complete | `DefaultGraphOrchestrationService.load` reads the authoritative stream |
+| 2 | complete | Projector replay plus `GraphExecutionProjectionReconciler` in dry-run and scheduler paths |
+| 3 | complete | `DefaultGraphSchedulingRepository.evaluateAndAppend` |
+| 4 | complete | Expected-head scheduler transaction and SQLite competing-writer tests |
+| 5 | complete | Stable runnable selection and `attemptClaim`; bounded-step test |
+| 6 | complete | `executionContext` plus repository `currentOwnership` exact fencing |
+| 7 | complete | Seven typed `invoke*` adapter methods outside store operations |
+| 8 | complete | `persistObservation` with current expected version |
+| 9 | complete | `finishTerminalObservation` validates observation before declaration |
+| 10 | complete | Half-life renewal and atomic terminal release; lease renewal test |
+| 11 | complete | Repeated scheduler cycles perform fixed-point dependency propagation |
+| 12 | complete | Versioned `GraphOrchestrationCycleReport` in text, JSON, and JSONL tests |
+
+### End-to-end scenarios
+
+| # | Status | Evidence |
+|---:|---|---|
+| 1 | complete | `testCreateIsInactiveDurableAndIdempotent` |
+| 2 | complete | `testCreateIsInactiveDurableAndIdempotent` exact redelivery |
+| 3 | complete | `testCreateRejectsConflictingIdempotencyReuse` |
+| 4 | complete | `testStartMakesArchitectSchedulableAndIsIdempotent` |
+| 5 | complete | `testCrashAfterAdapterAcceptanceRecoversConservatively` asserts one architect start |
+| 6 | complete | `testCompendiumRunsAllFourNodesAndPropagatesArtifacts` |
+| 7 | complete | Compendium test plus `GraphArtifactInputResolver` producer assertions |
+| 8 | complete | Compendium test resolves researcher output into graph execution |
+| 9 | complete | Compendium test resolves all architect, researcher, and graph inputs for reviewer |
+| 10 | complete | Compendium test asserts four completed attempts and completed run |
+| 11 | complete | `testRetryDelaySurvivesServiceRestart` asserts ordinals 1 and 2 |
+| 12 | complete | Same test reconstructs recorded eligibility in a new service |
+| 13 | complete | `testNonRetryableFailureBlocksDownstreamAndFailsRun` |
+| 14 | complete | `testCancellationBeforeClaimDoesNotInvokeExecutor` |
+| 15 | complete | Cancellation durability test asserts adapter cancellation operation |
+| 16 | complete | Same test asserts acknowledged and terminal-cancelled state |
+| 17 | complete | Same test asserts cancellation timeout and interruption |
+| 18 | complete | `testStaleClaimCannotPublishAfterLeaseTakeover` and stale orchestration test |
+| 19 | complete | `GraphExecutorRepositoryTests.testDuplicateObservationIsIdempotent` |
+| 20 | complete | `testCrashAfterStartRequestRecoversWithoutDuplicateStart` |
+| 21 | complete | `testCrashAfterAdapterAcceptanceRecoversConservatively` |
+| 22 | complete | `testSQLiteProcessRestartResumesSameGraphWithoutDuplicateStart` |
+| 23 | complete | `testRepeatedRunDoesNotDuplicateTerminalWork` |
+| 24 | complete | `testStepIsBoundedAndDryRunHasNoWritesOrInvocations` |
+| 25 | complete | `testRunJSONLPreservesTerminalGraphCompatibleRecords` plus real pipe test |
+| 26 | complete | CLI compendium test asserts four nodes and five artifact export records |
+| 27 | complete | `testSuccessfulExecutionReplaysByteIdenticallyAndDiffExplainsRun` |
+| 28 | complete | Same test asserts run, every node, artifacts, and event-range changes |

--- a/docs/architecture-decisions/004-local-process-and-graph-workspace.md
+++ b/docs/architecture-decisions/004-local-process-and-graph-workspace.md
@@ -1,0 +1,123 @@
+# Local Process Execution And Native Graph Workspace
+
+**Status:** Accepted
+**Date:** 2026-07-22
+**Scope:** Supervised direct processes, durable process evidence, graph documents,
+and the native Definition/Run/History workspace
+
+## Context
+
+The graph ledger, reconciliation, scheduler, claims, mutation commands, executor
+protocol, and deterministic executor were complete. The next step had to prove
+those contracts against operating-system processes without making tmux, a model
+provider, marker files, or the UI a second execution authority.
+
+## Decision
+
+### Direct processes precede tmux and model providers
+
+`SupervisedLocalProcessExecutor` is the first production adapter. It launches an
+absolute executable with an argument vector through `Foundation.Process`; it
+does not invoke a shell. Direct launch exposes the child PID, process group,
+executable, streams, exit reason, and cancellation behavior without terminal
+multiplexer state. Tmux and Codex, Qwen, Ollama, or OpenClaw adapters may later
+use their own supervision mechanisms, but must translate them through the same
+seven executor operations and typed observations.
+
+The native app and production CLI compose the same local adapter. The
+deterministic adapter remains available for isolated domain tests.
+
+### Durable identity and PID reuse
+
+A launch record binds the process PID to its operating-system birth identity,
+executable identity, invocation digest, workspace identity, run, node, attempt,
+claim, lease generation, executor instance, process group, and launch-record ID.
+Recovery classifies that complete identity as matching-running,
+matching-exited, identity-mismatch, or indeterminate. A PID match alone never
+authorizes observation, output, cancellation, or cleanup.
+
+Claim generation remains the graph fencing token. A recovered process can be
+alive while its executor command is stale; stale commands cannot publish.
+
+### Launch and recovery boundaries
+
+| Boundary | Durable adapter state | Recovery |
+|---|---|---|
+| before spawn | prepared launch record, no PID | launch once through `recover` |
+| spawn accepted | PID, birth and process-group identity | attach only on complete identity match |
+| child exited before observation | durable identity and exit evidence | report terminal result without relaunch |
+| identity mismatch | durable expected identity | report `identity_mismatch`; do not signal |
+| indeterminate evidence | durable expected identity | report conservative interruption/orphan evidence |
+
+Launch IDs include the fenced attempt identity, so retries create distinct
+records and duplicate starts return the original process.
+
+### Cancellation and timeout
+
+The child becomes its own process-group leader where the host permits it.
+Cancellation records intent before sending `SIGTERM` to the matching group. If
+the durable acknowledgement deadline passes, the adapter records escalation
+and sends `SIGKILL`. It never signals an identity mismatch or an unrelated PID.
+Cleanup is idempotent. Execution timeout remains an orchestration decision; its
+`interrupted` observation is not overwritten by result collection before the
+adapter cleans up the process.
+
+### Logs and artifacts
+
+Stdout and stderr are appended as sequenced records under the launch runtime
+root. Each stream has a byte limit, truncation evidence, UTF-8 fallback, and
+configured value redaction. Graph events receive an execution-log reference,
+not log bodies. The workspace log viewer reads that bounded store and supports
+follow and channel inspection.
+
+Only declared output paths contained by the workspace and writable roots are
+collected. Artifacts are size checked, SHA-256 addressed, and recorded with
+media type, logical role, sensitivity, attempt, and claim provenance.
+Undeclared files are ignored. Environment is empty by default and only named,
+allowlisted keys can be inherited or assigned.
+
+### Versioned definition documents
+
+`.openisland-graph.json` documents contain graph and definition IDs, metadata,
+nodes, explicit typed dependency edges, immutable executor specifications,
+policy, repository context, and separate layout metadata. Deterministic JSON
+round trips retain compatible unknown top-level fields. Validation rejects
+cycles, duplicate or unknown edges, self-dependencies, unsafe process
+specifications, and invalid layouts.
+
+The semantic definition digest excludes layout. Creating a run stores an
+immutable executable snapshot and digest; later document edits cannot alter
+that run. Active claims, current projection, secrets, artifact bodies, and
+unrestricted environment dumps do not belong in graph documents.
+
+### Native workspace and command boundary
+
+The workspace has explicit Definition, Run, and History modes. Its service is
+composed from `GraphMutating`, `GraphOrchestrating`, and
+`GraphTemporalInspecting`; SwiftUI receives typed command results and read
+models. Views cannot append events, edit SQLite, fabricate completion, bypass
+claims, or mutate an existing run definition.
+
+The Definition canvas owns only document and layout edits. Run mode projects
+authoritative execution, claims, attempts, blockers, artifacts, logs, and typed
+command availability. History mode reuses temporal history and causal
+explanation APIs. Committed revision streams, process-exit streams, and durable
+retry deadlines drive refresh; polling is not history.
+
+`Graph Workspace` is a singleton app window opened from the island button,
+Command-Shift-G, File commands, or Window menu. The last document, run, mode,
+selection, and viewport are restored when applicable.
+
+## Consequences
+
+- The local adapter proves process behavior without granting a terminal or
+  provider authority over graph state.
+- The same SQLite history is inspectable from the app and CLI.
+- Provider adapters must preserve identity, fencing, logs, artifacts,
+  cancellation, timeout, and recovery semantics.
+- Terminal Graph compatibility remains a stable CLI/JSONL/workspace-plan
+  boundary. Future MCP synchronization must call public mutation and temporal
+  services and must not write the store or visual state directly.
+- Tmux supervision, remote execution, mixed-provider graphs, collaborative
+  editing, and Liquid Glass redesign remain separate decisions.
+

--- a/docs/architecture-decisions/005-native-graph-authoring.md
+++ b/docs/architecture-decisions/005-native-graph-authoring.md
@@ -1,0 +1,128 @@
+# Native Graph Authoring And Run-Creation Boundary
+
+**Status:** Accepted
+**Date:** 2026-07-22
+**Scope:** Graph authoring state, document lifecycle, typed wiring, validation,
+undo, templates, and durable run creation
+
+## Context
+
+The durable graph runtime and first production executor were complete, but the
+native workspace could not construct an executable graph without fixture JSON
+or command-line assembly. Provider adapters would have hidden that gap behind
+provider-specific forms and made the editor, adapter, or UI a competing source
+of execution truth.
+
+## Decision
+
+### Authoring state is a document, not a run
+
+`GraphDefinitionDocument` is the canonical editable value. The view model owns
+selection, viewport, undo history, file state, diagnostics, run-creation draft,
+and definition/run association. SwiftUI bindings always call mutations against
+the current document rather than retaining stale node copies.
+
+Creating or editing a document emits no graph execution event. **Create Run**
+materializes an immutable `GraphExecutableDefinition` only after validation,
+input resolution, workspace checks, and backend compatibility succeed. All
+later Start, Step, Run, Retry, Cancel, and inspection behavior goes through the
+existing mutation, orchestration, and temporal service boundaries.
+
+### Lifecycle and version semantics
+
+| State | Allowed behavior | Run relationship |
+| --- | --- | --- |
+| unsaved editable | author, validate, save, close | no run exists |
+| saved editable | atomic save, Save As, revert, reopen | no semantic lock |
+| saved with runs | layout edits remain ordinary; semantic edits become Draft | prior snapshots stay immutable |
+| Draft | edit and save; Create Run is blocked | create a new definition version first |
+| new definition version | editable with incremented version and no associated runs | may create a new immutable run |
+
+File state includes URL, dirty digest, last saved digest, external-change
+evidence, schema version, validation time, and recent-document order. Writes
+are deterministic and atomic with optimistic external-modification checking.
+
+### Typed ports and artifacts
+
+Every node input and output has a stable ID and a port type. Artifact edges bind
+stable source node/output and target node/input identities. A shared pure
+connection evaluator serves drag, inspector, menu, and keyboard paths and
+rejects invalid topology or types before mutation. Runtime input roles are
+derived from accepted artifact bindings.
+
+Local-process `${input:role}` tokens address upstream artifacts;
+`${artifact:role}` tokens address outputs declared by the current node. Static
+validation mirrors the executor resolver so an unavailable token is an
+authoring error rather than a pre-launch runtime failure.
+
+### Validation architecture
+
+`GraphDefinitionValidator` is side-effect-free and returns typed diagnostics
+with severity, stable code, target, message, and suggested action. It runs
+incrementally after edits, on demand, and as a hard run-creation gate. The
+taxonomy covers empty/name/ID errors, topology, references, execution and
+argument tokens, local paths, artifact containment, typed ports, required
+inputs, provider multiplicity, role collisions, retry/timeout policy,
+executor/capability support, terminal outputs, reachability, sensitive
+literals, and immutable-definition mutation.
+
+The validation panel and node inspector project the same diagnostic values.
+Navigation selects the affected element; neither surface changes runtime state.
+
+### Undo, layout, and templates
+
+Authoring commands snapshot document plus selection before mutation. Undo/redo
+restores both and never sends execution mutations. Node drag coalesces into one
+entry. Layout metadata is excluded from semantic digests; automatic layout is
+deterministic and undoable.
+
+Templates use the ordinary graph-document factory. Blank, Linear,
+Fan-Out/Fan-In, Review Loop, Compendium Fill, and Local Process Example produce
+editable, serializable documents. Local templates use only the packaged helper
+executable; no committed graph JSON is decoded as their definition.
+
+### Provider-adapter readiness gate
+
+A provider adapter may be added only behind `GraphExecutorAdapter`. Its first
+node must expose credentials by reference, model selection, prompt template,
+structured output declaration, cancellation, logs, artifacts, and recovery
+through the same completed authoring and run-creation surfaces. It cannot own
+topology, persist secrets in documents, mutate projections, or bypass claims
+and lease fencing.
+
+## Requirement Audit
+
+| Requirement group | Status | Evidence |
+| --- | --- | --- |
+| Baseline usability audit | complete | Active execution plan preserves the pre-change capability audit and resolution. |
+| New/Open/Save/Save As/Validate/Create Run and guided empty state | complete | `GraphWorkspaceView`, `GraphWorkspaceViewModel`, `GraphWorkspaceTests`. |
+| Creation sheet, defaults, blank in-memory document | complete | `GraphWorkspaceAuthoringState`, `GraphWorkspaceTemplateFactory`, template tests. |
+| Toolbar, canvas, and keyboard node creation with stable identity | complete | `GraphWorkspaceView`, node-authoring and keyboard tests. |
+| Executable, reference, generic, and annotation node palette | complete | `GraphDefinitionNodeType`, `testNodePaletteCreatesExplicitExecutableAndReferenceTypes`. |
+| Full identity, execution, capability, input, output, retry, timeout, and validation inspector | complete | `GraphNodeInspector`, `testCompleteLocalProcessNodeAuthoringPreservesIdentityAndUndo`. |
+| Drag, inspector, dependency, keyboard, edge inspection, rejection, and deletion | complete | `GraphConnectionEvaluator`, canvas/view-model connection tests. |
+| Typed dependency, artifact, stream, and signal ports | complete | Typed edge model, connection evaluator, validator tests. |
+| Graph inputs, graph outputs, unresolved-input run gate, secret references | complete | View-model graph I/O test and Create Run sheet. |
+| First-class typed validator and navigable incremental panel | complete | `GraphDefinitionValidator`, validator tests, workspace validation test. |
+| New/Open/Save/Save As/Revert/Close/Recent, dirty/conflict/atomic behavior | complete | `GraphWorkspaceService`, lifecycle and external-modification tests. |
+| Draft versus immutable definition versions | complete | Graph inspector version action and versioning test. |
+| Canvas/inspector selection synchronization | complete | Selection, edge, validation-navigation, and undo tests. |
+| Document Undo/Redo and coalesced drag | complete | Authoring state and workspace/canvas tests. |
+| Deterministic Auto Layout/Fit/Reset | complete | Canvas controls and template/layout tests. |
+| Six editable built-in templates | complete | `GraphWorkspaceTemplateFactory`, `GraphWorkspaceTemplateTests`. |
+| Guided backend/input/workspace Create Run flow | complete | Create Run sheet, compatibility gate, workspace tests. |
+| UI-service-built generate/transform/verify execution | complete | `UIAuthoredGraphEndToEndTests`; save/reopen/restart/log/artifact/CLI parity assertions. |
+| UI-service-built architect/researcher/graph/reviewer execution | complete | `UIAuthoredGraphEndToEndTests`; no graph fixture input. |
+| Usability labels, guidance, keyboard, accessibility | complete | View labels/hints, entry-point test, packaged accessibility-tree acceptance. |
+| Full automated and packaged manual acceptance | complete | Test suite plus the active plan's 2026-07-22 acceptance record. |
+| Provider/tmux/Terminal Graph mutation/visual redesign exclusions | complete | No such adapter or redesign added; existing boundaries unchanged. |
+
+## Consequences
+
+- A graph can be authored, saved, reopened, versioned, run, and inspected from
+  the packaged app without JSON or CLI construction.
+- Definition documents and runtime history remain separate authorities.
+- Provider-specific work can now be evaluated one adapter and one node at a
+  time without weakening graph semantics.
+- Collaborative editing, active-run topology mutation, tmux, remote execution,
+  provider adapters, and broad visual redesign remain out of scope.

--- a/docs/exec-plans/active/2026-07-19-capability-first-orchestration-control-plane.md
+++ b/docs/exec-plans/active/2026-07-19-capability-first-orchestration-control-plane.md
@@ -2,7 +2,7 @@
 
 **Status:** Active
 **Started:** 2026-07-19
-**Current phase:** Phase 2, first real local executor adapter preparation
+**Current phase:** Phase 2 complete; provider adapters are the next graph-runtime task
 
 ## Problem
 
@@ -372,7 +372,8 @@ recent state transitions; polling cannot inflate metrics; timeline state survive
   history, explain, checkpoints, replay, diff, and redacted export.
 - [x] Add stable text, JSON, JSONL, completion, exit-code, telemetry, Unix pipeline, worktree,
   multi-project, and neutral Terminal Graph workspace-plan contracts.
-- [ ] Implement host-specific process-evidence adapters that emit canonical evidence.
+- [x] Implement a Darwin process-evidence adapter that emits canonical identity and exit
+  classifications without owning graph state.
 - [x] Add deterministic event-sourced scheduler decisions, runnable selection, fixed-point
   dependency failure propagation, and explicit reason codes.
 - [x] Add optimistic executor claims, renewable generation-fenced leases, explicit expiry and
@@ -394,11 +395,14 @@ recent state transitions; polling cannot inflate metrics; timeline state survive
 - [x] Execute the committed architect -> researcher -> graph -> reviewer fixture end to end with
   deterministic retry, cancellation, timeout, stale-generation, duplicate, crash, SQLite
   restart, replay, diff, export, and pipeline evidence.
-- [ ] Implement the first real supervised process executor for one local compendium node.
+- [x] Implement the supervised direct-process executor and run all four local compendium
+  nodes with durable identity, logs, artifacts, recovery, cancellation, and timeout.
 - [ ] Add typed handoff schemas on top of artifact references, then supervise a graph with at
   least two local models.
-- [ ] Add graph logs and metric projections to the shared command service; temporal graph
-  inspection is now exposed through the standalone CLI boundary.
+- [x] Add bounded process-log access to the native graph workspace and shared production
+  process runtime; aggregate graph metric projections remain Phase 3 work.
+- [x] Add versioned graph-definition documents and a native Definition/Run/History workspace
+  with a discoverable singleton entry point.
 
 ### Phase 3: Usage, inspection, and visual control plane
 
@@ -444,13 +448,13 @@ for quality, latency, cost, and context growth.
 5. **Complete:** mutation commands, provider-neutral executor protocol, fenced observation
    repository, bounded orchestration cycles, deterministic executor, artifact propagation,
    lease renewal, and four-node compendium execution across crash and restart boundaries.
-6. **Next:** implement one supervised local direct-process or tmux executor with durable
-   process identity and bounded log/artifact capture, then connect only the architect node.
-7. Implement host-specific process-evidence adapters that translate observations into
-   canonical exits and heartbeat leases without mutating history.
-8. Add non-local CLI usage metrics and local-model resource metrics as distinct projections.
-9. Add provider/model executors only after the local process adapter proves the command,
-   event, fencing, and recovery contracts.
+6. **Complete:** supervised direct-process execution, durable process identity, bounded logs,
+   declared artifacts, cancellation, timeout, recovery, and the four-node compendium graph.
+7. **Complete:** Darwin process evidence plus native graph documents and the singleton
+   Definition/Run/History workspace backed only by public graph services.
+8. **Next:** implement provider-specific agent adapters behind the proven executor boundary,
+   beginning with one supervised compendium node and evaluating providers independently.
+9. Add non-local CLI usage metrics and local-model resource metrics as distinct projections.
 10. Defer all visual redesign, including liquid glass, until orchestration behavior and
    operator information architecture are stable.
 
@@ -482,6 +486,27 @@ for quality, latency, cost, and context growth.
 - `4b3333f test: prove graph execution and restart invariants`
 - `5864b22 fix: remove cursor-sensitive test nondeterminism`
 - `15a47c8 feat: renew active orchestration leases`
+- `643a974 feat: add supervised local process executor`
+- `65044c2 feat: add durable process logs and artifacts`
+- `feab43b feat: add versioned graph definition documents`
+- `43a331f feat: add native graph workspace and entry button`
+- `5d70797 feat: run compendium graph with local processes`
+- `3d40d98 test: prove process recovery and graph workspace invariants`
+
+### Local process and workspace decisions
+
+- Supervised direct processes precede tmux and provider adapters because PID birth identity,
+  process groups, streams, exit status, and cancellation can be proven without inheriting a
+  terminal's lifecycle model.
+- Durable launch records bind OS identity to attempt, claim, generation, invocation,
+  executable, workspace, and executor instance. PID equality alone never permits recovery or
+  signaling.
+- Definition documents and layout metadata are versioned separately from immutable run
+  snapshots and event history. Layout does not affect the semantic digest.
+- The native workspace sends typed intents to mutation, orchestration, and temporal services;
+  it cannot manufacture events or edit projected state.
+- The app and CLI now compose the same local adapter and process-evidence source. The
+  deterministic adapter remains a test implementation.
 
 ### Temporal inspection and integration decisions
 

--- a/docs/exec-plans/active/2026-07-19-capability-first-orchestration-control-plane.md
+++ b/docs/exec-plans/active/2026-07-19-capability-first-orchestration-control-plane.md
@@ -2,7 +2,7 @@
 
 **Status:** Active
 **Started:** 2026-07-19
-**Current phase:** Phase 2, graph runtime recovery and execution truth
+**Current phase:** Phase 2, durable graph history and temporal inspection preparation
 
 ## Problem
 
@@ -180,9 +180,9 @@ Input ordering cannot change the result.
 - The stale compendium architect/researcher run is committed as an adapter-neutral JSON
   fixture. It is the restart baseline for interrupted/orphaned recovery and transitive
   dependency blocking.
-- The next migration boundary is persistence and replay, not a production executor or UI:
-  introduce store/evidence protocols, append-only event storage, and read-time reconciliation
-  before launching models.
+- Durable persistence and replay now use a versioned event envelope, deterministic projector,
+  snapshot cache boundary, evidence-isolated repository, and transactional SQLite store.
+  The next boundary is observational temporal inspection, not execution or UI mutation.
 
 ## Target Architecture
 
@@ -358,11 +358,20 @@ recent state transitions; polling cannot inflate metrics; timeline state survive
 - [x] Implement deterministic side-effect-free execution reconciliation.
 - [x] Commit the stale architect/researcher run as an adapter-neutral fixture and prove
   interrupted/orphaned recovery plus transitive downstream blocking.
-- [ ] Add append-only execution-event persistence and snapshot repositories behind protocols.
-- [ ] Add process-evidence adapters and reconcile persisted runs on startup and every read.
+- [x] Add append-only execution-event persistence and snapshot repositories behind protocols.
+- [x] Add optimistic concurrency, idempotent append, deterministic replay, explicit corruption
+  policy, and a production local SQLite implementation.
+- [x] Add a process-evidence boundary and reconcile persisted runs on every repository read,
+  returning projection and diagnostics when evidence is unavailable.
+- [x] Add content-addressed artifact references, checkpoint/fork metadata, durable human
+  interrupt facts, and OpenTelemetry-compatible internal vocabulary.
+- [x] Prove restart, replay, snapshots, concurrent writers, unknown events, retry ordinals,
+  sibling-write preservation, fixed-point reconciliation, and the stale compendium fixture.
+- [ ] Implement host-specific process-evidence adapters that emit canonical evidence.
 - [ ] Add scheduler-owned timeout, cancellation, retry, and failure propagation.
 - [ ] Replace the simulation runner with executor adapters for local models and CLI agents.
-- [ ] Add typed artifacts and handoffs, then supervise a graph with at least two local models.
+- [ ] Add typed handoff schemas on top of artifact references, then supervise a graph with at
+  least two local models.
 - [ ] Expose read-only graph inspect, logs, and metrics through the shared command service.
 - [ ] Add version-checked mutation commands for cancel, retry, and resume only after replay and
   restart behavior is proven.
@@ -399,18 +408,19 @@ for quality, latency, cost, and context growth.
 
 ## Immediate Execution Order
 
-1. Add `GraphExecutionStore` and `ProcessEvidenceSource` protocol boundaries, an append-only
-   execution-event store, and a read service that always applies `GraphExecutionReconciler`.
-2. Add restart/replay tests for duplicate events, stale snapshots, mismatched process identity,
-   crashed adapters, and retries with monotonic attempt ordinals.
-3. Implement process-evidence adapters that translate host observations into canonical exits
-   and heartbeat leases without exposing adapter concepts to the core graph model.
-4. Add scheduler policy and executor adapters only after read-time reconciliation and replay
-   are authoritative.
-5. Add read-only graph inspection, logs, and metrics; defer mutation commands until command
-   versioning and idempotency are tested.
-6. Add non-local CLI usage metrics and local-model resource metrics as distinct projections.
-7. Defer all visual redesign, including liquid glass, until orchestration behavior and
+1. Add temporal inspection APIs over the repository for list, inspect, history, explain,
+   checkpoint listing, dry-run replay, diff, and export.
+2. Expose those APIs through read-only `openisland graph` CLI commands with stable JSON output,
+   causal explanations, replay diagnostics, and OpenTelemetry-compatible CLI telemetry.
+3. Add integrity verification and redacted export policy before exposing artifact locators or
+   historical payloads broadly.
+4. Implement host-specific process-evidence adapters that translate observations into
+   canonical exits and heartbeat leases without mutating history.
+5. Add non-local CLI usage metrics and local-model resource metrics as distinct projections.
+6. Add scheduler policy and executor adapters only after temporal inspection proves persisted
+   and reconciled state is operator-debuggable.
+7. Defer mutation commands until command versioning and idempotency are tested.
+8. Defer all visual redesign, including liquid glass, until orchestration behavior and
    operator information architecture are stable.
 
 ## Progress Log
@@ -418,6 +428,13 @@ for quality, latency, cost, and context growth.
 - `fa64908 feat: recover native graph prototype`
 - `64a2bde feat: add authoritative graph execution state`
 - `6d3aa58 test: add stale compendium runtime fixture`
+- `79d7d1a docs: refine orchestration state and recovery plan`
+- `187367d fix: make graph reconciliation evidence ordering total`
+- `a4571b2 feat: add graph execution event store`
+- `fcb812b feat: add deterministic graph replay repository`
+- `2fc35b6 feat: add local SQLite graph persistence`
+- `38d0fc1 test: prove durable graph replay invariants`
+- `4f55d79 test: cover graph provenance and telemetry boundaries`
 
 ## Verification
 

--- a/docs/exec-plans/active/2026-07-19-capability-first-orchestration-control-plane.md
+++ b/docs/exec-plans/active/2026-07-19-capability-first-orchestration-control-plane.md
@@ -1,0 +1,273 @@
+# Capability-First Agent Orchestration Control Plane
+
+**Status:** Active
+**Started:** 2026-07-19
+**Current phase:** Phase 1, session truth and observability
+
+## Problem
+
+Open Island already has useful agent adapters, process discovery, approvals, questions,
+usage readers, and macOS surfaces. It is still primarily a session companion. The target
+is a local-first orchestration control plane that can run and supervise multi-model graphs,
+explain every state transition, operate research pipelines, and route durable context among
+local models, frontier models, Codex, terminals, and Obsidian.
+
+Project ancestry is not an architectural constraint. Jarvis may become a voice or command
+adapter, but it is not the privileged controller. Open Island owns orchestration state and
+policy because every interface must observe and operate the same graph.
+
+## Product Directives
+
+1. Design around capabilities and behaviors, not project names.
+2. Treat a host application, process, session, turn, graph run, and graph node as different
+   lifecycle scopes.
+3. Show only active or attention-requiring work on live surfaces. Completed and idle work
+   moves to history immediately and must not reappear through fallback discovery.
+4. Make events, logs, metrics, model calls, tools, resources, approvals, failures, retries,
+   handoffs, checkpoints, and artifacts first-class data.
+5. Use one normalized event contract across Qwen, Codex, Claude-family tools, Gemini,
+   OpenCode, Cursor, web workers, and future providers.
+6. Keep durable knowledge in user-controlled storage. Obsidian is the primary knowledge
+   plane; Open Island owns run state and provenance; provider-specific memory is imported
+   or exported through explicit context bundles.
+7. Fail open at adapter boundaries, but fail visibly inside a graph. Silent loss of state
+   is not acceptable.
+
+## Repository Audit
+
+The audit covered the complete repository file inventory, source and test symbol scans,
+documentation, scripts, and deep reads of the runtime paths that own events, discovery,
+liveness, state reduction, persistence, app-server integration, controls, and UI.
+
+### Existing foundations
+
+- Native SwiftUI/AppKit overlay and settings surfaces
+- Unix-socket bridge and normalized `AgentEvent` reducer
+- Adapters for Codex, Claude-family tools including Qwen, Gemini, OpenCode, and Cursor
+- Process, transcript, app-server, and terminal-session discovery
+- Approval and structured-question round trips
+- Session metadata, subagent/task display, usage readers, notifications, and jump targets
+- Local persistence, SSH transport, packaging, signing, update, and harness infrastructure
+
+### Structural gaps
+
+- Desktop host-process liveness was treated as per-thread liveness.
+- Live state and historical state were mixed, allowing inactive sessions to linger or return.
+- Agent events updated the latest session snapshot but did not form an operator-visible ledger.
+- Usage metrics exist, but run, node, model, tool, cost, latency, and resource metrics are not
+  normalized.
+- Subagents are metadata, not graph nodes with typed handoffs, budgets, retries, and checkpoints.
+- There is no scheduler, graph definition, artifact registry, evidence graph, context compiler,
+  evaluation layer, or unified terminal control API.
+
+## Target Architecture
+
+```mermaid
+flowchart LR
+    A["Agent and model adapters"] --> E["Normalized event ledger"]
+    W["Web and data adapters"] --> E
+    T["Terminal and app adapters"] --> E
+    E --> R["Session and graph reducers"]
+    R --> P["Scheduler and policy engine"]
+    P --> X["Node executors"]
+    X --> E
+    R --> O["Logs, metrics, traces, and history projections"]
+    R --> U["Native control surfaces and terminal API"]
+    R --> C["Context and evidence compiler"]
+    C --> Q["Local Qwen models"]
+    C --> F["Frontier models and Codex"]
+    C --> V["Obsidian knowledge plane"]
+    O --> U
+```
+
+The event ledger is the source of truth. Reducers build disposable projections for active
+sessions, graph runs, metrics, timelines, notifications, and history. Commands carry expected
+state versions so stale approvals or retries cannot mutate the wrong turn.
+
+Every executable node implements a common capability contract:
+
+- identity and parent graph/run/node relationships
+- lifecycle state and explicit reason
+- model, account, context-window, and resource assignment
+- typed input, output, artifact, and handoff envelopes
+- tool calls and permission boundaries
+- timestamps, token/cost/latency/resource metrics
+- retry, timeout, cancellation, checkpoint, and compensation policy
+- provenance links from claims to sources and transformations
+
+## AgentPeek Capability Parity
+
+The parity target is the behavior documented in AgentPeek's current product documentation,
+not its visual styling.
+
+| Capability | Required Open Island behavior | Phase |
+|---|---|---|
+| Compact live surface | Active rows with executing, thinking, waiting, idle, and attention state | 1-2 |
+| Activity and tool state | Current action, tool icon, command/input preview, and elapsed time | 1-2 |
+| Session metrics | Tokens, files touched, commands, diff lines, elapsed time, cost, and terminal | 1-2 |
+| Runtime metadata | Model, account, branch, context pressure, and subagent count | 2 |
+| Plans and todos | Live checklist with progress and focused plan view | 2 |
+| Latest response | Expandable Markdown response with full transcript route | 2 |
+| Timeline | Prompts, tools, permissions, questions, compactions, responses, failures, and retries | 1-2 |
+| Focused inspectors | Transcript, subagents, todos, tools, logs, metrics, artifacts, and graph views | 2 |
+| Nested subagents | Parent-child timelines, independent state, jump, export, cancel, and retry | 2-3 |
+| Session actions | Jump, copy ID/path, reveal files, dismiss, end, retry, fork, and export | 2 |
+| Inline permissions | Command/path/diff context, allow once, deny, persistent rule, and feedback | 2 |
+| Structured questions | Single/multi-select, freeform, annotations, timeout, and graph resumption | 2 |
+| Prompt composer | Follow-up, streaming response, cancel, queued prompts, and resume | 2 |
+| Quick routes | Skills, plugins, config, logs, workspace root, artifacts, and source files | 2 |
+| Usage dashboards | Active, 5-hour, 7-day, monthly, daily, raw token/spend, reset, and per-model views | 2 |
+| Floating widgets | Todos, usage, transcript, subagents, tools, graph health; multi-display persistence | 3 |
+| Agent board | Active, attention, blocked, retrying, and finished columns | 3 |
+| Notifications | Permission, budget, spend, pace, account handoff, stuck, task, quiet hours, and tests | 3 |
+| Local server discovery | Running dev servers with open, copy, inspect, and terminate actions | 3 |
+| Fast actions | Configurable commands and scripts with project context | 3 |
+| Views and menu bar | Named operator layouts, shortcuts, and low-friction background controls | 3 |
+| Settings and doctor | General, appearance, usage, notifications, shortcuts, performance, health, and about | 3 |
+
+Reference baseline:
+
+- <https://agentpeek.app/docs/>
+- <https://agentpeek.app/github-copilot/>
+- <https://agentpeek.app/permissions/>
+- <https://agentpeek.app/notifications/>
+- <https://agentpeek.app/views/>
+- <https://agentpeek.app/fast-actions/>
+- <https://agentpeek.app/log/>
+
+## Capabilities Beyond AgentPeek
+
+### Graph orchestration
+
+- Declarative DAG and hierarchical graph definitions with typed ports
+- Dynamic fan-out/fan-in, conditional routing, loops with explicit bounds, and human gates
+- Model router for local Qwen variants, Codex/frontier models, and specialist agents
+- Capacity-aware scheduling across RAM, VRAM, context windows, concurrency, cost, and deadlines
+- Typed handoffs that preserve objective, evidence, artifacts, open questions, and budget
+- Checkpoint/resume, retries with backoff, fallback models, cancellation propagation, and replay
+- Evaluator/critic nodes and policy-driven quality gates before synthesis or publication
+
+### Research and compendium production
+
+The dose-calculation regulations compendium becomes the first acceptance workload:
+
+```mermaid
+flowchart LR
+    S["Scope and jurisdictions"] --> P["Source planner"]
+    P --> C["Crawler and scraper workers"]
+    C --> N["Normalize and deduplicate"]
+    N --> E["Extract claims, rules, tables, and citations"]
+    E --> V["Source and contradiction validators"]
+    V --> Y["Synthesis and gap analysis"]
+    Y --> H["Human review gate"]
+    H --> O["Obsidian publisher and export"]
+```
+
+Required behavior includes robots/rate-limit policy, source snapshots, canonical URLs,
+content hashes, jurisdiction/effective-date metadata, claim-level citations, contradiction
+tracking, stale-source detection, and replayable transformations. No regulation claim may be
+published without source provenance.
+
+### Memory and context
+
+- Obsidian stores curated evergreen notes, compendiums, source records, decisions, and indexes.
+- Open Island stores graph/run state, event history, artifacts, provenance, metrics, and
+  context-manifest versions.
+- A context compiler selects only relevant vault notes, prior outcomes, user preferences,
+  source evidence, and tool schemas for each node.
+- Codex and other frontier clients receive versioned context bundles rather than uncontrolled
+  vault dumps.
+- Local Qwen workers can use local embeddings and retrieval while preserving the same evidence
+  and access-control contract.
+
+### Terminal control plane
+
+The terminal interface should eventually support:
+
+```text
+openisland status
+openisland sessions --active
+openisland graph run compendium.yaml
+openisland graph inspect <run-id>
+openisland logs <run-id> --follow
+openisland metrics <run-id>
+openisland approve|deny|answer <request-id>
+openisland retry|cancel|resume <node-id>
+openisland artifacts <run-id>
+openisland context explain <node-id>
+openisland vault publish <artifact-id>
+```
+
+The native app, terminal, future voice interface, and Codex integration call the same command
+service. None owns a parallel execution path.
+
+## Delivery Phases
+
+### Phase 1: Session truth and observability
+
+Goal: make live state trustworthy and establish the common telemetry vocabulary.
+
+- [x] Hide completed/idle Codex desktop threads immediately even when the host app remains open.
+- [x] Import only active app-server threads.
+- [x] Prevent completed or stale rollout records from resurrecting inactive desktop sessions.
+- [x] Add a normalized, bounded, persisted session timeline.
+- [x] Add aggregate event, tool, attention, completion, and elapsed metrics.
+- [x] Show recent timeline entries and core metrics in expanded live rows.
+- [x] Add lifecycle, deduplication, persistence, visibility, and rediscovery tests.
+- [ ] Capture structured errors and explicit state-transition reasons from every adapter.
+- [ ] Add active/history projections backed by an append-only event store.
+- [ ] Add model, token, cost, file, diff, command, latency, and resource metric events.
+
+Exit criteria: the active list has no ghost desktop sessions; each active session explains its
+recent state transitions; polling cannot inflate metrics; timeline state survives persistence.
+
+### Phase 2: Interaction and inspection parity
+
+Build full timeline/transcript/tools/todos/subagent inspectors, stacked prompts, richer
+permissions, plans, follow-up streaming/cancel, exports, quick routes, and per-model usage.
+Introduce a versioned command API and history browser.
+
+### Phase 3: Operator surfaces
+
+Build the agent board, floating widgets, layouts, menu-bar controls, local-server discovery,
+fast actions, notifications/budgets/quiet hours, performance controls, and a runtime doctor.
+
+### Phase 4: Graph runtime
+
+Add graph schemas, scheduler, node executors, typed handoffs, checkpoints, retries, fallback
+models, budgets, resource arbitration, artifact registry, and graph-level logs/traces/metrics.
+Run at least two local Qwen models concurrently in a supervised graph.
+
+### Phase 5: Research and knowledge plane
+
+Implement the web evidence pipeline, compendium schema, validators, source snapshots,
+claim-level provenance, Obsidian publishing, vault indexes, and context compiler. Complete a
+replayable dose-calculation regulations compendium run with review checkpoints.
+
+### Phase 6: Frontier/Codex integration and evaluation
+
+Expose the command and context services to Codex and frontier models, add model-selection
+policies and eval suites, benchmark local/frontier handoffs, and enforce regression budgets
+for quality, latency, cost, and context growth.
+
+## Verification
+
+Every phase requires:
+
+- reducer and adapter unit tests for all lifecycle transitions
+- replay tests from captured event fixtures
+- no-ghost-session and no-duplicate-metric regressions
+- graph crash/retry/cancel/resume fault injection
+- performance checks for idle CPU, memory, event throughput, and UI update rate
+- visual verification for compact/expanded views on notch, non-notch, and external displays
+- provenance tests that trace every published claim to a stored source snapshot
+- a committed execution round on a feature branch
+
+## Risks
+
+- Provider hooks differ in completeness; adapters must report confidence and degraded modes.
+- Transcript formats and desktop app-server protocols can change without notice.
+- Event history can grow without bounds unless retention and compaction are policy-controlled.
+- Local model concurrency can exhaust RAM/VRAM; scheduling must reserve resources before launch.
+- Vault retrieval can leak irrelevant or sensitive context; manifests need explicit scopes.
+- Regulations research is high stakes; provenance and human review are release gates, not polish.

--- a/docs/exec-plans/active/2026-07-19-capability-first-orchestration-control-plane.md
+++ b/docs/exec-plans/active/2026-07-19-capability-first-orchestration-control-plane.md
@@ -2,7 +2,7 @@
 
 **Status:** Active
 **Started:** 2026-07-19
-**Current phase:** Phase 2, durable graph history and temporal inspection preparation
+**Current phase:** Phase 2, durable scheduling and executor supervision preparation
 
 ## Problem
 
@@ -367,12 +367,17 @@ recent state transitions; polling cannot inflate metrics; timeline state survive
   interrupt facts, and OpenTelemetry-compatible internal vocabulary.
 - [x] Prove restart, replay, snapshots, concurrent writers, unknown events, retry ordinals,
   sibling-write preservation, fixed-point reconciliation, and the stale compendium fixture.
+- [x] Expose read-only temporal APIs and `openisland graph` commands for list, inspect,
+  history, explain, checkpoints, replay, diff, and redacted export.
+- [x] Add stable text, JSON, JSONL, completion, exit-code, telemetry, Unix pipeline, worktree,
+  multi-project, and neutral Terminal Graph workspace-plan contracts.
 - [ ] Implement host-specific process-evidence adapters that emit canonical evidence.
 - [ ] Add scheduler-owned timeout, cancellation, retry, and failure propagation.
 - [ ] Replace the simulation runner with executor adapters for local models and CLI agents.
 - [ ] Add typed handoff schemas on top of artifact references, then supervise a graph with at
   least two local models.
-- [ ] Expose read-only graph inspect, logs, and metrics through the shared command service.
+- [ ] Add graph logs and metric projections to the shared command service; temporal graph
+  inspection is now exposed through the standalone CLI boundary.
 - [ ] Add version-checked mutation commands for cancel, retry, and resume only after replay and
   restart behavior is proven.
 
@@ -408,19 +413,22 @@ for quality, latency, cost, and context growth.
 
 ## Immediate Execution Order
 
-1. Add temporal inspection APIs over the repository for list, inspect, history, explain,
-   checkpoint listing, dry-run replay, diff, and export.
-2. Expose those APIs through read-only `openisland graph` CLI commands with stable JSON output,
-   causal explanations, replay diagnostics, and OpenTelemetry-compatible CLI telemetry.
-3. Add integrity verification and redacted export policy before exposing artifact locators or
-   historical payloads broadly.
-4. Implement host-specific process-evidence adapters that translate observations into
+1. **Complete:** temporal inspection APIs for list, inspect, history, explain, checkpoint
+   listing, dry-run replay, diff, and export.
+2. **Complete:** read-only `openisland graph` CLI commands with stable JSON/JSONL, causal
+   explanations, replay diagnostics, bounded telemetry, and optional completion records.
+3. **Complete:** redacted artifact and repository-context exports plus deterministic neutral
+   workspace plans. Event/snapshot integrity policy remains enforced by the durable store.
+4. **Next:** add durable scheduler decision records, optimistic executor claims, renewable
+   leases, explicit retry policy, cancellation requests and acknowledgements, timeout
+   decisions, and deterministic failure propagation. Prove crash/restart and competing-worker
+   behavior without adding UI or model-specific launch code.
+5. Implement host-specific process-evidence adapters that translate observations into
    canonical exits and heartbeat leases without mutating history.
-5. Add non-local CLI usage metrics and local-model resource metrics as distinct projections.
-6. Add scheduler policy and executor adapters only after temporal inspection proves persisted
-   and reconciled state is operator-debuggable.
-7. Defer mutation commands until command versioning and idempotency are tested.
-8. Defer all visual redesign, including liquid glass, until orchestration behavior and
+6. Add non-local CLI usage metrics and local-model resource metrics as distinct projections.
+7. Add executor adapters only after scheduler decisions and claims are durable and inspectable.
+8. Defer mutation commands until command versioning and idempotency are tested.
+9. Defer all visual redesign, including liquid glass, until orchestration behavior and
    operator information architecture are stable.
 
 ## Progress Log
@@ -435,6 +443,27 @@ for quality, latency, cost, and context growth.
 - `2fc35b6 feat: add local SQLite graph persistence`
 - `38d0fc1 test: prove durable graph replay invariants`
 - `4f55d79 test: cover graph provenance and telemetry boundaries`
+- `77e017d docs: define durable graph history philosophy`
+- `d2c80cd feat: add temporal graph inspection APIs`
+- `3353374 feat: add read-only openisland graph commands`
+- `ed5ece0 feat: add terminal graph compatibility contracts`
+- `d1d7ce6 test: verify graph cli and streaming invariants`
+
+### Temporal inspection and integration decisions
+
+- The inspector depends on bounded read-store and snapshot-read protocols rather than SQLite.
+  Historical replay is side-effect-free and never updates snapshots.
+- Output schema version 1 separates text, JSON documents, and one-record-per-line JSONL.
+  Structured stdout is deterministic and diagnostics remain on stderr unless requested.
+- Open Island remains execution authority. Terminal Graph integration uses optional
+  environment context, typed semantic ports, stable external mapping keys, and a neutral
+  workspace plan; no Terminal Graph binary, private schema, state file, hook, or MCP call is
+  required.
+- Repository and artifact metadata is redaction-aware. CLI telemetry is bounded, local, and
+  excludes raw arguments, paths, environment values, prompts, and artifact bodies.
+- Durable scheduler decisions are the next correctness boundary. Mutation commands and
+  executor launching remain deferred until claims, leases, retries, cancellation, and restart
+  behavior are represented in history and proven under concurrency.
 
 ## Verification
 

--- a/docs/exec-plans/active/2026-07-19-capability-first-orchestration-control-plane.md
+++ b/docs/exec-plans/active/2026-07-19-capability-first-orchestration-control-plane.md
@@ -2,7 +2,7 @@
 
 **Status:** Active
 **Started:** 2026-07-19
-**Current phase:** Phase 2, deterministic executor adapter and mutation-command preparation
+**Current phase:** Phase 2, first real local executor adapter preparation
 
 ## Problem
 
@@ -182,7 +182,8 @@ Input ordering cannot change the result.
   dependency blocking.
 - Durable persistence and replay now use a versioned event envelope, deterministic projector,
   snapshot cache boundary, evidence-isolated repository, and transactional SQLite store.
-  The next boundary is observational temporal inspection, not execution or UI mutation.
+  Temporal inspection, durable scheduling, mutation commands, and deterministic execution now
+  share that history. The next boundary is one supervised local process adapter.
 
 ## Target Architecture
 
@@ -383,13 +384,21 @@ recent state transitions; polling cannot inflate metrics; timeline state survive
   success/failure/cancellation scenarios.
 - [x] Extend read-only graph inspection with schema-versioned policy, claim, lease, retry,
   cancellation, timeout, and scheduler-reason projections while preserving schema version 1.
-- [ ] Replace the simulation runner with executor adapters for local models and CLI agents.
+- [x] Add version-checked graph create, start, step, run, cancel, and retry commands with stable
+  text, JSON, JSONL, dry-run, exit-code, and expected-head contracts.
+- [x] Add a provider-neutral typed executor adapter, exact identity fencing, durable
+  intent/observation separation, terminal declarations, and content-addressed artifact handoffs.
+- [x] Add a bounded restart-safe orchestration service that schedules, claims, starts,
+  observes, renews leases, collects results, cleans up, releases claims, propagates
+  dependencies, and aggregates run outcomes without holding transactions across adapters.
+- [x] Execute the committed architect -> researcher -> graph -> reviewer fixture end to end with
+  deterministic retry, cancellation, timeout, stale-generation, duplicate, crash, SQLite
+  restart, replay, diff, export, and pipeline evidence.
+- [ ] Implement the first real supervised process executor for one local compendium node.
 - [ ] Add typed handoff schemas on top of artifact references, then supervise a graph with at
   least two local models.
 - [ ] Add graph logs and metric projections to the shared command service; temporal graph
   inspection is now exposed through the standalone CLI boundary.
-- [ ] Add version-checked mutation commands for cancel, retry, and resume only after replay and
-  restart behavior is proven.
 
 ### Phase 3: Usage, inspection, and visual control plane
 
@@ -432,16 +441,17 @@ for quality, latency, cost, and context growth.
 4. **Complete:** durable scheduling decisions, claims, renewable leases, retry,
    cancellation, timeout, fixed-point failure propagation, schema v2 read-only inspection,
    and SQLite restart/concurrency behavior.
-5. **Next:** implement graph mutation commands and an executor adapter boundary, then use a
-   no-op or deterministic test executor to create, claim, start, complete, retry, and cancel
-   the four-node compendium graph end to end before introducing real tmux, Codex, Qwen,
-   Ollama, or Terminal Graph MCP adapters.
-6. Implement host-specific process-evidence adapters that translate observations into
+5. **Complete:** mutation commands, provider-neutral executor protocol, fenced observation
+   repository, bounded orchestration cycles, deterministic executor, artifact propagation,
+   lease renewal, and four-node compendium execution across crash and restart boundaries.
+6. **Next:** implement one supervised local direct-process or tmux executor with durable
+   process identity and bounded log/artifact capture, then connect only the architect node.
+7. Implement host-specific process-evidence adapters that translate observations into
    canonical exits and heartbeat leases without mutating history.
-7. Add non-local CLI usage metrics and local-model resource metrics as distinct projections.
-8. Add real provider/model executors only after the deterministic executor proves the command,
+8. Add non-local CLI usage metrics and local-model resource metrics as distinct projections.
+9. Add provider/model executors only after the local process adapter proves the command,
    event, fencing, and recovery contracts.
-9. Defer all visual redesign, including liquid glass, until orchestration behavior and
+10. Defer all visual redesign, including liquid glass, until orchestration behavior and
    operator information architecture are stable.
 
 ## Progress Log
@@ -465,6 +475,13 @@ for quality, latency, cost, and context growth.
 - `a188b1a feat: add executor claims and renewable leases`
 - `7c63d59 feat: add retry cancellation and timeout protocols`
 - `395e6f5 test: prove scheduling concurrency and restart invariants`
+- `1fc3837 feat: add graph mutation service and commands`
+- `3342dac feat: add executor adapter and fencing protocol`
+- `54cea48 feat: add deterministic compendium executor`
+- `0b2628b feat: add bounded graph orchestration cycles`
+- `4b3333f test: prove graph execution and restart invariants`
+- `5864b22 fix: remove cursor-sensitive test nondeterminism`
+- `15a47c8 feat: renew active orchestration leases`
 
 ### Temporal inspection and integration decisions
 
@@ -480,9 +497,9 @@ for quality, latency, cost, and context growth.
   required.
 - Repository and artifact metadata is redaction-aware. CLI telemetry is bounded, local, and
   excludes raw arguments, paths, environment values, prompts, and artifact bodies.
-- Durable scheduler decisions and exclusive ownership are complete. The next correctness
-  boundary is a version-checked mutation command surface plus a deterministic executor adapter
-  that proves full graph execution without provider-specific launching.
+- Durable scheduler decisions, exclusive ownership, mutation commands, and deterministic
+  execution are complete. The next correctness boundary is durable process identity and
+  recovery for one supervised local executor.
 
 ### Durable scheduling and ownership decisions
 
@@ -501,6 +518,31 @@ for quality, latency, cost, and context growth.
 - See [ADR 002](../../architecture-decisions/002-durable-graph-scheduling.md) for the event
   taxonomy, phase table, precedence, transaction semantics, migration decisions, and complete
   requirement audit.
+
+### Mutation and executor decisions
+
+- `GraphExecutableDefinition` persists immutable node execution specifications, capability
+  requirements, workspace scope, environment-name allowlists, timeout policy, and artifact
+  roles. It does not contain provider credentials or unrestricted commands.
+- Mutation requests, scheduling decisions, claim ownership, start intent, adapter
+  observations, and terminal declarations are separate event classes. No CLI or adapter
+  return value mutates a projection directly.
+- Executor requests carry run, node, attempt, claim, executor, and lease-generation identity.
+  The repository rejects stale generations, inactive claims, mismatched owners, wrong
+  ordinals, completion before start, and invalid artifact provenance with stable codes.
+- A cycle persists intent before adapter work, performs adapter calls outside database
+  transactions, persists observations afterward at the expected head, and only then derives
+  terminal declarations. Active leases renew at half-life and every later interaction uses the
+  new fencing generation.
+- The committed deterministic fixture produces references only: section plan, researched
+  sections, relationship graph, and review verdict. Downstream resolution validates producer
+  run, node, attempt, ordinal, claim, role, digest, and completed-attempt provenance.
+- SQLite reopen, both start crash windows, retry delay, stale executor, cancellation, timeout,
+  duplicate observation, byte-identical replay, temporal diff, graph export, JSONL completion,
+  Unix pipe, and full app regression tests are the readiness baseline.
+- See [ADR 003](../../architecture-decisions/003-graph-mutation-and-executor-boundary.md) for
+  mutation semantics, adapter operations, fencing, lifecycle, transaction boundaries, crash
+  recovery, artifact flow, compendium execution, and real-adapter readiness criteria.
 
 ## Verification
 

--- a/docs/exec-plans/active/2026-07-19-capability-first-orchestration-control-plane.md
+++ b/docs/exec-plans/active/2026-07-19-capability-first-orchestration-control-plane.md
@@ -2,7 +2,7 @@
 
 **Status:** Active
 **Started:** 2026-07-19
-**Current phase:** Phase 2 complete; provider adapters are the next graph-runtime task
+**Current phase:** Phase 2 complete; one provider adapter is the next isolated capability
 
 ## Problem
 
@@ -403,6 +403,61 @@ recent state transitions; polling cannot inflate metrics; timeline state survive
   process runtime; aggregate graph metric projections remain Phase 3 work.
 - [x] Add versioned graph-definition documents and a native Definition/Run/History workspace
   with a discoverable singleton entry point.
+- [x] Complete native graph authoring so a blank document can be configured, typed, wired,
+  validated, saved, reopened, versioned, and executed without fixture JSON or CLI construction.
+
+#### Native Graph Workspace usability audit (2026-07-22)
+
+The audit below reflects the packaged-app workflow, not merely the presence of model methods.
+
+| Capability | Baseline status before authoring-completeness work | Evidence |
+| --- | --- | --- |
+| Create blank graph | incomplete | An icon immediately creates an unnamed `Untitled Graph`; there is no creation sheet, template choice, or defaults editor. |
+| Add node and stable ID | incomplete | Toolbar and empty state create only `node-N`; identity survives rename, but type and ID generation are not user-visible. |
+| Edit node and choose type | incomplete | Name, description, capabilities, and timeout only; every node is a hard-coded local process. |
+| Configure execution specification | fixture-only | Adapter and operation are read-only; executable, arguments, stdin, environment inheritance, and artifacts cannot be edited. |
+| Select executable and working directory | missing | No file or directory pickers are exposed. |
+| Environment allowlist | missing | Persisted by the schema but not editable. |
+| Input and output artifacts | missing | Runtime roles exist, but declarations and stable bindings are not authorable. |
+| Capabilities, retry, and timeout | incomplete | Required capabilities and execution timeout are editable as unstructured text/stepper; preferred capabilities, executor/platform, retry, cancellation, and inheritance are absent. |
+| Drag edge | missing | Canvas ports are decorative. |
+| Inspector or keyboard edge | incomplete | Two alphabetically selected nodes can be connected; source/destination intent, typed ports, and keyboard flow are absent. |
+| Delete/select edge | incomplete | Incoming edges can be deleted from a node inspector, but edges cannot be selected or inspected. |
+| Validate and show errors | incomplete | A single thrown error is placed in the status bar; no typed diagnostics or navigation panel exists. |
+| Save and Save As | incomplete | One save icon opens a panel only for an unsaved document; Save As, revert, close, atomic-conflict handling, dirty state, and external-modification detection are absent. |
+| Reopen and recent documents | incomplete | Open and one last-path restore exist; recent documents and a guided empty state do not. |
+| Unsaved changes | missing | No digest-backed dirty state or close prompt exists. |
+| Create run and choose executor | incomplete | A run is created immediately when any node exists; there is no validation gate, input resolution, compatibility report, workspace confirmation, or backend choice. |
+| Start run | working | Start, Step, and Run operate the durable runtime after creation. |
+| Reconnect to run | working but hidden | Last run and durable run selection restore, but definition/run association and associated-run count are not presented. |
+| Canvas selection and layout | incomplete | Node selection, movement, deterministic auto-layout, zoom, and delete work; movement is not undo-coalesced and fit/reset controls are ambiguous. |
+| Undo and redo | missing | No document undo history or standard commands exist. |
+| Empty-state guidance | incomplete | Only `Empty Graph` and `Add Node` appear after a document exists; create/open/recent/example entry points are absent. |
+
+Authoring readiness requires closing every missing or incomplete item above before provider-specific
+adapters begin. Ordinary layout edits remain outside semantic digests. Semantic edits to a
+definition that already owns runs must become a draft and receive a new immutable definition
+version before another run can be created.
+
+#### Native Graph Workspace resolution (2026-07-22)
+
+Every baseline gap above is closed. New/Open/Save/Save As/Validate/Create Run are visible;
+the empty state includes new/open/recent/example routes; the creation sheet supplies identity
+and execution defaults; the node palette and inspector author complete process specifications,
+typed inputs/outputs, capabilities, retry, and timeout; all connection paths share one typed
+evaluator; validation is incremental, navigable, and a hard run gate; lifecycle state includes
+dirty/conflict/recent/revert/close/atomic save; semantic drafts require a new immutable version;
+undo/redo and deterministic layout are document-only; and six templates are ordinary editable
+documents.
+
+Packaged acceptance built `Generate -> Transform -> Verify` from Blank Graph, saved, closed,
+reopened, created version 2 after a semantic correction, and completed at stream 87 with all
+three nodes terminal-completed and nine artifacts. The run exposed an invalid `${artifact:...}`
+upstream token that validation had not caught; `invalid_argument_token` now rejects that error
+and directs authors to `${input:role}`. The Compendium Fill template was renamed, saved under a
+new name, and completed `architect -> researcher -> graph -> reviewer` at stream 122 with nine
+artifacts. Logs and artifact projections were inspected in the packaged app; the Verify stderr
+contained the expected fixture diagnostic. See ADR 005 for the grouped requirement audit.
 
 ### Phase 3: Usage, inspection, and visual control plane
 
@@ -452,8 +507,10 @@ for quality, latency, cost, and context growth.
    declared artifacts, cancellation, timeout, recovery, and the four-node compendium graph.
 7. **Complete:** Darwin process evidence plus native graph documents and the singleton
    Definition/Run/History workspace backed only by public graph services.
-8. **Next:** implement provider-specific agent adapters behind the proven executor boundary,
-   beginning with one supervised compendium node and evaluating providers independently.
+8. **Next:** Implement one provider adapter at a time behind the existing executor boundary,
+   beginning with a single architect node, after confirming that provider credentials, model
+   selection, prompt templates, structured outputs, cancellation, logs, artifacts, and recovery
+   can all be configured through the completed graph-authoring UI.
 9. Add non-local CLI usage metrics and local-model resource metrics as distinct projections.
 10. Defer all visual redesign, including liquid glass, until orchestration behavior and
    operator information architecture are stable.
@@ -492,6 +549,14 @@ for quality, latency, cost, and context growth.
 - `43a331f feat: add native graph workspace and entry button`
 - `5d70797 feat: run compendium graph with local processes`
 - `3d40d98 test: prove process recovery and graph workspace invariants`
+- `7f45f89 feat: add complete graph document lifecycle`
+- `711f008 feat: add node and execution-spec authoring`
+- `4c7df04 feat: add typed dependency and artifact wiring`
+- `e064f01 feat: add graph validation and run creation flow`
+- `58ea9bd feat: add graph templates and authoring guidance`
+- `77e310a test: prove UI-built graphs execute end to end`
+- `ea33c35 feat: complete graph input binding inspector`
+- `773662f fix: harden graph authoring validation and entry points`
 
 ### Local process and workspace decisions
 
@@ -523,8 +588,10 @@ for quality, latency, cost, and context growth.
 - Repository and artifact metadata is redaction-aware. CLI telemetry is bounded, local, and
   excludes raw arguments, paths, environment values, prompts, and artifact bodies.
 - Durable scheduler decisions, exclusive ownership, mutation commands, and deterministic
-  execution are complete. The next correctness boundary is durable process identity and
-  recovery for one supervised local executor.
+  execution, supervised process recovery, and native graph authoring are complete. The next
+  correctness boundary is one provider adapter behind the existing executor protocol, gated
+  by the completed credentials, model, prompt, structured-output, cancellation, log, artifact,
+  and recovery authoring surfaces.
 
 ### Durable scheduling and ownership decisions
 
@@ -581,6 +648,22 @@ Every phase requires:
 - visual verification for compact/expanded views on notch, non-notch, and external displays
 - provenance tests that trace every published claim to a stored source snapshot
 - a committed execution round on a feature branch
+
+Native graph authoring passed its completion gate on 2026-07-22:
+
+- `swift test`: 227 XCTest cases and 335 Swift Testing tests passed with zero failures.
+- `scripts/lint-strings.sh` and `scripts/check-docs.sh`: passed.
+- `swift build` and `swift build -c release`: passed; the only release warning is the existing
+  `SessionState.swift` `@discardableResult` warning.
+- `scripts/package-app.sh`: passed helper builds, bundle verification, outside-repository smoke
+  launch, ZIP creation, and DMG creation. `codesign --verify --deep --strict` passed for the
+  ad-hoc signed app and embedded helpers.
+- A packaged-app graph authored entirely through the UI completed generate, transform, and
+  verify nodes at stream position 87 with nine artifacts. Save, close, reopen, definition
+  versioning, durable run creation, logs, artifacts, and terminal inspection were exercised.
+- The packaged Compendium Fill template completed architect, researcher, graph, and reviewer
+  nodes at stream position 122 with nine artifacts. The final package also passed a fresh
+  `File > New Graph` accessibility-tree smoke check with distinct cancel/create controls.
 
 ## Risks
 

--- a/docs/exec-plans/active/2026-07-19-capability-first-orchestration-control-plane.md
+++ b/docs/exec-plans/active/2026-07-19-capability-first-orchestration-control-plane.md
@@ -60,6 +60,28 @@ liveness, state reduction, persistence, app-server integration, controls, and UI
 - There is no scheduler, graph definition, artifact registry, evidence graph, context compiler,
   evaluation layer, or unified terminal control API.
 
+### Recovered graph work
+
+The graph feature is not a greenfield phase. Two earlier implementations are available and
+must be recovered before new graph abstractions are designed:
+
+- The original Open Island worktree contains an uncommitted native graph substrate:
+  `AgentTaskGraph`, `AgentGraphExecutor`, `SessionGraphCatalog`, a simulation model, graph
+  catalog and inspector views, a graph window controller, and core executor tests. It already
+  models DAG dependencies, bounded parallel batches, node states, cycle detection, and
+  success/failure outputs. Recover this code deliberately from the dirty worktree without
+  modifying or deleting the user's other uncommitted files.
+- The dose-regulations compendium repository contains a committed four-role Qwen workflow:
+  architect and researcher fan out in isolated worktrees, graph engineering fans in their
+  commits, and an independent reviewer gates the result. Role contracts, path allowlists,
+  handoff files, tmux launchers, status scripts, and model assignments are already present.
+
+The latest compendium graph attempt is also the first failure-replay fixture. The architect
+hit a tool-call limit and the researcher timed out, but both retained only `.started` markers
+and idle tmux shells, so the status command still reports them as running. The native runtime
+must replace this marker-based inference with authoritative process exit, node state, timeout,
+error, retry, and terminal-session evidence.
+
 ## Target Architecture
 
 ```mermaid
@@ -214,6 +236,9 @@ Goal: make live state trustworthy and establish the common telemetry vocabulary.
 - [x] Add aggregate event, tool, attention, completion, and elapsed metrics.
 - [x] Show recent timeline entries and core metrics in expanded live rows.
 - [x] Add lifecycle, deduplication, persistence, visibility, and rediscovery tests.
+- [x] Prune completed Codex records during startup and active-state persistence.
+- [x] Verify completed thread `019f2afd-e6fd-7e11-bdd4-945caba06867` cannot re-enter
+  the active island through cache or rollout restoration.
 - [ ] Capture structured errors and explicit state-transition reasons from every adapter.
 - [ ] Add active/history projections backed by an append-only event store.
 - [ ] Add model, token, cost, file, diff, command, latency, and resource metric events.
@@ -221,34 +246,63 @@ Goal: make live state trustworthy and establish the common telemetry vocabulary.
 Exit criteria: the active list has no ghost desktop sessions; each active session explains its
 recent state transitions; polling cannot inflate metrics; timeline state survives persistence.
 
-### Phase 2: Interaction and inspection parity
+### Phase 2: Recover and supervise the graph runtime
 
-Build full timeline/transcript/tools/todos/subagent inspectors, stacked prompts, richer
-permissions, plans, follow-up streaming/cancel, exports, quick routes, and per-model usage.
-Introduce a versioned command API and history browser.
+- Import the existing native graph model, executor, views, and tests into the feature branch.
+- Replace the simulation-only runner with executor adapters for local Qwen/Ollama and CLI agents.
+- Convert the four-role compendium workflow into a versioned graph fixture with typed handoffs.
+- Add authoritative process ownership, exit capture, timeout, cancellation, retry, and failure
+  propagation so failed nodes cannot remain "running."
+- Emit graph/run/node events into the same ledger and expose graph inspect, logs, metrics,
+  cancel, retry, and resume through a versioned command service and initial CLI.
+- Re-run the failed architect/researcher scenario as a deterministic regression, then complete
+  one supervised graph with at least two local Qwen models.
 
-### Phase 3: Operator surfaces
+### Phase 3: Usage, inspection, and visual control plane
 
-Build the agent board, floating widgets, layouts, menu-bar controls, local-server discovery,
-fast actions, notifications/budgets/quiet hours, performance controls, and a runtime doctor.
+- Implement CLI-specific usage collectors for non-local models, separated from local-model
+  resource telemetry. Normalize provider, CLI surface, account, model, billing window, token
+  counts, context pressure, spend, reset time, quota state, and collection freshness.
+- Show AgentPeek-class session and graph inspectors for timeline, transcript, tools, todos,
+  subagents, logs, metrics, artifacts, handoffs, graph health, and provider usage.
+- Add plans, follow-up/cancel, exports, quick routes, richer permissions, structured questions,
+  active/history browsing, and account/model-level usage views.
+- Establish a native liquid-glass visual system using macOS materials, vibrancy, restrained
+  highlights, translucent layering, adaptive contrast, and reduced-transparency fallbacks.
+  Glass styling must improve hierarchy without reducing metric density or legibility.
 
-### Phase 4: Graph runtime
-
-Add graph schemas, scheduler, node executors, typed handoffs, checkpoints, retries, fallback
-models, budgets, resource arbitration, artifact registry, and graph-level logs/traces/metrics.
-Run at least two local Qwen models concurrently in a supervised graph.
-
-### Phase 5: Research and knowledge plane
+### Phase 4: Research and knowledge plane
 
 Implement the web evidence pipeline, compendium schema, validators, source snapshots,
-claim-level provenance, Obsidian publishing, vault indexes, and context compiler. Complete a
-replayable dose-calculation regulations compendium run with review checkpoints.
+claim-level provenance, contradiction handling, stale-source detection, Obsidian publishing,
+vault indexes, and context compiler. Complete a replayable dose-calculation regulations
+compendium run with review checkpoints.
+
+### Phase 5: Expanded operator surfaces
+
+Build the agent board, floating widgets, saved layouts, menu-bar controls, local-server
+discovery, fast actions, notifications, budgets, quiet hours, performance controls, and a
+runtime doctor. Apply the liquid-glass system across these surfaces after their information
+architecture is stable.
 
 ### Phase 6: Frontier/Codex integration and evaluation
 
 Expose the command and context services to Codex and frontier models, add model-selection
 policies and eval suites, benchmark local/frontier handoffs, and enforce regression budgets
 for quality, latency, cost, and context growth.
+
+## Immediate Execution Order
+
+1. Keep completed and dead sessions out of startup, persistence, app-server, and rollout
+   projections; record explicit removal and suppression reasons.
+2. Recover the native graph implementation into this clean branch and make its tests part of
+   the normal suite.
+3. Replace compendium marker inference with graph-run and node state driven by owned processes,
+   exits, heartbeats, timeouts, and artifacts.
+4. Add the first `openisland graph` commands and stream the same state to the native inspector.
+5. Add non-local CLI usage metrics and local Qwen resource metrics as distinct projections.
+6. Apply the liquid-glass visual baseline to the live island and graph inspector, including
+   accessibility fallbacks and screenshot verification.
 
 ## Verification
 

--- a/docs/exec-plans/active/2026-07-19-capability-first-orchestration-control-plane.md
+++ b/docs/exec-plans/active/2026-07-19-capability-first-orchestration-control-plane.md
@@ -2,7 +2,7 @@
 
 **Status:** Active
 **Started:** 2026-07-19
-**Current phase:** Phase 2, durable scheduling and executor supervision preparation
+**Current phase:** Phase 2, deterministic executor adapter and mutation-command preparation
 
 ## Problem
 
@@ -372,7 +372,17 @@ recent state transitions; polling cannot inflate metrics; timeline state survive
 - [x] Add stable text, JSON, JSONL, completion, exit-code, telemetry, Unix pipeline, worktree,
   multi-project, and neutral Terminal Graph workspace-plan contracts.
 - [ ] Implement host-specific process-evidence adapters that emit canonical evidence.
-- [ ] Add scheduler-owned timeout, cancellation, retry, and failure propagation.
+- [x] Add deterministic event-sourced scheduler decisions, runnable selection, fixed-point
+  dependency failure propagation, and explicit reason codes.
+- [x] Add optimistic executor claims, renewable generation-fenced leases, explicit expiry and
+  release, exact-redelivery idempotency, and competing-writer exclusion.
+- [x] Add versioned retry/backoff policy, cancellation request/acknowledgement/terminal
+  protocol, and five explicit timeout decision kinds.
+- [x] Prove crash-before/after-claim behavior, SQLite contention/restart/takeover, retry-delay
+  recovery, scheduler idempotency, snapshot compatibility, and the four-node compendium
+  success/failure/cancellation scenarios.
+- [x] Extend read-only graph inspection with schema-versioned policy, claim, lease, retry,
+  cancellation, timeout, and scheduler-reason projections while preserving schema version 1.
 - [ ] Replace the simulation runner with executor adapters for local models and CLI agents.
 - [ ] Add typed handoff schemas on top of artifact references, then supervise a graph with at
   least two local models.
@@ -419,15 +429,18 @@ for quality, latency, cost, and context growth.
    explanations, replay diagnostics, bounded telemetry, and optional completion records.
 3. **Complete:** redacted artifact and repository-context exports plus deterministic neutral
    workspace plans. Event/snapshot integrity policy remains enforced by the durable store.
-4. **Next:** add durable scheduler decision records, optimistic executor claims, renewable
-   leases, explicit retry policy, cancellation requests and acknowledgements, timeout
-   decisions, and deterministic failure propagation. Prove crash/restart and competing-worker
-   behavior without adding UI or model-specific launch code.
-5. Implement host-specific process-evidence adapters that translate observations into
+4. **Complete:** durable scheduling decisions, claims, renewable leases, retry,
+   cancellation, timeout, fixed-point failure propagation, schema v2 read-only inspection,
+   and SQLite restart/concurrency behavior.
+5. **Next:** implement graph mutation commands and an executor adapter boundary, then use a
+   no-op or deterministic test executor to create, claim, start, complete, retry, and cancel
+   the four-node compendium graph end to end before introducing real tmux, Codex, Qwen,
+   Ollama, or Terminal Graph MCP adapters.
+6. Implement host-specific process-evidence adapters that translate observations into
    canonical exits and heartbeat leases without mutating history.
-6. Add non-local CLI usage metrics and local-model resource metrics as distinct projections.
-7. Add executor adapters only after scheduler decisions and claims are durable and inspectable.
-8. Defer mutation commands until command versioning and idempotency are tested.
+7. Add non-local CLI usage metrics and local-model resource metrics as distinct projections.
+8. Add real provider/model executors only after the deterministic executor proves the command,
+   event, fencing, and recovery contracts.
 9. Defer all visual redesign, including liquid glass, until orchestration behavior and
    operator information architecture are stable.
 
@@ -448,22 +461,46 @@ for quality, latency, cost, and context growth.
 - `3353374 feat: add read-only openisland graph commands`
 - `ed5ece0 feat: add terminal graph compatibility contracts`
 - `d1d7ce6 test: verify graph cli and streaming invariants`
+- `5746c87 feat: add deterministic graph scheduler decisions`
+- `a188b1a feat: add executor claims and renewable leases`
+- `7c63d59 feat: add retry cancellation and timeout protocols`
+- `395e6f5 test: prove scheduling concurrency and restart invariants`
 
 ### Temporal inspection and integration decisions
 
 - The inspector depends on bounded read-store and snapshot-read protocols rather than SQLite.
   Historical replay is side-effect-free and never updates snapshots.
-- Output schema version 1 separates text, JSON documents, and one-record-per-line JSONL.
-  Structured stdout is deterministic and diagnostics remain on stderr unless requested.
+- Output schema version 2 adds scheduling policy, claims, leases, retries, cancellation,
+  timeout, and reason-code inspection. Version 1 remains selectable. Text, JSON documents,
+  and one-record-per-line JSONL remain deterministic; diagnostics stay on stderr unless
+  requested.
 - Open Island remains execution authority. Terminal Graph integration uses optional
   environment context, typed semantic ports, stable external mapping keys, and a neutral
   workspace plan; no Terminal Graph binary, private schema, state file, hook, or MCP call is
   required.
 - Repository and artifact metadata is redaction-aware. CLI telemetry is bounded, local, and
   excludes raw arguments, paths, environment values, prompts, and artifact bodies.
-- Durable scheduler decisions are the next correctness boundary. Mutation commands and
-  executor launching remain deferred until claims, leases, retries, cancellation, and restart
-  behavior are represented in history and proven under concurrency.
+- Durable scheduler decisions and exclusive ownership are complete. The next correctness
+  boundary is a version-checked mutation command surface plus a deterministic executor adapter
+  that proves full graph execution without provider-specific launching.
+
+### Durable scheduling and ownership decisions
+
+- The pure scheduler consumes definition, projection, reconciliation, policy, logical time,
+  capabilities, claims/leases, and failure categories, then proposes events without I/O.
+- Event-sourced claims use the existing expected-head append transaction for exclusion; lease
+  generation is the executor fencing value and process liveness does not imply ownership.
+- Retry delay and bounded jitter are deterministic and recorded. Cancellation is a four-stage
+  protocol. Historical timeouts are explicit events, never replay-time wall-clock inference.
+- Schema migration is additive: no SQLite table migration is needed; old snapshots default a
+  missing scheduling projection to empty, old evaluation events may omit embedded policy, and
+  CLI schema version 1 remains supported alongside version 2.
+- The committed scheduling fixture is `architect -> researcher -> graph -> reviewer`, with
+  capability-specific workers and complete success, failure, retry, cancellation, contention,
+  and restart evidence.
+- See [ADR 002](../../architecture-decisions/002-durable-graph-scheduling.md) for the event
+  taxonomy, phase table, precedence, transaction semantics, migration decisions, and complete
+  requirement audit.
 
 ## Verification
 

--- a/docs/exec-plans/active/2026-07-19-capability-first-orchestration-control-plane.md
+++ b/docs/exec-plans/active/2026-07-19-capability-first-orchestration-control-plane.md
@@ -2,7 +2,7 @@
 
 **Status:** Active
 **Started:** 2026-07-19
-**Current phase:** Phase 1, session truth and observability
+**Current phase:** Phase 2, graph runtime recovery and execution truth
 
 ## Problem
 
@@ -81,6 +81,108 @@ hit a tool-call limit and the researcher timed out, but both retained only `.sta
 and idle tmux shells, so the status command still reports them as running. The native runtime
 must replace this marker-based inference with authoritative process exit, node state, timeout,
 error, retry, and terminal-session evidence.
+
+### Native prototype recovery inventory
+
+Only the portable definition, compatibility executor, and core tests were copied from the
+dirty source worktree. The source worktree, its stash, unrelated translation work, and graph
+UI files were not modified. "Discard" below means do not migrate the type into the
+authoritative runtime; it does not authorize deleting the source-worktree copy.
+
+| Recovered type | Classification | Decision |
+|---|---|---|
+| `AgentTaskNodeState` | replace | Keep for prototype compatibility; `ReconciledExecutionState` owns persisted runtime truth. |
+| `AgentExecutionKind` | amend | Keep for prototype decoding; migrate assignments to adapter-neutral executor registry IDs. |
+| `AgentTaskNode` | replace | It mixes definition, output, timestamps, and process state; split runtime identity and attempts into canonical records. |
+| `AgentTaskEdge` | reusable | Preserve as the declarative dependency primitive until typed ports require a versioned edge schema. |
+| `AgentTaskGraph` | amend | Preserve cycle/dependency behavior as an import and simulation model; remove runtime-state ownership during graph-definition versioning. |
+| `AgentTaskExecutionResult` | amend | Replace its output string with typed artifact and handoff envelopes when executor adapters arrive. |
+| `AgentGraphExecutionError` | reusable | Preserve cycle and stalled-graph diagnostics; extend with structured reasons at the scheduler boundary. |
+| `AgentGraphExecutor` | amend | Retain as a deterministic compatibility/simulation actor; a ledger-backed scheduler will replace it for production execution. |
+| private `NodeOutcome` | discard | Batch-local transport only; authoritative outcomes are `ExecutionEvent` and `ExecutionAttempt` records. |
+| `AgentTaskGraphTests` | reusable | Preserve the recovered dependency, cycle, and bounded-execution regression coverage. |
+
+Prototype candidates inspected but deliberately not recovered in this round:
+
+| Source artifact | Types | Classification and disposition |
+|---|---|---|
+| `SessionGraphCatalog.swift` | `SessionGraphSummary`, `SessionGraphCatalog`, private `GraphIdentity` | amend later; workspace-grouped sessions are a presentation projection, not a DAG. |
+| `AgentGraphPrototypeModel.swift` | `AgentGraphPrototypeModel` | discard after migration; it is a hard-coded timed simulation. |
+| `AgentTaskGraphPrototypeView.swift` | `AgentTaskGraphPrototypeView`, private node card and layout types | amend later against reconciled graph projections; no UI recovery in this task. |
+| `IslandGraphCatalogView.swift` | `IslandGraphCatalogView`, private row type | amend later to consume real graph runs instead of workspace groupings. |
+| `SessionGraphWindowView.swift` | `SessionGraphWindowView`, private canvas, node, layout, and edge types | amend later; visual topology is useful but inferred sequential edges are not authoritative. |
+| `SessionGraphWindowController.swift` | `SessionGraphWindowController` | reusable later as window lifecycle infrastructure. |
+| `LabSettingsPane.swift` | `LabSettingsPane` | discard as the graph-runtime owner; future navigation can host the recovered inspector without owning execution. |
+
+### Canonical execution records
+
+All canonical records are provider- and terminal-neutral. Adapter code may inspect tmux,
+process tables, provider storage, or marker files, but it must translate observations into
+these records before reconciliation.
+
+| Model | Authority |
+|---|---|
+| `GraphRun` | Identity and aggregate reconciled state for one execution of a versioned graph. |
+| `GraphNode` | Run-scoped dependency projection, executor registry ID, and latest reconciled node state. |
+| `ExecutionAttempt` | Monotonic retry ordinal, process ownership, lifecycle state, reason, and timing for one node attempt. |
+| `ProcessIdentity` | Opaque host and launch identity, with optional OS process metadata to prevent PID reuse ambiguity. |
+| `ProcessExit` | Adapter observation that an owned process ended; an exit code alone never proves task completion. |
+| `ExecutorHeartbeat` | Time-bounded lease proving that a matching executor instance was recently alive. |
+| `ExecutionEvent` | Ordered explicit lifecycle fact, including business-level completion, failure, interruption, or cancellation. |
+| `ReconciledExecutionState` | Shared state vocabulary: pending, ready, running, completed, failed, interrupted, orphaned, blocked, cancelled. |
+
+`ExecutionReconciliationInput` is the adapter handoff and
+`ExecutionReconciliationResult` is the disposable authoritative projection.
+`GraphExecutionReconciler` is deterministic and side-effect-free: it performs no process
+inspection, file access, clock reads, persistence, command execution, or provider decoding.
+
+### Reconciliation precedence
+
+Attempt evidence is evaluated in this exact order:
+
+1. The latest explicit terminal attempt event wins, ordered by `(sequence, occurredAt, id)`.
+2. A matching process exit without a terminal attempt event yields `interrupted`, including
+   exit code zero; business success requires an explicit completion event.
+3. A matching heartbeat whose lease includes `observedAt` yields `running`.
+4. A persisted or explicitly started running attempt without current evidence yields
+   `orphaned` when it has a recorded process identity.
+5. The same unsupported running claim yields `interrupted` when no process identity can be
+   recovered.
+6. Non-running attempt state is retained when none of the preceding evidence applies.
+
+Node dependency state is then recomputed to a fixed point, followed by run aggregation.
+Input ordering cannot change the result.
+
+| Condition | Attempt/node transition | Downstream/run consequence |
+|---|---|---|
+| explicit completion event | `running -> completed` | dependents can become `ready`; all-complete run becomes `completed` |
+| explicit failure event | `running -> failed` | unstarted dependents become `blocked`; inactive run becomes `failed` |
+| explicit interruption event or process exit | `running -> interrupted` | unstarted dependents become `blocked`; inactive run becomes `interrupted` |
+| stale lease with known process identity | `running -> orphaned` | unstarted dependents become `blocked`; inactive run becomes `orphaned` unless a higher aggregate failure exists |
+| unsupported start with no identity | `running -> interrupted` | unstarted dependents become `blocked` |
+| valid matching heartbeat | persisted state becomes/remains `running` | run remains `running` while active work exists |
+| every dependency completed | `pending/blocked -> ready` | node is eligible for a future scheduler decision |
+| any dependency failed, interrupted, orphaned, cancelled, or blocked | `pending/ready -> blocked` | blocking propagates transitively |
+| dependencies remain active or pending | `ready/blocked -> pending` | no execution is authorized |
+
+### Migration decisions
+
+- Existing `AgentTaskGraph` JSON remains a compatibility/import format, not the persistence
+  schema for live execution.
+- Canonical IDs are opaque strings so adapters can preserve external stable IDs; prototype
+  UUIDs are serialized into strings at the migration boundary.
+- `AgentExecutionKind` maps to an executor registry ID. Core state never switches directly on
+  Qwen, Codex, Ollama, tmux, rollout files, or marker-file concepts.
+- Persisted `running` state is always reconciled before a scheduler or operator surface reads
+  it. A snapshot cannot make itself authoritative.
+- Process and provider adapters emit `ProcessExit`, `ExecutorHeartbeat`, and `ExecutionEvent`
+  evidence. They do not mutate node state.
+- The stale compendium architect/researcher run is committed as an adapter-neutral JSON
+  fixture. It is the restart baseline for interrupted/orphaned recovery and transitive
+  dependency blocking.
+- The next migration boundary is persistence and replay, not a production executor or UI:
+  introduce store/evidence protocols, append-only event storage, and read-time reconciliation
+  before launching models.
 
 ## Target Architecture
 
@@ -248,15 +350,22 @@ recent state transitions; polling cannot inflate metrics; timeline state survive
 
 ### Phase 2: Recover and supervise the graph runtime
 
-- Import the existing native graph model, executor, views, and tests into the feature branch.
-- Replace the simulation-only runner with executor adapters for local Qwen/Ollama and CLI agents.
-- Convert the four-role compendium workflow into a versioned graph fixture with typed handoffs.
-- Add authoritative process ownership, exit capture, timeout, cancellation, retry, and failure
-  propagation so failed nodes cannot remain "running."
-- Emit graph/run/node events into the same ledger and expose graph inspect, logs, metrics,
-  cancel, retry, and resume through a versioned command service and initial CLI.
-- Re-run the failed architect/researcher scenario as a deterministic regression, then complete
-  one supervised graph with at least two local Qwen models.
+- [x] Recover the portable native graph model, compatibility executor, and tests without
+  modifying the original dirty worktree.
+- [x] Inventory every recovered type and explicitly retain, amend, replace, or discard it.
+- [x] Add canonical run, node, attempt, process, heartbeat, exit, event, and reconciled-state
+  records.
+- [x] Implement deterministic side-effect-free execution reconciliation.
+- [x] Commit the stale architect/researcher run as an adapter-neutral fixture and prove
+  interrupted/orphaned recovery plus transitive downstream blocking.
+- [ ] Add append-only execution-event persistence and snapshot repositories behind protocols.
+- [ ] Add process-evidence adapters and reconcile persisted runs on startup and every read.
+- [ ] Add scheduler-owned timeout, cancellation, retry, and failure propagation.
+- [ ] Replace the simulation runner with executor adapters for local models and CLI agents.
+- [ ] Add typed artifacts and handoffs, then supervise a graph with at least two local models.
+- [ ] Expose read-only graph inspect, logs, and metrics through the shared command service.
+- [ ] Add version-checked mutation commands for cancel, retry, and resume only after replay and
+  restart behavior is proven.
 
 ### Phase 3: Usage, inspection, and visual control plane
 
@@ -267,9 +376,6 @@ recent state transitions; polling cannot inflate metrics; timeline state survive
   subagents, logs, metrics, artifacts, handoffs, graph health, and provider usage.
 - Add plans, follow-up/cancel, exports, quick routes, richer permissions, structured questions,
   active/history browsing, and account/model-level usage views.
-- Establish a native liquid-glass visual system using macOS materials, vibrancy, restrained
-  highlights, translucent layering, adaptive contrast, and reduced-transparency fallbacks.
-  Glass styling must improve hierarchy without reducing metric density or legibility.
 
 ### Phase 4: Research and knowledge plane
 
@@ -282,8 +388,8 @@ compendium run with review checkpoints.
 
 Build the agent board, floating widgets, saved layouts, menu-bar controls, local-server
 discovery, fast actions, notifications, budgets, quiet hours, performance controls, and a
-runtime doctor. Apply the liquid-glass system across these surfaces after their information
-architecture is stable.
+runtime doctor. Visual redesign, including a liquid-glass system, is explicitly deferred
+until these surfaces and their information architecture are stable.
 
 ### Phase 6: Frontier/Codex integration and evaluation
 
@@ -293,16 +399,25 @@ for quality, latency, cost, and context growth.
 
 ## Immediate Execution Order
 
-1. Keep completed and dead sessions out of startup, persistence, app-server, and rollout
-   projections; record explicit removal and suppression reasons.
-2. Recover the native graph implementation into this clean branch and make its tests part of
-   the normal suite.
-3. Replace compendium marker inference with graph-run and node state driven by owned processes,
-   exits, heartbeats, timeouts, and artifacts.
-4. Add the first `openisland graph` commands and stream the same state to the native inspector.
-5. Add non-local CLI usage metrics and local Qwen resource metrics as distinct projections.
-6. Apply the liquid-glass visual baseline to the live island and graph inspector, including
-   accessibility fallbacks and screenshot verification.
+1. Add `GraphExecutionStore` and `ProcessEvidenceSource` protocol boundaries, an append-only
+   execution-event store, and a read service that always applies `GraphExecutionReconciler`.
+2. Add restart/replay tests for duplicate events, stale snapshots, mismatched process identity,
+   crashed adapters, and retries with monotonic attempt ordinals.
+3. Implement process-evidence adapters that translate host observations into canonical exits
+   and heartbeat leases without exposing adapter concepts to the core graph model.
+4. Add scheduler policy and executor adapters only after read-time reconciliation and replay
+   are authoritative.
+5. Add read-only graph inspection, logs, and metrics; defer mutation commands until command
+   versioning and idempotency are tested.
+6. Add non-local CLI usage metrics and local-model resource metrics as distinct projections.
+7. Defer all visual redesign, including liquid glass, until orchestration behavior and
+   operator information architecture are stable.
+
+## Progress Log
+
+- `fa64908 feat: recover native graph prototype`
+- `64a2bde feat: add authoritative graph execution state`
+- `6d3aa58 test: add stale compendium runtime fixture`
 
 ## Verification
 

--- a/docs/graph-cli.md
+++ b/docs/graph-cli.md
@@ -1,0 +1,304 @@
+# Temporal Graph Inspection CLI
+
+## Authority And Scope
+
+Open Island graph history is the authoritative execution record. The
+`openisland graph` commands in this release are read-only projections over that
+history. They do not append events, update snapshots, inspect mutation-capable
+adapters, start models, schedule work, claim executors, or change graph state.
+
+History, projection, reconciliation, and decisions remain separate:
+
+1. immutable events record what was declared or observed;
+2. deterministic replay projects persisted logical state;
+3. reconciliation compares that projection with optional process evidence;
+4. a future scheduler will make version-checked execution decisions.
+
+The stream sequence is authoritative ordering. Timestamps are descriptive and
+use ISO 8601 UTC encoding.
+
+## Command Reference
+
+```text
+openisland graph list [options]
+openisland graph inspect RUN_ID [options]
+openisland graph history RUN_ID [options]
+openisland graph explain RUN_ID [NODE_ID] [options]
+openisland graph checkpoint list RUN_ID [options]
+openisland graph replay RUN_ID --dry-run [options]
+openisland graph diff LEFT_REF RIGHT_REF [options]
+openisland graph export RUN_ID --format FORMAT [options]
+```
+
+Temporal references use these forms:
+
+| Form | Meaning |
+|---|---|
+| `RUN_ID` | Current stream head |
+| `RUN_ID@SEQUENCE` | Inclusive stream sequence |
+| `RUN_ID#CHECKPOINT` | Named checkpoint boundary |
+
+`graph replay` also accepts either `--to-sequence SEQUENCE` or
+`--checkpoint CHECKPOINT`. These options are mutually exclusive. `--dry-run` is
+required.
+
+`graph export` formats are `json`, `jsonl`, `mermaid`, and
+`terminal-workspace-plan`. JSON and JSONL preserve the normal structured
+envelopes. Mermaid is a deterministic text graph. The terminal workspace plan
+is the neutral integration model documented in
+[terminal-graph-integration.md](./terminal-graph-integration.md).
+
+## Options And Filters
+
+All applicable commands support:
+
+```text
+--output text|json|jsonl
+--schema-version 1
+--no-color
+--quiet
+--include-diagnostics
+--include-artifacts
+--emit-completion-record
+```
+
+`--emit-completion-record` is valid only with `--output jsonl`. `--quiet`
+executes and emits telemetry but suppresses successful stdout. Errors still go
+to stderr.
+
+Inspection filters are applied where their subject exists:
+
+| Option | Behavior |
+|---|---|
+| `--node NODE_ID` | Select a node or events associated with it |
+| `--attempt ATTEMPT_ID` | Select an attempt or its events |
+| `--state STATE` | Select reconciled run, node, or attempt state |
+| `--event-type TYPE` | Select history event type; repeatable |
+| `--since UTC_DATE` | Include history events at or after the date |
+| `--until UTC_DATE` | Include history events at or before the date |
+| `--after-sequence N` | Start event scanning after sequence `N` |
+| `--limit N` | Bound results; valid range is 1 through 1,000,000 |
+
+Replay evidence modes are:
+
+| Option | Behavior |
+|---|---|
+| `--without-live-evidence` | Reconcile without querying external evidence |
+| `--require-live-evidence` | Fail with exit 7 unless evidence is available |
+
+The modes are mutually exclusive. Historical boundaries never query live
+evidence because present evidence cannot establish historical process state.
+
+## Output Schema Version 1
+
+Text output is concise operator output. It is not a parsing contract.
+
+JSON is one complete document:
+
+```json
+{
+  "schemaVersion": 1,
+  "command": "graph.history",
+  "resultCount": 2,
+  "eventCount": 2,
+  "result": [],
+  "diagnostics": [],
+  "context": {}
+}
+```
+
+`diagnostics` and `context` are optional. Diagnostics appear in the document
+only when deliberately requested or required by that result. Otherwise,
+diagnostics are written to stderr.
+
+JSONL emits one self-contained record per line:
+
+```json
+{"schemaVersion":1,"command":"graph.history","recordType":"event","ordinal":0,"payload":{},"context":{}}
+```
+
+The record types are:
+
+| Command | JSONL `recordType` |
+|---|---|
+| `list` | `run` |
+| `inspect` | `inspection` |
+| `history` | `event` |
+| `explain` | `explanation` |
+| `checkpoint list` | `checkpoint` |
+| `replay` | `replay` |
+| `diff` | `change` |
+| `export` | `graph_entity`, `mermaid`, or `terminal_workspace_plan` |
+
+When explicitly requested, the final JSONL record is:
+
+```json
+{
+  "schemaVersion": 1,
+  "recordType": "completion",
+  "command": "graph.history",
+  "status": "success",
+  "exitCode": 0,
+  "resultCount": 2,
+  "eventCount": 2,
+  "lastSequence": 12,
+  "context": {}
+}
+```
+
+Structured stdout never contains banners, progress output, terminal cursor
+control, ANSI escapes, or incidental diagnostics. JSON encoding sorts keys.
+Collections use explicit stable ordering:
+
+- run summaries: newest `updatedAt` first, then `runID`;
+- events: stream sequence, then event ID;
+- nodes, artifacts, external mappings, and workspace-plan entities: stable ID;
+- attempts: node ID, ordinal, then attempt ID;
+- checkpoints: stream version, then checkpoint ID;
+- diff changes: category, entity ID, field, then values.
+
+IDs are read from durable history or derived from stable content and do not
+change across repeated reads.
+
+## Exit Codes
+
+| Code | Category | Meaning |
+|---:|---|---|
+| 0 | `success` | Complete successful read |
+| 2 | `invalid_arguments` | Invalid command, option, reference, or arguments |
+| 3 | `not_found` | Run or checkpoint does not exist |
+| 4 | `incompatible_schema` | Requested or persisted schema is unsupported |
+| 5 | `corrupt_history` | Corrupt history, invalid boundary, or replay failure |
+| 6 | `persistence_failure` | Read-store or database failure |
+| 7 | `evidence_unavailable` | Live evidence was explicitly required but unavailable |
+| 8 | `partial_result` | Reserved for a structured partial result with diagnostics |
+| 130 | `interrupted` | SIGINT termination |
+
+A downstream broken pipe is treated as normal pipeline completion. Other write
+errors remain failures. SIGPIPE is handled without emitting a crash report, and
+SIGINT exits 130.
+
+## Replay And Diff
+
+`graph replay --dry-run` loads an eligible snapshot only as a replay cache,
+validates it, and replays through the selected boundary. The result reports:
+
+- requested and resolved boundary;
+- stream head;
+- snapshot use, staleness, or bypass;
+- replayed event count and unknown-event diagnostics;
+- persisted projected run, node, and attempt states;
+- separately reconciled run, node, and attempt states;
+- process-evidence outcome and repository diagnostics.
+
+Replay never appends events or writes snapshots. Repeated calls with the same
+history, boundary, and evidence mode produce identical structured results.
+
+`graph diff` compares two run heads, checkpoints, or sequence boundaries. It
+reports graph-definition, run, node, attempt, event-set, artifact, evidence,
+reconciliation, and causal-reason changes. Timestamps alone are not semantic
+changes. Change records are deterministically sorted.
+
+## Causal Explanations
+
+`graph explain` returns concise prose and a structured explanation graph. The
+graph contains stable entities, reason nodes, typed edges, a shortest causal
+chain, blocking dependency IDs, supporting and ignored event IDs, and readiness
+requirements.
+
+Version 1 reason codes are:
+
+| Category | Reason codes |
+|---|---|
+| Persisted declarations | `run_terminal_declaration`, `run_derived_from_node`, `attempt_terminal_declaration`, `persisted_state` |
+| Process evidence | `matching_process_exit`, `valid_heartbeat`, `missing_process_identity`, `missing_executor_evidence` |
+| Evidence degradation | `evidence_unavailable`, `evidence_stale`, `evidence_permission_denied`, `evidence_adapter_failed`, `evidence_identity_mismatch` |
+| Dependency state | `dependency_failed`, `dependency_interrupted`, `dependency_orphaned`, `dependency_blocked`, `dependency_cancelled`, `dependency_pending`, `dependency_running`, `dependency_missing`, `dependencies_completed` |
+| Other | `no_execution_attempt`, `unknown_event_ignored` |
+
+Reason edges use `caused`, `blocked`, `observed`, `derived`, or `ignored`. This
+lets consumers answer why a node is pending or blocked, which dependency caused
+it, why an attempt is interrupted or orphaned, which evidence or event supports
+the state, what was ignored, the shortest causal chain, and what must become
+true for readiness without parsing prose.
+
+## Redaction
+
+Structured output does not expose prompt bodies, secrets, complete environment
+dumps, unrestricted command arguments, artifact bodies, sensitive storage
+locators, URL credentials, or private file contents.
+
+Artifact inspection always withholds the storage locator and returns explicit
+redaction metadata. Artifact IDs, content digests, media types, logical roles,
+producer identity, and sensitivity classification remain available for
+lineage. Repository paths are withheld unless Terminal Graph explicitly
+provides a project or worktree root. Endpoint credentials, query strings, and
+fragments are removed. Unknown secret-like, path-like, oversized, multiline, or
+credential-bearing `TG_*` values are redacted or bounded.
+
+There is no option to reveal secrets.
+
+## CLI Telemetry
+
+Each command emits a bounded, local OSLog record. Telemetry failure cannot
+change command success. Version 1 fields are:
+
+- command name and output mode;
+- monotonic duration and exit category;
+- result and event counts;
+- replay boundary and snapshot disposition;
+- reconciliation outcome;
+- Terminal Graph detected as a boolean;
+- piped output as a boolean.
+
+Telemetry excludes raw arguments, environment values, prompts, file or artifact
+contents, secrets, and unrestricted paths. No remote exporter is installed.
+
+## Numbered Requirement Audit
+
+This audit covers every explicitly numbered requirement in the temporal CLI
+implementation request. All entries are complete.
+
+### Stable output requirements
+
+| # | Status | Evidence |
+|---:|---|---|
+| 1 | complete | Concise renderers in `GraphCLI.swift`; every-command text coverage in `GraphCLIStreamingInvariantTests.testEveryCommandSupportsTextJSONAndJSONL` |
+| 2 | complete | `GraphCLIOutputDocument` and deterministic JSON test in `GraphCLITests.testJSONOutputIsVersionedDeterministicAndANSIFree` |
+| 3 | complete | `GraphCLIJSONLRecord`, paged history emission, and `GraphCLITests.testHistoryJSONLStreamsWithoutSkippingPageBoundary` |
+| 4 | complete | Structured sink isolation and ANSI assertions in `GraphCLITests.testJSONOutputIsVersionedDeterministicAndANSIFree` |
+| 5 | complete | Separate stdout/stderr sinks and `GraphCLITests.testInvalidArgumentsUseStderrAndLeaveStdoutEmpty` |
+| 6 | complete | Sorted-key encoder and deterministic collection builders; repeated-output diff test |
+| 7 | complete | Explicit ordering in inspector and models; event pagination and multi-project ordering tests |
+| 8 | complete | Shared ISO 8601 UTC encoder and structured-output tests |
+| 9 | complete | Durable IDs and stable mapping-key builders; repeated invocation and workspace-plan tests |
+| 10 | complete | `GraphCLIExitCode`, this exit table, and `GraphCLIStreamingInvariantTests.testExitCodeContractIsStable` |
+
+### Terminal Graph compatibility requirements
+
+| # | Status | Evidence |
+|---:|---|---|
+| 1 | complete | Paged one-line writes, signal handlers, file-descriptor sink, real Unix pipe, broken-pipe, SIGINT, and 5,000-event bounded-write tests |
+| 2 | complete | `GraphIntegrationPortKind`, `GraphIntegrationSemanticType`, neutral ports, and the typed-port mapping in the integration guide |
+| 3 | complete | `TerminalGraphEnvironmentDiscovery` plus absent, representative, malformed, bounded, and secret-redaction tests |
+| 4 | complete | `GitGraphRepositoryContextResolver`, `GraphWorkspaceContext`, worktree/path-redaction test, and deterministic multi-project test |
+| 5 | complete | `GraphTerminalWorkspacePlan`, deterministic builder/export tests, and the neutral schema documentation |
+| 6 | complete | `GraphVisualizationSynchronizationAdapter`, stable external mapping keys, sorted synchronization test, and future MCP boundary documentation |
+| 7 | complete | Stable exit categories, opt-in `GraphCLICompletionRecord`, signal tests, and hook/completion documentation |
+
+### Documentation requirements
+
+| # | Status | Evidence |
+|---:|---|---|
+| 1 | complete | Command Reference in this document |
+| 2 | complete | Output Schema Version 1 in this document |
+| 3 | complete | Exit Codes in this document |
+| 4 | complete | Authority And Scope plus Replay And Diff in this document |
+| 5 | complete | Causal Explanations in this document |
+| 6 | complete | Redaction in this document |
+| 7 | complete | [terminal-graph-integration.md](./terminal-graph-integration.md) |
+| 8 | complete | Terminal Pipelines examples for `tg run`, `tg send`, and `tg recv` |
+| 9 | complete | Worktrees And Multi-Project Workspaces |
+| 10 | complete | Future MCP Adapter |
+| 11 | complete | Neutral Workspace Plan |
+| 12 | complete | Boundary explicitly preserves Open Island execution authority and makes Terminal Graph an optional interaction surface |

--- a/docs/graph-cli.md
+++ b/docs/graph-cli.md
@@ -1,13 +1,12 @@
-# Temporal Graph Inspection CLI
+# Graph Control And Temporal Inspection CLI
 
 ## Authority And Scope
 
-Open Island graph history is the authoritative execution record. The
-`openisland graph` commands in this release are read-only projections over that
-history. They do not append events, update snapshots, call mutation-capable
-adapters, start models, schedule work, claim executors, or change graph state.
-The core scheduling repository may append scheduling events through its domain
-API; the CLI in this release can only inspect those events.
+Open Island graph history is the authoritative execution record. Mutation
+commands append versioned requests, decisions, observations, and declarations;
+inspection commands project that history without changing it. An adapter return
+value is never treated as execution success until its observation and matching
+terminal declaration are durable.
 
 History, projection, reconciliation, and decisions remain separate:
 
@@ -15,7 +14,9 @@ History, projection, reconciliation, and decisions remain separate:
 2. deterministic replay projects persisted logical state;
 3. reconciliation compares that projection with optional process evidence;
 4. the pure scheduler proposes version-checked execution decisions;
-5. claims establish exclusive ownership before a future executor acts.
+5. claims establish exclusive ownership before an executor acts;
+6. fenced executor commands produce typed observations;
+7. durable terminal declarations establish attempt and run outcomes.
 
 The stream sequence is authoritative ordering. Timestamps are descriptive and
 use ISO 8601 UTC encoding.
@@ -23,6 +24,12 @@ use ISO 8601 UTC encoding.
 ## Command Reference
 
 ```text
+openisland graph create DEFINITION --run-id RUN_ID --idempotency-key KEY [options]
+openisland graph start RUN_ID --idempotency-key KEY [options]
+openisland graph step RUN_ID [options]
+openisland graph run RUN_ID [--cycle-limit N] [options]
+openisland graph cancel RUN_ID [--node NODE_ID] --idempotency-key KEY [options]
+openisland graph retry RUN_ID NODE_ID --idempotency-key KEY [options]
 openisland graph list [options]
 openisland graph inspect RUN_ID [options]
 openisland graph history RUN_ID [options]
@@ -31,6 +38,21 @@ openisland graph checkpoint list RUN_ID [options]
 openisland graph replay RUN_ID --dry-run [options]
 openisland graph diff LEFT_REF RIGHT_REF [options]
 openisland graph export RUN_ID --format FORMAT [options]
+```
+
+Examples:
+
+```sh
+openisland graph create Tests/OpenIslandCoreTests/Fixtures/compendium-execution.json --run-id compendium-001 --idempotency-key create-001 --output json
+openisland graph start compendium-001 --idempotency-key start-001 --output json
+openisland graph step compendium-001 --expected-version 9 --output json
+openisland graph run compendium-001 --cycle-limit 100 --output jsonl --emit-completion-record
+openisland graph cancel compendium-001 --node researcher --idempotency-key cancel-researcher --output json
+openisland graph retry compendium-001 researcher --idempotency-key retry-researcher --output json
+openisland graph inspect compendium-001 --include-artifacts --output json
+openisland graph history compendium-001 --output jsonl
+openisland graph explain compendium-001 reviewer --output json
+openisland graph export compendium-001 --format mermaid
 ```
 
 Temporal references use these forms:
@@ -51,6 +73,29 @@ envelopes. Mermaid is a deterministic text graph. The terminal workspace plan
 is the neutral integration model documented in
 [terminal-graph-integration.md](./terminal-graph-integration.md).
 
+## Mutation And Execution Semantics
+
+| Command | Durable effect |
+|---|---|
+| `create` | Validates and records a versioned executable definition and digest. The run remains inactive. Same-key redelivery is idempotent; conflicting reuse fails. |
+| `start` | Records scheduling intent. It never bypasses scheduler decisions, claims, or leases. |
+| `step` | Performs one bounded replay, reconciliation, scheduling, claim, and executor-operation cycle. |
+| `run` | Repeats bounded cycles until terminal, stalled, waiting for cancellation, adapter unavailable, interrupted, or at the cycle limit. Reinvocation resumes history. |
+| `cancel` | Records run- or node-scoped cancellation intent. The adapter owner must acknowledge a running cancellation before terminal cancellation is declared. |
+| `retry` | Records an operator retry request only when policy permits. Attempt ordinals remain monotonic and recorded backoff is not bypassed. |
+
+`--dry-run` performs no writes and invokes no adapter. For `step` and `run`, it
+reports proposed scheduler decisions, the claim candidate, the executor
+operation, expected event types, and policy denials. `--expected-version`
+enforces the caller's observed stream head. Mutation idempotency keys are
+required for `create`, `start`, `cancel`, and `retry`; orchestration cycles are
+made idempotent by deterministic decision, claim, command, and observation IDs.
+
+The built-in CLI currently configures only the in-process deterministic
+executor. Its purpose is local validation of the control protocol, not real
+model work. Codex, Qwen, Ollama, tmux, and Terminal Graph MCP execution are not
+connected.
+
 ## Options And Filters
 
 All applicable commands support:
@@ -63,7 +108,15 @@ All applicable commands support:
 --include-diagnostics
 --include-artifacts
 --emit-completion-record
+--idempotency-key KEY
+--expected-version VERSION
+--dry-run
+--logical-time UTC_DATE
 ```
+
+Mutation-specific options also include `--run-id` for `create`, `--requested-by`
+and `--reason` for operator provenance, and `--cycle-limit` for `run` (1 through
+10,000).
 
 `--emit-completion-record` is valid only with `--output jsonl`. `--quiet`
 executes and emits telemetry but suppresses successful stdout. Errors still go
@@ -130,6 +183,8 @@ The record types are:
 
 | Command | JSONL `recordType` |
 |---|---|
+| `create`, `start`, `cancel`, `retry` | `mutation` |
+| `step`, `run` | `orchestration_cycle` |
 | `list` | `run` |
 | `inspect` | `inspection` |
 | `history` | `event` |
@@ -202,6 +257,12 @@ returned by scheduling inspection; only `hostIdentityPresent` is exposed.
 | 6 | `persistence_failure` | Read-store or database failure |
 | 7 | `evidence_unavailable` | Live evidence was explicitly required but unavailable |
 | 8 | `partial_result` | Reserved for a structured partial result with diagnostics |
+| 9 | `optimistic_conflict` | Expected stream version or idempotency identity conflicts |
+| 10 | `policy_denied` | Retry or another requested mutation is not allowed by policy |
+| 11 | `stale_executor` | Claim, executor, attempt, or lease generation failed fencing |
+| 12 | `adapter_unavailable` | The configured executor adapter cannot perform the operation |
+| 13 | `execution_terminal_failure` | The run terminated failed, interrupted, orphaned, or blocked |
+| 14 | `cancellation` | The run terminated cancelled |
 | 130 | `interrupted` | SIGINT termination |
 
 A downstream broken pipe is treated as normal pipeline completion. Other write

--- a/docs/graph-cli.md
+++ b/docs/graph-cli.md
@@ -4,15 +4,18 @@
 
 Open Island graph history is the authoritative execution record. The
 `openisland graph` commands in this release are read-only projections over that
-history. They do not append events, update snapshots, inspect mutation-capable
+history. They do not append events, update snapshots, call mutation-capable
 adapters, start models, schedule work, claim executors, or change graph state.
+The core scheduling repository may append scheduling events through its domain
+API; the CLI in this release can only inspect those events.
 
 History, projection, reconciliation, and decisions remain separate:
 
 1. immutable events record what was declared or observed;
 2. deterministic replay projects persisted logical state;
 3. reconciliation compares that projection with optional process evidence;
-4. a future scheduler will make version-checked execution decisions.
+4. the pure scheduler proposes version-checked execution decisions;
+5. claims establish exclusive ownership before a future executor acts.
 
 The stream sequence is authoritative ordering. Timestamps are descriptive and
 use ISO 8601 UTC encoding.
@@ -54,7 +57,7 @@ All applicable commands support:
 
 ```text
 --output text|json|jsonl
---schema-version 1
+--schema-version 1|2
 --no-color
 --quiet
 --include-diagnostics
@@ -89,7 +92,13 @@ Replay evidence modes are:
 The modes are mutually exclusive. Historical boundaries never query live
 evidence because present evidence cannot establish historical process state.
 
-## Output Schema Version 1
+## Output Schema Versions
+
+Version 2 is the default. Version 1 remains selectable for existing consumers.
+The document/record envelopes, exit codes, redaction rules, ordering, and
+JSONL streaming behavior are unchanged.
+
+### Version 1
 
 Text output is concise operator output. It is not a parsing contract.
 
@@ -160,6 +169,27 @@ Collections use explicit stable ordering:
 IDs are read from durable history or derived from stable content and do not
 change across repeated reads.
 
+### Version 2 scheduling fields
+
+Version 2 adds an optional `scheduling` object to `graph inspect` with:
+
+- the latest evaluation and complete versioned scheduler policy;
+- active claims with executor and capability identity, attempt ordinal, grant
+  sequence, lease start/expiry, generation, status, and host-presence Boolean;
+- deterministic claim history;
+- durable retries, policy, delay, and eligibility time;
+- pending cancellation and complete cancellation history;
+- explicit timeout decisions;
+- stable scheduler reason codes and ordered scheduling records.
+
+`graph explain` adds `schedulerReasons`. `graph diff` adds `scheduler`,
+`claim`, `retry`, `cancellation`, and `timeout` change categories. `graph
+history` exposes the versioned scheduling event taxonomy without changing its
+record envelope. Schema version 1 omits these additions.
+
+Node and attempt filters also filter scheduling entities. Host IDs are not
+returned by scheduling inspection; only `hostIdentityPresent` is exposed.
+
 ## Exit Codes
 
 | Code | Category | Meaning |
@@ -196,15 +226,16 @@ history, boundary, and evidence mode produce identical structured results.
 
 `graph diff` compares two run heads, checkpoints, or sequence boundaries. It
 reports graph-definition, run, node, attempt, event-set, artifact, evidence,
-reconciliation, and causal-reason changes. Timestamps alone are not semantic
-changes. Change records are deterministically sorted.
+reconciliation, causal-reason, scheduler, claim, retry, cancellation, and
+timeout changes. Timestamps alone are not semantic changes. Change records are
+deterministically sorted.
 
 ## Causal Explanations
 
 `graph explain` returns concise prose and a structured explanation graph. The
 graph contains stable entities, reason nodes, typed edges, a shortest causal
-chain, blocking dependency IDs, supporting and ignored event IDs, and readiness
-requirements.
+chain, blocking dependency IDs, supporting and ignored event IDs, readiness
+requirements, and version 2 scheduler reason codes.
 
 Version 1 reason codes are:
 

--- a/docs/graph-cli.md
+++ b/docs/graph-cli.md
@@ -91,10 +91,12 @@ enforces the caller's observed stream head. Mutation idempotency keys are
 required for `create`, `start`, `cancel`, and `retry`; orchestration cycles are
 made idempotent by deterministic decision, claim, command, and observation IDs.
 
-The built-in CLI currently configures only the in-process deterministic
-executor. Its purpose is local validation of the control protocol, not real
-model work. Codex, Qwen, Ollama, tmux, and Terminal Graph MCP execution are not
-connected.
+The built-in CLI configures the supervised local direct-process executor and
+the same durable process-evidence source as the native workspace. Set
+`OPENISLAND_PROCESS_RUNTIME_ROOT` to isolate launch records and logs; set
+`OPENISLAND_GRAPH_DATABASE_PATH` to select the graph store. The deterministic
+executor remains available to tests. Codex, Qwen, Ollama, OpenClaw, tmux, and
+Terminal Graph MCP execution are not connected.
 
 ## Options And Filters
 

--- a/docs/graph-workspace.md
+++ b/docs/graph-workspace.md
@@ -1,0 +1,60 @@
+# Graph Workspace
+
+The native Graph Workspace edits versioned graph definitions and operates
+durable runs through the same domain services as `openisland graph`.
+
+## Open The Workspace
+
+- Select **Graph Workspace** in the island toolbar.
+- Press Command-Shift-G.
+- Choose **Window -> Graph Workspace**.
+
+Repeated activation focuses the existing window. The workspace restores the
+last document, run, mode, selection, and viewport when those records still
+exist. Use **File -> New Graph** for an empty document or **File -> Open Graph
+Definition** to load JSON. **Open Compendium Example** loads the bundled
+architect-to-reviewer process graph.
+
+## Define A Graph
+
+Use **Definition** mode to add or remove nodes, edit stable node properties,
+assign required capabilities and process specifications, and configure retry
+and timeout policy. Drag from a typed dependency output to an input to connect
+nodes. Select an edge or node and use Delete to remove it. The canvas supports
+selection, multi-selection, drag positioning, pan, zoom, fit, automatic layout,
+keyboard navigation, context menus, and accessibility descriptions.
+
+Node positions are document layout metadata, not runtime state. Renaming a node
+does not change its stable ID. Validate before saving or creating a run; cycles,
+self-edges, duplicate edges, unknown nodes, and unsafe process paths are
+rejected. Save and export graph definitions as deterministic
+`.openisland-graph.json` files.
+
+## Run A Graph
+
+Creating a run records an immutable definition snapshot and digest. Switch to
+**Run**, then use **Start**, **Step**, or **Run**. Run advances scheduler and
+executor work until terminal state or an operator boundary. **Pause** stops only
+the local loop; it does not invent a durable paused state.
+
+Node inspection shows attempts, claims, lease generation, executor, blockers,
+retry eligibility, cancellation, timestamps, artifacts, and causal summary.
+**Open Logs** displays bounded stdout and stderr captured for the selected local
+process. **Export** writes the current authoritative run inspection.
+
+Cancel the selected node or entire run with the corresponding command. The
+request is durable before the supervised process group receives termination.
+Retry is enabled only when the typed policy decision permits it; the scheduler
+owns the next attempt ordinal and recorded eligibility time.
+
+## Inspect History
+
+Use **History** or **Inspect History** for events, scheduler decisions, claims,
+lease generations, retries, timeouts, artifacts, ignored evidence, checkpoints,
+and causal explanation. These views replay durable history and do not mutate
+the run. Equivalent terminal inspection is available through
+`openisland graph inspect`, `history`, `explain`, `replay`, `diff`, and `export`.
+
+Definition import and export are separate from run export. Importing a changed
+document never mutates a run already created from an earlier version.
+

--- a/docs/graph-workspace.md
+++ b/docs/graph-workspace.md
@@ -1,60 +1,113 @@
 # Graph Workspace
 
-The native Graph Workspace edits versioned graph definitions and operates
-durable runs through the same domain services as `openisland graph`.
+The native Graph Workspace authors versioned graph definitions and operates
+durable runs through the same domain services as `openisland graph`. Definition
+editing never appends run events, and run commands never rewrite a definition.
 
-## Open The Workspace
+## Open Or Create A Graph
 
-- Select **Graph Workspace** in the island toolbar.
-- Press Command-Shift-G.
-- Choose **Window -> Graph Workspace**.
+Open **Graph Workspace** from the island, the Window menu, or Command-Shift-G.
+The window is a singleton and restores the last available document, run, mode,
+selection, and viewport.
 
-Repeated activation focuses the existing window. The workspace restores the
-last document, run, mode, selection, and viewport when those records still
-exist. Use **File -> New Graph** for an empty document or **File -> Open Graph
-Definition** to load JSON. **Open Compendium Example** loads the bundled
-architect-to-reviewer process graph.
+Use **New Graph** to choose Blank Graph, Linear Pipeline, Fan-Out/Fan-In,
+Review Loop, Compendium Fill, or Local Process Example. The creation sheet sets
+the name, stable graph ID, definition version, description, default executor,
+retry and timeout defaults, and optional workspace. It creates an editable
+in-memory document, not a durable run.
 
-## Define A Graph
+An empty workspace offers new, open, recent, and example actions. **Open Graph**
+loads deterministic `.openisland-graph.json` documents.
 
-Use **Definition** mode to add or remove nodes, edit stable node properties,
-assign required capabilities and process specifications, and configure retry
-and timeout policy. Drag from a typed dependency output to an input to connect
-nodes. Select an edge or node and use Delete to remove it. The canvas supports
-selection, multi-selection, drag positioning, pan, zoom, fit, automatic layout,
-keyboard navigation, context menus, and accessibility descriptions.
+## Add And Configure Nodes
 
-Node positions are document layout metadata, not runtime state. Renaming a node
-does not change its stable ID. Validate before saving or creating a run; cycles,
-self-edges, duplicate edges, unknown nodes, and unsafe process paths are
-rejected. Save and export graph definitions as deterministic
-`.openisland-graph.json` files.
+Add nodes from the Edit menu, canvas menu, or keyboard command. The palette
+contains Local Process, Deterministic Test, Generic Agent, Input Reference,
+Output Reference, and Annotation. Only the first two are runnable. Reference
+and annotation nodes cannot accidentally enter executable dependencies.
 
-## Run A Graph
+Selecting a node opens its inspector:
 
-Creating a run records an immutable definition snapshot and digest. Switch to
-**Run**, then use **Start**, **Step**, or **Run**. Run advances scheduler and
-executor work until terminal state or an operator boundary. **Pause** stops only
-the local loop; it does not invent a durable paused state.
+- **Identity:** stable ID, name, description, type, and tags.
+- **Execution:** executable picker, discrete ordered arguments, workspace and
+  relative working directory, environment inheritance and allowlist, stdin,
+  output declarations, and reveal action.
+- **Capabilities:** required and preferred capabilities, executor kind, and
+  platform constraints.
+- **Inputs/Outputs:** typed ports, stable bindings, media types, runtime roles,
+  paths, required state, size limits, sensitivity, and visibility.
+- **Retry/Timeout:** graph-default inheritance or a complete node override.
+- **Validation:** node-local errors and warnings with corrective guidance.
 
-Node inspection shows attempts, claims, lease generation, executor, blockers,
-retry eligibility, cancellation, timestamps, artifacts, and causal summary.
-**Open Logs** displays bounded stdout and stderr captured for the selected local
-process. **Export** writes the current authoritative run inspection.
+Local-process arguments are vectors, never shell strings. `${workspace}`
+resolves the workspace, `${input:node_output}` resolves an upstream artifact,
+and `${artifact:structured_result}` resolves an output declared by the current
+node. Validation rejects unavailable roles before run creation.
 
-Cancel the selected node or entire run with the corresponding command. The
-request is durable before the supervised process group receives termination.
-Retry is enabled only when the typed policy decision permits it; the scheduler
-owns the next attempt ordinal and recorded eligibility time.
+## Connect Nodes
 
-## Inspect History
+Drag a dependency handle or typed output to a valid input, use the input
+binding's **Connect Upstream Output** menu, use **Add Dependency**, or use the
+keyboard dependency workflow. The same connection evaluator rejects self
+edges, cycles, duplicates, visual-node dependencies, incompatible port types,
+and incompatible media types before commit.
 
-Use **History** or **Inspect History** for events, scheduler decisions, claims,
-lease generations, retries, timeouts, artifacts, ignored evidence, checkpoints,
-and causal explanation. These views replay durable history and do not mutate
-the run. Equivalent terminal inspection is available through
-`openisland graph inspect`, `history`, `explain`, `replay`, `diff`, and `export`.
+Artifact bindings retain source node, source output, target input, role, and
+port identities. Selecting an edge opens its source, destination, type,
+required state, typed ports, and delete action. Escape cancels an in-progress
+connection.
 
-Definition import and export are separate from run export. Importing a changed
-document never mutates a run already created from an earlier version.
+Graph inputs support text, JSON, files, directories, artifact references,
+numbers, and Booleans. Sensitive values are runtime references, not persisted
+secrets. Graph outputs point to declared node outputs.
 
+## Validate And Save
+
+**Validate** opens a persistent diagnostic panel. Selecting a diagnostic
+selects its graph, node, or edge target. Validation runs after structural and
+execution edits and is a hard gate for **Create Run**. It covers identity,
+topology, execution specifications, local-process tokens and paths, typed
+ports, required bindings, artifact roles, policies, capabilities, reachability,
+terminal outputs, sensitive literals, and immutable-version rules.
+
+**Save** uses deterministic JSON and atomic replacement. **Document** provides
+Save As, Revert, and Close. Recent documents, dirty state, last saved digest,
+external modification, schema version, and last successful validation are
+tracked. An externally changed file is never silently overwritten. Closing a
+dirty document offers Save, Don't Save, and Cancel.
+
+Layout-only edits do not change the semantic digest. Once a definition owns a
+run, semantic edits produce a visible Draft. Use **Create New Definition
+Version** before creating another run. Existing runs retain their immutable
+definition snapshot and digest.
+
+Undo and Redo cover node, edge, inspector, artifact, policy, layout, and
+automatic-layout edits. A drag coalesces into one action. Undo never emits run
+mutations. **Auto Layout**, **Fit**, and **Reset** provide deterministic canvas
+control without changing node identity.
+
+## Create And Operate A Run
+
+**Create Run** shows graph identity, version, digest, validation state,
+compatible backend, workspace, unresolved graph inputs, policy warnings, and
+estimated node count. Supervised Local Process and Deterministic Test are
+available when compatible. Codex, Qwen, Ollama, and OpenClaw remain visible but
+disabled until adapters are configured.
+
+After creation, use **Start** to record run start, then **Step** or **Run**.
+Run mode projects authoritative nodes, attempts, claims, blockers, artifacts,
+and terminal state. Select a node and choose **Open Logs** for bounded stdout or
+stderr. **Inspect History** shows events, scheduler decisions, leases, retries,
+timeouts, checkpoints, and causal explanation. Retry and cancellation controls
+are enabled only when typed runtime policy permits them.
+
+The app and CLI inspect the same SQLite event history. Importing or editing a
+definition cannot mutate an existing run.
+
+## Keyboard And Accessibility
+
+Standard Save, Undo, Redo, Delete, and cancel shortcuts work while the graph
+window is focused. Commands also cover node creation, dependency creation,
+validation, and run creation. Critical controls have text labels or tooltips;
+nodes, edges, validation changes, modes, selections, sheet actions, and save
+state expose meaningful accessibility descriptions.

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,7 @@ This index is the repository map for humans and coding agents. Read these files 
 - [docs/notch-surface-model.md](./notch-surface-model.md) for the island surface routing model and debug harness intent
 - [docs/app-ghostty-codex-chain.md](./app-ghostty-codex-chain.md) for terminal environment findings across the current supported chain
 - [docs/architecture-decisions/001-durable-graph-history.md](./architecture-decisions/001-durable-graph-history.md) for graph event sourcing, replay, snapshots, reconciliation, artifacts, and local persistence
+- [docs/architecture-decisions/002-durable-graph-scheduling.md](./architecture-decisions/002-durable-graph-scheduling.md) for deterministic scheduling, executor claims, renewable leases, retry, cancellation, timeout, restart recovery, and scheduling inspection
 - [docs/graph-cli.md](./graph-cli.md) for the read-only temporal graph command, schema, exit-code, causal, replay, redaction, and telemetry contracts
 - [docs/terminal-graph-integration.md](./terminal-graph-integration.md) for Terminal Graph streams, typed ports, worktrees, workspace plans, hooks, and future MCP boundaries
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,8 @@ This index is the repository map for humans and coding agents. Read these files 
 - [docs/app-ghostty-codex-chain.md](./app-ghostty-codex-chain.md) for terminal environment findings across the current supported chain
 - [docs/architecture-decisions/001-durable-graph-history.md](./architecture-decisions/001-durable-graph-history.md) for graph event sourcing, replay, snapshots, reconciliation, artifacts, and local persistence
 - [docs/architecture-decisions/002-durable-graph-scheduling.md](./architecture-decisions/002-durable-graph-scheduling.md) for deterministic scheduling, executor claims, renewable leases, retry, cancellation, timeout, restart recovery, and scheduling inspection
-- [docs/graph-cli.md](./graph-cli.md) for the read-only temporal graph command, schema, exit-code, causal, replay, redaction, and telemetry contracts
+- [docs/architecture-decisions/003-graph-mutation-and-executor-boundary.md](./architecture-decisions/003-graph-mutation-and-executor-boundary.md) for mutation commands, fenced executor adapters, orchestration cycles, crash recovery, and artifact handoffs
+- [docs/graph-cli.md](./graph-cli.md) for graph mutation, execution, temporal inspection, schema, exit-code, redaction, and telemetry contracts
 - [docs/terminal-graph-integration.md](./terminal-graph-integration.md) for Terminal Graph streams, typed ports, worktrees, workspace plans, hooks, and future MCP boundaries
 
 ## Refactoring Plans

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,8 @@ This index is the repository map for humans and coding agents. Read these files 
 - [docs/architecture-decisions/001-durable-graph-history.md](./architecture-decisions/001-durable-graph-history.md) for graph event sourcing, replay, snapshots, reconciliation, artifacts, and local persistence
 - [docs/architecture-decisions/002-durable-graph-scheduling.md](./architecture-decisions/002-durable-graph-scheduling.md) for deterministic scheduling, executor claims, renewable leases, retry, cancellation, timeout, restart recovery, and scheduling inspection
 - [docs/architecture-decisions/003-graph-mutation-and-executor-boundary.md](./architecture-decisions/003-graph-mutation-and-executor-boundary.md) for mutation commands, fenced executor adapters, orchestration cycles, crash recovery, and artifact handoffs
+- [docs/architecture-decisions/004-local-process-and-graph-workspace.md](./architecture-decisions/004-local-process-and-graph-workspace.md) for supervised process identity, cancellation, logs, artifacts, graph documents, and the native workspace boundary
+- [docs/graph-workspace.md](./graph-workspace.md) for operating the native Definition, Run, and History workspace
 - [docs/graph-cli.md](./graph-cli.md) for graph mutation, execution, temporal inspection, schema, exit-code, redaction, and telemetry contracts
 - [docs/terminal-graph-integration.md](./terminal-graph-integration.md) for Terminal Graph streams, typed ports, worktrees, workspace plans, hooks, and future MCP boundaries
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@ This index is the repository map for humans and coding agents. Read these files 
 - [docs/architecture-decisions/002-durable-graph-scheduling.md](./architecture-decisions/002-durable-graph-scheduling.md) for deterministic scheduling, executor claims, renewable leases, retry, cancellation, timeout, restart recovery, and scheduling inspection
 - [docs/architecture-decisions/003-graph-mutation-and-executor-boundary.md](./architecture-decisions/003-graph-mutation-and-executor-boundary.md) for mutation commands, fenced executor adapters, orchestration cycles, crash recovery, and artifact handoffs
 - [docs/architecture-decisions/004-local-process-and-graph-workspace.md](./architecture-decisions/004-local-process-and-graph-workspace.md) for supervised process identity, cancellation, logs, artifacts, graph documents, and the native workspace boundary
+- [docs/architecture-decisions/005-native-graph-authoring.md](./architecture-decisions/005-native-graph-authoring.md) for complete native authoring, document versions, typed wiring, validation, undo, templates, and the run-creation boundary
 - [docs/graph-workspace.md](./graph-workspace.md) for operating the native Definition, Run, and History workspace
 - [docs/graph-cli.md](./graph-cli.md) for graph mutation, execution, temporal inspection, schema, exit-code, redaction, and telemetry contracts
 - [docs/terminal-graph-integration.md](./terminal-graph-integration.md) for Terminal Graph streams, typed ports, worktrees, workspace plans, hooks, and future MCP boundaries

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ This index is the repository map for humans and coding agents. Read these files 
 
 - [docs/notch-surface-model.md](./notch-surface-model.md) for the island surface routing model and debug harness intent
 - [docs/app-ghostty-codex-chain.md](./app-ghostty-codex-chain.md) for terminal environment findings across the current supported chain
+- [docs/architecture-decisions/001-durable-graph-history.md](./architecture-decisions/001-durable-graph-history.md) for graph event sourcing, replay, snapshots, reconciliation, artifacts, and local persistence
 
 ## Refactoring Plans
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ This index is the repository map for humans and coding agents. Read these files 
 ## Harness And Planning
 
 - [docs/exec-plans/README.md](./exec-plans/README.md) for the active and completed execution-plan convention
+- [docs/exec-plans/active/2026-07-19-capability-first-orchestration-control-plane.md](./exec-plans/active/2026-07-19-capability-first-orchestration-control-plane.md) for the active capability-first orchestration and AgentPeek parity plan
 - [docs/references/README.md](./references/README.md) for pinned reference material and external behavior baselines
 
 ## Superpowers Plans

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,8 @@ This index is the repository map for humans and coding agents. Read these files 
 - [docs/notch-surface-model.md](./notch-surface-model.md) for the island surface routing model and debug harness intent
 - [docs/app-ghostty-codex-chain.md](./app-ghostty-codex-chain.md) for terminal environment findings across the current supported chain
 - [docs/architecture-decisions/001-durable-graph-history.md](./architecture-decisions/001-durable-graph-history.md) for graph event sourcing, replay, snapshots, reconciliation, artifacts, and local persistence
+- [docs/graph-cli.md](./graph-cli.md) for the read-only temporal graph command, schema, exit-code, causal, replay, redaction, and telemetry contracts
+- [docs/terminal-graph-integration.md](./terminal-graph-integration.md) for Terminal Graph streams, typed ports, worktrees, workspace plans, hooks, and future MCP boundaries
 
 ## Refactoring Plans
 

--- a/docs/product.md
+++ b/docs/product.md
@@ -2,20 +2,25 @@
 
 ## Problem
 
-CLI coding agents are powerful, but they pull attention away from the editor and terminal. Developers need a lightweight control surface to monitor work, approve actions, answer questions, and return to the right session quickly — without handing their machine over to a closed-source paid app.
+Agent runtimes, local models, frontier models, terminals, and knowledge stores expose fragmented state and controls. Operators need one local-first control plane that can monitor and direct individual sessions today, then schedule, supervise, and explain multi-agent graphs without hiding execution behind provider-specific interfaces.
 
 ## Target User
 
 - macOS developers using terminal-based coding agents daily
 - Users running more than one agent or more than one terminal session
+- Users orchestrating local and frontier models across research and engineering workflows
+- Users maintaining a local knowledge base such as an Obsidian vault
 - Users who care about low latency, native behavior, and open-source transparency
 
 ## Product Principles
 
 - **Open source** — all code is public, all contributions are AI-produced
-- **Local first** — no server dependency, no accounts, no analytics
+- **Local first** — no hosted control-plane dependency, no required account, no product analytics
 - **Native macOS** — SwiftUI + AppKit, not a web wrapper
-- **Terminal-native** — built to support the terminal workflow, not replace it
+- **Capability first** — orchestration behavior is independent of project or provider names
+- **Observable by design** — state transitions, tools, metrics, failures, retries, and handoffs are inspectable
+- **One control plane** — native app, terminal, voice, and model clients share one state and command path
+- **Knowledge under user control** — durable context and outputs remain in user-owned local storage
 - **Fail open** — if the app or bridge is unavailable, agents keep running unchanged
 
 ## Supported Code Agents
@@ -54,18 +59,28 @@ CLI coding agents are powerful, but they pull attention away from the editor and
 - **i18n** — English and Simplified Chinese
 - **Session discovery** — auto-discover from local transcripts, persist across launches
 - **Process discovery** — match active agents via `ps`/`lsof`
+- **Session observability** — normalized event timelines and aggregate activity metrics
+- **Active-session hygiene** — live surfaces exclude idle, completed, ended, and stale desktop threads
 - **DMG packaging** — signing, notarization, GitHub Actions release workflow
 - **Auto-update** — Sparkle-based automatic updates with appcast
 
 ## Success Criteria
 
 - Agent events appear in the overlay with low latency
+- Live surfaces never show a session solely because its host application is running
+- Operators can explain session state from its timeline and metrics
 - Approval and answer actions round-trip back to the source process
 - The app can restore focus to the owning terminal window reliably
 - Idle resource usage remains low enough for all-day background use
 
 ## Future Directions
 
-- Warp precision jump support
-- Sound packs, themes, and onboarding polish
-- Deeper terminal split targeting
+- Full AgentPeek-class inspection, interaction, usage, notification, widget, board, and operator surfaces
+- Declarative graph orchestration with typed handoffs, scheduling, budgets, retries, and checkpoints
+- Concurrent local Qwen execution with frontier-model routing and evaluation
+- Evidence-preserving web research and compendium production
+- Obsidian publishing, retrieval, provenance, and context compilation
+- A unified terminal API for sessions, graphs, logs, metrics, approvals, artifacts, and memory
+
+The active design and delivery sequence lives in
+[the capability-first orchestration plan](./exec-plans/active/2026-07-19-capability-first-orchestration-control-plane.md).

--- a/docs/terminal-graph-integration.md
+++ b/docs/terminal-graph-integration.md
@@ -1,0 +1,172 @@
+# Terminal Graph Integration
+
+## Boundary
+
+Open Island remains the authoritative execution system. Terminal Graph is an
+optional visualization, terminal, spatial interaction, worktree, and future MCP
+surface. It may render or route read-only Open Island data, but it does not own
+canonical graph IDs, execution history, reconciliation, or scheduler decisions.
+
+Open Island Core does not import Terminal Graph internals, require `tg`, write
+Terminal Graph state, install hooks, or call its MCP server. Compatibility uses
+stable CLI, JSON, JSONL, environment, workspace-plan, and adapter contracts.
+Ordinary CLI operation is identical when Terminal Graph is absent.
+
+## Terminal Pipelines
+
+The structured modes are non-TTY dependent, line buffered, ANSI-free, and keep
+diagnostics on stderr. Recommended Terminal Graph pipelines include:
+
+```sh
+openisland graph history RUN_ID --output jsonl | tg run jq .
+openisland graph history RUN_ID --output jsonl | tg send
+tg run --out openisland graph list --output jsonl
+tg recv | jq 'select(.recordType == "event")'
+```
+
+For lifecycle-aware nodes, request a final completion record:
+
+```sh
+openisland graph history RUN_ID \
+  --output jsonl \
+  --emit-completion-record |
+  tg send
+```
+
+Each JSONL object is written as one bounded line. Open Island stops cleanly when
+a downstream reader closes, ignores SIGPIPE crash behavior, and returns 130 for
+SIGINT. A completion record is emitted only when requested and only after all
+result records. It carries the command, category, exit code, result count, event
+count, last sequence, and optional execution context.
+
+CI does not require `tg`. The compatibility suite exercises the same contracts
+with real Unix pipes, an early-closing `head` reader, process signals, fixture
+environments, and the neutral models.
+
+## Typed Port Mapping
+
+Open Island describes logical ports, not Terminal Graph paths or private port
+objects.
+
+| Kind | Open Island semantic types | Recommended use |
+|---|---|---|
+| stream | `stream.event_history`, `stream.log_records`, `stream.jsonl_records` | Event history, logs, and generic JSONL flow |
+| signal | `signal.refresh`, `signal.select`, `signal.open`, `signal.focus`, `signal.completion` | Stateless operator or lifecycle notifications |
+| state | `state.current_run_summary`, `state.selected_run`, `state.selected_checkpoint`, `state.workspace_context` | Replaceable current selection or context |
+
+The neutral port contract includes a stable ID, kind, direction, semantic type,
+and label. A Terminal Graph adapter may map these to its public port API. That
+mapping must remain outside Open Island Core.
+
+## Environment Discovery
+
+Any `TG_*` value marks Terminal Graph as detected. Version 1 recognizes:
+
+```text
+TG_NODE_ID
+TG_WORKSPACE_ID
+TG_PROJECT_ID
+TG_GROUP_ID
+TG_EXTERNAL_CONTEXT_ID
+TG_PROJECT_ROOT
+TG_WORKTREE_ROOT
+TG_MCP_URL
+TG_PORT_IN
+TG_PORT_OUT
+```
+
+Unknown `TG_*` names are preserved as bounded integration context when safe, so
+new public values do not require immediate core changes. Secret-like names,
+credential-bearing values, unknown absolute paths, empty or oversized values,
+and arbitrary multiline content are redacted. MCP URLs lose credentials,
+queries, and fragments.
+
+Discovery can add optional context to structured output and telemetry records
+only a detection boolean. Command correctness never depends on an environment
+value, FIFO, endpoint, or unrestricted path.
+
+## Worktrees And Multi-Project Workspaces
+
+Repository context is optional and read-only. The Git resolver distinguishes:
+
+- canonical project root, based on the common Git directory when available;
+- current worktree root;
+- stable redacted repository identity;
+- current branch, commit, and dirty-state indicator;
+- external workspace and source-project association.
+
+It does not assume the branch is `main`, resolve away symlink intent, modify a
+worktree, create or delete a branch, or persist arbitrary paths. Paths are
+exposed only when Terminal Graph explicitly supplied a project or worktree
+root; otherwise path fields state that they were redacted.
+
+`GraphWorkspaceContext` represents zero, one, or many repositories and includes
+an optional selected repository identity. Repositories sort by stable identity,
+so a Terminal Graph multi-project workspace can correlate several worktrees
+without changing graph identity.
+
+## Neutral Workspace Plan
+
+Generate a versioned plan without writing Terminal Graph files:
+
+```sh
+openisland graph export RUN_ID \
+  --format terminal-workspace-plan \
+  --output json
+```
+
+`GraphTerminalWorkspacePlan` version 1 contains:
+
+| Field | Meaning |
+|---|---|
+| `schemaVersion` | Neutral plan schema, currently 1 |
+| `planID` | Stable content-derived plan identity |
+| `graphRunID` | Canonical Open Island run ID |
+| `graphDefinitionVersion`, `graphDefinitionDigest` | Immutable definition correlation |
+| `authority` | Always `openisland` |
+| `workspaceContext` | Optional redaction-aware multi-project context |
+| `terminals` | Suggested terminal nodes sorted by stable ID |
+| `connections` | Suggested typed connection intents sorted by stable ID |
+
+Each suggested terminal has a stable external mapping key, label, command as an
+argument array, optional startup command, repository and worktree association,
+logical group, run and node association, ports, layout hint, and sensitivity
+classification. Suggested connections identify source and target mapping keys,
+dependency/provenance/selection/completion intent, semantic types, and label.
+
+Mapping keys are derived from canonical Open Island run and entity IDs. External
+canvas IDs are correlations only and can be replaced without changing history.
+Commands do not contain shell interpolation or hard-coded Terminal Graph paths.
+
+## Future MCP Adapter
+
+`GraphVisualizationSynchronizationAdapter` is the read-only future-facing
+boundary. Its request consumes a graph inspection, neutral workspace plan, and
+existing external mappings. Its result returns sorted canonical-to-external
+mappings and diagnostics.
+
+A future Terminal Graph MCP adapter may:
+
+1. read `graph inspect`, history, explanation, and workspace-plan output;
+2. create or update public node, connection, group, and workspace resources;
+3. preserve stable external mapping keys for idempotent synchronization;
+4. return external IDs only as correlation metadata;
+5. repeat synchronization without duplicating entities;
+6. refresh the visualization without appending or rewriting Open Island history.
+
+It must not infer scheduler authorization from canvas state, make an external
+node ID canonical, or mutate graph execution in response to visualization
+drift. No MCP operation is performed by this release.
+
+## Hooks And Completion
+
+Future Terminal Graph hooks may trigger read-only refresh, select, open, focus,
+or completion signals. They should consume the documented exit codes and the
+optional versioned completion record. Hook scripts must be explicitly installed
+by an operator or a future isolated adapter; Open Island does not install them.
+
+Terminal lifecycle events are observations, not business completion. A shell
+exit, including exit code zero, cannot by itself declare an Open Island attempt
+completed. Adapters must translate process observations into canonical evidence,
+while authoritative terminal outcomes remain explicit execution events.
+

--- a/scripts/launch-dev-app.sh
+++ b/scripts/launch-dev-app.sh
@@ -22,11 +22,13 @@ cd "$repo_root"
 swift build -c debug --product OpenIslandApp
 swift build -c debug --product OpenIslandHooks
 swift build -c debug --product OpenIslandSetup
+swift build -c debug --product OpenIslandProcessFixtureAgent
 
 build_root="$(swift build -c debug --show-bin-path)"
 app_binary="$build_root/OpenIslandApp"
 hooks_binary="$build_root/OpenIslandHooks"
 setup_binary="$build_root/OpenIslandSetup"
+process_fixture_binary="$build_root/OpenIslandProcessFixtureAgent"
 
 python3 "$brand_script"
 if [ "$skip_setup" = false ]; then
@@ -43,8 +45,13 @@ sleep 2
 command cp "$app_binary" "$bundle_binary"
 command cp "$hooks_binary" "$bundle_dir/Contents/Helpers/OpenIslandHooks"
 command cp "$setup_binary" "$bundle_dir/Contents/Helpers/OpenIslandSetup"
+command cp "$process_fixture_binary" "$bundle_dir/Contents/Helpers/OpenIslandProcessFixtureAgent"
 command cp "$brand_icon" "$bundle_dir/Contents/Resources/OpenIsland.icns"
-chmod +x "$bundle_binary" "$bundle_dir/Contents/Helpers/OpenIslandHooks" "$bundle_dir/Contents/Helpers/OpenIslandSetup"
+chmod +x \
+    "$bundle_binary" \
+    "$bundle_dir/Contents/Helpers/OpenIslandHooks" \
+    "$bundle_dir/Contents/Helpers/OpenIslandSetup" \
+    "$bundle_dir/Contents/Helpers/OpenIslandProcessFixtureAgent"
 
 # Add rpath so the binary can find Sparkle.framework in Contents/Frameworks/.
 install_name_tool -add_rpath @loader_path/../Frameworks "$bundle_binary" 2>/dev/null || true

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -33,11 +33,13 @@ fi
 swift build -c release "${arch_flags[@]}" --product OpenIslandApp
 swift build -c release "${arch_flags[@]}" --product OpenIslandHooks
 swift build -c release "${arch_flags[@]}" --product OpenIslandSetup
+swift build -c release "${arch_flags[@]}" --product OpenIslandProcessFixtureAgent
 
 build_bin_dir="$(swift build -c release "${arch_flags[@]}" --show-bin-path)"
 app_binary="$build_bin_dir/OpenIslandApp"
 hooks_binary="$build_bin_dir/OpenIslandHooks"
 setup_binary="$build_bin_dir/OpenIslandSetup"
+process_fixture_binary="$build_bin_dir/OpenIslandProcessFixtureAgent"
 brand_icon="$repo_root/Assets/Brand/OpenIsland.icns"
 
 python3 "$brand_script"
@@ -49,6 +51,7 @@ mkdir -p "$bundle_dir/Contents/MacOS" "$bundle_dir/Contents/Helpers" "$bundle_di
 cp "$app_binary" "$bundle_dir/Contents/MacOS/OpenIslandApp"
 cp "$hooks_binary" "$bundle_dir/Contents/Helpers/OpenIslandHooks"
 cp "$setup_binary" "$bundle_dir/Contents/Helpers/OpenIslandSetup"
+cp "$process_fixture_binary" "$bundle_dir/Contents/Helpers/OpenIslandProcessFixtureAgent"
 cp "$brand_icon" "$bundle_dir/Contents/Resources/OpenIsland.icns"
 
 # Copy Sparkle.framework for auto-update support.
@@ -72,7 +75,8 @@ fi
 chmod +x \
     "$bundle_dir/Contents/MacOS/OpenIslandApp" \
     "$bundle_dir/Contents/Helpers/OpenIslandHooks" \
-    "$bundle_dir/Contents/Helpers/OpenIslandSetup"
+    "$bundle_dir/Contents/Helpers/OpenIslandSetup" \
+    "$bundle_dir/Contents/Helpers/OpenIslandProcessFixtureAgent"
 
 # Add rpath so the binary can find Sparkle.framework in Contents/Frameworks/.
 install_name_tool -add_rpath @loader_path/../Frameworks "$bundle_dir/Contents/MacOS/OpenIslandApp" 2>/dev/null || true
@@ -126,6 +130,7 @@ for required in \
     "Contents/MacOS/OpenIslandApp" \
     "Contents/Helpers/OpenIslandHooks" \
     "Contents/Helpers/OpenIslandSetup" \
+    "Contents/Helpers/OpenIslandProcessFixtureAgent" \
     "Contents/Resources/OpenIsland.icns" \
     "Contents/Resources/OpenIsland_OpenIslandApp.bundle" \
 ; do
@@ -190,6 +195,8 @@ if [[ -n "$signing_identity" ]]; then
         "$bundle_dir/Contents/Helpers/OpenIslandHooks"
     codesign --force --options runtime --timestamp --sign "$signing_identity" \
         "$bundle_dir/Contents/Helpers/OpenIslandSetup"
+    codesign --force --options runtime --timestamp --sign "$signing_identity" \
+        "$bundle_dir/Contents/Helpers/OpenIslandProcessFixtureAgent"
 
     codesign \
         --force \
@@ -210,6 +217,7 @@ else
     fi
     codesign --force --sign - "$bundle_dir/Contents/Helpers/OpenIslandHooks" 2>/dev/null || true
     codesign --force --sign - "$bundle_dir/Contents/Helpers/OpenIslandSetup" 2>/dev/null || true
+    codesign --force --sign - "$bundle_dir/Contents/Helpers/OpenIslandProcessFixtureAgent" 2>/dev/null || true
     codesign --force --sign - "$bundle_dir" 2>/dev/null || true
 fi
 


### PR DESCRIPTION
## Summary

Adds first-class support for OpenAI-compatible HTTP runtimes to the graph execution system.

### Highlights

- Add `OpenAICompatibleGraphExecutor`
- Add runtime catalog for OpenAI-compatible providers
- Register executor in `GraphWorkspaceService`
- Route execution using `adapterKind`
- Support Ollama and other OpenAI-compatible endpoints
- Update graph validation and authoring definitions
- Add runtime catalog tests
- Preserve explicit unbound behavior for missing CLI profiles

## Validation

Passed:

- `swift build`
- `swift test`

Results:

- 241 XCTest tests passed
- 335 Swift Testing tests passed
- 0 failures
- 1 intentionally skipped integration test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Graph Workspace for creating, editing, validating, saving, and running graph definitions.
  * Added graph templates, visual node connections, run controls, logs, history, diagnostics, retry, cancellation, and export tools.
  * Added durable graph execution with local-process and OpenAI-compatible runtimes.
  * Added Graph CLI commands with text, JSON, JSONL, Mermaid, replay, inspection, diff, and workspace-plan exports.
  * Added session observability timelines, metrics, and improved live-session filtering.
* **Documentation**
  * Added guides for Graph Workspace, Graph CLI, execution history, scheduling, and integrations.
* **Bug Fixes**
  * Improved session restoration, process recovery, pointer tracking, and completed-session cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->