### PR TITLE
feat: add CLI commands for the Claude usage bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,13 @@ swift run OpenIslandSetup uninstall
 
 #### Connect Claude Code
 
-Claude usage setup is available from the app's Settings window and remains opt-in. The bridge writes a managed `statusLine.command` to `~/.open-island/bin/open-island-statusline`, caches `rate_limits` into `/tmp/open-island-rl.json`, and refuses to overwrite an existing custom status line automatically.
+Claude usage setup is available from the app's Settings window and remains opt-in. The bridge writes a managed `statusLine.command` to `~/.open-island/bin/open-island-statusline` and caches `rate_limits` into `/tmp/open-island-rl.json`. When you already have a custom status line, it installs in **wrapper mode** — your original command keeps running unchanged while the bridge tees `rate_limits` to the cache. Because rate limits are account-wide, one terminal `claude` render seeds the cache and the panel then reflects total usage (including Desktop sessions). Manage installation from the Settings window, or via CLI:
+
+```zsh
+swift run OpenIslandSetup installClaudeUsage    # install; auto-wraps an existing custom status line
+swift run OpenIslandSetup statusClaudeUsage     # report managed / wrapper / repair state
+swift run OpenIslandSetup uninstallClaudeUsage  # remove and restore the original status line
+```
 
 ### Repository Map
 

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -1051,13 +1051,10 @@ final class HookInstallationCoordinator {
 
     func installClaudeUsageBridge() {
         updateClaudeUsageBridge(userMessage: "Installing Claude usage bridge.", intent: .installed) { manager in
-            do {
-                return try manager.install()
-            } catch ClaudeStatusLineInstallationError.existingStatusLineConflict {
-                // User already has a custom statusLine (e.g. claude-hud). Install as a
-                // wrapper so their script keeps running and we still get rate_limits.
-                return try manager.installAsWrapper()
-            }
+            // Managed install, auto-wrapping any existing custom statusLine
+            // (e.g. claude-hud) so the user's script keeps running and we still
+            // capture rate_limits. Shared with the OpenIslandSetup CLI.
+            try manager.installPreservingExisting()
         }
     }
 

--- a/Sources/OpenIslandCore/ClaudeStatusLineInstallationManager.swift
+++ b/Sources/OpenIslandCore/ClaudeStatusLineInstallationManager.swift
@@ -171,6 +171,14 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
     /// command while still teeing `rate_limits` to the cache.
     @discardableResult
     public func installPreservingExisting() throws -> ClaudeStatusLineInstallationStatus {
+        // Re-installing over our own wrapper must stay idempotent. install()
+        // would not throw (the managed script isn't a "conflict"), so it would
+        // replace the wrapper with the plain managed script and orphan the saved
+        // original command — silently disabling the user's status line. Detect
+        // the wrapper up front and rebuild it from the saved original instead.
+        if try status().managedStatusLineIsWrapper {
+            return try installAsWrapper()
+        }
         do {
             return try install()
         } catch ClaudeStatusLineInstallationError.existingStatusLineConflict {
@@ -184,12 +192,6 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
     @discardableResult
     public func installAsWrapper() throws -> ClaudeStatusLineInstallationStatus {
         let currentStatus = try status()
-        guard currentStatus.hasConflictingStatusLine,
-              let originalCommand = currentStatus.statusLineCommand,
-              !originalCommand.isEmpty
-        else {
-            throw ClaudeStatusLineInstallationError.wrappableCommandMissing
-        }
 
         try fileManager.createDirectory(at: claudeDirectory, withIntermediateDirectories: true)
         try fileManager.createDirectory(at: scriptDirectoryURL, withIntermediateDirectories: true)
@@ -199,10 +201,28 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
         let delegateScriptURL = scriptDirectoryURL.appendingPathComponent(Self.wrappedDelegateScriptName)
         var mutatedSettings = try loadSettings(at: settingsURL)
 
-        // Preserve the user's original statusLine dict so uninstall can restore it verbatim.
-        if let originalStatusLine = mutatedSettings["statusLine"] {
-            mutatedSettings[openIslandOriginalStatusLineKey] = originalStatusLine
+        // Resolve the command to wrap. When we're already wrapping, the live
+        // statusLine points at our managed script, so the user's real command
+        // lives under the saved-original key — prefer it so repeated installs
+        // rebuild the wrapper idempotently instead of wrapping our own wrapper.
+        let originalStatusLine: Any
+        let originalCommand: String
+        if currentStatus.managedStatusLineIsWrapper,
+           let saved = mutatedSettings[openIslandOriginalStatusLineKey] as? [String: Any],
+           let command = saved["command"] as? String, !command.isEmpty {
+            originalStatusLine = saved
+            originalCommand = command
+        } else if currentStatus.hasConflictingStatusLine,
+                  let liveStatusLine = mutatedSettings["statusLine"],
+                  let command = currentStatus.statusLineCommand, !command.isEmpty {
+            originalStatusLine = liveStatusLine
+            originalCommand = command
+        } else {
+            throw ClaudeStatusLineInstallationError.wrappableCommandMissing
         }
+
+        // Preserve the user's original statusLine so uninstall can restore it verbatim.
+        mutatedSettings[openIslandOriginalStatusLineKey] = originalStatusLine
         mutatedSettings["statusLine"] = managedStatusLine(for: scriptURL)
 
         let settingsData = try serializeSettings(mutatedSettings)

--- a/Sources/OpenIslandCore/ClaudeStatusLineInstallationManager.swift
+++ b/Sources/OpenIslandCore/ClaudeStatusLineInstallationManager.swift
@@ -163,6 +163,21 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
         return try status()
     }
 
+    /// Install the usage bridge, transparently falling back to wrapper mode when
+    /// the user already has a custom `statusLine.command`. This is the single
+    /// decision point shared by the app's Settings action and the
+    /// OpenIslandSetup CLI, so both behave identically: a plain managed install
+    /// when no status line exists, or a wrapper that preserves the user's
+    /// command while still teeing `rate_limits` to the cache.
+    @discardableResult
+    public func installPreservingExisting() throws -> ClaudeStatusLineInstallationStatus {
+        do {
+            return try install()
+        } catch ClaudeStatusLineInstallationError.existingStatusLineConflict {
+            return try installAsWrapper()
+        }
+    }
+
     /// Install in "wrap mode": keep the user's existing statusLine command working,
     /// but prepend our cache-writing shim. The original command is saved under
     /// `_openIslandOriginalStatusLine` so `uninstall()` can restore it verbatim.

--- a/Sources/OpenIslandSetup/OpenIslandSetupCLI.swift
+++ b/Sources/OpenIslandSetup/OpenIslandSetupCLI.swift
@@ -238,11 +238,15 @@ private struct SetupCommand {
 
     private func uninstallClaudeUsage() throws {
         let manager = ClaudeStatusLineInstallationManager(claudeDirectory: claudeDirectory)
+        // Capture wrapper state before uninstall — only a wrapper had an
+        // original command to restore. Post-uninstall `hasConflictingStatusLine`
+        // would also be true for a status line we never managed.
+        let wasWrapper = (try? manager.status())?.managedStatusLineIsWrapper ?? false
         let status = try manager.uninstall()
 
         print("Removed Claude usage bridge.")
         print("Claude dir: \(status.claudeDirectory.path)")
-        if status.hasConflictingStatusLine {
+        if wasWrapper {
             print("Restored your original statusLine command.")
         }
     }

--- a/Sources/OpenIslandSetup/OpenIslandSetupCLI.swift
+++ b/Sources/OpenIslandSetup/OpenIslandSetupCLI.swift
@@ -25,6 +25,9 @@ private struct SetupCommand {
         case installClaude
         case uninstallClaude
         case statusClaude
+        case installClaudeUsage
+        case uninstallClaudeUsage
+        case statusClaudeUsage
         case installKimi
         case uninstallKimi
         case statusKimi
@@ -111,6 +114,12 @@ private struct SetupCommand {
             try uninstallClaude()
         case .statusClaude:
             try statusClaude()
+        case .installClaudeUsage:
+            try installClaudeUsage()
+        case .uninstallClaudeUsage:
+            try uninstallClaudeUsage()
+        case .statusClaudeUsage:
+            try statusClaudeUsage()
         case .installKimi:
             try installKimi()
         case .uninstallKimi:
@@ -212,6 +221,47 @@ private struct SetupCommand {
         }
     }
 
+    private func installClaudeUsage() throws {
+        let manager = ClaudeStatusLineInstallationManager(claudeDirectory: claudeDirectory)
+        let status = try manager.installPreservingExisting()
+
+        if status.managedStatusLineIsWrapper {
+            print("Installed Claude usage bridge (wrapper mode) — your existing statusLine is preserved.")
+        } else {
+            print("Installed Claude usage bridge.")
+        }
+        print("Claude dir: \(status.claudeDirectory.path)")
+        print("Status line script: \(status.scriptURL.path)")
+        print("Rate-limit cache: \(status.cacheURL.path)")
+        print("Run a Claude Code turn in a terminal to seed the account-wide rate-limit cache.")
+    }
+
+    private func uninstallClaudeUsage() throws {
+        let manager = ClaudeStatusLineInstallationManager(claudeDirectory: claudeDirectory)
+        let status = try manager.uninstall()
+
+        print("Removed Claude usage bridge.")
+        print("Claude dir: \(status.claudeDirectory.path)")
+        if status.hasConflictingStatusLine {
+            print("Restored your original statusLine command.")
+        }
+    }
+
+    private func statusClaudeUsage() throws {
+        let manager = ClaudeStatusLineInstallationManager(claudeDirectory: claudeDirectory)
+        let status = try manager.status()
+
+        print("Claude dir: \(status.claudeDirectory.path)")
+        print("Managed status line configured: \(status.managedStatusLineConfigured ? "yes" : "no")")
+        print("Managed status line installed: \(status.managedStatusLineInstalled ? "yes" : "no")")
+        print("Wrapper mode: \(status.managedStatusLineIsWrapper ? "yes" : "no")")
+        print("Needs repair: \(status.managedStatusLineNeedsRepair ? "yes" : "no")")
+        if let command = status.statusLineCommand {
+            print("Current statusLine command: \(command)")
+        }
+        print("Rate-limit cache: \(status.cacheURL.path)")
+    }
+
     private func installKimi() throws {
         guard let hooksBinary else {
             throw SetupError.usage
@@ -270,6 +320,9 @@ private enum SetupError: Error, LocalizedError {
               swift run OpenIslandSetup installClaude [--hooks-binary /abs/path/to/OpenIslandHooks] [--claude-dir /abs/path/to/.claude]
               swift run OpenIslandSetup uninstallClaude [--claude-dir /abs/path/to/.claude]
               swift run OpenIslandSetup statusClaude [--hooks-binary /abs/path/to/OpenIslandHooks] [--claude-dir /abs/path/to/.claude]
+              swift run OpenIslandSetup installClaudeUsage [--claude-dir /abs/path/to/.claude]
+              swift run OpenIslandSetup uninstallClaudeUsage [--claude-dir /abs/path/to/.claude]
+              swift run OpenIslandSetup statusClaudeUsage [--claude-dir /abs/path/to/.claude]
               swift run OpenIslandSetup installKimi [--hooks-binary /abs/path/to/OpenIslandHooks] [--kimi-dir /abs/path/to/.kimi]
               swift run OpenIslandSetup uninstallKimi [--kimi-dir /abs/path/to/.kimi]
               swift run OpenIslandSetup statusKimi [--hooks-binary /abs/path/to/OpenIslandHooks] [--kimi-dir /abs/path/to/.kimi]

--- a/Tests/OpenIslandCoreTests/ClaudeUsageTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeUsageTests.swift
@@ -419,6 +419,53 @@ struct ClaudeUsageTests {
         #expect(!finalStatus.managedStatusLineIsWrapper)
         #expect(finalStatus.statusLineCommand == finalStatus.scriptURL.path)
     }
+
+    @Test
+    func installPreservingExistingIsIdempotentWhenAlreadyWrapping() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-claude-idempotent-\(UUID().uuidString)", isDirectory: true)
+        let claudeDirectory = rootURL.appendingPathComponent(".claude", isDirectory: true)
+        let scriptDirectory = rootURL
+            .appendingPathComponent(".open-island", isDirectory: true)
+            .appendingPathComponent("bin", isDirectory: true)
+        let manager = ClaudeStatusLineInstallationManager(
+            claudeDirectory: claudeDirectory,
+            scriptDirectoryURL: scriptDirectory
+        )
+        let settingsURL = claudeDirectory.appendingPathComponent("settings.json")
+
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let originalCommand = "/usr/local/bin/custom-status --flag"
+        try FileManager.default.createDirectory(at: claudeDirectory, withIntermediateDirectories: true)
+        try JSONSerialization.data(
+            withJSONObject: [
+                "statusLine": ["type": "command", "command": originalCommand, "padding": 0],
+            ],
+            options: [.prettyPrinted, .sortedKeys]
+        ).write(to: settingsURL, options: .atomic)
+
+        let first = try manager.installPreservingExisting()
+        #expect(first.managedStatusLineIsWrapper)
+
+        // A second install must NOT downgrade the wrapper to a plain managed
+        // script or clobber the saved original command.
+        let second = try manager.installPreservingExisting()
+        #expect(second.managedStatusLineIsWrapper)
+        #expect(second.managedStatusLineInstalled)
+
+        let delegateURL = scriptDirectory
+            .appendingPathComponent(ClaudeStatusLineInstallationManager.wrappedDelegateScriptName)
+        let wrapperContents = try String(contentsOf: second.scriptURL, encoding: .utf8)
+        #expect(wrapperContents.contains(delegateURL.path))
+
+        let delegateContents = try String(contentsOf: delegateURL, encoding: .utf8)
+        #expect(delegateContents.contains(originalCommand))
+
+        let settings = try jsonObject(from: Data(contentsOf: settingsURL))
+        let saved = settings[openIslandOriginalStatusLineKey] as? [String: Any]
+        #expect(saved?["command"] as? String == originalCommand)
+    }
 }
 
 private func jsonObject(from data: Data) throws -> [String: Any] {

--- a/Tests/OpenIslandCoreTests/ClaudeUsageTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeUsageTests.swift
@@ -360,8 +360,10 @@ struct ClaudeUsageTests {
     }
 
     @Test
-    func claudeStatusLineInstallAutoFallsBackToWrapperViaHandler() throws {
-        // Simulates HookInstallationCoordinator's catch-and-fall-back behavior.
+    func installPreservingExistingWrapsWhenCustomStatusLinePresent() throws {
+        // installPreservingExisting is the single decision point shared by the
+        // app UI and the OpenIslandSetup CLI: managed install, auto-wrapping a
+        // pre-existing custom statusLine instead of throwing.
         let rootURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("open-island-claude-fallback-\(UUID().uuidString)", isDirectory: true)
         let claudeDirectory = rootURL.appendingPathComponent(".claude", isDirectory: true)
@@ -384,15 +386,38 @@ struct ClaudeUsageTests {
             options: [.prettyPrinted, .sortedKeys]
         ).write(to: settingsURL, options: .atomic)
 
-        let finalStatus: ClaudeStatusLineInstallationStatus
-        do {
-            finalStatus = try manager.install()
-        } catch ClaudeStatusLineInstallationError.existingStatusLineConflict {
-            finalStatus = try manager.installAsWrapper()
-        }
+        let finalStatus = try manager.installPreservingExisting()
 
         #expect(finalStatus.managedStatusLineIsWrapper)
         #expect(finalStatus.managedStatusLineInstalled)
+
+        // The user's original command must still run via the delegate.
+        let delegateURL = scriptDirectory
+            .appendingPathComponent(ClaudeStatusLineInstallationManager.wrappedDelegateScriptName)
+        let delegateContents = try String(contentsOf: delegateURL, encoding: .utf8)
+        #expect(delegateContents.contains("/usr/local/bin/custom-status"))
+    }
+
+    @Test
+    func installPreservingExistingUsesManagedScriptWhenNoStatusLinePresent() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-claude-managed-\(UUID().uuidString)", isDirectory: true)
+        let claudeDirectory = rootURL.appendingPathComponent(".claude", isDirectory: true)
+        let scriptDirectory = rootURL
+            .appendingPathComponent(".open-island", isDirectory: true)
+            .appendingPathComponent("bin", isDirectory: true)
+        let manager = ClaudeStatusLineInstallationManager(
+            claudeDirectory: claudeDirectory,
+            scriptDirectoryURL: scriptDirectory
+        )
+
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let finalStatus = try manager.installPreservingExisting()
+
+        #expect(finalStatus.managedStatusLineInstalled)
+        #expect(!finalStatus.managedStatusLineIsWrapper)
+        #expect(finalStatus.statusLineCommand == finalStatus.scriptURL.path)
     }
 }
 


### PR DESCRIPTION
## Problem

The Claude **usage bridge** (the managed status line that tees `rate_limits` into `/tmp/open-island-rl.json`, feeding the notch usage panel) could only be installed from the app's **Settings window**. That leaves two gaps:

- No **headless / scriptable** install — you can't set it up from a terminal, a dotfiles script, or a provisioning step, unlike the hook installers (`installClaude`, `installKimi`, …).
- Users with a **custom status line** (e.g. a Claude Desktop workflow that also runs terminal `claude`) had no obvious path: the docs said the bridge "refuses to overwrite an existing custom status line," even though the manager already supports a non-destructive **wrapper mode**.

This matters for Desktop-app users specifically: Desktop's headless `stream-json` mode never renders a status line, but rate limits are account-wide, so one terminal `claude` render through the bridge seeds the cache and the Desktop pill then shows Claude usage. Getting the bridge installed (in wrapper mode, preserving the user's status line) is the enabler.

## Change

- Add `installClaudeUsage` / `uninstallClaudeUsage` / `statusClaudeUsage` to `OpenIslandSetup`, mirroring the existing hook-installer commands.
- Extract the "install, auto-wrapping an existing custom `statusLine`" decision into `ClaudeStatusLineInstallationManager.installPreservingExisting()`, so the app UI and the CLI share **one** code path. The app's `installClaudeUsageBridge()` now calls it instead of duplicating the `try install()` / `catch → installAsWrapper()` fallback.
- `installClaudeUsage` reports whether it landed in managed or wrapper mode; `uninstallClaudeUsage` restores the original status line; `statusClaudeUsage` prints managed/wrapper/repair state.

No behavior change for existing users — the app's Settings action produces the identical result (it now routes through the shared method).

## Testing

- Two new `OpenIslandCore` tests for `installPreservingExisting`: wraps when a custom `statusLine` is present (and the original command still runs via the delegate); uses the plain managed script when none exists. Full `ClaudeUsageTests` suite green (10/10).
- Verified end-to-end on a real machine with a custom status line: `installClaudeUsage` installed in wrapper mode (original `statusLine` preserved under `_openIslandOriginalStatusLine`), and piping a status-line payload through the installed script wrote a correctly-shaped `/tmp/open-island-rl.json` while still running the user's original command.
- `scripts/check-docs.sh` passes; README updated (CLI commands + corrected wrapper behavior).

> Note: `AppModelSessionListTests` has 4 pre-existing failures on a clean `main` (unrelated to this change, verified separately).

---

### 中文摘要

Claude **用量桥接**（写入 `/tmp/open-island-rl.json` 的托管 status line，为 notch 用量面板供数）此前只能从应用的设置窗口安装，无法在终端中无头安装或脚本化；且对已有自定义 status line 的用户（如同时使用终端 `claude` 的 Claude 桌面工作流）不友好。

本 PR 为 `OpenIslandSetup` 新增 `installClaudeUsage` / `uninstallClaudeUsage` / `statusClaudeUsage` 命令，与现有 hook 安装命令对齐；并将"安装并在存在自定义 status line 时自动进入 wrapper 模式"的判定抽取为 `ClaudeStatusLineInstallationManager.installPreservingExisting()`，供应用 UI 与 CLI 共用同一路径。由于额度是账户级的，终端 `claude` 的一次渲染即可通过桥接为缓存供数，桌面会话的用量随之显示。新增两个测试并更新 README。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claude usage setup now installs in wrapper mode when a custom status line already exists, preserving the user’s current `statusLine.command`.
  * Added `installClaudeUsage`, `uninstallClaudeUsage`, and `statusClaudeUsage` subcommands.
  * Status reporting now includes wrapper/repair state plus the current status line (when present) and the rate-limit cache location.
* **Documentation**
  * Updated Claude usage setup documentation and CLI instructions to reflect the new opt-in wrapper behavior and reporting details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->