### PR TITLE
feat: surface Claude Code /rename session names

### DIFF
--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -115,6 +115,11 @@ extension AgentSession {
     }
 
     var spotlightWorkspaceName: String {
+        if let customName = customSessionName?.trimmedForSurface,
+           !customName.isEmpty {
+            return customName
+        }
+
         if let workspaceName = jumpTarget?.workspaceName.trimmedForSurface,
            !workspaceName.isEmpty {
             return workspaceName

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -702,6 +702,9 @@ final class AppModel {
         monitoring.onCodexAppMaintenanceTick = { [weak self] in
             self?.discovery.maintainCodexAppSessionsIfNeeded()
         }
+        monitoring.onMaintenanceTick = { [weak self] in
+            self?.discovery.refreshClaudeSessionNamesIfNeeded()
+        }
         refreshOverlayDisplayConfiguration()
         hasFinishedInit = true
     }
@@ -867,6 +870,9 @@ final class AppModel {
         case .off:
             return nil
         case .sessionName:
+            if let customName = session.customSessionName, !customName.isEmpty {
+                return customName
+            }
             let workspace = session.jumpTarget?.workspaceName ?? ""
             if !workspace.isEmpty { return workspace }
             return session.title.isEmpty ? session.tool.displayName : session.title

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -870,7 +870,9 @@ final class AppModel {
         case .off:
             return nil
         case .sessionName:
-            if let customName = session.customSessionName, !customName.isEmpty {
+            if let customName = session.customSessionName?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+                !customName.isEmpty {
                 return customName
             }
             let workspace = session.jumpTarget?.workspaceName ?? ""

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -33,6 +33,11 @@ final class ProcessMonitoringCoordinator {
     @ObservationIgnored
     var onCodexAppMaintenanceTick: (() -> Void)?
 
+    /// Fires on every monitor tick regardless of which agents are running.
+    /// Callees are expected to throttle internally.
+    @ObservationIgnored
+    var onMaintenanceTick: (() -> Void)?
+
     @ObservationIgnored
     let activeAgentProcessDiscovery = ActiveAgentProcessDiscovery()
 
@@ -175,6 +180,8 @@ final class ProcessMonitoringCoordinator {
                     }
                     hadTrackedLiveSessions = hasTrackedLiveSessions
                 }
+
+                self.onMaintenanceTick?()
 
                 let wakeInterval = Self.monitoringWakeInterval(
                     isResolvingInitialLiveSessions: self.isResolvingInitialLiveSessions,

--- a/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
+++ b/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
@@ -61,6 +61,9 @@ final class SessionDiscoveryCoordinator {
     private let claudeTranscriptDiscovery = ClaudeTranscriptDiscovery()
 
     @ObservationIgnored
+    private let claudeLiveSessionIndex = ClaudeLiveSessionIndex()
+
+    @ObservationIgnored
     private var codexSessionPersistenceTask: Task<Void, Never>?
 
     @ObservationIgnored
@@ -355,6 +358,7 @@ final class SessionDiscoveryCoordinator {
             agentID: discovered.agentID ?? existing.agentID,
             agentType: discovered.agentType ?? existing.agentType,
             worktreeBranch: discovered.worktreeBranch ?? existing.worktreeBranch,
+            customTitle: discovered.customTitle ?? existing.customTitle,
             activeSubagents: existing.activeSubagents.isEmpty ? discovered.activeSubagents : existing.activeSubagents
         )
         return merged.isEmpty ? nil : merged
@@ -407,6 +411,64 @@ final class SessionDiscoveryCoordinator {
             now: now
         ) {
             onAgentEvent?(event)
+        }
+    }
+
+    // MARK: - Claude live session names
+
+    @ObservationIgnored
+    private var lastClaudeSessionNameRefreshDate: Date = .distantPast
+
+    /// Picks up `/rename` names of running Claude Code sessions from the
+    /// live session index (`<config dir>/sessions/*.json`). Transcript
+    /// discovery only runs at startup, so without this a mid-session
+    /// rename would not appear until the next app launch. Throttled
+    /// internally; safe to call from the monitor loop.
+    func refreshClaudeSessionNamesIfNeeded() {
+        let now = Date.now
+        guard now.timeIntervalSince(lastClaudeSessionNameRefreshDate) >= 5 else { return }
+        lastClaudeSessionNameRefreshDate = now
+
+        guard state.sessions.contains(where: { $0.tool == .claudeCode && !$0.isSessionEnded }) else {
+            return
+        }
+
+        let index = claudeLiveSessionIndex
+        Task.detached(priority: .utility) { [weak self] in
+            let names = index.userAssignedSessionNames()
+            guard !names.isEmpty else { return }
+            await MainActor.run { [weak self] in
+                self?.applyClaudeLiveSessionNames(names)
+            }
+        }
+    }
+
+    private func applyClaudeLiveSessionNames(_ namesBySessionID: [String: String]) {
+        var didChange = false
+
+        for session in state.sessions {
+            guard session.tool == .claudeCode,
+                  let name = namesBySessionID[session.id],
+                  session.claudeMetadata?.customTitle != name else {
+                continue
+            }
+
+            var metadata = session.claudeMetadata ?? ClaudeSessionMetadata()
+            metadata.customTitle = name
+            onAgentEvent?(
+                .claudeSessionMetadataUpdated(
+                    ClaudeSessionMetadataUpdated(
+                        sessionID: session.id,
+                        claudeMetadata: metadata,
+                        timestamp: .now
+                    )
+                )
+            )
+            didChange = true
+        }
+
+        if didChange {
+            scheduleClaudeSessionPersistence()
         }
     }
 

--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -540,6 +540,14 @@ public extension AgentSession {
         return false
     }
 
+    /// Name the user assigned to the session inside the agent itself
+    /// (e.g. Claude Code's `/rename`). UI surfaces prefer this over the
+    /// derived workspace title; `title` stays untouched because terminal
+    /// attachment matching depends on its derived form.
+    var customSessionName: String? {
+        claudeMetadata?.customTitle
+    }
+
     var currentToolName: String? {
         codexMetadata?.currentTool ?? claudeMetadata?.currentTool ?? openCodeMetadata?.currentTool ?? cursorMetadata?.currentTool
     }

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -2084,6 +2084,7 @@ public final class BridgeServer: @unchecked Sendable {
                 ? existing?.agentType
                 : update.agentType ?? existing?.agentType,
             worktreeBranch: update.worktreeBranch ?? existing?.worktreeBranch,
+            customTitle: update.customTitle ?? existing?.customTitle,
             activeSubagents: existing?.activeSubagents ?? [],
             activeTasks: existing?.activeTasks ?? []
         )

--- a/Sources/OpenIslandCore/ClaudeHooks.swift
+++ b/Sources/OpenIslandCore/ClaudeHooks.swift
@@ -259,6 +259,10 @@ public struct ClaudeSessionMetadata: Equatable, Codable, Sendable {
     public var agentID: String?
     public var agentType: String?
     public var worktreeBranch: String?
+    /// User-assigned session name (Claude Code `/rename` or `--name`).
+    /// Sourced from `custom-title` transcript records and the live
+    /// `~/.claude/sessions/*.json` files — never auto-generated titles.
+    public var customTitle: String?
     public var activeSubagents: [ClaudeSubagentInfo]
     public var activeTasks: [ClaudeTaskInfo]
 
@@ -275,6 +279,7 @@ public struct ClaudeSessionMetadata: Equatable, Codable, Sendable {
         agentID: String? = nil,
         agentType: String? = nil,
         worktreeBranch: String? = nil,
+        customTitle: String? = nil,
         activeSubagents: [ClaudeSubagentInfo] = [],
         activeTasks: [ClaudeTaskInfo] = []
     ) {
@@ -290,6 +295,7 @@ public struct ClaudeSessionMetadata: Equatable, Codable, Sendable {
         self.agentID = agentID
         self.agentType = agentType
         self.worktreeBranch = worktreeBranch
+        self.customTitle = customTitle
         self.activeSubagents = activeSubagents
         self.activeTasks = activeTasks
     }
@@ -307,6 +313,7 @@ public struct ClaudeSessionMetadata: Equatable, Codable, Sendable {
             && agentID == nil
             && agentType == nil
             && worktreeBranch == nil
+            && customTitle == nil
             && activeSubagents.isEmpty
             && activeTasks.isEmpty
     }

--- a/Sources/OpenIslandCore/ClaudeLiveSessionIndex.swift
+++ b/Sources/OpenIslandCore/ClaudeLiveSessionIndex.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Reads Claude Code's live session index at `<config dir>/sessions/`.
+///
+/// Claude Code maintains one small JSON file per running process
+/// (`{pid}.json`) containing the session id and its current name. The
+/// `name` field reflects `/rename` immediately, which makes this the
+/// live complement to the `custom-title` transcript records that
+/// `ClaudeTranscriptDiscovery` picks up on startup. Files are removed
+/// when the session exits.
+public final class ClaudeLiveSessionIndex: @unchecked Sendable {
+
+    public static var defaultRootURL: URL {
+        ClaudeConfigDirectory.resolved()
+            .appendingPathComponent("sessions", isDirectory: true)
+    }
+
+    private let rootURL: URL?
+    private let fileManager: FileManager
+
+    /// - Parameter rootURL: Injectable for tests. When `nil`, the root is
+    ///   resolved per call so a changed Claude config directory takes
+    ///   effect without restarting the app.
+    public init(
+        rootURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) {
+        self.rootURL = rootURL
+        self.fileManager = fileManager
+    }
+
+    /// Session names the user assigned themselves (`/rename`, `--name`),
+    /// keyed by session id.
+    ///
+    /// Auto-generated names are excluded: Claude Code marks those with
+    /// `nameSource` values like `"derived"` or `"auto"`, while user-assigned
+    /// names carry `"user"` or omit the field entirely.
+    public func userAssignedSessionNames() -> [String: String] {
+        let rootURL = rootURL ?? Self.defaultRootURL
+        guard let fileURLs = try? fileManager.contentsOfDirectory(
+            at: rootURL,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else {
+            return [:]
+        }
+
+        var namesBySessionID: [String: String] = [:]
+
+        for fileURL in fileURLs where fileURL.pathExtension == "json" {
+            guard let data = try? Data(contentsOf: fileURL),
+                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let sessionID = object["sessionId"] as? String,
+                  !sessionID.isEmpty,
+                  let name = object["name"] as? String,
+                  !name.isEmpty else {
+                continue
+            }
+
+            if let nameSource = object["nameSource"] as? String,
+               nameSource != "user" {
+                continue
+            }
+
+            namesBySessionID[sessionID] = name
+        }
+
+        return namesBySessionID
+    }
+}

--- a/Sources/OpenIslandCore/ClaudeTranscriptDiscovery.swift
+++ b/Sources/OpenIslandCore/ClaudeTranscriptDiscovery.swift
@@ -98,7 +98,13 @@ public final class ClaudeTranscriptDiscovery: @unchecked Sendable {
                 return
             }
 
-            if let value = object["sessionId"] as? String, !value.isEmpty {
+            let topLevelType = object["type"] as? String
+
+            // Custom-title records can reference other session ids (e.g.
+            // forked "(Branch)" sessions sharing one transcript) — they
+            // must not reassign the transcript's session identity.
+            if let value = object["sessionId"] as? String, !value.isEmpty,
+               topLevelType != "custom-title" {
                 sessionID = value
             }
 
@@ -110,8 +116,6 @@ public final class ClaudeTranscriptDiscovery: @unchecked Sendable {
                let timestamp = ISO8601DateFormatter().date(from: timestampText) {
                 updatedAt = timestamp
             }
-
-            let topLevelType = object["type"] as? String
             let message = object["message"] as? [String: Any]
             let role = message?["role"] as? String
 

--- a/Sources/OpenIslandCore/ClaudeTranscriptDiscovery.swift
+++ b/Sources/OpenIslandCore/ClaudeTranscriptDiscovery.swift
@@ -88,6 +88,9 @@ public final class ClaudeTranscriptDiscovery: @unchecked Sendable {
         var currentTool: String?
         var currentToolInputPreview: String?
         var pendingToolUses: [String: (name: String, preview: String?)] = [:]
+        // `/rename` appends `{"type":"custom-title","customTitle":…,"sessionId":…}`
+        // records; Claude Code applies them last-wins per session id.
+        var customTitlesBySessionID: [String: String] = [:]
 
         let processLine: (String) -> Void = { line in
             guard let data = line.data(using: .utf8),
@@ -156,6 +159,12 @@ public final class ClaudeTranscriptDiscovery: @unchecked Sendable {
                       let summary = object["summary"] as? String,
                       !summary.isEmpty {
                 lastAssistantMessage = summary
+            } else if topLevelType == "custom-title",
+                      let customTitle = object["customTitle"] as? String,
+                      !customTitle.isEmpty,
+                      let titleSessionID = object["sessionId"] as? String,
+                      !titleSessionID.isEmpty {
+                customTitlesBySessionID[titleSessionID] = customTitle
             }
         }
 
@@ -188,7 +197,8 @@ public final class ClaudeTranscriptDiscovery: @unchecked Sendable {
             lastAssistantMessage: lastAssistantMessage,
             currentTool: currentTool,
             currentToolInputPreview: currentToolInputPreview,
-            model: model
+            model: model,
+            customTitle: customTitlesBySessionID[sessionID]
         )
         let summary = lastAssistantMessage
             ?? lastUserPrompt

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -57,6 +57,7 @@ public struct SessionState: Equatable, Sendable {
         switch event {
         case let .sessionStarted(payload):
             let preservedFirstSeenAt = sessionsByID[payload.sessionID]?.firstSeenAt
+            let preservedCustomTitle = sessionsByID[payload.sessionID]?.claudeMetadata?.customTitle
             var session = AgentSession(
                 id: payload.sessionID,
                 title: payload.title,
@@ -74,6 +75,13 @@ public struct SessionState: Equatable, Sendable {
                 openCodeMetadata: payload.openCodeMetadata?.isEmpty == true ? nil : payload.openCodeMetadata,
                 cursorMetadata: payload.cursorMetadata?.isEmpty == true ? nil : payload.cursorMetadata
             )
+            // A re-start of a known session (resume/clear/compact) carries no
+            // custom title in its hook payload — keep the one already tracked.
+            if session.claudeMetadata?.customTitle == nil, let preservedCustomTitle {
+                var metadata = session.claudeMetadata ?? ClaudeSessionMetadata()
+                metadata.customTitle = preservedCustomTitle
+                session.claudeMetadata = metadata
+            }
             session.isRemote = payload.isRemote
             session.isHookManaged = payload.origin == .live
             // Codex.app sessions use app-level liveness (NSRunningApplication)

--- a/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
+++ b/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
@@ -205,7 +205,7 @@ struct AgentSessionPresentationTests {
             ),
             claudeMetadata: ClaudeSessionMetadata(
                 initialUserPrompt: "Refactor the checkout flow.",
-                customTitle: "checkout-flow"
+                customTitle: "  checkout-flow  "
             )
         )
 

--- a/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
+++ b/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
@@ -214,6 +214,30 @@ struct AgentSessionPresentationTests {
     }
 
     @Test
+    func whitespaceOnlyCustomNameFallsBackToWorkspaceName() {
+        let session = AgentSession(
+            id: "session-1",
+            title: "Claude · open-island",
+            tool: .claudeCode,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Working",
+            updatedAt: Date(timeIntervalSince1970: 10_000),
+            jumpTarget: JumpTarget(
+                terminalApp: "Ghostty",
+                workspaceName: "open-island",
+                paneTitle: "claude ~/tmp/open-island",
+                workingDirectory: "/tmp/open-island",
+                terminalSessionID: "ghostty-1"
+            ),
+            claudeMetadata: ClaudeSessionMetadata(customTitle: "   ")
+        )
+
+        #expect(session.spotlightWorkspaceName == "open-island")
+    }
+
+    @Test
     func sessionWithoutCustomNameKeepsWorkspaceHeadline() {
         let session = AgentSession(
             id: "session-1",

--- a/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
+++ b/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
@@ -184,6 +184,62 @@ struct AgentSessionPresentationTests {
     }
 
     @Test
+    func customSessionNameWinsOverWorkspaceNameInHeadline() {
+        // A Claude Code `/rename` name replaces the workspace name on all
+        // spotlight surfaces (Philipp's request from the Slack thread).
+        let session = AgentSession(
+            id: "session-1",
+            title: "Claude · open-island",
+            tool: .claudeCode,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Working",
+            updatedAt: Date(timeIntervalSince1970: 10_000),
+            jumpTarget: JumpTarget(
+                terminalApp: "Ghostty",
+                workspaceName: "open-island",
+                paneTitle: "claude ~/tmp/open-island",
+                workingDirectory: "/tmp/open-island",
+                terminalSessionID: "ghostty-1"
+            ),
+            claudeMetadata: ClaudeSessionMetadata(
+                initialUserPrompt: "Refactor the checkout flow.",
+                customTitle: "checkout-flow"
+            )
+        )
+
+        #expect(session.spotlightWorkspaceName == "checkout-flow")
+        #expect(session.spotlightHeadlineText == "checkout-flow · Refactor the checkout flow.")
+    }
+
+    @Test
+    func sessionWithoutCustomNameKeepsWorkspaceHeadline() {
+        let session = AgentSession(
+            id: "session-1",
+            title: "Claude · open-island",
+            tool: .claudeCode,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Working",
+            updatedAt: Date(timeIntervalSince1970: 10_000),
+            jumpTarget: JumpTarget(
+                terminalApp: "Ghostty",
+                workspaceName: "open-island",
+                paneTitle: "claude ~/tmp/open-island",
+                workingDirectory: "/tmp/open-island",
+                terminalSessionID: "ghostty-1"
+            ),
+            claudeMetadata: ClaudeSessionMetadata(
+                initialUserPrompt: "Refactor the checkout flow."
+            )
+        )
+
+        #expect(session.spotlightWorkspaceName == "open-island")
+    }
+
+    @Test
     func liveHeadlineUsesLatestPromptForAttachedSession() {
         let session = AgentSession(
             id: "session-1",

--- a/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
@@ -118,6 +118,78 @@ struct ClaudeHooksTests {
     }
 
     @Test
+    func claudeTranscriptDiscoveryRecoversCustomTitleLastWins() throws {
+        // `/rename` appends `custom-title` records to the transcript;
+        // Claude Code treats them as last-wins per session id.
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-claude-discovery-title-\(UUID().uuidString)", isDirectory: true)
+        let workspaceDirectory = rootURL
+            .appendingPathComponent("projects", isDirectory: true)
+            .appendingPathComponent("-tmp-demo-repo", isDirectory: true)
+        let transcriptURL = workspaceDirectory.appendingPathComponent("session-renamed.jsonl")
+        let discovery = ClaudeTranscriptDiscovery(rootURL: rootURL.appendingPathComponent("projects", isDirectory: true))
+
+        defer {
+            try? FileManager.default.removeItem(at: rootURL)
+        }
+
+        try FileManager.default.createDirectory(at: workspaceDirectory, withIntermediateDirectories: true)
+        let transcript = """
+        {"cwd":"/tmp/demo-repo","sessionId":"session-renamed","type":"user","message":{"role":"user","content":"Refactor the checkout flow."},"timestamp":"2026-04-03T03:20:00Z"}
+        {"type":"custom-title","customTitle":"checkout-flow","sessionId":"session-renamed"}
+        {"cwd":"/tmp/demo-repo","sessionId":"session-renamed","type":"assistant","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"Starting the refactor."}]},"timestamp":"2026-04-03T03:20:02Z"}
+        {"type":"custom-title","customTitle":"checkout-flow-v2","sessionId":"session-renamed"}
+        {"cwd":"/tmp/demo-repo","sessionId":"session-renamed","type":"assistant","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"Done with the refactor."}]},"timestamp":"2026-04-03T03:20:06Z"}
+        """
+        try transcript.write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+        let sessions = discovery.discoverRecentSessions(
+            now: ISO8601DateFormatter().date(from: "2026-04-03T03:20:10Z")!
+        )
+
+        #expect(sessions.count == 1)
+        let session = try #require(sessions.first)
+        #expect(session.id == "session-renamed")
+        #expect(session.claudeMetadata?.customTitle == "checkout-flow-v2")
+        // The derived title stays untouched — terminal attachment matching depends on it.
+        #expect(session.title == "Claude · demo-repo")
+        #expect(session.customSessionName == "checkout-flow-v2")
+    }
+
+    @Test
+    func claudeTranscriptDiscoveryIgnoresCustomTitleOfOtherSessions() throws {
+        // Forked/branched transcripts can contain custom-title records for
+        // other session ids; only the record matching this session applies.
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-claude-discovery-fork-\(UUID().uuidString)", isDirectory: true)
+        let workspaceDirectory = rootURL
+            .appendingPathComponent("projects", isDirectory: true)
+            .appendingPathComponent("-tmp-demo-repo", isDirectory: true)
+        let transcriptURL = workspaceDirectory.appendingPathComponent("session-plain.jsonl")
+        let discovery = ClaudeTranscriptDiscovery(rootURL: rootURL.appendingPathComponent("projects", isDirectory: true))
+
+        defer {
+            try? FileManager.default.removeItem(at: rootURL)
+        }
+
+        try FileManager.default.createDirectory(at: workspaceDirectory, withIntermediateDirectories: true)
+        let transcript = """
+        {"type":"custom-title","customTitle":"other-session-name","sessionId":"session-other"}
+        {"cwd":"/tmp/demo-repo","sessionId":"session-plain","type":"user","message":{"role":"user","content":"Just a regular session."},"timestamp":"2026-04-03T03:20:00Z"}
+        {"cwd":"/tmp/demo-repo","sessionId":"session-plain","type":"assistant","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"On it."}]},"timestamp":"2026-04-03T03:20:02Z"}
+        """
+        try transcript.write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+        let sessions = discovery.discoverRecentSessions(
+            now: ISO8601DateFormatter().date(from: "2026-04-03T03:20:10Z")!
+        )
+
+        let session = try #require(sessions.first)
+        #expect(session.id == "session-plain")
+        #expect(session.claudeMetadata?.customTitle == nil)
+    }
+
+    @Test
     func claudeTranscriptDiscoveryStreamsTranscriptsLargerThanReadChunk() throws {
         // Pins streaming behavior across read-chunk boundaries. The
         // pre-fix `parseSession` used `String(contentsOf:)` which on

--- a/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
@@ -190,6 +190,42 @@ struct ClaudeHooksTests {
     }
 
     @Test
+    func claudeTranscriptDiscoveryKeepsSessionIdentityWhenForeignCustomTitleAppearsLast() throws {
+        // A custom-title record for another session id as the final
+        // transcript line must not reassign the session's identity.
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-claude-discovery-fork-last-\(UUID().uuidString)", isDirectory: true)
+        let workspaceDirectory = rootURL
+            .appendingPathComponent("projects", isDirectory: true)
+            .appendingPathComponent("-tmp-demo-repo", isDirectory: true)
+        let transcriptURL = workspaceDirectory.appendingPathComponent("session-primary.jsonl")
+        let discovery = ClaudeTranscriptDiscovery(rootURL: rootURL.appendingPathComponent("projects", isDirectory: true))
+
+        defer {
+            try? FileManager.default.removeItem(at: rootURL)
+        }
+
+        try FileManager.default.createDirectory(at: workspaceDirectory, withIntermediateDirectories: true)
+        let transcript = """
+        {"cwd":"/tmp/demo-repo","sessionId":"session-primary","type":"user","message":{"role":"user","content":"Work on the primary session."},"timestamp":"2026-04-03T03:20:00Z"}
+        {"type":"custom-title","customTitle":"primary-name","sessionId":"session-primary"}
+        {"cwd":"/tmp/demo-repo","sessionId":"session-primary","type":"assistant","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"Primary session reply."}]},"timestamp":"2026-04-03T03:20:02Z"}
+        {"type":"custom-title","customTitle":"branch-name","sessionId":"session-branch"}
+        """
+        try transcript.write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+        let sessions = discovery.discoverRecentSessions(
+            now: ISO8601DateFormatter().date(from: "2026-04-03T03:20:10Z")!
+        )
+
+        let session = try #require(sessions.first)
+        #expect(session.id == "session-primary")
+        #expect(session.title == "Claude · demo-repo")
+        #expect(session.claudeMetadata?.customTitle == "primary-name")
+        #expect(session.claudeMetadata?.lastAssistantMessage == "Primary session reply.")
+    }
+
+    @Test
     func claudeTranscriptDiscoveryStreamsTranscriptsLargerThanReadChunk() throws {
         // Pins streaming behavior across read-chunk boundaries. The
         // pre-fix `parseSession` used `String(contentsOf:)` which on

--- a/Tests/OpenIslandCoreTests/ClaudeLiveSessionIndexTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeLiveSessionIndexTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+struct ClaudeLiveSessionIndexTests {
+    private func makeSessionsDirectory() throws -> URL {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-claude-live-index-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        return rootURL
+    }
+
+    @Test
+    func returnsUserAssignedNamesOnly() throws {
+        let rootURL = try makeSessionsDirectory()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        // `/rename` / `--name` writes `name` without a `nameSource`.
+        try #"{"pid":100,"sessionId":"session-user","name":"checkout-flow","status":"busy"}"#
+            .write(to: rootURL.appendingPathComponent("100.json"), atomically: true, encoding: .utf8)
+        // Explicit user marker.
+        try #"{"pid":101,"sessionId":"session-user-explicit","name":"payments","nameSource":"user"}"#
+            .write(to: rootURL.appendingPathComponent("101.json"), atomically: true, encoding: .utf8)
+        // Auto-generated names are marked "derived" (or "auto") and must be skipped.
+        try #"{"pid":102,"sessionId":"session-derived","name":"open-vibe-island-db","nameSource":"derived"}"#
+            .write(to: rootURL.appendingPathComponent("102.json"), atomically: true, encoding: .utf8)
+        try #"{"pid":103,"sessionId":"session-auto","name":"generated-topic","nameSource":"auto"}"#
+            .write(to: rootURL.appendingPathComponent("103.json"), atomically: true, encoding: .utf8)
+        // No name at all.
+        try #"{"pid":104,"sessionId":"session-unnamed","status":"idle"}"#
+            .write(to: rootURL.appendingPathComponent("104.json"), atomically: true, encoding: .utf8)
+        // Malformed JSON must not break the scan.
+        try #"{"pid":105,"sessionId":"#
+            .write(to: rootURL.appendingPathComponent("105.json"), atomically: true, encoding: .utf8)
+        // Non-JSON files are ignored.
+        try "not a session".write(to: rootURL.appendingPathComponent("notes.txt"), atomically: true, encoding: .utf8)
+
+        let index = ClaudeLiveSessionIndex(rootURL: rootURL)
+        let names = index.userAssignedSessionNames()
+
+        #expect(names == [
+            "session-user": "checkout-flow",
+            "session-user-explicit": "payments",
+        ])
+    }
+
+    @Test
+    func returnsEmptyForMissingDirectory() {
+        let missingURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-claude-live-index-missing-\(UUID().uuidString)", isDirectory: true)
+
+        let index = ClaudeLiveSessionIndex(rootURL: missingURL)
+
+        #expect(index.userAssignedSessionNames().isEmpty)
+    }
+}

--- a/Tests/OpenIslandCoreTests/ClaudeSessionRegistryTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeSessionRegistryTests.swift
@@ -38,7 +38,8 @@ struct ClaudeSessionRegistryTests {
                     lastAssistantMessage: "Implementing the registry.",
                     currentTool: "Task",
                     currentToolInputPreview: "Implement ClaudeSessionRegistry",
-                    model: "sonnet"
+                    model: "sonnet",
+                    customTitle: "registry-hardening"
                 )
             ),
         ]
@@ -48,6 +49,7 @@ struct ClaudeSessionRegistryTests {
 
         #expect(reloaded == records)
         #expect(reloaded.first?.session.claudeMetadata?.transcriptPath == "/tmp/claude.jsonl")
+        #expect(reloaded.first?.session.claudeMetadata?.customTitle == "registry-hardening")
         #expect(reloaded.first?.session.jumpTarget?.terminalTTY == "/dev/ttys002")
     }
 

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -336,6 +336,92 @@ struct SessionStateTests {
     }
 
     @Test
+    func preservesClaudeCustomTitleAcrossSessionRestart() {
+        // `/rename` names arrive via metadata updates; a later re-start of
+        // the same session (resume/clear/compact) carries no custom title
+        // in its hook payload and must not wipe the tracked one.
+        var state = SessionState()
+        let startedAt = Date(timeIntervalSince1970: 5_000)
+
+        state.apply(
+            .sessionStarted(
+                SessionStarted(
+                    sessionID: "claude-renamed",
+                    title: "Claude · open-island",
+                    tool: .claudeCode,
+                    origin: .live,
+                    summary: "Working",
+                    timestamp: startedAt
+                )
+            )
+        )
+
+        state.apply(
+            .claudeSessionMetadataUpdated(
+                ClaudeSessionMetadataUpdated(
+                    sessionID: "claude-renamed",
+                    claudeMetadata: ClaudeSessionMetadata(customTitle: "checkout-flow"),
+                    timestamp: startedAt.addingTimeInterval(5)
+                )
+            )
+        )
+        #expect(state.session(id: "claude-renamed")?.claudeMetadata?.customTitle == "checkout-flow")
+
+        state.apply(
+            .sessionStarted(
+                SessionStarted(
+                    sessionID: "claude-renamed",
+                    title: "Claude · open-island",
+                    tool: .claudeCode,
+                    origin: .live,
+                    summary: "Resumed",
+                    timestamp: startedAt.addingTimeInterval(10),
+                    claudeMetadata: ClaudeSessionMetadata(startupSource: .resume)
+                )
+            )
+        )
+
+        #expect(state.session(id: "claude-renamed")?.claudeMetadata?.customTitle == "checkout-flow")
+        #expect(state.session(id: "claude-renamed")?.claudeMetadata?.startupSource == .resume)
+    }
+
+    @Test
+    func sessionStartCustomTitleWinsOverPreservedOne() {
+        var state = SessionState()
+        let startedAt = Date(timeIntervalSince1970: 5_000)
+
+        state.apply(
+            .sessionStarted(
+                SessionStarted(
+                    sessionID: "claude-renamed",
+                    title: "Claude · open-island",
+                    tool: .claudeCode,
+                    origin: .live,
+                    summary: "Working",
+                    timestamp: startedAt,
+                    claudeMetadata: ClaudeSessionMetadata(customTitle: "old-name")
+                )
+            )
+        )
+
+        state.apply(
+            .sessionStarted(
+                SessionStarted(
+                    sessionID: "claude-renamed",
+                    title: "Claude · open-island",
+                    tool: .claudeCode,
+                    origin: .live,
+                    summary: "Restarted",
+                    timestamp: startedAt.addingTimeInterval(10),
+                    claudeMetadata: ClaudeSessionMetadata(customTitle: "new-name")
+                )
+            )
+        )
+
+        #expect(state.session(id: "claude-renamed")?.claudeMetadata?.customTitle == "new-name")
+    }
+
+    @Test
     func preservesLiveSessionOriginFromStartEvent() {
         var state = SessionState()
 


### PR DESCRIPTION
## What

Session names assigned inside Claude Code via `/rename` (or `claude --name`) now show up in Open Island — in the panel row headline and in the closed-island **Session name** center label. Previously the island only ever showed the workspace (folder) name derived from `cwd`, so users who rename their parallel sessions to stay oriented couldn't see those names here.

## How Claude Code persists renames (verified empirically against Claude Code 2.1.220)

- `/rename` appends `{"type":"custom-title","customTitle":"…","sessionId":"…"}` to the session transcript JSONL, applied **last-wins** per session id. Auto-generated titles use a different record type (`ai-title`), so the two never mix.
- While a session is running, `<config dir>/sessions/{pid}.json` carries the current `name` plus a `nameSource` marker — `"derived"`/`"auto"` for generated names, `"user"` or absent for user-assigned ones. The file is removed when the session exits.

## Changes

- **`ClaudeTranscriptDiscovery`** parses `custom-title` records (last-wins, keyed by the record's `sessionId`) → renames survive app restarts and cold-start recovery.
- **New `ClaudeLiveSessionIndex`** reads `<config dir>/sessions/*.json` so a mid-session `/rename` appears within seconds, via a new throttled (5 s) refresh on the existing monitor loop. Only user-assigned names are used; auto-generated ones are deliberately excluded so behavior for un-renamed sessions is unchanged.
- **`ClaudeSessionMetadata.customTitle`** carries the name through the bridge metadata merge, session re-starts (resume/clear/compact), discovery merge, and the on-disk session registry.
- **Presentation**: `spotlightWorkspaceName` and the `.sessionName` center-label branch prefer the custom name. The derived `title` (`"Claude · <workspace>"`) stays untouched on purpose — terminal attachment matching (`TerminalSessionAttachmentProbe`) depends on it, and project grouping stays by workspace.

## Testing

- 8 new tests: transcript parsing (last-wins, foreign-session records ignored), live-index filtering (`user` vs `derived`/`auto` vs malformed files), `SessionState` custom-title preservation across session restarts, registry round-trip, and presentation precedence.
- `swift build` + full `swift test` pass (333 tests).
- Record formats validated against real transcripts and live session files produced by Claude Code 2.1.220, including a `--name`d headless session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claude session names and spotlight titles now use user-assigned custom titles when available.
  * Custom titles are discovered from both transcript data and live session information.
  * Custom titles are merged into session metadata and persisted across saved/loaded state.
* **Bug Fixes**
  * Improved handling for whitespace-only/empty custom titles with proper fallback to workspace names.
  * Preserves custom titles across session restarts when the new payload omits them.
* **Tests**
  * Expanded coverage for custom-title discovery, live-session indexing, persistence, and spotlight fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->