### PR TITLE
fix: label hook diagnostics by agent

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -120,8 +120,7 @@ final class AppModel {
     var isOpenCodeSetupBusy: Bool { hooks.isOpenCodeSetupBusy }
     var openCodePluginStatusTitle: String { hooks.openCodePluginStatusTitle }
     var openCodePluginStatusSummary: String { hooks.openCodePluginStatusSummary }
-    var claudeHealthReport: HookHealthReport? { hooks.claudeHealthReport }
-    var codexHealthReport: HookHealthReport? { hooks.codexHealthReport }
+    var healthReports: [HookHealthReport] { hooks.healthReports }
     var cursorHooksInstalled: Bool { hooks.cursorHooksInstalled }
     var isCursorHookSetupBusy: Bool { hooks.isCursorHookSetupBusy }
     var cursorHookStatus: CursorHookInstallationStatus? { hooks.cursorHookStatus }

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -462,8 +462,11 @@ final class HookInstallationCoordinator {
     var codexHealthReport: HookHealthReport?
     var claudeHealthReport: HookHealthReport?
     var openCodeHealthReport: HookHealthReport?
-    var cursorHealthReport: HookHealthReport?
-    var geminiHealthReport: HookHealthReport?
+
+    /// Every report produced by the last check, in display order.
+    var healthReports: [HookHealthReport] {
+        [claudeHealthReport, codexHealthReport, openCodeHealthReport].compactMap(\.self)
+    }
 
 
     /// Runs health checks for Claude, Codex and OpenCode hooks.

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -780,34 +780,21 @@ struct SetupSettingsPane: View {
     }
 
     private var hasErrors: Bool {
-        let claudeErrors = model.claudeHealthReport?.errors.count ?? 0
-        let codexErrors = model.codexHealthReport?.errors.count ?? 0
-        return claudeErrors + codexErrors > 0
+        model.healthReports.contains { !$0.errors.isEmpty }
     }
 
     private var hasRepairableIssues: Bool {
-        let claude = model.claudeHealthReport?.repairableIssues.isEmpty == false
-        let codex = model.codexHealthReport?.repairableIssues.isEmpty == false
-        return claude || codex
-    }
-
-    private var hasNotices: Bool {
-        let claude = model.claudeHealthReport?.notices.isEmpty == false
-        let codex = model.codexHealthReport?.notices.isEmpty == false
-        return claude || codex
+        model.healthReports.contains { !$0.repairableIssues.isEmpty }
     }
 
     @ViewBuilder
     private var hookDiagnosticsSection: some View {
         Section {
-            if let claudeReport = model.claudeHealthReport, !claudeReport.issues.isEmpty {
-                issueList(report: claudeReport)
-            }
-            if let codexReport = model.codexHealthReport, !codexReport.issues.isEmpty {
-                issueList(report: codexReport)
+            ForEach(model.healthReports.filter { !$0.issues.isEmpty }) { report in
+                issueList(report: report)
             }
 
-            if model.claudeHealthReport == nil && model.codexHealthReport == nil {
+            if model.healthReports.isEmpty {
                 HStack {
                     Text(lang.t("setup.diagnostics.notRun"))
                         .foregroundStyle(.secondary)
@@ -856,7 +843,7 @@ struct SetupSettingsPane: View {
     @ViewBuilder
     private func issueList(report: HookHealthReport) -> some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text(report.agent == "claude" ? "Claude Code" : "Codex")
+            Text(report.agent.displayName)
                 .font(.caption)
                 .fontWeight(.semibold)
                 .foregroundStyle(.secondary)

--- a/Sources/OpenIslandCore/HookHealthCheck.swift
+++ b/Sources/OpenIslandCore/HookHealthCheck.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-/// Structured diagnostic result for a single hook integration (Claude or Codex).
-public struct HookHealthReport: Equatable, Sendable {
+/// Structured diagnostic result for a single hook integration.
+public struct HookHealthReport: Equatable, Sendable, Identifiable {
     public enum Severity: Equatable, Sendable {
         /// A real problem that may prevent hooks from working.
         case error
@@ -63,10 +63,32 @@ public struct HookHealthReport: Equatable, Sendable {
         }
     }
 
-    public var agent: String  // "claude" or "codex"
+    /// The integration a report covers. Adding an agent here is what makes it
+    /// show up correctly in Settings diagnostics — the UI reads `displayName`
+    /// instead of pattern-matching identifiers.
+    public enum Agent: String, CaseIterable, Codable, Sendable {
+        case claude
+        case codex
+        case openCode = "opencode"
+
+        public var displayName: String {
+            switch self {
+            case .claude:
+                "Claude Code"
+            case .codex:
+                "Codex"
+            case .openCode:
+                "OpenCode"
+            }
+        }
+    }
+
+    public var agent: Agent
     public var issues: [Issue]
     public var binaryPath: String?
     public var configPath: String?
+
+    public var id: Agent { agent }
 
     /// True when there are no errors (info-level notices are fine).
     public var isHealthy: Bool { errors.isEmpty }
@@ -86,7 +108,7 @@ public struct HookHealthReport: Equatable, Sendable {
         issues.filter(\.isAutoRepairable)
     }
 
-    public init(agent: String, issues: [Issue] = [], binaryPath: String? = nil, configPath: String? = nil) {
+    public init(agent: Agent, issues: [Issue] = [], binaryPath: String? = nil, configPath: String? = nil) {
         self.agent = agent
         self.issues = issues
         self.binaryPath = binaryPath
@@ -140,7 +162,7 @@ public enum HookHealthCheck {
                     }
 
                     // Check for other hooks (informational)
-                    var otherNames = findThirdPartyHookNames(in: data, agent: "claude")
+                    var otherNames = findThirdPartyHookNames(in: data)
                     if containsClaudeIslandHook(in: data) {
                         otherNames.append("claude-island")
                     }
@@ -161,7 +183,7 @@ public enum HookHealthCheck {
         }
 
         return HookHealthReport(
-            agent: "claude",
+            agent: .claude,
             issues: issues,
             binaryPath: resolvedBinaryPath,
             configPath: settingsPath
@@ -206,7 +228,7 @@ public enum HookHealthCheck {
                         issues.append(.staleCommandPath(recorded: cmd, configPath: hooksPath))
                     }
 
-                    let otherNames = findThirdPartyHookNames(in: data, agent: "codex")
+                    let otherNames = findThirdPartyHookNames(in: data)
                     if !otherNames.isEmpty {
                         issues.append(.otherHooksDetected(names: otherNames.sorted()))
                     }
@@ -224,7 +246,7 @@ public enum HookHealthCheck {
         }
 
         return HookHealthReport(
-            agent: "codex",
+            agent: .codex,
             issues: issues,
             binaryPath: resolvedBinaryPath,
             configPath: hooksPath
@@ -249,7 +271,7 @@ public enum HookHealthCheck {
         }
 
         return HookHealthReport(
-            agent: "opencode",
+            agent: .openCode,
             issues: issues,
             binaryPath: nil,
             configPath: pluginFileURL.path
@@ -324,7 +346,7 @@ public enum HookHealthCheck {
     }
 
     /// Finds third-party (non-Open Island) hook command names for display.
-    private static func findThirdPartyHookNames(in data: Data, agent: String) -> [String] {
+    private static func findThirdPartyHookNames(in data: Data) -> [String] {
         guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let hooks = root["hooks"] as? [String: Any] else {
             return []

--- a/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
+++ b/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
@@ -333,4 +333,21 @@ struct AgentSessionPresentationTests {
         #expect(session.spotlightSecondaryText == "Running Search")
         #expect(session.displayCurrentToolName == "Search")
     }
+
+    @Test
+    func hookHealthReportsCarryTheirOwnDisplayName() {
+        // Regression: Settings rendered every non-Claude report as "Codex".
+        #expect(HookHealthCheck.checkClaude().agent == .claude)
+        #expect(HookHealthCheck.checkCodex().agent == .codex)
+        #expect(HookHealthCheck.checkOpenCode().agent == .openCode)
+
+        for agent in HookHealthReport.Agent.allCases {
+            #expect(agent.displayName.isEmpty == false)
+            #expect(HookHealthReport(agent: agent).id == agent)
+        }
+
+        #expect(HookHealthReport.Agent.openCode.displayName == "OpenCode")
+        #expect(Set(HookHealthReport.Agent.allCases.map(\.displayName)).count
+            == HookHealthReport.Agent.allCases.count)
+    }
 }


### PR DESCRIPTION
Fixes Settings labelling every non-Claude hook health report as "Codex". References #501 tangentially — primarily a diagnostics-panel bug, not the usage-display bug that issue tracks.

Settings rendered every health report as either "Claude Code" or "Codex" by string-matching `report.agent`, so OpenCode issues showed up labelled "Codex", and the diagnostics summary only aggregated the Claude and Codex reports even though OpenCode's was already being computed.

Type `HookHealthReport.agent` as an enum that owns its own display name, aggregate the reports through one list, and drop the `cursorHealthReport` and `geminiHealthReport` properties that were never assigned, the unused `agent` parameter on `findThirdPartyHookNames`, and the unused `hasNotices` helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded hook health diagnostics to support Claude, Codex, and OpenCode in a unified view.
  * Displayed health issues grouped by agent with clear, user-friendly agent names.
  * Added consistent statuses for diagnostics, including not run, all healthy, and repairable issues.

* **Bug Fixes**
  * Improved health status aggregation so errors and repairable issues are accurately reflected across all supported agents.
  * Ensured agent identities and display names remain consistent throughout diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->