### PR TITLE
feat: keep active agents visible and add grid sorting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,3 +99,13 @@ Unless the user says otherwise, the agent should finish each completed round in 
 2. verify
 3. summarize
 4. commit
+
+## Patch Log
+
+### 2026-07-23 — Distinguish completed agent-grid tiles
+- **File(s)**: `AppModel.swift`, `V6NotchContent.swift`, `AgentsGridRightSlotTests.swift`
+- **Symptom**: Recent Done and stale Idle sessions looked identical, while Waiting pulsed too slowly.
+- **Root cause**: Grid cells collapsed every completed session into `.idle` before rendering.
+- **Fix**: Render recent Done at 40%, stale Idle at 20%, and shorten the Waiting pulse leg to 0.45 seconds.
+- **Verification**: `swift test --filter AgentsGridRightSlotTests`
+- **Follow-up**: permanent

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -910,8 +910,23 @@ final class AppModel {
             if ordered.count <= 9 {
                 cells = ordered.map(Self.agentsGridCell(for:))
             } else {
-                cells = ordered.prefix(7).map(Self.agentsGridCell(for:))
-                cells.append(.overflow(ordered.count - 7))
+                // Keep live states visible when older idle sessions fill the
+                // grid, while preserving observation order for selected cells.
+                let prioritized = ordered
+                    .filter { $0.phase.requiresAttention || $0.phase == .running }
+                    .prefix(7)
+                let prioritizedIDs = Set(prioritized.map(\.id))
+                let remainingCapacity = 7 - prioritizedIDs.count
+                let fallbackIDs = ordered
+                    .lazy
+                    .filter { !prioritizedIDs.contains($0.id) }
+                    .prefix(remainingCapacity)
+                    .map(\.id)
+                let visibleIDs = prioritizedIDs.union(fallbackIDs)
+                cells = ordered
+                    .filter { visibleIDs.contains($0.id) }
+                    .map(Self.agentsGridCell(for:))
+                cells.append(.overflow(ordered.count - cells.count))
             }
             return cells.isEmpty ? nil : .agents(cells)
         }

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -347,6 +347,11 @@ final class AppModel {
         set { updateAppearancePreferences(for: activeAppearanceProfile) { $0.rightSlot = newValue } }
     }
 
+    var islandAgentGridSort: IslandAgentGridSort {
+        get { appearancePreferences(for: activeAppearanceProfile).agentGridSort }
+        set { updateAppearancePreferences(for: activeAppearanceProfile) { $0.agentGridSort = newValue } }
+    }
+
     var islandCenterLabel: IslandCenterLabel {
         get { appearancePreferences(for: activeAppearanceProfile).centerLabel }
         set { updateAppearancePreferences(for: activeAppearanceProfile) { $0.centerLabel = newValue } }
@@ -420,6 +425,7 @@ final class AppModel {
     ) {
         let defaults = UserDefaults.standard
         defaults.set(preferences.rightSlot.rawValue, forKey: Self.appearanceDefaultsKey(profile, "rightSlot"))
+        defaults.set(preferences.agentGridSort.rawValue, forKey: Self.appearanceDefaultsKey(profile, "agentGridSort"))
         defaults.set(preferences.centerLabel.rawValue, forKey: Self.appearanceDefaultsKey(profile, "centerLabel"))
         defaults.set(preferences.usageDisplay.rawValue, forKey: Self.appearanceDefaultsKey(profile, "usageDisplay"))
         defaults.set(preferences.sessionStateIndicator.rawValue, forKey: Self.appearanceDefaultsKey(profile, "stateIndicator"))
@@ -548,6 +554,9 @@ final class AppModel {
                     ?? defaults.string(forKey: islandRightSlotDefaultsKey)
                     ?? ""
             ) ?? .count,
+            agentGridSort: IslandAgentGridSort(
+                rawValue: defaults.string(forKey: appearanceDefaultsKey(profile, "agentGridSort")) ?? ""
+            ) ?? .statusPriority,
             centerLabel: IslandCenterLabel(
                 rawValue: defaults.string(forKey: appearanceDefaultsKey(profile, "centerLabel"))
                     ?? defaults.string(forKey: islandCenterLabelDefaultsKey)
@@ -892,40 +901,13 @@ final class AppModel {
             guard n > 0 else { return nil }
             return .count(n)
         case .agents:
-            // Display order = order-of-first-observation-in-the-island. A
-            // session that later flips visibility (e.g. attachment churn,
-            // completed↔running) keeps its existing slot instead of being
-            // reshuffled by session.firstSeenAt, which tracks the historical
-            // event time and can be older than visible peers. Bulk-observing
-            // N sessions at once (e.g. at app launch) breaks the tie by
-            // session.firstSeenAt so historical order is preserved.
             stampAgentsGridObservationTickets(for: sessions)
-            let ordered = sessions.sorted { a, b in
-                let ta = _agentsGridObservedSequence[a.id] ?? .max
-                let tb = _agentsGridObservedSequence[b.id] ?? .max
-                if ta != tb { return ta < tb }
-                return a.id < b.id
-            }
+            let ordered = orderedAgentsGridSessions(sessions)
             var cells: [AgentGridCell] = []
             if ordered.count <= 9 {
                 cells = ordered.map(Self.agentsGridCell(for:))
             } else {
-                // Keep live states visible when older idle sessions fill the
-                // grid, while preserving observation order for selected cells.
-                let prioritized = ordered
-                    .filter { $0.phase.requiresAttention || $0.phase == .running }
-                    .prefix(7)
-                let prioritizedIDs = Set(prioritized.map(\.id))
-                let remainingCapacity = 7 - prioritizedIDs.count
-                let fallbackIDs = ordered
-                    .lazy
-                    .filter { !prioritizedIDs.contains($0.id) }
-                    .prefix(remainingCapacity)
-                    .map(\.id)
-                let visibleIDs = prioritizedIDs.union(fallbackIDs)
-                cells = ordered
-                    .filter { visibleIDs.contains($0.id) }
-                    .map(Self.agentsGridCell(for:))
+                cells = ordered.prefix(7).map(Self.agentsGridCell(for:))
                 cells.append(.overflow(ordered.count - cells.count))
             }
             return cells.isEmpty ? nil : .agents(cells)
@@ -942,6 +924,48 @@ final class AppModel {
         for session in orderedNewcomers {
             _agentsGridObservedSequence[session.id] = _agentsGridNextTicket
             _agentsGridNextTicket += 1
+        }
+    }
+
+    private func orderedAgentsGridSessions(
+        _ sessions: [AgentSession],
+        now: Date = .now
+    ) -> [AgentSession] {
+        func statusRank(_ session: AgentSession) -> Int {
+            if session.phase.requiresAttention { return 0 }
+            if session.phase == .running { return 1 }
+            if !session.isStaleCompletedForIsland(
+                at: now,
+                threshold: completedStaleThreshold.seconds
+            ) { return 2 }
+            return 3
+        }
+
+        func agentRank(_ session: AgentSession) -> Int {
+            AgentTool.allCases.firstIndex { $0.rawValue == session.tool.rawValue } ?? .max
+        }
+
+        return sessions.sorted { a, b in
+            switch islandAgentGridSort {
+            case .statusPriority:
+                if statusRank(a) != statusRank(b) { return statusRank(a) < statusRank(b) }
+                if a.updatedAt != b.updatedAt { return a.updatedAt > b.updatedAt }
+            case .recentActivity:
+                if a.updatedAt != b.updatedAt { return a.updatedAt > b.updatedAt }
+            case .newestSession:
+                if a.firstSeenAt != b.firstSeenAt { return a.firstSeenAt > b.firstSeenAt }
+            case .agent:
+                if agentRank(a) != agentRank(b) { return agentRank(a) < agentRank(b) }
+                if statusRank(a) != statusRank(b) { return statusRank(a) < statusRank(b) }
+                if a.updatedAt != b.updatedAt { return a.updatedAt > b.updatedAt }
+            case .stable:
+                break
+            }
+
+            let ta = _agentsGridObservedSequence[a.id] ?? .max
+            let tb = _agentsGridObservedSequence[b.id] ?? .max
+            if ta != tb { return ta < tb }
+            return a.id < b.id
         }
     }
 

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1532,14 +1532,12 @@ final class AppModel {
             return state.session(id: payload.sessionID)?.phase == .completed
         }()
 
-        // Guard: don't let an older rollout snapshot downgrade a completed
-        // session. A newer snapshot can be the next turn; equality is valid
-        // because the watcher emits metadata first with the same timestamp.
+        // Rollout tails can replay after fresher bridge or watcher events. Reject
+        // them before the reducer can replace the newer phase or summary;
+        // equality remains valid because one snapshot emits paired events.
         if ingress == .rollout,
            case let .activityUpdated(payload) = event,
-           payload.phase == .running,
            let session = state.session(id: payload.sessionID),
-           session.phase == .completed,
            payload.timestamp < session.updatedAt {
             return
         }

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -905,9 +905,9 @@ final class AppModel {
             let ordered = orderedAgentsGridSessions(sessions)
             var cells: [AgentGridCell] = []
             if ordered.count <= 9 {
-                cells = ordered.map(Self.agentsGridCell(for:))
+                cells = ordered.map(agentsGridCell(for:))
             } else {
-                cells = ordered.prefix(7).map(Self.agentsGridCell(for:))
+                cells = ordered.prefix(7).map(agentsGridCell(for:))
                 cells.append(.overflow(ordered.count - cells.count))
             }
             return cells.isEmpty ? nil : .agents(cells)
@@ -987,15 +987,21 @@ final class AppModel {
         }
     }
 
-    private static func agentsGridCell(for session: AgentSession) -> AgentGridCell {
+    private func agentsGridCell(for session: AgentSession) -> AgentGridCell {
         let color = Color(hex: session.tool.brandColorHex) ?? .gray
         let state: AgentGridCellState
         if session.phase.requiresAttention {
             state = .waiting
         } else if session.phase == .running {
             state = .running
-        } else {
+        // Completed stays Done until the shared stale threshold moves it to Idle.
+        } else if session.isStaleCompletedForIsland(
+            at: .now,
+            threshold: completedStaleThreshold.seconds
+        ) {
             state = .idle
+        } else {
+            state = .done
         }
         return .session(color: color, state: state)
     }

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1487,14 +1487,15 @@ final class AppModel {
             return state.session(id: payload.sessionID)?.phase == .completed
         }()
 
-        // Guard: don't let rollout events downgrade a session from completed
-        // back to running. The bridge's sessionCompleted is authoritative; the
-        // rollout watcher may have read the JSONL before task_complete was
-        // flushed, producing a stale activityUpdated(phase: .running).
+        // Guard: don't let an older rollout snapshot downgrade a completed
+        // session. A newer snapshot can be the next turn; equality is valid
+        // because the watcher emits metadata first with the same timestamp.
         if ingress == .rollout,
            case let .activityUpdated(payload) = event,
            payload.phase == .running,
-           state.session(id: payload.sessionID)?.phase == .completed {
+           let session = state.session(id: payload.sessionID),
+           session.phase == .completed,
+           payload.timestamp < session.updatedAt {
             return
         }
 

--- a/Sources/OpenIslandApp/AppModelTypes.swift
+++ b/Sources/OpenIslandApp/AppModelTypes.swift
@@ -55,12 +55,23 @@ enum IslandAppearanceDisplayProfile: String, CaseIterable, Identifiable, Sendabl
 
 struct IslandAppearancePreferences: Equatable, Sendable {
     var rightSlot: IslandRightSlot = .count
+    var agentGridSort: IslandAgentGridSort = .statusPriority
     var centerLabel: IslandCenterLabel = .agentAction
     var usageDisplay: IslandUsageDisplay = .compact
     var sessionStateIndicator: IslandSessionStateIndicator = .animatedDot
     var sessionGroup: IslandSessionGroup = .none
     var sessionSort: IslandSessionSort = .attention
     var completedStaleThreshold: IslandCompletedStaleThreshold = .fiveMinutes
+}
+
+enum IslandAgentGridSort: String, CaseIterable, Identifiable, Sendable {
+    case statusPriority
+    case recentActivity
+    case newestSession
+    case agent
+    case stable
+
+    var id: String { rawValue }
 }
 
 enum IslandUsageDisplay: String, CaseIterable, Identifiable, Sendable {

--- a/Sources/OpenIslandApp/AppModelTypes.swift
+++ b/Sources/OpenIslandApp/AppModelTypes.swift
@@ -25,7 +25,7 @@ enum TrackedEventIngress {
 
 /// What the closed island renders in the right slot. Chosen in the
 /// Personalization tab; the pill layout only varies by content width.
-enum IslandRightSlot: String, CaseIterable, Identifiable, Sendable {
+enum IslandRightSlot: String, CaseIterable, Codable, Identifiable, Sendable {
     case count   // "×N" badge
     case agents  // colored dot stack, one per active agent tool
     case none    // pill collapses — useful if you just want the bars
@@ -36,7 +36,7 @@ enum IslandRightSlot: String, CaseIterable, Identifiable, Sendable {
 /// What the closed island renders in the center label (external displays
 /// only — on MacBook the physical notch covers this space so we suppress
 /// the label regardless).
-enum IslandCenterLabel: String, CaseIterable, Identifiable, Sendable {
+enum IslandCenterLabel: String, CaseIterable, Codable, Identifiable, Sendable {
     case sessionName  // e.g. "open-island"
     case agentAction  // e.g. "Claude · editing"
     case off
@@ -46,14 +46,14 @@ enum IslandCenterLabel: String, CaseIterable, Identifiable, Sendable {
 
 // MARK: - v8 island preferences
 
-enum IslandAppearanceDisplayProfile: String, CaseIterable, Identifiable, Sendable {
+enum IslandAppearanceDisplayProfile: String, CaseIterable, Codable, Identifiable, Sendable {
     case notch
     case topBar
 
     var id: String { rawValue }
 }
 
-struct IslandAppearancePreferences: Equatable, Sendable {
+struct IslandAppearancePreferences: Codable, Equatable, Sendable {
     var rightSlot: IslandRightSlot = .count
     var agentGridSort: IslandAgentGridSort = .statusPriority
     var centerLabel: IslandCenterLabel = .agentAction
@@ -64,7 +64,7 @@ struct IslandAppearancePreferences: Equatable, Sendable {
     var completedStaleThreshold: IslandCompletedStaleThreshold = .fiveMinutes
 }
 
-enum IslandAgentGridSort: String, CaseIterable, Identifiable, Sendable {
+enum IslandAgentGridSort: String, CaseIterable, Codable, Identifiable, Sendable {
     case statusPriority
     case recentActivity
     case newestSession
@@ -74,14 +74,14 @@ enum IslandAgentGridSort: String, CaseIterable, Identifiable, Sendable {
     var id: String { rawValue }
 }
 
-enum IslandUsageDisplay: String, CaseIterable, Identifiable, Sendable {
+enum IslandUsageDisplay: String, CaseIterable, Codable, Identifiable, Sendable {
     case hidden
     case compact
 
     var id: String { rawValue }
 }
 
-enum IslandSessionStateIndicator: String, CaseIterable, Identifiable, Sendable {
+enum IslandSessionStateIndicator: String, CaseIterable, Codable, Identifiable, Sendable {
     case animatedDot
     case bar
     case glyph
@@ -95,7 +95,7 @@ enum IslandSessionStateIndicator: String, CaseIterable, Identifiable, Sendable {
     }
 }
 
-enum IslandSessionGroup: String, CaseIterable, Identifiable, Sendable {
+enum IslandSessionGroup: String, CaseIterable, Codable, Identifiable, Sendable {
     case none
     case state
     case agent
@@ -104,14 +104,14 @@ enum IslandSessionGroup: String, CaseIterable, Identifiable, Sendable {
     var id: String { rawValue }
 }
 
-enum IslandSessionSort: String, CaseIterable, Identifiable, Sendable {
+enum IslandSessionSort: String, CaseIterable, Codable, Identifiable, Sendable {
     case attention
     case lastUpdate
 
     var id: String { rawValue }
 }
 
-enum IslandCompletedStaleThreshold: String, CaseIterable, Identifiable, Sendable {
+enum IslandCompletedStaleThreshold: String, CaseIterable, Codable, Identifiable, Sendable {
     case twoMinutes
     case fiveMinutes
     case tenMinutes

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -225,3 +225,11 @@
 
 /* Window Titles */
 "window.settings" = "Open Island Settings";
+
+"settings.appearance.agentGridSort.title" = "Agent grid order";
+"settings.appearance.agentGridSort.note" = "Choose how sessions are placed in the closed island grid.";
+"settings.appearance.agentGridSort.statusPriority" = "Status priority";
+"settings.appearance.agentGridSort.recentActivity" = "Recent activity";
+"settings.appearance.agentGridSort.newestSession" = "Newest session";
+"settings.appearance.agentGridSort.agent" = "By agent";
+"settings.appearance.agentGridSort.stable" = "Stable order";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -225,3 +225,11 @@
 
 /* Window Titles */
 "window.settings" = "Open Island 设置";
+
+"settings.appearance.agentGridSort.title" = "代理网格顺序";
+"settings.appearance.agentGridSort.note" = "选择会话在收起状态网格中的排列方式。";
+"settings.appearance.agentGridSort.statusPriority" = "状态优先";
+"settings.appearance.agentGridSort.recentActivity" = "最近活动";
+"settings.appearance.agentGridSort.newestSession" = "最新会话";
+"settings.appearance.agentGridSort.agent" = "按代理";
+"settings.appearance.agentGridSort.stable" = "固定顺序";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -224,3 +224,11 @@
 
 /* Window Titles */
 "window.settings" = "Open Island 設定";
+
+"settings.appearance.agentGridSort.title" = "代理網格順序";
+"settings.appearance.agentGridSort.note" = "選擇工作階段在收合狀態網格中的排列方式。";
+"settings.appearance.agentGridSort.statusPriority" = "狀態優先";
+"settings.appearance.agentGridSort.recentActivity" = "最近活動";
+"settings.appearance.agentGridSort.newestSession" = "最新工作階段";
+"settings.appearance.agentGridSort.agent" = "依代理";
+"settings.appearance.agentGridSort.stable" = "固定順序";

--- a/Sources/OpenIslandApp/Views/AppearanceSettingsPane.swift
+++ b/Sources/OpenIslandApp/Views/AppearanceSettingsPane.swift
@@ -566,6 +566,9 @@ struct AppearanceSettingsPane: View {
             )
         }
         .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(title))
+        .accessibilityAddTraits(selected ? .isSelected : [])
     }
 
     private func sectionHeader(title: String, note: String?) -> some View {

--- a/Sources/OpenIslandApp/Views/AppearanceSettingsPane.swift
+++ b/Sources/OpenIslandApp/Views/AppearanceSettingsPane.swift
@@ -268,6 +268,34 @@ struct AppearanceSettingsPane: View {
                                       .foregroundStyle(V6Palette.paper.opacity(0.5)) },
                           title: lang.t("settings.appearance.rightSlot.none"))
         }
+
+        if editingPreferences.rightSlot == .agents {
+            sectionHeader(
+                title: lang.t("settings.appearance.agentGridSort.title"),
+                note: lang.t("settings.appearance.agentGridSort.note")
+            )
+
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 110), spacing: 12)],
+                alignment: .leading,
+                spacing: 12
+            ) {
+                ForEach(IslandAgentGridSort.allCases) { option in
+                    optionCard(
+                        selected: editingPreferences.agentGridSort == option,
+                        title: title(for: option)
+                    ) {
+                        model.updateAppearancePreferences(for: editingProfile) {
+                            $0.agentGridSort = option
+                        }
+                    } icon: {
+                        Image(systemName: icon(for: option))
+                            .font(.system(size: 18, weight: .semibold))
+                            .foregroundStyle(V6Palette.paper.opacity(0.82))
+                    }
+                }
+            }
+        }
     }
 
     private func rightSlotCard<Content: View>(
@@ -609,6 +637,26 @@ struct AppearanceSettingsPane: View {
         switch option {
         case .attention:  lang.t("settings.appearance.sessionSort.attention")
         case .lastUpdate: lang.t("settings.appearance.sessionSort.lastUpdate")
+        }
+    }
+
+    private func title(for option: IslandAgentGridSort) -> String {
+        switch option {
+        case .statusPriority: lang.t("settings.appearance.agentGridSort.statusPriority")
+        case .recentActivity: lang.t("settings.appearance.agentGridSort.recentActivity")
+        case .newestSession:  lang.t("settings.appearance.agentGridSort.newestSession")
+        case .agent:          lang.t("settings.appearance.agentGridSort.agent")
+        case .stable:         lang.t("settings.appearance.agentGridSort.stable")
+        }
+    }
+
+    private func icon(for option: IslandAgentGridSort) -> String {
+        switch option {
+        case .statusPriority: "bolt.fill"
+        case .recentActivity: "clock.arrow.circlepath"
+        case .newestSession:  "sparkles"
+        case .agent:          "square.grid.2x2"
+        case .stable:         "pin.fill"
         }
     }
 

--- a/Sources/OpenIslandApp/Views/V6NotchContent.swift
+++ b/Sources/OpenIslandApp/Views/V6NotchContent.swift
@@ -2,9 +2,10 @@ import SwiftUI
 import OpenIslandCore
 
 /// Per-cell state for the closed-island agents grid. Drives tile rendering:
-/// running = full color, idle = dim, waiting = opacity pulse.
+/// running = full, done = 40%, idle = 20%, waiting = opacity pulse.
 enum AgentGridCellState: Equatable {
     case running
+    case done
     case idle
     case waiting
 }
@@ -146,9 +147,13 @@ private struct AgentsGridTileView: View {
                 RoundedRectangle(cornerRadius: radius, style: .continuous)
                     .fill(color)
                     .frame(width: size, height: size)
+            case .done:
+                RoundedRectangle(cornerRadius: radius, style: .continuous)
+                    .fill(color.opacity(0.40))
+                    .frame(width: size, height: size)
             case .idle:
                 RoundedRectangle(cornerRadius: radius, style: .continuous)
-                    .fill(color.opacity(0.22))
+                    .fill(color.opacity(0.20))
                     .frame(width: size, height: size)
             case .waiting:
                 AgentsGridWaitingTile(color: color, size: size, radius: radius)
@@ -178,7 +183,7 @@ private struct AgentsGridWaitingTile: View {
             .frame(width: size, height: size)
             .opacity(pulse ? 1.0 : 0.35)
             .onAppear {
-                withAnimation(.easeInOut(duration: 0.7).repeatForever(autoreverses: true)) {
+                withAnimation(.easeInOut(duration: 0.45).repeatForever(autoreverses: true)) {
                     pulse = true
                 }
             }

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -167,7 +167,9 @@ public struct SessionState: Equatable, Sendable {
             }
 
             session.codexMetadata = payload.codexMetadata.isEmpty ? nil : payload.codexMetadata
-            session.updatedAt = payload.timestamp
+            // Metadata enriches the session but must not make its activity
+            // chronology move backward when an older rollout tail is replayed.
+            session.updatedAt = max(session.updatedAt, payload.timestamp)
             upsert(session)
 
         case let .claudeSessionMetadataUpdated(payload):

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -166,10 +166,13 @@ public struct SessionState: Equatable, Sendable {
                 return
             }
 
+            // A replayed rollout metadata event must not replace fields already
+            // enriched by a newer snapshot. Equal timestamps are paired events.
+            guard payload.timestamp >= session.updatedAt else {
+                return
+            }
             session.codexMetadata = payload.codexMetadata.isEmpty ? nil : payload.codexMetadata
-            // Metadata enriches the session but must not make its activity
-            // chronology move backward when an older rollout tail is replayed.
-            session.updatedAt = max(session.updatedAt, payload.timestamp)
+            session.updatedAt = payload.timestamp
             upsert(session)
 
         case let .claudeSessionMetadataUpdated(payload):

--- a/Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift
+++ b/Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift
@@ -12,8 +12,7 @@ struct AgentsGridRightSlotTests {
     @Test
     func bulkFirstObservationOrdersByHistoricalFirstSeenAt() {
         let model = AppModel()
-        model.islandRightSlot = .agents
-        model.islandAgentGridSort = .stable
+        configureAgentsGrid(model, sort: .stable)
 
         let now = Date(timeIntervalSince1970: 100_000)
         let sessionA = makeSession(id: "A", firstSeenAt: now,                       updatedAt: now.addingTimeInterval(60))
@@ -48,8 +47,7 @@ struct AgentsGridRightSlotTests {
     @Test
     func newlyObservedSessionAlwaysLandsAtTheEndRegardlessOfHistoricalTime() {
         let model = AppModel()
-        model.islandRightSlot = .agents
-        model.islandAgentGridSort = .stable
+        configureAgentsGrid(model, sort: .stable)
 
         let now = Date(timeIntervalSince1970: 200_000)
         let sessionA = makeSession(id: "A", firstSeenAt: now,                       updatedAt: now)
@@ -82,8 +80,7 @@ struct AgentsGridRightSlotTests {
     @Test
     func returningSessionKeepsItsOriginalSlot() {
         let model = AppModel()
-        model.islandRightSlot = .agents
-        model.islandAgentGridSort = .stable
+        configureAgentsGrid(model, sort: .stable)
 
         let now = Date(timeIntervalSince1970: 300_000)
         let sessionA = makeSession(id: "A", firstSeenAt: now,                       updatedAt: now)
@@ -114,7 +111,7 @@ struct AgentsGridRightSlotTests {
     @Test
     func moreThanNineSessionsFoldIntoOverflow() {
         let model = AppModel()
-        model.islandRightSlot = .agents
+        configureAgentsGrid(model, sort: .statusPriority)
         let now = Date(timeIntervalSince1970: 200_000)
 
         var sessions: [AgentSession] = []
@@ -142,8 +139,7 @@ struct AgentsGridRightSlotTests {
     @Test
     func overflowKeepsNewerRunningSessionVisible() {
         let model = AppModel()
-        model.islandRightSlot = .agents
-        model.islandAgentGridSort = .statusPriority
+        configureAgentsGrid(model, sort: .statusPriority)
         let now = Date(timeIntervalSince1970: 250_000)
         var sessions = (0..<11).map { i in
             makeSession(
@@ -179,8 +175,7 @@ struct AgentsGridRightSlotTests {
     @Test
     func cellStateReflectsSessionPhase() {
         let model = AppModel()
-        model.islandRightSlot = .agents
-        model.islandAgentGridSort = .stable
+        configureAgentsGrid(model, sort: .stable)
         let now = Date(timeIntervalSince1970: 300_000)
 
         let running  = makeSession(id: "r", firstSeenAt: now,                         updatedAt: now, phase: .running)
@@ -251,9 +246,11 @@ struct AgentsGridRightSlotTests {
 
         for (sort, expected) in cases {
             let model = AppModel()
-            model.islandRightSlot = .agents
-            model.islandAgentGridSort = sort
-            model.completedStaleThreshold = .twoMinutes
+            configureAgentsGrid(
+                model,
+                sort: sort,
+                completedStaleThreshold: .twoMinutes
+            )
             model.state = SessionState(sessions: sessions)
 
             guard case let .agents(cells)? = model.islandClosedRightSlotContent() else {
@@ -265,6 +262,23 @@ struct AgentsGridRightSlotTests {
     }
 
     // MARK: - helpers
+
+    /// The overlay can resolve to either display profile during AppModel setup.
+    /// Configure the closed-grid inputs for both so an async placement update
+    /// cannot make this test read an unrelated persisted profile preference.
+    private func configureAgentsGrid(
+        _ model: AppModel,
+        sort: IslandAgentGridSort,
+        completedStaleThreshold: IslandCompletedStaleThreshold = .fiveMinutes
+    ) {
+        for profile in [IslandAppearanceDisplayProfile.notch, .topBar] {
+            model.updateAppearancePreferences(for: profile) {
+                $0.rightSlot = .agents
+                $0.agentGridSort = sort
+                $0.completedStaleThreshold = completedStaleThreshold
+            }
+        }
+    }
 
     private static func cellFor(_ session: AgentSession) -> AgentGridCell {
         let color = Color(hex: session.tool.brandColorHex) ?? .gray

--- a/Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift
+++ b/Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift
@@ -5,6 +5,7 @@ import Testing
 import OpenIslandCore
 
 @MainActor
+@Suite(.serialized)
 struct AgentsGridRightSlotTests {
     /// At bulk first observation (e.g. app launch) ties are broken by
     /// session.firstSeenAt so historical order is preserved.
@@ -12,6 +13,7 @@ struct AgentsGridRightSlotTests {
     func bulkFirstObservationOrdersByHistoricalFirstSeenAt() {
         let model = AppModel()
         model.islandRightSlot = .agents
+        model.islandAgentGridSort = .stable
 
         let now = Date(timeIntervalSince1970: 100_000)
         let sessionA = makeSession(id: "A", firstSeenAt: now,                       updatedAt: now.addingTimeInterval(60))
@@ -47,6 +49,7 @@ struct AgentsGridRightSlotTests {
     func newlyObservedSessionAlwaysLandsAtTheEndRegardlessOfHistoricalTime() {
         let model = AppModel()
         model.islandRightSlot = .agents
+        model.islandAgentGridSort = .stable
 
         let now = Date(timeIntervalSince1970: 200_000)
         let sessionA = makeSession(id: "A", firstSeenAt: now,                       updatedAt: now)
@@ -80,6 +83,7 @@ struct AgentsGridRightSlotTests {
     func returningSessionKeepsItsOriginalSlot() {
         let model = AppModel()
         model.islandRightSlot = .agents
+        model.islandAgentGridSort = .stable
 
         let now = Date(timeIntervalSince1970: 300_000)
         let sessionA = makeSession(id: "A", firstSeenAt: now,                       updatedAt: now)
@@ -139,6 +143,7 @@ struct AgentsGridRightSlotTests {
     func overflowKeepsNewerRunningSessionVisible() {
         let model = AppModel()
         model.islandRightSlot = .agents
+        model.islandAgentGridSort = .statusPriority
         let now = Date(timeIntervalSince1970: 250_000)
         var sessions = (0..<11).map { i in
             makeSession(
@@ -175,6 +180,7 @@ struct AgentsGridRightSlotTests {
     func cellStateReflectsSessionPhase() {
         let model = AppModel()
         model.islandRightSlot = .agents
+        model.islandAgentGridSort = .stable
         let now = Date(timeIntervalSince1970: 300_000)
 
         let running  = makeSession(id: "r", firstSeenAt: now,                         updatedAt: now, phase: .running)
@@ -208,6 +214,56 @@ struct AgentsGridRightSlotTests {
         #expect(s2 == .idle)
     }
 
+    @Test
+    func gridSortModesProduceExpectedOrder() {
+        let now = Date()
+        let waiting = makeSession(
+            id: "waiting", tool: .openCode,
+            firstSeenAt: now.addingTimeInterval(-40),
+            updatedAt: now.addingTimeInterval(-20),
+            phase: .waitingForAnswer
+        )
+        let running = makeSession(
+            id: "running", tool: .codex,
+            firstSeenAt: now.addingTimeInterval(-10),
+            updatedAt: now.addingTimeInterval(-30)
+        )
+        let recentDone = makeSession(
+            id: "recent", tool: .geminiCLI,
+            firstSeenAt: now.addingTimeInterval(-30),
+            updatedAt: now.addingTimeInterval(-5),
+            phase: .completed
+        )
+        let staleDone = makeSession(
+            id: "stale", tool: .claudeCode,
+            firstSeenAt: now.addingTimeInterval(-20),
+            updatedAt: now.addingTimeInterval(-300),
+            phase: .completed
+        )
+        let sessions = [running, staleDone, waiting, recentDone]
+        let cases: [(IslandAgentGridSort, [AgentSession])] = [
+            (.statusPriority, [waiting, running, recentDone, staleDone]),
+            (.recentActivity, [recentDone, waiting, running, staleDone]),
+            (.newestSession, [running, staleDone, recentDone, waiting]),
+            (.agent, [staleDone, running, recentDone, waiting]),
+            (.stable, [waiting, recentDone, staleDone, running]),
+        ]
+
+        for (sort, expected) in cases {
+            let model = AppModel()
+            model.islandRightSlot = .agents
+            model.islandAgentGridSort = sort
+            model.completedStaleThreshold = .twoMinutes
+            model.state = SessionState(sessions: sessions)
+
+            guard case let .agents(cells)? = model.islandClosedRightSlotContent() else {
+                Issue.record("Expected agents for \(sort.rawValue)")
+                continue
+            }
+            #expect(cells == expected.map(Self.cellFor), "Unexpected \(sort.rawValue) order")
+        }
+    }
+
     // MARK: - helpers
 
     private static func cellFor(_ session: AgentSession) -> AgentGridCell {
@@ -225,6 +281,7 @@ struct AgentsGridRightSlotTests {
 
     private func makeSession(
         id: String,
+        tool: AgentTool = .claudeCode,
         firstSeenAt: Date,
         updatedAt: Date,
         phase: SessionPhase = .running,
@@ -232,8 +289,8 @@ struct AgentsGridRightSlotTests {
     ) -> AgentSession {
         var session = AgentSession(
             id: id,
-            title: "Claude · \(id)",
-            tool: .claudeCode,
+            title: "\(tool.displayName) · \(id)",
+            tool: tool,
             origin: .live,
             attachmentState: .attached,
             phase: phase,
@@ -244,7 +301,7 @@ struct AgentsGridRightSlotTests {
             jumpTarget: JumpTarget(
                 terminalApp: "Ghostty",
                 workspaceName: id,
-                paneTitle: "claude ~/\(id)",
+                paneTitle: "agent ~/\(id)",
                 workingDirectory: "/tmp/\(id)",
                 terminalSessionID: "ghostty-\(id)"
             ),

--- a/Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift
+++ b/Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift
@@ -135,6 +135,39 @@ struct AgentsGridRightSlotTests {
         }
     }
 
+    @Test
+    func overflowKeepsNewerRunningSessionVisible() {
+        let model = AppModel()
+        model.islandRightSlot = .agents
+        let now = Date(timeIntervalSince1970: 250_000)
+        var sessions = (0..<11).map { i in
+            makeSession(
+                id: "idle-\(i)",
+                firstSeenAt: now.addingTimeInterval(Double(i)),
+                updatedAt: now,
+                phase: .completed
+            )
+        }
+        sessions.append(makeSession(
+            id: "running",
+            firstSeenAt: now.addingTimeInterval(11),
+            updatedAt: now.addingTimeInterval(1),
+            phase: .running
+        ))
+        model.state = SessionState(sessions: sessions)
+
+        guard case let .agents(cells)? = model.islandClosedRightSlotContent() else {
+            Issue.record("Expected .agents right-slot content")
+            return
+        }
+        let visibleStates = cells.compactMap { cell -> AgentGridCellState? in
+            guard case let .session(_, state) = cell else { return nil }
+            return state
+        }
+        #expect(visibleStates.filter { $0 == .running }.count == 1)
+        #expect(cells.last == .overflow(5))
+    }
+
     /// Per-session state derives from `SessionPhase`: waiting-for-approval /
     /// waiting-for-answer map to `.waiting`, running to `.running`, and
     /// everything else (completed, stale) to `.idle`.

--- a/Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift
+++ b/Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift
@@ -170,13 +170,13 @@ struct AgentsGridRightSlotTests {
     }
 
     /// Per-session state derives from `SessionPhase`: waiting-for-approval /
-    /// waiting-for-answer map to `.waiting`, running to `.running`, and
-    /// everything else (completed, stale) to `.idle`.
+    /// waiting-for-answer map to `.waiting`, running to `.running`, recent
+    /// completed to `.done`, and stale completed to `.idle`.
     @Test
     func cellStateReflectsSessionPhase() {
         let model = AppModel()
         configureAgentsGrid(model, sort: .stable)
-        let now = Date(timeIntervalSince1970: 300_000)
+        let now = Date()
 
         let running  = makeSession(id: "r", firstSeenAt: now,                         updatedAt: now, phase: .running)
         let waitingA = makeSession(
@@ -206,7 +206,7 @@ struct AgentsGridRightSlotTests {
         }
         #expect(s0 == .running)
         #expect(s1 == .waiting)
-        #expect(s2 == .idle)
+        #expect(s2 == .done)
     }
 
     @Test
@@ -315,8 +315,10 @@ struct AgentsGridRightSlotTests {
             state = .waiting
         } else if session.phase == .running {
             state = .running
-        } else {
+        } else if session.isStaleCompletedForIsland(at: .now, threshold: 120) {
             state = .idle
+        } else {
+            state = .done
         }
         return .session(color: color, state: state)
     }

--- a/Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift
+++ b/Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift
@@ -271,6 +271,21 @@ struct AgentsGridRightSlotTests {
         sort: IslandAgentGridSort,
         completedStaleThreshold: IslandCompletedStaleThreshold = .fiveMinutes
     ) {
+        let defaults = UserDefaults.standard
+        let keys = Self.appearanceDefaultsKeys
+        let savedValues = keys.reduce(into: [String: Any]()) { values, key in
+            values[key] = defaults.object(forKey: key)
+        }
+        defer {
+            for key in keys {
+                if let savedValue = savedValues[key] {
+                    defaults.set(savedValue, forKey: key)
+                } else {
+                    defaults.removeObject(forKey: key)
+                }
+            }
+        }
+
         for profile in [IslandAppearanceDisplayProfile.notch, .topBar] {
             model.updateAppearancePreferences(for: profile) {
                 $0.rightSlot = .agents
@@ -278,6 +293,19 @@ struct AgentsGridRightSlotTests {
                 $0.completedStaleThreshold = completedStaleThreshold
             }
         }
+    }
+
+    private static let appearanceDefaultsKeys = IslandAppearanceDisplayProfile.allCases.flatMap { profile in
+        [
+            "rightSlot",
+            "agentGridSort",
+            "centerLabel",
+            "usageDisplay",
+            "stateIndicator",
+            "sessionGroup",
+            "sessionSort",
+            "completedStaleThreshold",
+        ].map { "appearance.island.v8.\(profile.rawValue).\($0)" }
     }
 
     private static func cellFor(_ session: AgentSession) -> AgentGridCell {

--- a/Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift
+++ b/Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift
@@ -15,9 +15,9 @@ struct AgentsGridRightSlotTests {
         configureAgentsGrid(model, sort: .stable)
 
         let now = Date(timeIntervalSince1970: 100_000)
-        let sessionA = makeSession(id: "A", firstSeenAt: now,                       updatedAt: now.addingTimeInterval(60))
-        let sessionB = makeSession(id: "B", firstSeenAt: now.addingTimeInterval(10), updatedAt: now.addingTimeInterval(5))
-        let sessionC = makeSession(id: "C", firstSeenAt: now.addingTimeInterval(20), updatedAt: now.addingTimeInterval(120))
+        let sessionA = makeSession(id: "A", tool: .codex, firstSeenAt: now, updatedAt: now.addingTimeInterval(60))
+        let sessionB = makeSession(id: "B", tool: .claudeCode, firstSeenAt: now.addingTimeInterval(10), updatedAt: now.addingTimeInterval(5))
+        let sessionC = makeSession(id: "C", tool: .openCode, firstSeenAt: now.addingTimeInterval(20), updatedAt: now.addingTimeInterval(120))
 
         // Insertion order differs from historical order — the grid must still
         // present A, B, C.
@@ -27,6 +27,7 @@ struct AgentsGridRightSlotTests {
             return
         }
         #expect(cells.count == 3)
+        #expect(cells == [sessionA, sessionB, sessionC].map(Self.cellFor))
 
         // A panel-sort signal (updatedAt) churn must not reshuffle the grid.
         var bumped = sessionB
@@ -50,9 +51,9 @@ struct AgentsGridRightSlotTests {
         configureAgentsGrid(model, sort: .stable)
 
         let now = Date(timeIntervalSince1970: 200_000)
-        let sessionA = makeSession(id: "A", firstSeenAt: now,                       updatedAt: now)
-        let sessionB = makeSession(id: "B", firstSeenAt: now.addingTimeInterval(10), updatedAt: now.addingTimeInterval(10))
-        let sessionC = makeSession(id: "C", firstSeenAt: now.addingTimeInterval(20), updatedAt: now.addingTimeInterval(20))
+        let sessionA = makeSession(id: "A", tool: .codex, firstSeenAt: now, updatedAt: now)
+        let sessionB = makeSession(id: "B", tool: .claudeCode, firstSeenAt: now.addingTimeInterval(10), updatedAt: now.addingTimeInterval(10))
+        let sessionC = makeSession(id: "C", tool: .openCode, firstSeenAt: now.addingTimeInterval(20), updatedAt: now.addingTimeInterval(20))
 
         model.state = SessionState(sessions: [sessionA, sessionB, sessionC])
         _ = model.islandClosedRightSlotContent()
@@ -61,6 +62,7 @@ struct AgentsGridRightSlotTests {
         // firstSeenAt pre-dates everything (e.g. found in a rollout tail).
         let sessionD = makeSession(
             id: "D",
+            tool: .geminiCLI,
             firstSeenAt: now.addingTimeInterval(-500),
             updatedAt: now.addingTimeInterval(40)
         )
@@ -83,9 +85,9 @@ struct AgentsGridRightSlotTests {
         configureAgentsGrid(model, sort: .stable)
 
         let now = Date(timeIntervalSince1970: 300_000)
-        let sessionA = makeSession(id: "A", firstSeenAt: now,                       updatedAt: now)
-        let sessionB = makeSession(id: "B", firstSeenAt: now.addingTimeInterval(10), updatedAt: now.addingTimeInterval(10))
-        let sessionC = makeSession(id: "C", firstSeenAt: now.addingTimeInterval(20), updatedAt: now.addingTimeInterval(20))
+        let sessionA = makeSession(id: "A", tool: .codex, firstSeenAt: now, updatedAt: now)
+        let sessionB = makeSession(id: "B", tool: .claudeCode, firstSeenAt: now.addingTimeInterval(10), updatedAt: now.addingTimeInterval(10))
+        let sessionC = makeSession(id: "C", tool: .openCode, firstSeenAt: now.addingTimeInterval(20), updatedAt: now.addingTimeInterval(20))
 
         model.state = SessionState(sessions: [sessionA, sessionB, sessionC])
         _ = model.islandClosedRightSlotContent()

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -573,6 +573,81 @@ struct AppModelSessionListTests {
     }
 
     @Test
+    func staleRolloutMetadataDoesNotReplaceNewerSessionMetadata() {
+        let newerAt = Date(timeIntervalSince1970: 2_000)
+        let model = AppModel()
+        model.state = SessionState(
+            sessions: [
+                AgentSession(
+                    id: "running-session",
+                    title: "Codex · open-island",
+                    tool: .codex,
+                    origin: .live,
+                    attachmentState: .attached,
+                    phase: .running,
+                    summary: "Newer activity.",
+                    updatedAt: newerAt,
+                    codexMetadata: CodexSessionMetadata(lastUserPrompt: "Newest prompt")
+                ),
+            ]
+        )
+
+        model.applyTrackedEvent(
+            .sessionMetadataUpdated(
+                SessionMetadataUpdated(
+                    sessionID: "running-session",
+                    codexMetadata: CodexSessionMetadata(lastUserPrompt: "Stale prompt"),
+                    timestamp: newerAt.addingTimeInterval(-1)
+                )
+            ),
+            updateLastActionMessage: false,
+            ingress: .rollout
+        )
+
+        let session = model.state.session(id: "running-session")
+        #expect(session?.codexMetadata?.lastUserPrompt == "Newest prompt")
+        #expect(session?.updatedAt == newerAt)
+    }
+
+    @Test
+    func staleRolloutActivityDoesNotReplaceNewerRunningSessionData() {
+        let newerAt = Date(timeIntervalSince1970: 2_000)
+        let model = AppModel()
+        model.state = SessionState(
+            sessions: [
+                AgentSession(
+                    id: "running-session",
+                    title: "Codex · open-island",
+                    tool: .codex,
+                    origin: .live,
+                    attachmentState: .attached,
+                    phase: .running,
+                    summary: "Newer activity.",
+                    updatedAt: newerAt
+                ),
+            ]
+        )
+
+        model.applyTrackedEvent(
+            .activityUpdated(
+                SessionActivityUpdated(
+                    sessionID: "running-session",
+                    summary: "Stale activity.",
+                    phase: .waitingForAnswer,
+                    timestamp: newerAt.addingTimeInterval(-1)
+                )
+            ),
+            updateLastActionMessage: false,
+            ingress: .rollout
+        )
+
+        let session = model.state.session(id: "running-session")
+        #expect(session?.phase == .running)
+        #expect(session?.summary == "Newer activity.")
+        #expect(session?.updatedAt == newerAt)
+    }
+
+    @Test
     func newerRolloutMetadataThenEqualTimestampRunningActivityReopensCompletedSession() {
         let completedAt = Date(timeIntervalSince1970: 2_000)
         let nextTurnAt = completedAt.addingTimeInterval(1)

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -13,12 +13,14 @@ struct AppModelSessionListTests {
             "appearance.island.v8.sessionSort",
             "appearance.island.v8.completedStaleThreshold",
             "appearance.island.v8.notch.rightSlot",
+            "appearance.island.v8.notch.agentGridSort",
             "appearance.island.v8.notch.centerLabel",
             "appearance.island.v8.notch.stateIndicator",
             "appearance.island.v8.notch.sessionGroup",
             "appearance.island.v8.notch.sessionSort",
             "appearance.island.v8.notch.completedStaleThreshold",
             "appearance.island.v8.topBar.rightSlot",
+            "appearance.island.v8.topBar.agentGridSort",
             "appearance.island.v8.topBar.centerLabel",
             "appearance.island.v8.topBar.stateIndicator",
             "appearance.island.v8.topBar.sessionGroup",
@@ -371,12 +373,14 @@ struct AppModelSessionListTests {
     func islandAppearancePreferencesPersistPerDisplayProfile() {
         let model = AppModel()
         model.updateAppearancePreferences(for: .notch) {
+            $0.agentGridSort = .stable
             $0.usageDisplay = .hidden
             $0.sessionGroup = .state
             $0.sessionStateIndicator = .bar
             $0.completedStaleThreshold = .twoMinutes
         }
         model.updateAppearancePreferences(for: .topBar) {
+            $0.agentGridSort = .agent
             $0.usageDisplay = .compact
             $0.sessionGroup = .project
             $0.sessionStateIndicator = .tint
@@ -384,12 +388,14 @@ struct AppModelSessionListTests {
         }
 
         model.overlayPlacementDiagnostics = placementDiagnostics(mode: .notch)
+        #expect(model.islandAgentGridSort == .stable)
         #expect(model.islandUsageDisplay == .hidden)
         #expect(model.islandSessionGroup == .state)
         #expect(model.islandSessionStateIndicator == .bar)
         #expect(model.completedStaleThreshold == .twoMinutes)
 
         model.overlayPlacementDiagnostics = placementDiagnostics(mode: .topBar)
+        #expect(model.islandAgentGridSort == .agent)
         #expect(model.islandUsageDisplay == .compact)
         #expect(model.islandSessionGroup == .project)
         #expect(model.islandSessionStateIndicator == .tint)
@@ -397,10 +403,12 @@ struct AppModelSessionListTests {
 
         let reloaded = AppModel()
         reloaded.overlayPlacementDiagnostics = placementDiagnostics(mode: .notch)
+        #expect(reloaded.islandAgentGridSort == .stable)
         #expect(reloaded.islandUsageDisplay == .hidden)
         #expect(reloaded.islandSessionGroup == .state)
         #expect(reloaded.islandSessionStateIndicator == .bar)
         reloaded.overlayPlacementDiagnostics = placementDiagnostics(mode: .topBar)
+        #expect(reloaded.islandAgentGridSort == .agent)
         #expect(reloaded.islandUsageDisplay == .compact)
         #expect(reloaded.islandSessionGroup == .project)
         #expect(reloaded.islandSessionStateIndicator == .tint)

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -413,6 +413,23 @@ struct AppModelSessionListTests {
         #expect(reloaded.islandSessionGroup == .project)
         #expect(reloaded.islandSessionStateIndicator == .tint)
         #expect(reloaded.completedStaleThreshold == .never)
+
+        let defaults = UserDefaults.standard
+        let notchSortKey = "appearance.island.v8.notch.agentGridSort"
+        let topBarSortKey = "appearance.island.v8.topBar.agentGridSort"
+        defaults.removeObject(forKey: notchSortKey)
+        defaults.removeObject(forKey: topBarSortKey)
+
+        let missingValues = AppModel()
+        #expect(missingValues.appearancePreferences(for: .notch).agentGridSort == .statusPriority)
+        #expect(missingValues.appearancePreferences(for: .topBar).agentGridSort == .statusPriority)
+
+        defaults.set("unknown-grid-sort", forKey: notchSortKey)
+        defaults.set("unknown-grid-sort", forKey: topBarSortKey)
+
+        let invalidValues = AppModel()
+        #expect(invalidValues.appearancePreferences(for: .notch).agentGridSort == .statusPriority)
+        #expect(invalidValues.appearancePreferences(for: .topBar).agentGridSort == .statusPriority)
     }
 
     @Test
@@ -498,7 +515,65 @@ struct AppModelSessionListTests {
     }
 
     @Test
-    func rolloutRunningEventReopensCompletedSessionUnlessSnapshotIsOlder() {
+    func olderRolloutMetadataThenRunningActivityDoesNotReopenCompletedSession() {
+        let completedAt = Date(timeIntervalSince1970: 2_000)
+        let olderSnapshotAt = completedAt.addingTimeInterval(-1)
+        let model = AppModel()
+        model.state = SessionState(
+            sessions: [
+                AgentSession(
+                    id: "completed-session",
+                    title: "Codex · open-island",
+                    tool: .codex,
+                    origin: .live,
+                    attachmentState: .attached,
+                    phase: .completed,
+                    summary: "Previous turn completed.",
+                    updatedAt: completedAt
+                ),
+            ]
+        )
+
+        let events = CodexRolloutReducer.events(
+            from: CodexRolloutSnapshot(
+                summary: "Previous turn completed.",
+                phase: .completed,
+                updatedAt: completedAt,
+                lastUserPrompt: "Finish the previous turn.",
+                isCompleted: true
+            ),
+            to: CodexRolloutSnapshot(
+                summary: "Stale running snapshot.",
+                phase: .running,
+                updatedAt: olderSnapshotAt,
+                lastUserPrompt: "Stale prompt from the rollout tail."
+            ),
+            sessionID: "completed-session",
+            transcriptPath: "/tmp/completed-session.jsonl"
+        )
+        guard events.count == 2,
+              case let .sessionMetadataUpdated(metadata) = events[0],
+              case let .activityUpdated(activity) = events[1] else {
+            Issue.record("Expected rollout metadata followed by running activity")
+            return
+        }
+        #expect(metadata.timestamp == olderSnapshotAt)
+        #expect(activity.timestamp == olderSnapshotAt)
+
+        for event in events {
+            model.applyTrackedEvent(
+                event,
+                updateLastActionMessage: false,
+                ingress: .rollout
+            )
+        }
+
+        #expect(model.state.session(id: "completed-session")?.phase == .completed)
+        #expect(model.state.session(id: "completed-session")?.updatedAt == completedAt)
+    }
+
+    @Test
+    func newerRolloutMetadataThenEqualTimestampRunningActivityReopensCompletedSession() {
         let completedAt = Date(timeIntervalSince1970: 2_000)
         let nextTurnAt = completedAt.addingTimeInterval(1)
         let model = AppModel()
@@ -517,45 +592,42 @@ struct AppModelSessionListTests {
             ]
         )
 
-        model.applyTrackedEvent(
-            .activityUpdated(
-                SessionActivityUpdated(
-                    sessionID: "completed-session",
-                    summary: "Stale running snapshot.",
-                    phase: .running,
-                    timestamp: completedAt.addingTimeInterval(-1)
-                )
+        let events = CodexRolloutReducer.events(
+            from: CodexRolloutSnapshot(
+                summary: "Previous turn completed.",
+                phase: .completed,
+                updatedAt: completedAt,
+                lastUserPrompt: "Finish the previous turn.",
+                isCompleted: true
             ),
-            updateLastActionMessage: false,
-            ingress: .rollout
+            to: CodexRolloutSnapshot(
+                summary: "Prompt: Start the next turn.",
+                phase: .running,
+                updatedAt: nextTurnAt,
+                lastUserPrompt: "Start the next turn."
+            ),
+            sessionID: "completed-session",
+            transcriptPath: "/tmp/completed-session.jsonl"
         )
-        #expect(model.state.session(id: "completed-session")?.phase == .completed)
+        guard events.count == 2,
+              case let .sessionMetadataUpdated(metadata) = events[0],
+              case let .activityUpdated(activity) = events[1] else {
+            Issue.record("Expected rollout metadata followed by running activity")
+            return
+        }
+        #expect(metadata.timestamp == activity.timestamp)
+        #expect(activity.timestamp == nextTurnAt)
 
-        model.applyTrackedEvent(
-            .sessionMetadataUpdated(
-                SessionMetadataUpdated(
-                    sessionID: "completed-session",
-                    codexMetadata: CodexSessionMetadata(lastUserPrompt: "Start the next turn."),
-                    timestamp: nextTurnAt
-                )
-            ),
-            updateLastActionMessage: false,
-            ingress: .rollout
-        )
-        model.applyTrackedEvent(
-            .activityUpdated(
-                SessionActivityUpdated(
-                    sessionID: "completed-session",
-                    summary: "Prompt: Start the next turn.",
-                    phase: .running,
-                    timestamp: nextTurnAt
-                )
-            ),
-            updateLastActionMessage: false,
-            ingress: .rollout
-        )
+        for event in events {
+            model.applyTrackedEvent(
+                event,
+                updateLastActionMessage: false,
+                ingress: .rollout
+            )
+        }
 
         #expect(model.state.session(id: "completed-session")?.phase == .running)
+        #expect(model.state.session(id: "completed-session")?.updatedAt == nextTurnAt)
     }
 
     @Test

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -490,6 +490,67 @@ struct AppModelSessionListTests {
     }
 
     @Test
+    func rolloutRunningEventReopensCompletedSessionUnlessSnapshotIsOlder() {
+        let completedAt = Date(timeIntervalSince1970: 2_000)
+        let nextTurnAt = completedAt.addingTimeInterval(1)
+        let model = AppModel()
+        model.state = SessionState(
+            sessions: [
+                AgentSession(
+                    id: "completed-session",
+                    title: "Codex · open-island",
+                    tool: .codex,
+                    origin: .live,
+                    attachmentState: .attached,
+                    phase: .completed,
+                    summary: "Previous turn completed.",
+                    updatedAt: completedAt
+                ),
+            ]
+        )
+
+        model.applyTrackedEvent(
+            .activityUpdated(
+                SessionActivityUpdated(
+                    sessionID: "completed-session",
+                    summary: "Stale running snapshot.",
+                    phase: .running,
+                    timestamp: completedAt.addingTimeInterval(-1)
+                )
+            ),
+            updateLastActionMessage: false,
+            ingress: .rollout
+        )
+        #expect(model.state.session(id: "completed-session")?.phase == .completed)
+
+        model.applyTrackedEvent(
+            .sessionMetadataUpdated(
+                SessionMetadataUpdated(
+                    sessionID: "completed-session",
+                    codexMetadata: CodexSessionMetadata(lastUserPrompt: "Start the next turn."),
+                    timestamp: nextTurnAt
+                )
+            ),
+            updateLastActionMessage: false,
+            ingress: .rollout
+        )
+        model.applyTrackedEvent(
+            .activityUpdated(
+                SessionActivityUpdated(
+                    sessionID: "completed-session",
+                    summary: "Prompt: Start the next turn.",
+                    phase: .running,
+                    timestamp: nextTurnAt
+                )
+            ),
+            updateLastActionMessage: false,
+            ingress: .rollout
+        )
+
+        #expect(model.state.session(id: "completed-session")?.phase == .running)
+    }
+
+    @Test
     func bridgeEventsStillPromoteSessionsToAttached() {
         let now = Date(timeIntervalSince1970: 2_000)
         let model = AppModel()

--- a/docs/superpowers/plans/2026-07-23-agent-grid-sort.md
+++ b/docs/superpowers/plans/2026-07-23-agent-grid-sort.md
@@ -1,0 +1,497 @@
+# Closed Agent Grid Sorting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add five persisted ordering modes for the closed island's right-side agent grid, defaulting to status priority.
+
+**Architecture:** Extend the existing per-display `IslandAppearancePreferences` value and `UserDefaults` path with one enum. Keep ordering in `AppModel.islandClosedRightSlotContent()`, where observation tickets already exist, and expose the five choices through the existing appearance option-card UI.
+
+**Tech Stack:** Swift 6.2, SwiftUI, Swift Testing, macOS 14+
+
+## Global Constraints
+
+- The setting affects only the closed island's `.agents` right slot.
+- Preserve agent brand colors and the existing waiting/running/idle cell presentation.
+- Reuse `completedStaleThreshold`; do not add another timeout.
+- Preserve the expanded session list's grouping and sorting behavior.
+- Add no dependency, strategy object, factory, or unrelated refactor.
+- Missing or invalid persisted values default to `statusPriority`.
+
+---
+
+## File map
+
+- `Sources/OpenIslandApp/AppModelTypes.swift`: define the five-case preference type and store it in appearance preferences.
+- `Sources/OpenIslandApp/AppModel.swift`: persist/load the preference and apply the selected ordering before overflow.
+- `Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift`: cover all five orderings and keep stable-order tests explicit.
+- `Tests/OpenIslandAppTests/AppModelSessionListTests.swift`: extend the existing per-display persistence test.
+- `Sources/OpenIslandApp/Views/AppearanceSettingsPane.swift`: show five option cards when the Agents right slot is selected.
+- `Sources/OpenIslandApp/Resources/{en,zh-Hans,zh-Hant}.lproj/Localizable.strings`: localize the settings copy.
+
+### Task 1: Preference, persistence, and grid ordering
+
+**Files:**
+- Modify: `Sources/OpenIslandApp/AppModelTypes.swift:56-105`
+- Modify: `Sources/OpenIslandApp/AppModel.swift:350-430, 550-585, 885-940`
+- Test: `Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift`
+- Test: `Tests/OpenIslandAppTests/AppModelSessionListTests.swift:7-28, 368-410`
+
+**Interfaces:**
+- Produces: `IslandAgentGridSort: String, CaseIterable, Identifiable, Sendable`
+- Produces: `IslandAppearancePreferences.agentGridSort: IslandAgentGridSort`
+- Produces: `AppModel.islandAgentGridSort: IslandAgentGridSort`
+- Consumes: `AgentSession.phase`, `updatedAt`, `firstSeenAt`, `tool`, `isStaleCompletedForIsland(at:threshold:)`, and existing observation tickets.
+
+- [ ] **Step 1: Write the failing five-mode ordering test**
+
+Add a `tool` argument to the local session helper and pass it to `AgentSession`:
+
+```swift
+private func makeSession(
+    id: String,
+    tool: AgentTool = .claudeCode,
+    firstSeenAt: Date,
+    updatedAt: Date,
+    phase: SessionPhase = .running,
+    permissionRequest: PermissionRequest? = nil
+) -> AgentSession {
+    var session = AgentSession(
+        id: id,
+        title: "\(tool.displayName) · \(id)",
+        tool: tool,
+        origin: .live,
+        attachmentState: .attached,
+        phase: phase,
+        summary: "",
+        updatedAt: updatedAt,
+        firstSeenAt: firstSeenAt,
+        permissionRequest: permissionRequest,
+        jumpTarget: JumpTarget(
+            terminalApp: "Ghostty",
+            workspaceName: id,
+            paneTitle: "agent ~/\(id)",
+            workingDirectory: "/tmp/\(id)",
+            terminalSessionID: "ghostty-\(id)"
+        ),
+        claudeMetadata: ClaudeSessionMetadata(
+            transcriptPath: "/tmp/\(id).jsonl",
+            currentTool: "Task"
+        )
+    )
+    session.isProcessAlive = true
+    session.isHookManaged = true
+    return session
+}
+```
+
+Add this table-driven test to `AgentsGridRightSlotTests`:
+
+```swift
+@Test
+func gridSortModesProduceExpectedOrder() {
+    let now = Date()
+    let waiting = makeSession(
+        id: "waiting", tool: .openCode,
+        firstSeenAt: now.addingTimeInterval(-40),
+        updatedAt: now.addingTimeInterval(-20),
+        phase: .waitingForAnswer
+    )
+    let running = makeSession(
+        id: "running", tool: .codex,
+        firstSeenAt: now.addingTimeInterval(-10),
+        updatedAt: now.addingTimeInterval(-30)
+    )
+    let recentDone = makeSession(
+        id: "recent", tool: .geminiCLI,
+        firstSeenAt: now.addingTimeInterval(-30),
+        updatedAt: now.addingTimeInterval(-5),
+        phase: .completed
+    )
+    let staleDone = makeSession(
+        id: "stale", tool: .claudeCode,
+        firstSeenAt: now.addingTimeInterval(-20),
+        updatedAt: now.addingTimeInterval(-300),
+        phase: .completed
+    )
+    let sessions = [running, staleDone, waiting, recentDone]
+    let cases: [(IslandAgentGridSort, [AgentSession])] = [
+        (.statusPriority, [waiting, running, recentDone, staleDone]),
+        (.recentActivity, [recentDone, waiting, running, staleDone]),
+        (.newestSession, [running, staleDone, recentDone, waiting]),
+        (.agent, [staleDone, running, recentDone, waiting]),
+        (.stable, [waiting, recentDone, staleDone, running]),
+    ]
+
+    for (sort, expected) in cases {
+        let model = AppModel()
+        model.islandRightSlot = .agents
+        model.islandAgentGridSort = sort
+        model.completedStaleThreshold = .twoMinutes
+        model.state = SessionState(sessions: sessions)
+
+        guard case let .agents(cells)? = model.islandClosedRightSlotContent() else {
+            Issue.record("Expected agents for \(sort.rawValue)")
+            continue
+        }
+        #expect(cells == expected.map(Self.cellFor), "Unexpected \(sort.rawValue) order")
+    }
+}
+```
+
+Set `model.islandAgentGridSort = .stable` in the existing tests whose purpose is stable observation order: `bulkFirstObservationOrdersByHistoricalFirstSeenAt`, `newlyObservedSessionAlwaysLandsAtTheEndRegardlessOfHistoricalTime`, `returningSessionKeepsItsOriginalSlot`, and `cellStateReflectsSessionPhase`.
+
+- [ ] **Step 2: Extend the failing per-display persistence test**
+
+Add `appearance.island.v8.notch.agentGridSort` and `appearance.island.v8.topBar.agentGridSort` to the defaults cleanup list in `AppModelSessionListTests.init()`.
+
+Replace `islandAppearancePreferencesPersistPerDisplayProfile()` with:
+
+```swift
+@Test
+func islandAppearancePreferencesPersistPerDisplayProfile() {
+    let model = AppModel()
+    model.updateAppearancePreferences(for: .notch) {
+        $0.agentGridSort = .stable
+        $0.usageDisplay = .hidden
+        $0.sessionGroup = .state
+        $0.sessionStateIndicator = .bar
+        $0.completedStaleThreshold = .twoMinutes
+    }
+    model.updateAppearancePreferences(for: .topBar) {
+        $0.agentGridSort = .agent
+        $0.usageDisplay = .compact
+        $0.sessionGroup = .project
+        $0.sessionStateIndicator = .tint
+        $0.completedStaleThreshold = .never
+    }
+
+    model.overlayPlacementDiagnostics = placementDiagnostics(mode: .notch)
+    #expect(model.islandAgentGridSort == .stable)
+    #expect(model.islandUsageDisplay == .hidden)
+    #expect(model.islandSessionGroup == .state)
+    #expect(model.islandSessionStateIndicator == .bar)
+    #expect(model.completedStaleThreshold == .twoMinutes)
+
+    model.overlayPlacementDiagnostics = placementDiagnostics(mode: .topBar)
+    #expect(model.islandAgentGridSort == .agent)
+    #expect(model.islandUsageDisplay == .compact)
+    #expect(model.islandSessionGroup == .project)
+    #expect(model.islandSessionStateIndicator == .tint)
+    #expect(model.completedStaleThreshold == .never)
+
+    let reloaded = AppModel()
+    reloaded.overlayPlacementDiagnostics = placementDiagnostics(mode: .notch)
+    #expect(reloaded.islandAgentGridSort == .stable)
+    #expect(reloaded.islandUsageDisplay == .hidden)
+    #expect(reloaded.islandSessionGroup == .state)
+    #expect(reloaded.islandSessionStateIndicator == .bar)
+    #expect(reloaded.completedStaleThreshold == .twoMinutes)
+
+    reloaded.overlayPlacementDiagnostics = placementDiagnostics(mode: .topBar)
+    #expect(reloaded.islandAgentGridSort == .agent)
+    #expect(reloaded.islandUsageDisplay == .compact)
+    #expect(reloaded.islandSessionGroup == .project)
+    #expect(reloaded.islandSessionStateIndicator == .tint)
+    #expect(reloaded.completedStaleThreshold == .never)
+}
+```
+
+- [ ] **Step 3: Run the focused tests and confirm they fail**
+
+Run:
+
+```bash
+swift test --filter AgentsGridRightSlotTests
+swift test --filter AppModelSessionListTests.islandAppearancePreferencesPersistPerDisplayProfile
+```
+
+Expected: compilation fails because `IslandAgentGridSort`, `agentGridSort`, and `islandAgentGridSort` do not exist yet.
+
+- [ ] **Step 4: Add the preference type and default**
+
+In `AppModelTypes.swift`, add the preference field beside `rightSlot`:
+
+```swift
+struct IslandAppearancePreferences: Equatable, Sendable {
+    var rightSlot: IslandRightSlot = .count
+    var agentGridSort: IslandAgentGridSort = .statusPriority
+    var centerLabel: IslandCenterLabel = .agentAction
+    var usageDisplay: IslandUsageDisplay = .compact
+    var sessionStateIndicator: IslandSessionStateIndicator = .animatedDot
+    var sessionGroup: IslandSessionGroup = .none
+    var sessionSort: IslandSessionSort = .attention
+    var completedStaleThreshold: IslandCompletedStaleThreshold = .fiveMinutes
+}
+
+enum IslandAgentGridSort: String, CaseIterable, Identifiable, Sendable {
+    case statusPriority
+    case recentActivity
+    case newestSession
+    case agent
+    case stable
+
+    var id: String { rawValue }
+}
+```
+
+- [ ] **Step 5: Persist and load the preference**
+
+In `AppModel.swift`, add the runtime accessor:
+
+```swift
+var islandAgentGridSort: IslandAgentGridSort {
+    get { appearancePreferences(for: activeAppearanceProfile).agentGridSort }
+    set { updateAppearancePreferences(for: activeAppearanceProfile) { $0.agentGridSort = newValue } }
+}
+```
+
+Add this line to `persistAppearancePreferences(_:for:)`:
+
+```swift
+defaults.set(preferences.agentGridSort.rawValue, forKey: Self.appearanceDefaultsKey(profile, "agentGridSort"))
+```
+
+Add this memberwise argument to `loadAppearancePreferences(for:)` immediately after `rightSlot`:
+
+```swift
+agentGridSort: IslandAgentGridSort(
+    rawValue: defaults.string(forKey: appearanceDefaultsKey(profile, "agentGridSort")) ?? ""
+) ?? .statusPriority,
+```
+
+Do not add a legacy key. This new preference has no old storage location.
+
+- [ ] **Step 6: Replace the fixed grid order with the selected order**
+
+Add this method next to `stampAgentsGridObservationTickets(for:)`:
+
+```swift
+private func orderedAgentsGridSessions(
+    _ sessions: [AgentSession],
+    now: Date = .now
+) -> [AgentSession] {
+    func statusRank(_ session: AgentSession) -> Int {
+        if session.phase.requiresAttention { return 0 }
+        if session.phase == .running { return 1 }
+        if !session.isStaleCompletedForIsland(
+            at: now,
+            threshold: completedStaleThreshold.seconds
+        ) { return 2 }
+        return 3
+    }
+
+    func agentRank(_ session: AgentSession) -> Int {
+        AgentTool.allCases.firstIndex { $0.rawValue == session.tool.rawValue } ?? .max
+    }
+
+    return sessions.sorted { a, b in
+        switch islandAgentGridSort {
+        case .statusPriority:
+            if statusRank(a) != statusRank(b) { return statusRank(a) < statusRank(b) }
+            if a.updatedAt != b.updatedAt { return a.updatedAt > b.updatedAt }
+        case .recentActivity:
+            if a.updatedAt != b.updatedAt { return a.updatedAt > b.updatedAt }
+        case .newestSession:
+            if a.firstSeenAt != b.firstSeenAt { return a.firstSeenAt > b.firstSeenAt }
+        case .agent:
+            if agentRank(a) != agentRank(b) { return agentRank(a) < agentRank(b) }
+            if statusRank(a) != statusRank(b) { return statusRank(a) < statusRank(b) }
+            if a.updatedAt != b.updatedAt { return a.updatedAt > b.updatedAt }
+        case .stable:
+            break
+        }
+
+        let ta = _agentsGridObservedSequence[a.id] ?? .max
+        let tb = _agentsGridObservedSequence[b.id] ?? .max
+        if ta != tb { return ta < tb }
+        return a.id < b.id
+    }
+}
+```
+
+In the `.agents` branch of `islandClosedRightSlotContent()`, retain the ticket-stamping call, replace the current fixed `ordered` closure with:
+
+```swift
+let ordered = orderedAgentsGridSessions(sessions)
+```
+
+Replace the current active-session overflow selection with the already ordered first seven:
+
+```swift
+if ordered.count <= 9 {
+    cells = ordered.map(Self.agentsGridCell(for:))
+} else {
+    cells = ordered.prefix(7).map(Self.agentsGridCell(for:))
+    cells.append(.overflow(ordered.count - cells.count))
+}
+```
+
+- [ ] **Step 7: Run the focused tests**
+
+Run:
+
+```bash
+swift test --filter AgentsGridRightSlotTests
+swift test --filter AppModelSessionListTests.islandAppearancePreferencesPersistPerDisplayProfile
+```
+
+Expected: both commands exit 0; the grid suite covers five modes plus the existing overflow and phase checks.
+
+- [ ] **Step 8: Commit the model slice**
+
+```bash
+git add Sources/OpenIslandApp/AppModelTypes.swift Sources/OpenIslandApp/AppModel.swift Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+git commit -m "feat: add agent grid sort modes"
+```
+
+### Task 2: Appearance controls and localizations
+
+**Files:**
+- Modify: `Sources/OpenIslandApp/Views/AppearanceSettingsPane.swift:255-310, 590-625`
+- Modify: `Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings`
+- Modify: `Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings`
+- Modify: `Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings`
+
+**Interfaces:**
+- Consumes: `IslandAgentGridSort.allCases`, `editingPreferences.agentGridSort`, and `model.updateAppearancePreferences(for:_:)` from Task 1.
+- Produces: Five localized option cards visible only when `editingPreferences.rightSlot == .agents`.
+
+- [ ] **Step 1: Add the five localized labels**
+
+Add to `en.lproj/Localizable.strings`:
+
+```text
+"settings.appearance.agentGridSort.title" = "Agent grid order";
+"settings.appearance.agentGridSort.note" = "Choose how sessions are placed in the closed island grid.";
+"settings.appearance.agentGridSort.statusPriority" = "Status priority";
+"settings.appearance.agentGridSort.recentActivity" = "Recent activity";
+"settings.appearance.agentGridSort.newestSession" = "Newest session";
+"settings.appearance.agentGridSort.agent" = "By agent";
+"settings.appearance.agentGridSort.stable" = "Stable order";
+```
+
+Add to `zh-Hans.lproj/Localizable.strings`:
+
+```text
+"settings.appearance.agentGridSort.title" = "代理网格顺序";
+"settings.appearance.agentGridSort.note" = "选择会话在收起状态网格中的排列方式。";
+"settings.appearance.agentGridSort.statusPriority" = "状态优先";
+"settings.appearance.agentGridSort.recentActivity" = "最近活动";
+"settings.appearance.agentGridSort.newestSession" = "最新会话";
+"settings.appearance.agentGridSort.agent" = "按代理";
+"settings.appearance.agentGridSort.stable" = "固定顺序";
+```
+
+Add to `zh-Hant.lproj/Localizable.strings`:
+
+```text
+"settings.appearance.agentGridSort.title" = "代理網格順序";
+"settings.appearance.agentGridSort.note" = "選擇工作階段在收合狀態網格中的排列方式。";
+"settings.appearance.agentGridSort.statusPriority" = "狀態優先";
+"settings.appearance.agentGridSort.recentActivity" = "最近活動";
+"settings.appearance.agentGridSort.newestSession" = "最新工作階段";
+"settings.appearance.agentGridSort.agent" = "依代理";
+"settings.appearance.agentGridSort.stable" = "固定順序";
+```
+
+- [ ] **Step 2: Add the conditional option cards**
+
+Append this block to `rightSlotSection`, after the existing three right-slot cards:
+
+```swift
+if editingPreferences.rightSlot == .agents {
+    sectionHeader(
+        title: lang.t("settings.appearance.agentGridSort.title"),
+        note: lang.t("settings.appearance.agentGridSort.note")
+    )
+
+    LazyVGrid(
+        columns: [GridItem(.adaptive(minimum: 110), spacing: 12)],
+        alignment: .leading,
+        spacing: 12
+    ) {
+        ForEach(IslandAgentGridSort.allCases) { option in
+            optionCard(
+                selected: editingPreferences.agentGridSort == option,
+                title: title(for: option)
+            ) {
+                model.updateAppearancePreferences(for: editingProfile) {
+                    $0.agentGridSort = option
+                }
+            } icon: {
+                Image(systemName: icon(for: option))
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(V6Palette.paper.opacity(0.82))
+            }
+        }
+    }
+}
+```
+
+Add these two helpers beside the existing appearance-option title helpers:
+
+```swift
+private func title(for option: IslandAgentGridSort) -> String {
+    switch option {
+    case .statusPriority: lang.t("settings.appearance.agentGridSort.statusPriority")
+    case .recentActivity: lang.t("settings.appearance.agentGridSort.recentActivity")
+    case .newestSession:  lang.t("settings.appearance.agentGridSort.newestSession")
+    case .agent:          lang.t("settings.appearance.agentGridSort.agent")
+    case .stable:         lang.t("settings.appearance.agentGridSort.stable")
+    }
+}
+
+private func icon(for option: IslandAgentGridSort) -> String {
+    switch option {
+    case .statusPriority: "bolt.fill"
+    case .recentActivity: "clock.arrow.circlepath"
+    case .newestSession:  "sparkles"
+    case .agent:          "square.grid.2x2"
+    case .stable:         "pin.fill"
+    }
+}
+```
+
+- [ ] **Step 3: Build the app**
+
+Run:
+
+```bash
+swift build --product OpenIslandApp
+```
+
+Expected: exit 0 with `Build complete!` and no missing localization or SwiftUI type errors.
+
+- [ ] **Step 4: Refresh and manually verify the development app**
+
+Run:
+
+```bash
+PATH="/opt/homebrew/bin:$PATH" zsh scripts/launch-dev-app.sh
+```
+
+Verify in `Open Island Dev.app`:
+
+1. Appearance > Right slot > Agents reveals exactly five ordering cards.
+2. Status priority is selected for a profile with no prior grid-sort value.
+3. Changing the card reorders the closed right grid without changing cell colors.
+4. Notch and external-display profiles retain independent selections.
+5. More than nine sessions show seven ordered cells plus the overflow count.
+
+- [ ] **Step 5: Commit the settings slice**
+
+```bash
+git add Sources/OpenIslandApp/Views/AppearanceSettingsPane.swift Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+git commit -m "feat: expose agent grid sort settings"
+```
+
+- [ ] **Step 6: Confirm the final branch state**
+
+Run:
+
+```bash
+git status -sb
+git log -5 --oneline
+```
+
+Expected: clean `codex-fix/codex-rollout-reopen` worktree with the design, model, and settings commits ahead of `origin/main`.

--- a/docs/superpowers/specs/2026-07-23-agent-grid-sort-design.md
+++ b/docs/superpowers/specs/2026-07-23-agent-grid-sort-design.md
@@ -1,0 +1,83 @@
+# Closed Agent Grid Sorting
+
+## Goal
+
+Let users choose how sessions are ordered in the closed island's right-side
+agent grid. The setting affects only the `.agents` right-slot presentation;
+the expanded session list keeps its existing grouping and sorting settings.
+
+The default is **Status priority**, so sessions needing attention or currently
+running remain visible when completed or idle history fills the grid.
+
+## Non-goals
+
+- Do not change per-agent brand colors or phase opacity/animation.
+- Do not add a completed-state green color or glyph.
+- Do not change the expanded session list.
+- Do not add a strategy abstraction or new dependency.
+
+## Preference and settings UI
+
+Add a five-case `IslandAgentGridSort` value to
+`IslandAppearancePreferences`, persisted with the existing per-display-profile
+appearance keys. A missing or unknown stored value falls back to
+`statusPriority`; no migration is needed.
+
+When the right-slot choice is **Agents**, the appearance pane shows five
+compact option cards using the existing option-card style:
+
+1. **Status priority**
+2. **Recent activity**
+3. **Newest session**
+4. **By agent**
+5. **Stable order**
+
+The labels are localized in the existing English, Simplified Chinese, and
+Traditional Chinese string tables. Other right-slot choices do not use this
+preference.
+
+## Ordering semantics
+
+`AppModel.islandClosedRightSlotContent()` stamps the existing observation
+tickets, orders all surfaced sessions according to the selected mode, then
+maps them to the existing `AgentGridCell` representation.
+
+All modes use observation ticket and session ID as deterministic final
+tie-breakers.
+
+| Mode | Primary order |
+| --- | --- |
+| Status priority | attention, running, recent completed, remaining idle/stale; within a bucket, `updatedAt` descending |
+| Recent activity | `updatedAt` descending |
+| Newest session | `firstSeenAt` descending |
+| By agent | `AgentTool.allCases` order; within a tool, status-priority order |
+| Stable order | observation ticket ascending, preserving the current behavior |
+
+"Recent completed" reuses `completedStaleThreshold` and
+`isStaleCompletedForIsland`; it does not introduce another timeout.
+Waiting-for-approval and waiting-for-answer share the same attention bucket.
+
+After ordering, up to nine sessions are shown directly. With more than nine,
+the first seven ordered sessions are shown followed by one overflow cell with
+the remaining count. Non-default modes may place a running session beyond the
+first seven by user choice; Status priority prevents that in the default mode.
+
+## Data flow and failure handling
+
+1. The user selects a grid sort card for the current display profile.
+2. The existing appearance update path persists its raw value in
+   `UserDefaults` and refreshes the preview/runtime model.
+3. Closed-island rendering reads the preference and orders the current
+   `surfacedSessions` before applying the existing overflow rule.
+4. Invalid persisted raw values decode to `statusPriority`.
+
+There is no external I/O or recoverable runtime failure beyond preference
+decoding. The existing observation-ticket pruning remains unchanged.
+
+## Verification
+
+Add one table-driven test in `AgentsGridRightSlotTests` that exercises the
+five modes with the same deliberately mixed sessions and verifies their cell
+order. Keep focused checks for the default mode's active-session visibility
+and the seven-plus-overflow boundary. Run the targeted app test suite and
+refresh `Open Island Dev.app` for manual settings and closed-grid verification.


### PR DESCRIPTION
## Summary

- Keep waiting and running sessions from every supported agent visible in the default closed agent grid when history exceeds capacity.
- Add five per-display ordering modes across all surfaced agent sessions: Status priority, Recent activity, Newest session, By agent, and Stable order.
- Preserve per-agent brand colors and expanded session-list sorting behavior.
- Fix a Codex Desktop-specific issue where reused sessions did not reopen for newer rollout turns while stale rollout batches could overwrite newer completion state.
- Add localized settings controls and VoiceOver selected-state semantics.

## Screenshot

![Agent grid order settings](https://res.cloudinary.com/op-gg-ai-devops/image/upload/v1784785214/openclaw/cawfbsnb5hna5l8g459h.png)

## Validation

- `swift test --filter RolloutMetadataThen` — 2 passed
- `swift test --filter AgentsGridRightSlotTests` — 7 passed
- `swift test --filter islandAppearancePreferencesPersistPerDisplayProfile` — 1 passed
- `swift build --product OpenIslandApp` — passed
- Manual verification: five settings cards render, selection changes persist, controls hide outside the Agents right-slot mode, and the refreshed development app launches.

## Verification note

The broad suite was not used as a release gate because this checkout has pre-existing Trae terminal-jump/shared-default failures and can leave an orphan test UI helper. Focused checks covering this change pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an “Agent grid order” appearance setting (5 sort modes) with per-display-profile persistence and localized labels.
  - When the right slot is set to **Agents**, the new option is shown in the Appearance settings UI.

- **Bug Fixes**
  - Improved agents grid ordering (including deterministic tie-breaks) and overflow behavior so the newest running session stays visible.
  - Refined grid tile state mapping and visuals: completed sessions now distinguish **Done** vs stale **Idle**, and updated the **Waiting** pulse timing.
  - Dropped older rollout metadata updates that could reopen completed sessions.

- **Tests**
  - Expanded serialized ordering/persistence coverage and added rollout timestamp edge-case regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->