### PR TITLE
refactor: drive usage pills from a provider registry

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -20,7 +20,6 @@ final class AppModel {
     private static let hapticFeedbackEnabledDefaultsKey = "app.hapticFeedbackEnabled"
     private static let islandRightSlotDefaultsKey = "appearance.island.v6.rightSlot"
     private static let islandCenterLabelDefaultsKey = "appearance.island.v6.centerLabel"
-    private static let showCodexUsageDefaultsKey = "app.showCodexUsage"
     private static let completionReplyEnabledDefaultsKey = "feature.completionReply.enabled"
     private static let suppressFrontmostNotificationsDefaultsKey = "app.suppressFrontmostNotifications"
     private static let legacyIslandSessionStateIndicatorDefaultsKey = "appearance.island.v8.stateIndicator"
@@ -246,11 +245,86 @@ final class AppModel {
             UserDefaults.standard.set(hapticFeedbackEnabled, forKey: Self.hapticFeedbackEnabledDefaultsKey)
         }
     }
-    var showCodexUsage: Bool = false {
-        didSet {
-            guard hasFinishedInit, showCodexUsage != oldValue else { return }
-            UserDefaults.standard.set(showCodexUsage, forKey: Self.showCodexUsageDefaultsKey)
+    /// Opt-in state for usage providers that carry a Settings toggle. Providers
+    /// without one (`optInDefaultsKey == nil`) are gated by their install state
+    /// and are always considered enabled.
+    private(set) var usageProviderOptIn: [UsageProvider: Bool] = [:]
+
+    /// Usage windows for every enabled provider that currently has data, in
+    /// registry order. The island pill and Settings summaries both read this
+    /// instead of reaching for a specific provider's snapshot.
+    var usageProviderStatuses: [UsageProviderStatus] {
+        UsageProvider.allCases.compactMap { provider in
+            guard isUsageProviderEnabled(provider),
+                  let snapshot = usageSnapshot(for: provider) else {
+                return nil
+            }
+
+            let windows = snapshot.windowSummaries
+            guard !windows.isEmpty else {
+                return nil
+            }
+
+            return UsageProviderStatus(
+                provider: provider,
+                windows: windows,
+                capturedAt: snapshot.summarizedAt
+            )
         }
+    }
+
+    /// The one place that binds a provider to the cache it reads.
+    func usageSnapshot(for provider: UsageProvider) -> (any UsageSnapshotSummarizing)? {
+        switch provider {
+        case .claude:
+            claudeUsageSnapshot
+        case .codex:
+            codexUsageSnapshot
+        }
+    }
+
+    func isUsageProviderEnabled(_ provider: UsageProvider) -> Bool {
+        guard provider.optInDefaultsKey != nil else {
+            return true
+        }
+
+        return usageProviderOptIn[provider] ?? false
+    }
+
+    func setUsageProvider(_ provider: UsageProvider, enabled: Bool) {
+        guard let key = provider.optInDefaultsKey,
+              isUsageProviderEnabled(provider) != enabled else {
+            return
+        }
+
+        usageProviderOptIn[provider] = enabled
+        UserDefaults.standard.set(enabled, forKey: key)
+
+        // Toggling used to only persist, so a provider switched on mid-session
+        // stayed blank until the next launch.
+        if enabled {
+            hooks.startUsageMonitoring(for: provider)
+        } else {
+            hooks.stopUsageMonitoring(for: provider)
+        }
+    }
+
+    private static func loadUsageProviderOptIn() -> [UsageProvider: Bool] {
+        var optIn: [UsageProvider: Bool] = [:]
+
+        for provider in UsageProvider.optional {
+            guard let key = provider.optInDefaultsKey else { continue }
+
+            if UserDefaults.standard.object(forKey: key) != nil {
+                optIn[provider] = UserDefaults.standard.bool(forKey: key)
+            } else if let probeURL = provider.installationProbeURL {
+                optIn[provider] = FileManager.default.fileExists(atPath: probeURL.path)
+            } else {
+                optIn[provider] = false
+            }
+        }
+
+        return optIn
     }
     var completionReplyEnabled: Bool = false {
         didSet {
@@ -601,13 +675,7 @@ final class AppModel {
         showDockIcon = UserDefaults.standard.bool(forKey: Self.showDockIconDefaultsKey)
         hapticFeedbackEnabled = UserDefaults.standard.bool(forKey: Self.hapticFeedbackEnabledDefaultsKey)
         suppressFrontmostNotifications = UserDefaults.standard.bool(forKey: Self.suppressFrontmostNotificationsDefaultsKey)
-        if UserDefaults.standard.object(forKey: Self.showCodexUsageDefaultsKey) != nil {
-            showCodexUsage = UserDefaults.standard.bool(forKey: Self.showCodexUsageDefaultsKey)
-        } else {
-            showCodexUsage = FileManager.default.fileExists(
-                atPath: CodexRolloutDiscovery.defaultRootURL.path
-            )
-        }
+        usageProviderOptIn = Self.loadUsageProviderOptIn()
         completionReplyEnabled = UserDefaults.standard.bool(forKey: Self.completionReplyEnabledDefaultsKey)
         launchAtLoginEnabled = LaunchAtLoginService.shared.isEnabled
         appearanceSettingsProfile = IslandAppearanceDisplayProfile(
@@ -1089,11 +1157,8 @@ final class AppModel {
             hooks.refreshCCForkHookStatuses()
             hooks.refreshOpenCodePluginStatus()
             hooks.refreshCursorHookStatus()
-            hooks.refreshClaudeUsageState()
-            hooks.startClaudeUsageMonitoringIfNeeded()
-            if showCodexUsage {
-                hooks.refreshCodexUsageState()
-                hooks.startCodexUsageMonitoringIfNeeded()
+            for provider in UsageProvider.allCases where isUsageProviderEnabled(provider) {
+                hooks.startUsageMonitoring(for: provider)
             }
             updateChecker.startIfNeeded()
 

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -254,13 +254,19 @@ final class AppModel {
     /// registry order. The island pill and Settings summaries both read this
     /// instead of reaching for a specific provider's snapshot.
     var usageProviderStatuses: [UsageProviderStatus] {
+        usageProviderStatuses(at: .now)
+    }
+
+    func usageProviderStatuses(at referenceDate: Date) -> [UsageProviderStatus] {
         UsageProvider.allCases.compactMap { provider in
             guard isUsageProviderEnabled(provider),
                   let snapshot = usageSnapshot(for: provider) else {
                 return nil
             }
 
-            let windows = snapshot.windowSummaries
+            // A cache that has outlived its window describes usage that has
+            // already reset, so it must not keep driving the pill.
+            let windows = snapshot.liveWindowSummaries(at: referenceDate)
             guard !windows.isEmpty else {
                 return nil
             }

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -239,7 +239,7 @@ final class HookInstallationCoordinator {
             return nil
         }
 
-        var components = snapshot.windowSummaries.map { window in
+        var components = snapshot.liveWindowSummaries(at: .now).map { window in
             "\(window.label) \(window.roundedUsedPercentage)%"
         }
         components.append(contentsOf: extraComponents)

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -90,11 +90,10 @@ final class HookInstallationCoordinator {
         ClaudeStatusLineInstallationManager()
     }
 
+    /// Poll loops per usage provider, keyed so a provider switched off in
+    /// Settings can be stopped without touching the others.
     @ObservationIgnored
-    private var claudeUsageMonitorTask: Task<Void, Never>?
-
-    @ObservationIgnored
-    private var codexUsageMonitorTask: Task<Void, Never>?
+    private var usageMonitorTasks: [UsageProvider: Task<Void, Never>] = [:]
 
     @ObservationIgnored
     private var relativeTimestampFormatter: RelativeDateTimeFormatter {
@@ -228,20 +227,27 @@ final class HookInstallationCoordinator {
     }
 
     var claudeUsageSummaryText: String? {
-        guard let snapshot = claudeUsageSnapshot else {
+        usageSummaryText(for: claudeUsageSnapshot)
+    }
+
+    /// Renders any provider's snapshot as `5h 12% · 7d 40% · updated 2m ago`.
+    func usageSummaryText(
+        for snapshot: (any UsageSnapshotSummarizing)?,
+        extraComponents: [String] = []
+    ) -> String? {
+        guard let snapshot else {
             return nil
         }
 
-        var components: [String] = []
-        if let fiveHour = snapshot.fiveHour {
-            components.append("5h \(fiveHour.roundedUsedPercentage)%")
+        var components = snapshot.windowSummaries.map { window in
+            "\(window.label) \(window.roundedUsedPercentage)%"
         }
-        if let sevenDay = snapshot.sevenDay {
-            components.append("7d \(sevenDay.roundedUsedPercentage)%")
+        components.append(contentsOf: extraComponents)
+
+        if let summarizedAt = snapshot.summarizedAt {
+            components.append("updated \(relativeTimestampFormatter.localizedString(for: summarizedAt, relativeTo: .now))")
         }
-        if let cachedAt = snapshot.cachedAt {
-            components.append("updated \(relativeTimestampFormatter.localizedString(for: cachedAt, relativeTo: .now))")
-        }
+
         return components.isEmpty ? nil : components.joined(separator: " · ")
     }
 
@@ -262,23 +268,10 @@ final class HookInstallationCoordinator {
     }
 
     var codexUsageSummaryText: String? {
-        guard let snapshot = codexUsageSnapshot else {
-            return nil
-        }
-
-        var components = snapshot.windows.map { window in
-            "\(window.label) \(window.roundedUsedPercentage)%"
-        }
-
-        if let planType = snapshot.planType {
-            components.append("plan \(planType)")
-        }
-
-        if let capturedAt = snapshot.capturedAt {
-            components.append("updated \(relativeTimestampFormatter.localizedString(for: capturedAt, relativeTo: .now))")
-        }
-
-        return components.isEmpty ? nil : components.joined(separator: " · ")
+        usageSummaryText(
+            for: codexUsageSnapshot,
+            extraComponents: codexUsageSnapshot?.planType.map { ["plan \($0)"] } ?? []
+        )
     }
 
     var openCodePluginStatusTitle: String {
@@ -1069,29 +1062,35 @@ final class HookInstallationCoordinator {
 
     // MARK: - Monitoring
 
-    func startClaudeUsageMonitoringIfNeeded() {
-        guard claudeUsageMonitorTask == nil else { return }
+    /// Starts (or keeps) the poll loop for a usage provider, refreshing once
+    /// immediately so the pill fills in without waiting out the interval.
+    func startUsageMonitoring(for provider: UsageProvider) {
+        guard usageMonitorTasks[provider] == nil else { return }
 
-        claudeUsageMonitorTask = Task { @MainActor [weak self] in
+        refreshUsageState(for: provider)
+
+        usageMonitorTasks[provider] = Task { @MainActor [weak self] in
             guard let self else { return }
 
             while !Task.isCancelled {
-                self.refreshClaudeUsageState()
-                try? await Task.sleep(for: .seconds(5))
+                try? await Task.sleep(for: provider.pollInterval)
+                guard !Task.isCancelled else { return }
+                self.refreshUsageState(for: provider)
             }
         }
     }
 
-    func startCodexUsageMonitoringIfNeeded() {
-        guard codexUsageMonitorTask == nil else { return }
+    func stopUsageMonitoring(for provider: UsageProvider) {
+        usageMonitorTasks.removeValue(forKey: provider)?.cancel()
+    }
 
-        codexUsageMonitorTask = Task { @MainActor [weak self] in
-            guard let self else { return }
-
-            while !Task.isCancelled {
-                self.refreshCodexUsageState()
-                try? await Task.sleep(for: .seconds(120))
-            }
+    /// Re-reads one provider's usage cache.
+    func refreshUsageState(for provider: UsageProvider) {
+        switch provider {
+        case .claude:
+            refreshClaudeUsageState()
+        case .codex:
+            refreshCodexUsageState()
         }
     }
 

--- a/Sources/OpenIslandApp/UsageProvider.swift
+++ b/Sources/OpenIslandApp/UsageProvider.swift
@@ -1,0 +1,166 @@
+import Foundation
+import OpenIslandCore
+
+/// Subscription-usage providers Open Island can surface in the opened header.
+///
+/// This is the single registry for anything provider-specific about usage:
+/// labels, the harness whose sessions draw down the quota, and how the provider
+/// is gated in Settings. Adding a provider means adding a case here plus a
+/// snapshot source in `AppModel` — no new branches at the display sites.
+///
+/// Raw values are stable identifiers used for pill and window IDs and for the
+/// opt-in defaults key, so they must not change once shipped.
+enum UsageProvider: String, CaseIterable, Identifiable, Sendable {
+    case claude
+    case codex
+
+    var id: String { rawValue }
+
+    /// Label shown on the usage pill when the header lane has room.
+    var title: String {
+        switch self {
+        case .claude:
+            "Claude"
+        case .codex:
+            "Codex"
+        }
+    }
+
+    /// Abbreviated label used when the notch squeezes the header lane.
+    var shortTitle: String {
+        switch self {
+        case .claude:
+            "Cl"
+        case .codex:
+            "Cx"
+        }
+    }
+
+    /// The provider whose quota this tool's sessions draw down.
+    ///
+    /// Claude Code forks (Qoder, Factory, CodeBuddy, Kimi, Qwen) reuse Claude
+    /// Code's hook format but bill against their own vendors, so they map to no
+    /// provider and leave the pill on whatever is already selected.
+    init?(tool: AgentTool?) {
+        switch tool {
+        case .claudeCode:
+            self = .claude
+        case .codex:
+            self = .codex
+        default:
+            return nil
+        }
+    }
+
+    /// How often to re-read this provider's cache. Claude's status line
+    /// rewrites its cache on every turn, so it is cheap to poll often; Codex
+    /// usage means scanning rollout files, so it polls lazily.
+    var pollInterval: Duration {
+        switch self {
+        case .claude:
+            .seconds(5)
+        case .codex:
+            .seconds(120)
+        }
+    }
+
+    // MARK: - Opt-in
+
+    /// `UserDefaults` key gating this provider's passive polling.
+    ///
+    /// `nil` means the provider carries no toggle because it is gated by its
+    /// own install state instead — Claude usage only exists once the user
+    /// installs the managed status line bridge from Settings.
+    var optInDefaultsKey: String? {
+        switch self {
+        case .claude:
+            nil
+        case .codex:
+            "app.showCodexUsage"
+        }
+    }
+
+    /// Localization key for the Settings toggle, for providers that have one.
+    var optInLabelKey: String? {
+        switch self {
+        case .claude:
+            nil
+        case .codex:
+            "settings.general.showCodexUsage"
+        }
+    }
+
+    /// Path whose presence implies the user actually runs this harness. Used to
+    /// pick a sane default the first time the toggle is read, so Codex users
+    /// see their usage without hunting for the switch.
+    var installationProbeURL: URL? {
+        switch self {
+        case .claude:
+            nil
+        case .codex:
+            CodexRolloutDiscovery.defaultRootURL
+        }
+    }
+
+    /// Providers the user can switch on and off in Settings, in display order.
+    static var optional: [UsageProvider] {
+        allCases.filter { $0.optInDefaultsKey != nil }
+    }
+}
+
+/// A provider's current usage windows, ready for display.
+struct UsageProviderStatus: Identifiable, Equatable {
+    let provider: UsageProvider
+    let windows: [UsageWindowSummary]
+    let capturedAt: Date?
+
+    var id: UsageProvider { provider }
+
+    var title: String { provider.title }
+
+    var shortTitle: String { provider.shortTitle }
+
+    /// The window closest to its limit — what the collapsed pill reports.
+    var peakWindow: UsageWindowSummary? {
+        windows.max { lhs, rhs in
+            lhs.usedPercentage < rhs.usedPercentage
+        }
+    }
+
+    var peakWindowLabel: String {
+        peakWindow?.label ?? ""
+    }
+
+    var peakUsedPercentage: Double {
+        peakWindow?.usedPercentage ?? 0
+    }
+
+    var peakUsagePercentage: Int {
+        peakWindow?.roundedUsedPercentage ?? 0
+    }
+}
+
+/// Decides which usage provider the opened header shows.
+enum UsageProviderSelection {
+    static func provider(for tool: AgentTool?) -> UsageProvider? {
+        UsageProvider(tool: tool)
+    }
+
+    /// Manual pick wins, then the harness in the closed-island spotlight, then
+    /// whatever provider has data.
+    static func selected(
+        available: [UsageProvider],
+        activeTool: AgentTool?,
+        override: UsageProvider?
+    ) -> UsageProvider? {
+        if let override, available.contains(override) {
+            return override
+        }
+
+        if let active = provider(for: activeTool), available.contains(active) {
+            return active
+        }
+
+        return available.first
+    }
+}

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -99,7 +99,8 @@ struct IslandPanelView: View {
     private static let headerTopPadding: CGFloat = 2
     private static let notchHeaderHorizontalPadding: CGFloat = 46
     private static let notchLaneSafetyInset: CGFloat = 12
-    private static let minimumRightUsageLaneWidth: CGFloat = 58
+    /// How old a usage cache gets before the tooltip calls out its age.
+    private static let staleUsageThreshold: TimeInterval = 15 * 60
 
     var model: AppModel
     private var lang: LanguageManager { model.lang }
@@ -108,6 +109,8 @@ struct IslandPanelView: View {
     @State private var showingQuitConfirmation = false
     @State private var keepsOpenedSurfaceMounted = false
     @State private var openedSurfaceMountGeneration: UInt64 = 0
+    @State private var usageProviderOverride: UsageProvider?
+    @State private var isUsageDropdownPresented = false
 
     private var isOpened: Bool {
         model.notchStatus == .opened
@@ -192,6 +195,10 @@ struct IslandPanelView: View {
         }
         .onChange(of: model.notchStatus) { _, status in
             syncOpenedSurfaceMount(with: status)
+        }
+        .onChange(of: activeUsageProvider) {
+            usageProviderOverride = nil
+            isUsageDropdownPresented = false
         }
     }
 
@@ -338,24 +345,16 @@ struct IslandPanelView: View {
     private var openedHeaderContent: some View {
         if usesNotchAwareOpenedHeader {
             GeometryReader { geometry in
-                let providers = openedUsageProviders
-                let providerGroups = splitUsageProviders(providers)
                 let metrics = openedHeaderMetrics(for: geometry.size.width)
 
                 HStack(spacing: 0) {
-                    usageLaneView(providerGroups.left, alignment: .leading)
+                    openedUsageSelector
                         .frame(width: metrics.leftUsageWidth, alignment: .leading)
 
                     Color.clear
                         .frame(width: metrics.centerGapWidth)
 
-                    HStack(spacing: Self.headerControlSpacing) {
-                        if metrics.rightUsageWidth > 0, !providerGroups.right.isEmpty {
-                            usageLaneView(providerGroups.right, alignment: .trailing)
-                                .frame(width: metrics.rightUsageWidth, alignment: .trailing)
-                        }
-                        openedHeaderButtons
-                    }
+                    openedHeaderButtons
                     .frame(width: metrics.rightLaneWidth, alignment: .trailing)
                 }
                 .padding(.horizontal, openedHeaderHorizontalPadding)
@@ -363,7 +362,7 @@ struct IslandPanelView: View {
             }
         } else {
             HStack(spacing: 12) {
-                openedUsageSummary
+                openedUsageSelector
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                 openedHeaderButtons
@@ -844,124 +843,106 @@ struct IslandPanelView: View {
 
     // MARK: - Helpers
 
-    @ViewBuilder
-    private var openedUsageSummary: some View {
-        let providers = openedUsageProviders
-
-        if providers.isEmpty == false {
-            ViewThatFits(in: .horizontal) {
-                compactUsageSummaryView(providers, usesShortTitles: false)
-                compactUsageSummaryView(providers, usesShortTitles: true)
-            }
-        } else {
-            Color.clear
-        }
-    }
-
-    private var openedUsageProviders: [UsageProviderPresentation] {
+    private var openedUsageProviders: [UsageProviderStatus] {
         guard model.islandUsageDisplay == .compact else {
             return []
         }
 
-        var providers: [UsageProviderPresentation] = []
-
-        if let snapshot = model.claudeUsageSnapshot,
-           snapshot.isEmpty == false {
-            var windows: [UsageWindowPresentation] = []
-
-            if let fiveHour = snapshot.fiveHour {
-                windows.append(
-                    UsageWindowPresentation(
-                        id: "claude-5h",
-                        label: "5h",
-                        usedPercentage: fiveHour.usedPercentage,
-                        resetsAt: fiveHour.resetsAt
-                    )
-                )
-            }
-
-            if let sevenDay = snapshot.sevenDay {
-                windows.append(
-                    UsageWindowPresentation(
-                        id: "claude-7d",
-                        label: "7d",
-                        usedPercentage: sevenDay.usedPercentage,
-                        resetsAt: sevenDay.resetsAt
-                    )
-                )
-            }
-
-            if windows.isEmpty == false {
-                providers.append(
-                    UsageProviderPresentation(
-                        id: "claude",
-                        title: "Claude",
-                        windows: windows
-                    )
-                )
-            }
-        }
-
-        if model.showCodexUsage,
-           let snapshot = model.codexUsageSnapshot,
-           snapshot.isEmpty == false {
-            let windows = snapshot.windows.map { window in
-                UsageWindowPresentation(
-                    id: "codex-\(window.key)",
-                    label: window.label,
-                    usedPercentage: window.usedPercentage,
-                    resetsAt: window.resetsAt
-                )
-            }
-
-            if windows.isEmpty == false {
-                providers.append(
-                    UsageProviderPresentation(
-                        id: "codex",
-                        title: "Codex",
-                        windows: windows
-                    )
-                )
-            }
-        }
-
-        return providers
+        return model.usageProviderStatuses
     }
 
-    private func splitUsageProviders(
-        _ providers: [UsageProviderPresentation]
-    ) -> (left: [UsageProviderPresentation], right: [UsageProviderPresentation]) {
-        switch providers.count {
-        case 0:
-            return ([], [])
-        case 1:
-            return ([providers[0]], [])
-        case 2:
-            return ([providers[0]], [providers[1]])
-        default:
-            let splitIndex = Int(ceil(Double(providers.count) / 2.0))
-            return (
-                Array(providers.prefix(splitIndex)),
-                Array(providers.dropFirst(splitIndex))
-            )
-        }
+    private var activeUsageProvider: UsageProvider? {
+        UsageProviderSelection.provider(for: model.islandClosedSpotlight?.tool)
+    }
+
+    private var selectedUsageProvider: UsageProviderStatus? {
+        let providers = openedUsageProviders
+        let selected = UsageProviderSelection.selected(
+            available: providers.map(\.provider),
+            activeTool: model.islandClosedSpotlight?.tool,
+            override: usageProviderOverride
+        )
+        return providers.first { $0.provider == selected }
     }
 
     @ViewBuilder
-    private func usageLaneView(
-        _ providers: [UsageProviderPresentation],
-        alignment: Alignment
-    ) -> some View {
-        if providers.isEmpty {
-            Color.clear
-                .frame(maxWidth: .infinity)
-        } else {
-            ViewThatFits(in: .horizontal) {
-                compactUsageSummaryView(providers, usesShortTitles: false)
-                compactUsageSummaryView(providers, usesShortTitles: true)
+    private var openedUsageSelector: some View {
+        let providers = openedUsageProviders
+
+        if let selected = selectedUsageProvider {
+            Button {
+                withAnimation(.easeOut(duration: 0.16)) {
+                    isUsageDropdownPresented.toggle()
+                }
+            } label: {
+                ViewThatFits(in: .horizontal) {
+                    compactUsageChip(
+                        selected,
+                        usesShortTitle: false,
+                        showsChevron: providers.count > 1,
+                        isExpanded: isUsageDropdownPresented
+                    )
+                    compactUsageChip(
+                        selected,
+                        usesShortTitle: true,
+                        showsChevron: providers.count > 1,
+                        isExpanded: isUsageDropdownPresented
+                    )
+                }
             }
-            .frame(maxWidth: .infinity, alignment: alignment)
+            .buttonStyle(.plain)
+            .fixedSize(horizontal: true, vertical: false)
+            .accessibilityLabel("Usage provider")
+            .accessibilityValue(usageMenuTitle(for: selected))
+            .popover(
+                isPresented: $isUsageDropdownPresented,
+                attachmentAnchor: .rect(.bounds),
+                arrowEdge: .top
+            ) {
+                usageProviderDropdown(providers, selected: selected.provider)
+                    .presentationCompactAdaptation(.popover)
+            }
+        } else {
+            Color.clear
         }
+    }
+
+    private func usageProviderDropdown(
+        _ providers: [UsageProviderStatus],
+        selected: UsageProvider
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            ForEach(providers) { provider in
+                Button {
+                    withAnimation(.easeInOut(duration: 0.16)) {
+                        usageProviderOverride = provider.provider
+                        isUsageDropdownPresented = false
+                    }
+                } label: {
+                    compactUsageChip(provider, usesShortTitle: false)
+                        .overlay {
+                            Capsule()
+                                .strokeBorder(
+                                    provider.provider == selected
+                                        ? usageColor(for: provider.peakUsedPercentage).opacity(0.5)
+                                        : .clear,
+                                    lineWidth: 1
+                                )
+                        }
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(usageMenuTitle(for: provider))
+            }
+        }
+        .padding(9)
+        .background(V6Palette.ink.opacity(0.98))
+    }
+
+    private func usageMenuTitle(for provider: UsageProviderStatus) -> String {
+        let windows = provider.windows.map {
+            "\($0.label) \($0.roundedUsedPercentage)%"
+        }.joined(separator: " · ")
+        return "\(provider.title) — \(windows)"
     }
 
     private func openedHeaderMetrics(for totalWidth: CGFloat) -> OpenedHeaderMetrics {
@@ -969,12 +950,11 @@ struct IslandPanelView: View {
         let contentWidth = max(0, totalWidth - (horizontalPadding * 2))
         guard usesNotchAwareOpenedHeader,
               let screen = targetOverlayScreen else {
-            let rightLaneWidth = min(contentWidth, openedHeaderButtonsWidth + (contentWidth / 2))
+            let rightLaneWidth = min(contentWidth, openedHeaderButtonsWidth)
             let leftUsageWidth = max(0, contentWidth - rightLaneWidth)
             return OpenedHeaderMetrics(
                 leftUsageWidth: leftUsageWidth,
                 centerGapWidth: 0,
-                rightUsageWidth: max(0, rightLaneWidth - openedHeaderButtonsWidth - Self.headerControlSpacing),
                 rightLaneWidth: rightLaneWidth
             )
         }
@@ -995,42 +975,25 @@ struct IslandPanelView: View {
 
         let leftUsageWidth = max(0, rawLeftWidth - Self.notchLaneSafetyInset)
         let rightAvailableWidth = max(0, rawRightWidth - Self.notchLaneSafetyInset)
-        let proposedRightUsageWidth = max(
-            0,
-            rightAvailableWidth - openedHeaderButtonsWidth - Self.headerControlSpacing
-        )
-        let rightUsageWidth = proposedRightUsageWidth >= Self.minimumRightUsageLaneWidth
-            ? proposedRightUsageWidth
-            : 0
         let rightLaneWidth = min(
             contentWidth,
-            openedHeaderButtonsWidth
-                + (rightUsageWidth > 0 ? Self.headerControlSpacing + rightUsageWidth : 0)
+            min(openedHeaderButtonsWidth, rightAvailableWidth)
         )
         let centerGapWidth = max(0, contentWidth - leftUsageWidth - rightLaneWidth)
 
         return OpenedHeaderMetrics(
             leftUsageWidth: leftUsageWidth,
             centerGapWidth: centerGapWidth,
-            rightUsageWidth: rightUsageWidth,
             rightLaneWidth: rightLaneWidth
         )
     }
 
-    private func compactUsageSummaryView(
-        _ providers: [UsageProviderPresentation],
-        usesShortTitles: Bool
+    private func compactUsageChip(
+        _ provider: UsageProviderStatus,
+        usesShortTitle: Bool,
+        showsChevron: Bool = false,
+        isExpanded: Bool = false
     ) -> some View {
-        HStack(spacing: 7) {
-            ForEach(providers) { provider in
-                compactUsageChip(provider, usesShortTitle: usesShortTitles)
-            }
-        }
-        .lineLimit(1)
-        .fixedSize(horizontal: true, vertical: false)
-    }
-
-    private func compactUsageChip(_ provider: UsageProviderPresentation, usesShortTitle: Bool) -> some View {
         HStack(spacing: 5) {
             Text(usesShortTitle ? provider.shortTitle : provider.title)
                 .font(.system(size: 11, weight: .semibold))
@@ -1043,6 +1006,14 @@ struct IslandPanelView: View {
             Text("\(provider.peakUsagePercentage)%")
                 .font(.system(size: 11.5, weight: .bold, design: .monospaced))
                 .foregroundStyle(usageColor(for: provider.peakUsedPercentage))
+
+            if showsChevron {
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 7.5, weight: .bold))
+                    .foregroundStyle(.white.opacity(0.34))
+                    .rotationEffect(.degrees(isExpanded ? 180 : 0))
+                    .animation(.easeInOut(duration: 0.16), value: isExpanded)
+            }
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
@@ -1054,8 +1025,8 @@ struct IslandPanelView: View {
         .help(usageHelpText(for: provider))
     }
 
-    private func usageHelpText(for provider: UsageProviderPresentation) -> String {
-        provider.windows.map { window in
+    private func usageHelpText(for provider: UsageProviderStatus) -> String {
+        var components = provider.windows.map { window in
             var parts = ["\(window.label) \(window.roundedUsedPercentage)%"]
             if let resetsAt = window.resetsAt,
                let remaining = remainingDurationString(until: resetsAt) {
@@ -1063,7 +1034,16 @@ struct IslandPanelView: View {
             }
             return parts.joined(separator: " ")
         }
-        .joined(separator: " · ")
+
+        // The cache only refreshes while the harness runs, so say how old these
+        // numbers are once they stop tracking the live quota.
+        if let capturedAt = provider.capturedAt,
+           Date.now.timeIntervalSince(capturedAt) >= Self.staleUsageThreshold,
+           let age = durationString(for: Date.now.timeIntervalSince(capturedAt)) {
+            components.append("updated \(age) ago")
+        }
+
+        return components.joined(separator: " · ")
     }
 
     private func headerPill(_ title: String, tint: Color) -> some View {
@@ -1087,7 +1067,10 @@ struct IslandPanelView: View {
     }
 
     private func remainingDurationString(until date: Date) -> String? {
-        let interval = date.timeIntervalSinceNow
+        durationString(for: date.timeIntervalSinceNow)
+    }
+
+    private func durationString(for interval: TimeInterval) -> String? {
         guard interval > 0 else {
             return nil
         }
@@ -1110,56 +1093,9 @@ struct IslandPanelView: View {
     }
 }
 
-private struct UsageProviderPresentation: Identifiable {
-    let id: String
-    let title: String
-    let windows: [UsageWindowPresentation]
-
-    var peakWindow: UsageWindowPresentation? {
-        windows.max { lhs, rhs in
-            lhs.usedPercentage < rhs.usedPercentage
-        }
-    }
-
-    var peakWindowLabel: String {
-        peakWindow?.label ?? ""
-    }
-
-    var peakUsedPercentage: Double {
-        peakWindow?.usedPercentage ?? 0
-    }
-
-    var peakUsagePercentage: Int {
-        peakWindow?.roundedUsedPercentage ?? 0
-    }
-
-    var shortTitle: String {
-        switch id {
-        case "claude":
-            "Cl"
-        case "codex":
-            "Cx"
-        default:
-            String(title.prefix(2))
-        }
-    }
-}
-
-private struct UsageWindowPresentation: Identifiable {
-    let id: String
-    let label: String
-    let usedPercentage: Double
-    let resetsAt: Date?
-
-    var roundedUsedPercentage: Int {
-        Int(usedPercentage.rounded())
-    }
-}
-
 private struct OpenedHeaderMetrics {
     let leftUsageWidth: CGFloat
     let centerGapWidth: CGFloat
-    let rightUsageWidth: CGFloat
     let rightLaneWidth: CGFloat
 }
 
@@ -1209,7 +1145,7 @@ private struct IslandSessionRow: View {
             at: referenceDate,
             threshold: completedStaleThreshold
         )
-        let defaultShowsDetail = !isStaleCompleted && (rawPresence != .inactive || isActionable)
+        let defaultShowsDetail = !isStaleCompleted && (rawPresence == .running || isActionable)
         let showsDetail = detailOverride ?? defaultShowsDetail
         let presence = isStaleCompleted
             ? .inactive
@@ -1410,7 +1346,9 @@ private struct IslandSessionRow: View {
         Text(title)
             .font(.system(size: 10.5, weight: .medium, design: .monospaced))
             .foregroundStyle(V6Palette.paper.opacity(presentation == .notification ? 0.52 : 0.7))
-            .padding(.horizontal, 8)
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
+            .padding(.horizontal, 7)
             .padding(.vertical, 3)
             .background(.white.opacity(presentation == .notification ? 0.045 : 0.06), in: Capsule())
     }

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -635,10 +635,14 @@ struct SetupSettingsPane: View {
                     Text(lang.t("settings.general.uninstallConfirmMessage.claudeUsage"))
                 }
 
-                Toggle(lang.t("settings.general.showCodexUsage"), isOn: Binding(
-                    get: { model.showCodexUsage },
-                    set: { model.showCodexUsage = $0 }
-                ))
+                ForEach(UsageProvider.optional) { provider in
+                    if let labelKey = provider.optInLabelKey {
+                        Toggle(lang.t(labelKey), isOn: Binding(
+                            get: { model.isUsageProviderEnabled(provider) },
+                            set: { model.setUsageProvider(provider, enabled: $0) }
+                        ))
+                    }
+                }
             } header: {
                 HStack(spacing: 4) {
                     Text(lang.t("setup.section.usage"))

--- a/Sources/OpenIslandCore/UsageSnapshot.swift
+++ b/Sources/OpenIslandCore/UsageSnapshot.swift
@@ -28,6 +28,20 @@ public struct UsageWindowSummary: Equatable, Sendable, Identifiable {
     public var roundedUsedPercentage: Int {
         Int(usedPercentage.rounded())
     }
+
+    /// True once the window's reset time has passed.
+    ///
+    /// Usage caches are only rewritten while the harness runs — Claude Code
+    /// writes on each turn, Codex on each rollout append. So a window past its
+    /// reset is not "current usage at 10%", it is a number from the previous
+    /// window that nothing has refreshed yet.
+    public func hasReset(by referenceDate: Date) -> Bool {
+        guard let resetsAt else {
+            return false
+        }
+
+        return resetsAt <= referenceDate
+    }
 }
 
 /// A provider-agnostic view of one usage cache.
@@ -36,6 +50,14 @@ public protocol UsageSnapshotSummarizing: Sendable {
     var windowSummaries: [UsageWindowSummary] { get }
     /// When the underlying cache was last written, if known.
     var summarizedAt: Date? { get }
+}
+
+extension UsageSnapshotSummarizing {
+    /// Windows that still describe current usage — rolled-over windows are
+    /// dropped rather than shown with their stale percentage.
+    public func liveWindowSummaries(at referenceDate: Date) -> [UsageWindowSummary] {
+        windowSummaries.filter { !$0.hasReset(by: referenceDate) }
+    }
 }
 
 extension ClaudeUsageSnapshot: UsageSnapshotSummarizing {

--- a/Sources/OpenIslandCore/UsageSnapshot.swift
+++ b/Sources/OpenIslandCore/UsageSnapshot.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// One rate-limit window, normalized across providers.
+///
+/// Providers report windows in their own shape — Claude Code caches fixed
+/// `five_hour` / `seven_day` entries, Codex rollouts carry `primary` /
+/// `secondary` entries whose length comes from the payload. Everything
+/// downstream (island pill, settings summary) only needs this shape, so new
+/// providers plug in by conforming to `UsageSnapshotSummarizing` rather than by
+/// adding another branch at every display site.
+public struct UsageWindowSummary: Equatable, Sendable, Identifiable {
+    /// Provider-local window key (`5h`, `primary`, …).
+    public let key: String
+    /// Short human label rendered on the pill (`5h`, `7d`, `1d 12h`, …).
+    public let label: String
+    public let usedPercentage: Double
+    public let resetsAt: Date?
+
+    public init(key: String, label: String, usedPercentage: Double, resetsAt: Date?) {
+        self.key = key
+        self.label = label
+        self.usedPercentage = usedPercentage
+        self.resetsAt = resetsAt
+    }
+
+    public var id: String { key }
+
+    public var roundedUsedPercentage: Int {
+        Int(usedPercentage.rounded())
+    }
+}
+
+/// A provider-agnostic view of one usage cache.
+public protocol UsageSnapshotSummarizing: Sendable {
+    /// Windows in display order, or empty when the cache holds nothing usable.
+    var windowSummaries: [UsageWindowSummary] { get }
+    /// When the underlying cache was last written, if known.
+    var summarizedAt: Date? { get }
+}
+
+extension ClaudeUsageSnapshot: UsageSnapshotSummarizing {
+    public var windowSummaries: [UsageWindowSummary] {
+        var summaries: [UsageWindowSummary] = []
+
+        if let fiveHour {
+            summaries.append(
+                UsageWindowSummary(
+                    key: "5h",
+                    label: "5h",
+                    usedPercentage: fiveHour.usedPercentage,
+                    resetsAt: fiveHour.resetsAt
+                )
+            )
+        }
+
+        if let sevenDay {
+            summaries.append(
+                UsageWindowSummary(
+                    key: "7d",
+                    label: "7d",
+                    usedPercentage: sevenDay.usedPercentage,
+                    resetsAt: sevenDay.resetsAt
+                )
+            )
+        }
+
+        return summaries
+    }
+
+    public var summarizedAt: Date? { cachedAt }
+}
+
+extension CodexUsageSnapshot: UsageSnapshotSummarizing {
+    public var windowSummaries: [UsageWindowSummary] {
+        windows.map { window in
+            UsageWindowSummary(
+                key: window.key,
+                label: window.label,
+                usedPercentage: window.usedPercentage,
+                resetsAt: window.resetsAt
+            )
+        }
+    }
+
+    public var summarizedAt: Date? { capturedAt }
+}

--- a/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
+++ b/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
@@ -333,4 +333,241 @@ struct AgentSessionPresentationTests {
         #expect(session.spotlightSecondaryText == "Running Search")
         #expect(session.displayCurrentToolName == "Search")
     }
+
+    @Test
+    func codexChildThreadIsRecognizedAsSubagent() {
+        let session = AgentSession(
+            id: "child",
+            title: "Codex · worktree",
+            tool: .codex,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Working",
+            updatedAt: .now,
+            codexMetadata: CodexSessionMetadata(parentThreadID: "parent")
+        )
+
+        #expect(session.isSubagentSession)
+    }
+
+    @Test
+    func codexDesktopRootWorkspaceUsesRolloutRepositoryPath() {
+        let session = AgentSession(
+            id: "session-1",
+            title: "Codex · /",
+            tool: .codex,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Thinking",
+            updatedAt: .now,
+            jumpTarget: JumpTarget(
+                terminalApp: "Codex.app",
+                workspaceName: "/",
+                paneTitle: "Codex",
+                workingDirectory: "/",
+                codexThreadID: "session-1"
+            ),
+            codexMetadata: CodexSessionMetadata(
+                workspacePath: "/Users/aditya/Developer/projects/open-vibe-island"
+            )
+        )
+
+        #expect(session.spotlightWorkspaceName == "open-vibe-island")
+        #expect(session.spotlightHeadlineText == "open-vibe-island")
+    }
+
+    @Test
+    func usageProviderSelectionFollowsActiveHarnessAndAllowsInspectionOverride() {
+        let available = UsageProvider.allCases
+
+        // Every harness selects its own provider; harnesses without one fall
+        // back to the first pill that has data.
+        for tool in AgentTool.allCases {
+            let expected = UsageProvider(tool: tool) ?? available.first
+            #expect(
+                UsageProviderSelection.selected(
+                    available: available,
+                    activeTool: tool,
+                    override: nil
+                ) == expected,
+                "\(tool.rawValue) selected the wrong usage provider"
+            )
+        }
+
+        // A manual pick from the dropdown outranks the active harness.
+        for provider in available {
+            #expect(
+                UsageProviderSelection.selected(
+                    available: available,
+                    activeTool: .codex,
+                    override: provider
+                ) == provider
+            )
+        }
+
+        // An override for a provider without data is ignored.
+        #expect(
+            UsageProviderSelection.selected(
+                available: [.codex],
+                activeTool: nil,
+                override: .claude
+            ) == .codex
+        )
+        #expect(
+            UsageProviderSelection.selected(
+                available: [],
+                activeTool: .claudeCode,
+                override: .claude
+            ) == nil
+        )
+    }
+
+    @Test
+    func usageProviderMapsOnlyFirstPartyHarnesses() {
+        #expect(UsageProvider(tool: .claudeCode) == .claude)
+        #expect(UsageProvider(tool: .codex) == .codex)
+        #expect(UsageProvider(tool: nil) == nil)
+
+        // Claude Code forks share the hook format but bill their own vendors,
+        // so they must not adopt Claude's usage windows.
+        let unmapped = AgentTool.allCases.filter { $0 != .claudeCode && $0 != .codex }
+        for tool in unmapped {
+            #expect(UsageProvider(tool: tool) == nil, "\(tool.rawValue) should not map to a usage provider")
+        }
+
+        // Every provider round-trips through its raw identifier.
+        for provider in UsageProvider.allCases {
+            #expect(UsageProvider(rawValue: provider.id) == provider)
+        }
+    }
+
+    @Test
+    func usageProviderRegistryIsSelfConsistent() {
+        for provider in UsageProvider.allCases {
+            #expect(provider.title.isEmpty == false)
+            #expect(provider.shortTitle.isEmpty == false)
+            #expect(provider.pollInterval > .zero)
+
+            // A provider is either toggleable in Settings (key + label) or
+            // gated by its install state — never half of each.
+            #expect((provider.optInDefaultsKey == nil) == (provider.optInLabelKey == nil))
+        }
+
+        // Identifiers and labels stay distinct so pills and defaults keys
+        // cannot shadow each other.
+        #expect(Set(UsageProvider.allCases.map(\.id)).count == UsageProvider.allCases.count)
+        #expect(Set(UsageProvider.allCases.map(\.shortTitle)).count == UsageProvider.allCases.count)
+        #expect(Set(UsageProvider.optional.compactMap(\.optInDefaultsKey)).count == UsageProvider.optional.count)
+
+        #expect(UsageProvider.optional.allSatisfy { $0.optInDefaultsKey != nil })
+        #expect(UsageProvider.optional.contains(.codex))
+        // Claude usage is gated by installing the status line bridge instead.
+        #expect(UsageProvider.optional.contains(.claude) == false)
+    }
+
+    @Test
+    func usageSnapshotsNormalizeIntoProviderAgnosticWindows() {
+        let resetsAt = Date(timeIntervalSince1970: 20_000)
+        let claude = ClaudeUsageSnapshot(
+            fiveHour: ClaudeUsageWindow(usedPercentage: 42.4, resetsAt: resetsAt),
+            sevenDay: ClaudeUsageWindow(usedPercentage: 91.6, resetsAt: nil),
+            cachedAt: Date(timeIntervalSince1970: 10_000)
+        )
+
+        #expect(claude.windowSummaries.map(\.label) == ["5h", "7d"])
+        #expect(claude.windowSummaries.map(\.roundedUsedPercentage) == [42, 92])
+        #expect(claude.windowSummaries.first?.resetsAt == resetsAt)
+        #expect(claude.summarizedAt == Date(timeIntervalSince1970: 10_000))
+
+        // A snapshot with only one window still normalizes cleanly.
+        let partial = ClaudeUsageSnapshot(
+            fiveHour: nil,
+            sevenDay: ClaudeUsageWindow(usedPercentage: 5, resetsAt: nil)
+        )
+        #expect(partial.windowSummaries.map(\.key) == ["7d"])
+
+        let codex = CodexUsageSnapshot(
+            sourceFilePath: "/tmp/rollout.jsonl",
+            capturedAt: Date(timeIntervalSince1970: 30_000),
+            windows: [
+                CodexUsageWindow(
+                    key: "primary",
+                    label: "5h",
+                    usedPercentage: 12.5,
+                    leftPercentage: 87.5,
+                    windowMinutes: 300,
+                    resetsAt: resetsAt
+                ),
+                CodexUsageWindow(
+                    key: "secondary",
+                    label: "7d",
+                    usedPercentage: 60,
+                    leftPercentage: 40,
+                    windowMinutes: 10_080,
+                    resetsAt: nil
+                ),
+            ]
+        )
+
+        #expect(codex.windowSummaries.map(\.key) == ["primary", "secondary"])
+        #expect(codex.windowSummaries.map(\.label) == ["5h", "7d"])
+        #expect(codex.windowSummaries.map(\.roundedUsedPercentage) == [13, 60])
+        #expect(codex.summarizedAt == Date(timeIntervalSince1970: 30_000))
+
+        // Peak selection drives the collapsed pill for either provider.
+        let claudeStatus = UsageProviderStatus(
+            provider: .claude,
+            windows: claude.windowSummaries,
+            capturedAt: claude.summarizedAt
+        )
+        #expect(claudeStatus.peakWindowLabel == "7d")
+        #expect(claudeStatus.peakUsagePercentage == 92)
+
+        let codexStatus = UsageProviderStatus(
+            provider: .codex,
+            windows: codex.windowSummaries,
+            capturedAt: codex.summarizedAt
+        )
+        #expect(codexStatus.peakWindowLabel == "7d")
+        #expect(codexStatus.peakUsagePercentage == 60)
+        #expect(codexStatus.shortTitle == UsageProvider.codex.shortTitle)
+    }
+
+    @Test
+    func injectedContextAndInternalApprovalPayloadStayOutOfSessionRows() {
+        let session = AgentSession(
+            id: "session-1",
+            title: "Codex · worktree",
+            tool: .codex,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .completed,
+            summary: "Done",
+            updatedAt: .now,
+            codexMetadata: CodexSessionMetadata(
+                initialUserPrompt: "<recommended_plugins>internal setup</recommended_plugins>",
+                lastUserPrompt: """
+                # Files mentioned by the user:
+                ## screenshot.png
+
+                ## My request for Codex:
+                Fix the session list.
+                """,
+                lastAssistantMessage: #"{"risk_level":"low","outcome":"allow","rationale":"internal"}"#
+            )
+        )
+
+        #expect(session.spotlightHeadlineText == "worktree")
+        #expect(session.spotlightPromptLineText == "You: Fix the session list.")
+        #expect(session.spotlightActivityLineText == "Completed")
+
+        var attachmentOnlySession = session
+        attachmentOnlySession.codexMetadata?.lastUserPrompt = """
+        # Files mentioned by the user:
+        ## screenshot.png
+        """
+        #expect(attachmentOnlySession.spotlightPromptLineText == nil)
+    }
 }

--- a/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
+++ b/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
@@ -335,50 +335,6 @@ struct AgentSessionPresentationTests {
     }
 
     @Test
-    func codexChildThreadIsRecognizedAsSubagent() {
-        let session = AgentSession(
-            id: "child",
-            title: "Codex · worktree",
-            tool: .codex,
-            origin: .live,
-            attachmentState: .attached,
-            phase: .running,
-            summary: "Working",
-            updatedAt: .now,
-            codexMetadata: CodexSessionMetadata(parentThreadID: "parent")
-        )
-
-        #expect(session.isSubagentSession)
-    }
-
-    @Test
-    func codexDesktopRootWorkspaceUsesRolloutRepositoryPath() {
-        let session = AgentSession(
-            id: "session-1",
-            title: "Codex · /",
-            tool: .codex,
-            origin: .live,
-            attachmentState: .attached,
-            phase: .running,
-            summary: "Thinking",
-            updatedAt: .now,
-            jumpTarget: JumpTarget(
-                terminalApp: "Codex.app",
-                workspaceName: "/",
-                paneTitle: "Codex",
-                workingDirectory: "/",
-                codexThreadID: "session-1"
-            ),
-            codexMetadata: CodexSessionMetadata(
-                workspacePath: "/Users/aditya/Developer/projects/open-vibe-island"
-            )
-        )
-
-        #expect(session.spotlightWorkspaceName == "open-vibe-island")
-        #expect(session.spotlightHeadlineText == "open-vibe-island")
-    }
-
-    @Test
     func usageProviderSelectionFollowsActiveHarnessAndAllowsInspectionOverride() {
         let available = UsageProvider.allCases
 
@@ -536,38 +492,55 @@ struct AgentSessionPresentationTests {
     }
 
     @Test
-    func injectedContextAndInternalApprovalPayloadStayOutOfSessionRows() {
-        let session = AgentSession(
-            id: "session-1",
-            title: "Codex · worktree",
-            tool: .codex,
-            origin: .live,
-            attachmentState: .attached,
-            phase: .completed,
-            summary: "Done",
-            updatedAt: .now,
-            codexMetadata: CodexSessionMetadata(
-                initialUserPrompt: "<recommended_plugins>internal setup</recommended_plugins>",
-                lastUserPrompt: """
-                # Files mentioned by the user:
-                ## screenshot.png
-
-                ## My request for Codex:
-                Fix the session list.
-                """,
-                lastAssistantMessage: #"{"risk_level":"low","outcome":"allow","rationale":"internal"}"#
-            )
+    func usageWindowsExpireAtTheirResetTime() {
+        let resetsAt = Date(timeIntervalSince1970: 20_000)
+        let window = UsageWindowSummary(
+            key: "5h",
+            label: "5h",
+            usedPercentage: 10,
+            resetsAt: resetsAt
         )
 
-        #expect(session.spotlightHeadlineText == "worktree")
-        #expect(session.spotlightPromptLineText == "You: Fix the session list.")
-        #expect(session.spotlightActivityLineText == "Completed")
+        #expect(window.hasReset(by: resetsAt.addingTimeInterval(-1)) == false)
+        // The reset instant itself already belongs to the next window.
+        #expect(window.hasReset(by: resetsAt))
+        #expect(window.hasReset(by: resetsAt.addingTimeInterval(1)))
 
-        var attachmentOnlySession = session
-        attachmentOnlySession.codexMetadata?.lastUserPrompt = """
-        # Files mentioned by the user:
-        ## screenshot.png
-        """
-        #expect(attachmentOnlySession.spotlightPromptLineText == nil)
+        // Without a reset time there is nothing to expire against, so the
+        // window keeps counting rather than silently vanishing.
+        let openEnded = UsageWindowSummary(
+            key: "7d",
+            label: "7d",
+            usedPercentage: 40,
+            resetsAt: nil
+        )
+        #expect(openEnded.hasReset(by: .distantFuture) == false)
+
+        let snapshot = CodexUsageSnapshot(
+            sourceFilePath: "/tmp/rollout.jsonl",
+            capturedAt: resetsAt,
+            windows: [
+                CodexUsageWindow(
+                    key: "primary",
+                    label: "5h",
+                    usedPercentage: 10,
+                    leftPercentage: 90,
+                    windowMinutes: 300,
+                    resetsAt: resetsAt
+                ),
+                CodexUsageWindow(
+                    key: "secondary",
+                    label: "7d",
+                    usedPercentage: 40,
+                    leftPercentage: 60,
+                    windowMinutes: 10_080,
+                    resetsAt: resetsAt.addingTimeInterval(86_400)
+                ),
+            ]
+        )
+
+        #expect(snapshot.liveWindowSummaries(at: resetsAt.addingTimeInterval(-1)).count == 2)
+        #expect(snapshot.liveWindowSummaries(at: resetsAt.addingTimeInterval(1)).map(\.key) == ["secondary"])
+        #expect(snapshot.liveWindowSummaries(at: resetsAt.addingTimeInterval(200_000)).isEmpty)
     }
 }

--- a/Tests/OpenIslandAppTests/AppModelUsageProviderTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelUsageProviderTests.swift
@@ -1,0 +1,161 @@
+import Foundation
+import Testing
+@testable import OpenIslandApp
+import OpenIslandCore
+
+/// Drives the same path the island header reads: snapshots land on the hook
+/// coordinator, `AppModel` turns them into pills.
+@MainActor
+@Suite(.serialized)
+struct AppModelUsageProviderTests {
+    private static let codexOptInKey = "app.showCodexUsage"
+
+    init() {
+        UserDefaults.standard.removeObject(forKey: Self.codexOptInKey)
+    }
+
+    private func claudeSnapshot() -> ClaudeUsageSnapshot {
+        ClaudeUsageSnapshot(
+            fiveHour: ClaudeUsageWindow(usedPercentage: 30, resetsAt: nil),
+            sevenDay: ClaudeUsageWindow(usedPercentage: 80, resetsAt: nil),
+            cachedAt: Date(timeIntervalSince1970: 1_000)
+        )
+    }
+
+    private func codexSnapshot() -> CodexUsageSnapshot {
+        CodexUsageSnapshot(
+            sourceFilePath: "/tmp/rollout.jsonl",
+            capturedAt: Date(timeIntervalSince1970: 2_000),
+            planType: "pro",
+            windows: [
+                CodexUsageWindow(
+                    key: "primary",
+                    label: "5h",
+                    usedPercentage: 20,
+                    leftPercentage: 80,
+                    windowMinutes: 300,
+                    resetsAt: nil
+                ),
+            ]
+        )
+    }
+
+    @Test
+    func usageStatusesFollowSnapshotsAndOptIn() {
+        UserDefaults.standard.set(false, forKey: Self.codexOptInKey)
+        let model = AppModel()
+
+        #expect(model.usageProviderStatuses.isEmpty)
+
+        model.hooks.claudeUsageSnapshot = claudeSnapshot()
+        model.hooks.codexUsageSnapshot = codexSnapshot()
+
+        // Codex is opted out, so only Claude produces a pill.
+        #expect(model.usageProviderStatuses.map(\.provider) == [.claude])
+        #expect(model.usageProviderStatuses.first?.peakUsagePercentage == 80)
+        #expect(model.usageProviderStatuses.first?.peakWindowLabel == "7d")
+
+        model.setUsageProvider(.codex, enabled: true)
+        #expect(model.usageProviderStatuses.map(\.provider) == [.claude, .codex])
+        #expect(model.usageProviderStatuses.last?.peakUsagePercentage == 20)
+
+        model.setUsageProvider(.codex, enabled: false)
+        #expect(model.usageProviderStatuses.map(\.provider) == [.claude])
+
+        // An empty snapshot yields no pill rather than a 0% one.
+        model.hooks.claudeUsageSnapshot = ClaudeUsageSnapshot(fiveHour: nil, sevenDay: nil)
+        #expect(model.usageProviderStatuses.isEmpty)
+
+        UserDefaults.standard.removeObject(forKey: Self.codexOptInKey)
+    }
+
+    @Test
+    func claudeUsageNeedsNoOptInWhileCodexPersistsIts() {
+        UserDefaults.standard.set(false, forKey: Self.codexOptInKey)
+        let model = AppModel()
+
+        // Claude is gated by installing the bridge, not by a toggle.
+        #expect(model.isUsageProviderEnabled(.claude))
+        model.setUsageProvider(.claude, enabled: false)
+        #expect(model.isUsageProviderEnabled(.claude))
+
+        #expect(model.isUsageProviderEnabled(.codex) == false)
+        model.setUsageProvider(.codex, enabled: true)
+        #expect(model.isUsageProviderEnabled(.codex))
+        #expect(UserDefaults.standard.bool(forKey: Self.codexOptInKey))
+
+        // The stored key is what a fresh launch reads back.
+        let reloaded = AppModel()
+        #expect(reloaded.isUsageProviderEnabled(.codex))
+
+        model.setUsageProvider(.codex, enabled: false)
+        #expect(UserDefaults.standard.bool(forKey: Self.codexOptInKey) == false)
+        #expect(AppModel().isUsageProviderEnabled(.codex) == false)
+
+        UserDefaults.standard.removeObject(forKey: Self.codexOptInKey)
+    }
+
+    @Test
+    func codexOptInDefaultsToWhetherTheHarnessIsInstalled() {
+        UserDefaults.standard.removeObject(forKey: Self.codexOptInKey)
+
+        let probeExists = UsageProvider.codex.installationProbeURL.map {
+            FileManager.default.fileExists(atPath: $0.path)
+        } ?? false
+
+        #expect(AppModel().isUsageProviderEnabled(.codex) == probeExists)
+    }
+
+    @Test
+    func rolledOverWindowsStopDrivingThePill() {
+        // Reproduces the reported reading: a 12h-old Claude cache whose 5h
+        // window reset 7h ago still headlined the pill as "5h 10%", which reads
+        // like the weekly number sitting in the wrong slot.
+        let cachedAt = Date(timeIntervalSince1970: 100_000)
+        let now = cachedAt.addingTimeInterval(12 * 3_600)
+
+        let model = AppModel()
+        model.hooks.claudeUsageSnapshot = ClaudeUsageSnapshot(
+            fiveHour: ClaudeUsageWindow(
+                usedPercentage: 10,
+                resetsAt: cachedAt.addingTimeInterval(4 * 3_600)
+            ),
+            sevenDay: ClaudeUsageWindow(
+                usedPercentage: 2,
+                resetsAt: cachedAt.addingTimeInterval(6 * 86_400)
+            ),
+            cachedAt: cachedAt
+        )
+
+        let statuses = model.usageProviderStatuses(at: now)
+        let claude = try! #require(statuses.first { $0.provider == .claude })
+
+        // The expired 5h window is gone; the pill reports the window that is
+        // still running.
+        #expect(claude.windows.map(\.label) == ["7d"])
+        #expect(claude.peakWindowLabel == "7d")
+        #expect(claude.peakUsagePercentage == 2)
+
+        // Before the reset, both windows count.
+        let earlier = cachedAt.addingTimeInterval(3_600)
+        #expect(model.usageProviderStatuses(at: earlier).first?.windows.map(\.label) == ["5h", "7d"])
+        #expect(model.usageProviderStatuses(at: earlier).first?.peakWindowLabel == "5h")
+
+        // Once every window has rolled over the provider drops out entirely
+        // rather than showing dead numbers.
+        #expect(model.usageProviderStatuses(at: cachedAt.addingTimeInterval(8 * 86_400)).isEmpty)
+    }
+
+    @Test
+    func usageSnapshotLookupCoversEveryProvider() {
+        let model = AppModel()
+        model.hooks.claudeUsageSnapshot = claudeSnapshot()
+        model.hooks.codexUsageSnapshot = codexSnapshot()
+
+        // Every registered provider resolves to a cache — a new case without a
+        // snapshot source would silently never render.
+        for provider in UsageProvider.allCases {
+            #expect(model.usageSnapshot(for: provider) != nil, "\(provider.id) has no snapshot source")
+        }
+    }
+}


### PR DESCRIPTION
Closes #501.

Overlaps with #613. That PR restructures the same UsageProviderPresentation and UsageWindowPresentation types in IslandPanelView.swift to show Codex usage as remaining percentage instead of used percentage. This PR takes a different approach (a UsageProvider registry instead of string IDs) and also fixes stale/expired windows still being displayed, which #613 does not address. Whichever merges first, the other needs a rebase.

## Problem

Usage was written as two hardcoded pipelines. Provider identity lived in raw "claude" / "codex" strings that had to agree across the selection helper, the pill IDs, and a shortTitle switch. The island rebuilt each snapshot shape by hand, summary text was duplicated per provider, and the Codex toggle only persisted, so switching it on mid-session left the pill blank until the next launch.

Usage caches are also only rewritten while a harness runs, so a cache that outlives its window kept reporting the previous window's number. A 12h-old Claude cache whose 5h window had reset 7h earlier still headlined the pill as "5h 10%", reading like the weekly figure in the wrong slot, since the peak picker promotes the stale value over the live 7d window.

## Changes

- UsageProvider is the single registry now: labels, which harness draws down the quota, the Settings opt-in key, poll interval.
- UsageSnapshotSummarizing (Core) normalizes Claude's five_hour/seven_day and Codex's primary/secondary into one UsageWindowSummary shape.
- Windows past their resets_at are dropped from both the pill and the Settings summary. A provider disappears once every window has rolled over instead of showing dead numbers.
- Toggling a provider in Settings starts or stops its poll loop immediately instead of only persisting.

## Testing

swift build, swift test. Pre-existing failures in AppModelSessionListTests and AgentsGridRightSlotTests reproduce identically against a clean main with none of this branch's changes applied. Unrelated flakiness, not introduced here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for usage monitoring across multiple providers with individual opt-in settings.
  * Added a provider selector to switch between available usage summaries.
  * Usage displays now show active limits, reset times, and stale-data indicators.
  * Provider selection can follow the active tool or a manual override.

* **Bug Fixes**
  * Usage windows now disappear after their reset time.
  * Improved session detail and notification badge presentation.

* **Tests**
  * Added coverage for provider selection, opt-in behavior, usage expiry, and summary formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->