### PR TITLE
feat: replace Gemini CLI support with Antigravity CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,6 @@ The project is past MVP and welcomes new ideas and creative directions, but the 
 - `Sources/OpenIslandCore/SessionState.swift` — pure reducer
 - `Sources/OpenIslandCore/AgentEvent.swift` — event enum driving all transitions
 - `Sources/OpenIslandCore/BridgeTransport.swift` + `BridgeServer.swift` — socket protocol & dispatch
-- `Sources/OpenIslandCore/{Claude,Codex,Gemini,Kimi,Cursor}Hooks.swift` etc. — per-agent hook payload models
+- `Sources/OpenIslandCore/{Claude,Codex,Antigravity,Kimi,Cursor}Hooks.swift` etc. — per-agent hook payload models
 - `Sources/OpenIslandHooks/main.swift` — hook CLI entry
 - `docs/product.md`, `docs/architecture.md`, `AGENTS.md` — design / working-agreement docs

--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ Think of it as an open-source [Vibe Island](https://vibeisland.app/) — **free,
 - **Open source** — GPL v3, fork it, mod it, ship your own version
 - **Local-first** — No server, no telemetry, no account. Everything runs on your Mac
 - **Native macOS** — SwiftUI + AppKit, not an Electron wrapper
-- **Multi-agent** — One surface for Claude Code, Codex, Cursor, Gemini CLI, OpenCode, and more
+- **Multi-agent** — One surface for Claude Code, Codex, Cursor, Antigravity CLI, OpenCode, and more
 - **Multi-terminal** — Jump back to the exact terminal/IDE session in one click
 
 ## Supported Agents & Terminals
 
-**10 agents**: Claude Code, Codex, Cursor, Gemini CLI, Kimi CLI, OpenCode, Qoder, Qwen Code, Factory, CodeBuddy
+**10 agents**: Claude Code, Codex, Cursor, Antigravity CLI, Kimi CLI, OpenCode, Qoder, Qwen Code, Factory, CodeBuddy
 
 **15+ terminals & IDEs**: Terminal.app, Ghostty, iTerm2, WezTerm, Zellij, tmux, cmux, Kaku, VS Code, Cursor, Windsurf, Trae, JetBrains IDEs (IDEA, WebStorm, PyCharm, GoLand, CLion, RubyMine, PhpStorm, Rider, RustRover)
 
@@ -71,7 +71,7 @@ Think of it as an open-source [Vibe Island](https://vibeisland.app/) — **free,
 | **Factory** | Supported | Claude Code fork — same hook format, config at `~/.factory/settings.json` |
 | **CodeBuddy** | Supported | Claude Code fork — same hook format, config at `~/.codebuddy/settings.json` |
 | **Cursor** | Supported | Hook integration via `~/.cursor/hooks.json`, session tracking, workspace jump-back |
-| **Gemini CLI** | Supported | Hook integration via `~/.gemini/settings.json`, session tracking, fire-and-forget events |
+| **Antigravity CLI** | Supported | Hook integration via `~/.antigravity/settings.json`, session tracking, event notifications (`SessionStart`, `BeforeAgent`, `AfterAgent`, `SessionEnd`, `Notification`) |
 | **Kimi CLI** | Supported | Hook integration via `~/.kimi/config.toml` `[[hooks]]`, session tracking, permission flow (reuses Claude payload) |
 
 ### Terminals & IDEs
@@ -270,7 +270,7 @@ Developers who already live in the terminal and want a better way to work with c
 - **Factory** — Claude Code fork. Same hook format and events via `~/.factory/settings.json`. Use `--source factory` with the hooks binary.
 - **CodeBuddy** — Claude Code fork. Same hook format and events via `~/.codebuddy/settings.json`. Use `--source codebuddy` with the hooks binary.
 - **Cursor** — Hook-based integration via `~/.cursor/hooks.json`. Receives `beforeSubmitPrompt`, `beforeShellExecution`, `beforeMCPExecution`, `beforeReadFile`, `afterFileEdit`, and `stop` events. Session persistence across app launches. Workspace jump-back via `cursor -r`. Use `--source cursor` with the hooks binary.
-- **Gemini CLI** — Hook-based integration via `~/.gemini/settings.json`. Receives `SessionStart`, `PreToolUse`, `PostToolUse`, `Stop`, and `UserPromptSubmit` events. Fire-and-forget (no block/deny). Use `--source gemini` with the hooks binary.
+- **Antigravity CLI** — Hook-based integration via `~/.antigravity/settings.json` (or `~/.gemini/antigravity-cli/settings.json`). Receives `SessionStart`, `BeforeAgent`, `AfterAgent`, `SessionEnd`, and `Notification` events. Fire-and-forget (no block/deny). Use `--source antigravity` with the hooks binary.
 - **Kimi CLI** — Hook-based integration via `~/.kimi/config.toml` `[[hooks]]` array (Moonshot AI). Kimi's hook payload is byte-compatible with Claude Code, so Open Island reuses the Claude decode path and adds a dedicated TOML installer. Subscribes to `SessionStart`, `UserPromptSubmit`, `Stop`, `Notification`, `PreToolUse`, and `PostToolUse`. Requires the Kimi CLI Hooks Beta. Use `--source kimi` with the hooks binary. Manage installation from the Settings window, or via CLI:
 
   ```sh

--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -182,15 +182,15 @@ struct ActiveAgentProcessDiscovery {
                 continue
             }
 
-            if isGeminiProcess(command: process.command) {
-                let claimKey = "gemini:\(process.pid)"
+            if isAntigravityProcess(command: process.command) {
+                let claimKey = "antigravity:\(process.pid)"
                 guard claimedKeys.insert(claimKey).inserted else {
                     continue
                 }
 
                 let lsofOutput = lsofOutput(pid: process.pid)
                 snapshots.append(ProcessSnapshot(
-                    tool: .geminiCLI,
+                    tool: .antigravityCLI,
                     sessionID: nil,
                     workingDirectory: lsofOutput.flatMap(workingDirectory(from:)),
                     terminalTTY: process.terminalTTY,
@@ -739,17 +739,29 @@ struct ActiveAgentProcessDiscovery {
         return false
     }
 
-    private func isGeminiProcess(command: String) -> Bool {
+    private func isAntigravityProcess(command: String) -> Bool {
         let lowered = command.lowercased()
         guard let firstToken = lowered.split(separator: " ").first.map(String.init) else {
             return false
         }
 
-        return firstToken == "gemini"
+        return firstToken == "antigravity"
+            || firstToken == "agy"
+            || firstToken.hasSuffix("/antigravity")
+            || firstToken.hasSuffix("/agy")
+            || lowered.contains("/bin/antigravity")
+            || lowered.contains("/bin/agy")
+            || lowered.contains("antigravity-cli")
+            || lowered.contains("antigravity_cli")
+            || firstToken == "gemini"
             || firstToken.hasSuffix("/gemini")
             || lowered.contains("/bin/gemini")
             || lowered.contains("/google/gemini-cli")
             || lowered.contains("/@google/gemini-cli")
+    }
+
+    private func isGeminiProcess(command: String) -> Bool {
+        isAntigravityProcess(command: command)
     }
 
     /// Matches the `kimi` CLI (Moonshot) entry-point. `kimi-info` / `kimi-mcp` /

--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -208,6 +208,8 @@ extension AgentSession {
             return "Codex"
         case .geminiCLI:
             return "Gemini"
+        case .antigravityCLI:
+            return "Antigravity"
         case .openCode:
             return "OpenCode"
         case .qoder:

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -132,6 +132,11 @@ final class AppModel {
     var geminiHookStatus: GeminiHookInstallationStatus? { hooks.geminiHookStatus }
     var geminiHookStatusTitle: String { hooks.geminiHookStatusTitle }
     var geminiHookStatusSummary: String { hooks.geminiHookStatusSummary }
+    var antigravityHooksInstalled: Bool { hooks.antigravityHooksInstalled }
+    var isAntigravityHookSetupBusy: Bool { hooks.isAntigravityHookSetupBusy }
+    var antigravityHookStatus: AntigravityHookInstallationStatus? { hooks.antigravityHookStatus }
+    var antigravityHookStatusTitle: String { hooks.antigravityHookStatusTitle }
+    var antigravityHookStatusSummary: String { hooks.antigravityHookStatusSummary }
     var kimiHooksInstalled: Bool { hooks.kimiHooksInstalled }
     var isKimiHookSetupBusy: Bool { hooks.isKimiHookSetupBusy }
     var kimiHookStatus: KimiHookInstallationStatus? { hooks.kimiHookStatus }
@@ -190,6 +195,9 @@ final class AppModel {
     func refreshGeminiHookStatus() { hooks.refreshGeminiHookStatus() }
     func installGeminiHooks() { hooks.installGeminiHooks() }
     func uninstallGeminiHooks() { hooks.uninstallGeminiHooks() }
+    func refreshAntigravityHookStatus() { hooks.refreshAntigravityHookStatus() }
+    func installAntigravityHooks() { hooks.installAntigravityHooks() }
+    func uninstallAntigravityHooks() { hooks.uninstallAntigravityHooks() }
     func refreshKimiHookStatus() { hooks.refreshKimiHookStatus() }
     func installKimiHooks() { hooks.installKimiHooks() }
     func uninstallKimiHooks() { hooks.uninstallKimiHooks() }

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -20,7 +20,11 @@ final class HookInstallationCoordinator {
     var codebuddyHookStatus: ClaudeHookInstallationStatus?
     var openCodePluginStatus: OpenCodePluginInstallationStatus?
     var cursorHookStatus: CursorHookInstallationStatus?
-    var geminiHookStatus: GeminiHookInstallationStatus?
+    var geminiHookStatus: GeminiHookInstallationStatus? {
+        get { antigravityHookStatus }
+        set { antigravityHookStatus = newValue }
+    }
+    var antigravityHookStatus: AntigravityHookInstallationStatus?
     var kimiHookStatus: KimiHookInstallationStatus?
     var claudeStatusLineStatus: ClaudeStatusLineInstallationStatus?
     var claudeUsageSnapshot: ClaudeUsageSnapshot?
@@ -34,7 +38,11 @@ final class HookInstallationCoordinator {
     var isCodebuddyHookSetupBusy = false
     var isOpenCodeSetupBusy = false
     var isCursorHookSetupBusy = false
-    var isGeminiHookSetupBusy = false
+    var isGeminiHookSetupBusy: Bool {
+        get { isAntigravityHookSetupBusy }
+        set { isAntigravityHookSetupBusy = newValue }
+    }
+    var isAntigravityHookSetupBusy = false
     var isKimiHookSetupBusy = false
     var isClaudeUsageSetupBusy = false
 
@@ -80,7 +88,11 @@ final class HookInstallationCoordinator {
     private let cursorHookInstallationManager = CursorHookInstallationManager()
 
     @ObservationIgnored
-    private let geminiHookInstallationManager = GeminiHookInstallationManager()
+    private let antigravityHookInstallationManager = AntigravityHookInstallationManager()
+
+    private var geminiHookInstallationManager: AntigravityHookInstallationManager {
+        antigravityHookInstallationManager
+    }
 
     @ObservationIgnored
     private let kimiHookInstallationManager = KimiHookInstallationManager()
@@ -138,7 +150,11 @@ final class HookInstallationCoordinator {
     }
 
     var geminiHooksInstalled: Bool {
-        geminiHookStatus?.managedHooksPresent == true
+        antigravityHooksInstalled
+    }
+
+    var antigravityHooksInstalled: Bool {
+        antigravityHookStatus?.managedHooksPresent == true
     }
 
     var kimiHooksInstalled: Bool {
@@ -334,20 +350,28 @@ final class HookInstallationCoordinator {
     }
 
     var geminiHookStatusTitle: String {
-        guard let status = geminiHookStatus else { return "Gemini hooks loading" }
-        return status.managedHooksPresent ? "Gemini hooks installed" : "Gemini hooks not installed"
+        antigravityHookStatusTitle
+    }
+
+    var antigravityHookStatusTitle: String {
+        guard let status = antigravityHookStatus else { return "Antigravity hooks loading" }
+        return status.managedHooksPresent ? "Antigravity hooks installed" : "Antigravity hooks not installed"
     }
 
     var geminiHookStatusSummary: String {
-        guard let status = geminiHookStatus else {
-            return "Reading ~/.gemini/settings.json."
+        antigravityHookStatusSummary
+    }
+
+    var antigravityHookStatusSummary: String {
+        guard let status = antigravityHookStatus else {
+            return "Reading ~/.antigravity/settings.json."
         }
 
         if hooksBinaryURL == nil {
             return "Build OpenIslandHooks before installing."
         }
 
-        return status.managedHooksPresent ? "managed hooks present" : "no managed Gemini hooks"
+        return status.managedHooksPresent ? "managed hooks present" : "no managed Antigravity hooks"
     }
 
     var kimiHookStatusTitle: String {
@@ -719,14 +743,18 @@ final class HookInstallationCoordinator {
     }
 
     func refreshGeminiHookStatus() {
+        refreshAntigravityHookStatus()
+    }
+
+    func refreshAntigravityHookStatus() {
         Task { [weak self] in
             guard let self else { return }
 
             do {
-                let status = try self.geminiHookInstallationManager.status(hooksBinaryURL: self.hooksBinaryURL)
-                self.geminiHookStatus = status
+                let status = try self.antigravityHookInstallationManager.status(hooksBinaryURL: self.hooksBinaryURL)
+                self.antigravityHookStatus = status
             } catch {
-                self.onStatusMessage?("Failed to read Gemini hook status: \(error.localizedDescription)")
+                self.onStatusMessage?("Failed to read Antigravity hook status: \(error.localizedDescription)")
             }
         }
     }
@@ -1016,18 +1044,26 @@ final class HookInstallationCoordinator {
     }
 
     func installGeminiHooks() {
+        installAntigravityHooks()
+    }
+
+    func installAntigravityHooks() {
         guard let hooksBinaryURL else {
             onStatusMessage?("Could not find a local OpenIslandHooks binary. Build the package first.")
             return
         }
 
-        updateGeminiHooks(userMessage: "Installing Gemini hooks.", intent: .installed) { manager in
+        updateAntigravityHooks(userMessage: "Installing Antigravity hooks.", intent: .installed) { manager in
             try manager.install(hooksBinaryURL: hooksBinaryURL)
         }
     }
 
     func uninstallGeminiHooks() {
-        updateGeminiHooks(userMessage: "Removing Gemini hooks.", intent: .uninstalled) { manager in
+        uninstallAntigravityHooks()
+    }
+
+    func uninstallAntigravityHooks() {
+        updateAntigravityHooks(userMessage: "Removing Antigravity hooks.", intent: .uninstalled) { manager in
             try manager.uninstall()
         }
     }
@@ -1210,25 +1246,33 @@ final class HookInstallationCoordinator {
         intent: AgentHookIntent,
         operation: @escaping (GeminiHookInstallationManager) throws -> GeminiHookInstallationStatus
     ) {
-        isGeminiHookSetupBusy = true
+        updateAntigravityHooks(userMessage: userMessage, intent: intent, operation: operation)
+    }
+
+    private func updateAntigravityHooks(
+        userMessage: String,
+        intent: AgentHookIntent,
+        operation: @escaping (AntigravityHookInstallationManager) throws -> AntigravityHookInstallationStatus
+    ) {
+        isAntigravityHookSetupBusy = true
         onStatusMessage?(userMessage)
 
         Task { [weak self] in
             guard let self else { return }
 
-            defer { self.isGeminiHookSetupBusy = false }
+            defer { self.isAntigravityHookSetupBusy = false }
 
             do {
-                let status = try operation(self.geminiHookInstallationManager)
-                self.geminiHookStatus = status
-                self.intentStore.setIntent(intent, for: .gemini)
+                let status = try operation(self.antigravityHookInstallationManager)
+                self.antigravityHookStatus = status
+                self.intentStore.setIntent(intent, for: .antigravity)
                 if status.managedHooksPresent {
-                    self.onStatusMessage?("Gemini hooks are installed and ready.")
+                    self.onStatusMessage?("Antigravity hooks are installed and ready.")
                 } else {
-                    self.onStatusMessage?("Gemini hooks are not installed.")
+                    self.onStatusMessage?("Antigravity hooks are not installed.")
                 }
             } catch {
-                self.onStatusMessage?("Gemini hook update failed: \(error.localizedDescription)")
+                self.onStatusMessage?("Antigravity hook update failed: \(error.localizedDescription)")
             }
         }
     }

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -417,6 +417,7 @@ struct SetupSettingsPane: View {
     @State private var confirmingUninstallCodebuddy = false
     @State private var confirmingUninstallCursor = false
     @State private var confirmingUninstallGemini = false
+    @State private var confirmingUninstallAntigravity = false
     @State private var confirmingUninstallKimi = false
     @State private var confirmingUninstallClaudeUsage = false
 
@@ -570,20 +571,20 @@ struct SetupSettingsPane: View {
                 }
 
                 hookRow(
-                    name: "Gemini CLI",
-                    installed: model.geminiHooksInstalled,
-                    busy: model.isGeminiHookSetupBusy,
-                    configLocationURL: geminiHookConfigURL,
-                    installAction: { model.installGeminiHooks() },
-                    uninstallAction: { confirmingUninstallGemini = true }
+                    name: "Antigravity CLI",
+                    installed: model.antigravityHooksInstalled,
+                    busy: model.isAntigravityHookSetupBusy,
+                    configLocationURL: antigravityHookConfigURL,
+                    installAction: { model.installAntigravityHooks() },
+                    uninstallAction: { confirmingUninstallAntigravity = true }
                 )
-                .alert(lang.t("settings.general.uninstallConfirmTitle"), isPresented: $confirmingUninstallGemini) {
+                .alert(lang.t("settings.general.uninstallConfirmTitle"), isPresented: $confirmingUninstallAntigravity) {
                     Button(lang.t("settings.general.uninstallConfirmAction"), role: .destructive) {
-                        model.uninstallGeminiHooks()
+                        model.uninstallAntigravityHooks()
                     }
                     Button(lang.t("settings.general.cancel"), role: .cancel) {}
                 } message: {
-                    Text("This will remove Open Island hooks from ~/.gemini/settings.json.")
+                    Text("This will remove Open Island hooks from ~/.antigravity/settings.json.")
                 }
 
                 hookRow(
@@ -677,6 +678,7 @@ struct SetupSettingsPane: View {
                     if !model.factoryHooksInstalled { model.installFactoryHooks() }
                     if !model.codebuddyHooksInstalled { model.installCodebuddyHooks() }
                     if !model.cursorHooksInstalled { model.installCursorHooks() }
+                    if !model.antigravityHooksInstalled { model.installAntigravityHooks() }
                     if !model.geminiHooksInstalled { model.installGeminiHooks() }
                     if !model.kimiHooksInstalled { model.installKimiHooks() }
                     if !model.claudeUsageInstalled { model.installClaudeUsageBridge() }
@@ -699,24 +701,16 @@ struct SetupSettingsPane: View {
                         Text(ClaudeConfigDirectory.resolved().path)
                             .font(.caption)
                             .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
                     }
                 } icon: {
                     Image(systemName: "folder")
                 }
                 Spacer()
-                if ClaudeConfigDirectory.customDirectory != nil {
-                    Button(lang.t("setup.claudeConfigDir.reset")) {
-                        model.updateClaudeConfigDirectory(to: nil)
-                    }
-                    .font(.caption)
-                }
-                Button(lang.t("setup.claudeConfigDir.choose")) {
+                Button(lang.t("setup.claudeConfigDir.change")) {
                     let panel = NSOpenPanel()
-                    panel.canChooseDirectories = true
                     panel.canChooseFiles = false
-                    panel.canCreateDirectories = true
+                    panel.canChooseDirectories = true
+                    panel.allowsMultipleSelection = false
                     panel.showsHiddenFiles = true
                     panel.prompt = lang.t("setup.claudeConfigDir.choose")
                     if panel.runModal() == .OK, let url = panel.url {
@@ -740,7 +734,7 @@ struct SetupSettingsPane: View {
     private var allReady: Bool {
         model.claudeHooksInstalled && model.codexHooksInstalled && model.openCodePluginInstalled
             && model.qoderHooksInstalled && model.qwenCodeHooksInstalled && model.factoryHooksInstalled && model.codebuddyHooksInstalled
-            && model.cursorHooksInstalled && model.geminiHooksInstalled && model.kimiHooksInstalled && model.claudeUsageInstalled
+            && model.cursorHooksInstalled && model.antigravityHooksInstalled && model.kimiHooksInstalled && model.claudeUsageInstalled
     }
 
     @ViewBuilder
@@ -774,9 +768,12 @@ struct SetupSettingsPane: View {
         return model.codexHookStatus?.configURL ?? model.codexHookStatus?.hooksURL
     }
 
+    private var antigravityHookConfigURL: URL {
+        model.antigravityHookStatus?.settingsURL ?? AntigravityHookInstallationManager.defaultAntigravityDirectory().appendingPathComponent("settings.json")
+    }
+
     private var geminiHookConfigURL: URL {
-        FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".gemini/settings.json")
+        antigravityHookConfigURL
     }
 
     private var hasErrors: Bool {

--- a/Sources/OpenIslandCore/AgentEvent.swift
+++ b/Sources/OpenIslandCore/AgentEvent.swift
@@ -12,6 +12,7 @@ public struct SessionStarted: Equatable, Codable, Sendable {
     public var codexMetadata: CodexSessionMetadata?
     public var claudeMetadata: ClaudeSessionMetadata?
     public var geminiMetadata: GeminiSessionMetadata?
+    public var antigravityMetadata: AntigravitySessionMetadata?
     public var openCodeMetadata: OpenCodeSessionMetadata?
     public var cursorMetadata: CursorSessionMetadata?
     public var isRemote: Bool
@@ -28,6 +29,7 @@ public struct SessionStarted: Equatable, Codable, Sendable {
         codexMetadata: CodexSessionMetadata? = nil,
         claudeMetadata: ClaudeSessionMetadata? = nil,
         geminiMetadata: GeminiSessionMetadata? = nil,
+        antigravityMetadata: AntigravitySessionMetadata? = nil,
         openCodeMetadata: OpenCodeSessionMetadata? = nil,
         cursorMetadata: CursorSessionMetadata? = nil,
         isRemote: Bool = false
@@ -43,6 +45,7 @@ public struct SessionStarted: Equatable, Codable, Sendable {
         self.codexMetadata = codexMetadata
         self.claudeMetadata = claudeMetadata
         self.geminiMetadata = geminiMetadata
+        self.antigravityMetadata = antigravityMetadata ?? geminiMetadata
         self.openCodeMetadata = openCodeMetadata
         self.cursorMetadata = cursorMetadata
         self.isRemote = isRemote
@@ -174,21 +177,23 @@ public struct ClaudeSessionMetadataUpdated: Equatable, Codable, Sendable {
     }
 }
 
-public struct GeminiSessionMetadataUpdated: Equatable, Codable, Sendable {
+public struct AntigravitySessionMetadataUpdated: Equatable, Codable, Sendable {
     public var sessionID: String
-    public var geminiMetadata: GeminiSessionMetadata
+    public var antigravityMetadata: AntigravitySessionMetadata
     public var timestamp: Date
 
     public init(
         sessionID: String,
-        geminiMetadata: GeminiSessionMetadata,
+        antigravityMetadata: AntigravitySessionMetadata,
         timestamp: Date
     ) {
         self.sessionID = sessionID
-        self.geminiMetadata = geminiMetadata
+        self.antigravityMetadata = antigravityMetadata
         self.timestamp = timestamp
     }
 }
+
+public typealias GeminiSessionMetadataUpdated = AntigravitySessionMetadataUpdated
 
 public struct OpenCodeSessionMetadataUpdated: Equatable, Codable, Sendable {
     public var sessionID: String
@@ -248,6 +253,7 @@ public enum AgentEvent: Equatable, Codable, Sendable {
     case sessionMetadataUpdated(SessionMetadataUpdated)
     case claudeSessionMetadataUpdated(ClaudeSessionMetadataUpdated)
     case geminiSessionMetadataUpdated(GeminiSessionMetadataUpdated)
+    case antigravitySessionMetadataUpdated(AntigravitySessionMetadataUpdated)
     case openCodeSessionMetadataUpdated(OpenCodeSessionMetadataUpdated)
     case cursorSessionMetadataUpdated(CursorSessionMetadataUpdated)
     case actionableStateResolved(ActionableStateResolved)

--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -4,6 +4,7 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
     case claudeCode
     case codex
     case geminiCLI
+    case antigravityCLI
     case openCode
     case qoder
     case qwenCode
@@ -20,6 +21,8 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
             "Codex"
         case .geminiCLI:
             "Gemini CLI"
+        case .antigravityCLI:
+            "Antigravity CLI"
         case .openCode:
             "OpenCode"
         case .qoder:
@@ -45,6 +48,8 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
             "CODEX"
         case .geminiCLI:
             "GEMINI"
+        case .antigravityCLI:
+            "ANTIGRAVITY"
         case .openCode:
             "OPENCODE"
         case .qoder:

--- a/Sources/OpenIslandCore/AntigravityHookInstallationManager.swift
+++ b/Sources/OpenIslandCore/AntigravityHookInstallationManager.swift
@@ -1,0 +1,178 @@
+import Foundation
+
+public struct AntigravityHookInstallationStatus: Equatable, Sendable {
+    public var antigravityDirectory: URL
+    public var settingsURL: URL
+    public var manifestURL: URL
+    public var hooksBinaryURL: URL?
+    public var managedHooksPresent: Bool
+    public var manifest: AntigravityHookInstallerManifest?
+
+    public init(
+        antigravityDirectory: URL,
+        settingsURL: URL,
+        manifestURL: URL,
+        hooksBinaryURL: URL?,
+        managedHooksPresent: Bool,
+        manifest: AntigravityHookInstallerManifest?
+    ) {
+        self.antigravityDirectory = antigravityDirectory
+        self.settingsURL = settingsURL
+        self.manifestURL = manifestURL
+        self.hooksBinaryURL = hooksBinaryURL
+        self.managedHooksPresent = managedHooksPresent
+        self.manifest = manifest
+    }
+}
+
+public typealias GeminiHookInstallationStatus = AntigravityHookInstallationStatus
+
+public final class AntigravityHookInstallationManager: @unchecked Sendable {
+    public let antigravityDirectory: URL
+    public let managedHooksBinaryURL: URL
+    private let fileManager: FileManager
+
+    public static func defaultAntigravityDirectory(fileManager: FileManager = .default) -> URL {
+        let home = fileManager.homeDirectoryForCurrentUser
+        let primary = home.appendingPathComponent(".antigravity", isDirectory: true)
+        let fallback = home.appendingPathComponent(".gemini", isDirectory: true)
+
+        if fileManager.fileExists(atPath: primary.path) {
+            return primary
+        } else if fileManager.fileExists(atPath: fallback.path) {
+            return fallback
+        }
+        return primary
+    }
+
+    public init(
+        antigravityDirectory: URL? = nil,
+        managedHooksBinaryURL: URL = ManagedHooksBinary.defaultURL(),
+        fileManager: FileManager = .default
+    ) {
+        self.antigravityDirectory = antigravityDirectory ?? Self.defaultAntigravityDirectory(fileManager: fileManager)
+        self.managedHooksBinaryURL = managedHooksBinaryURL.standardizedFileURL
+        self.fileManager = fileManager
+    }
+
+    public func status(hooksBinaryURL: URL? = nil) throws -> AntigravityHookInstallationStatus {
+        let settingsURL = antigravityDirectory.appendingPathComponent("settings.json")
+        let manifestURL = antigravityDirectory.appendingPathComponent(AntigravityHookInstallerManifest.fileName)
+        let resolvedBinaryURL = resolvedHooksBinaryURL(explicitURL: hooksBinaryURL)
+        let settingsData = try? Data(contentsOf: settingsURL)
+        let manifest = try loadManifest(at: manifestURL)
+        let managedCommand = manifest?.hookCommand ?? resolvedBinaryURL.map { AntigravityHookInstaller.hookCommand(for: $0.path) }
+        let uninstallMutation = try AntigravityHookInstaller.uninstallSettingsJSON(
+            existingData: settingsData,
+            managedCommand: managedCommand
+        )
+
+        return AntigravityHookInstallationStatus(
+            antigravityDirectory: antigravityDirectory,
+            settingsURL: settingsURL,
+            manifestURL: manifestURL,
+            hooksBinaryURL: resolvedBinaryURL,
+            managedHooksPresent: uninstallMutation.managedHooksPresent,
+            manifest: manifest
+        )
+    }
+
+    @discardableResult
+    public func install(hooksBinaryURL: URL) throws -> AntigravityHookInstallationStatus {
+        try fileManager.createDirectory(at: antigravityDirectory, withIntermediateDirectories: true)
+
+        let settingsURL = antigravityDirectory.appendingPathComponent("settings.json")
+        let manifestURL = antigravityDirectory.appendingPathComponent(AntigravityHookInstallerManifest.fileName)
+        let existingSettings = try? Data(contentsOf: settingsURL)
+        let installedBinaryURL = try ManagedHooksBinary.install(
+            from: hooksBinaryURL,
+            to: managedHooksBinaryURL,
+            fileManager: fileManager
+        )
+        let command = AntigravityHookInstaller.hookCommand(for: installedBinaryURL.path)
+        let mutation = try AntigravityHookInstaller.installSettingsJSON(
+            existingData: existingSettings,
+            hookCommand: command
+        )
+
+        if mutation.changed, fileManager.fileExists(atPath: settingsURL.path) {
+            try backupFile(at: settingsURL)
+        }
+
+        if let contents = mutation.contents {
+            try contents.write(to: settingsURL, options: .atomic)
+        }
+
+        let manifest = AntigravityHookInstallerManifest(hookCommand: command)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(manifest).write(to: manifestURL, options: .atomic)
+
+        return try status(hooksBinaryURL: installedBinaryURL)
+    }
+
+    @discardableResult
+    public func uninstall() throws -> AntigravityHookInstallationStatus {
+        let settingsURL = antigravityDirectory.appendingPathComponent("settings.json")
+        let manifestURL = antigravityDirectory.appendingPathComponent(AntigravityHookInstallerManifest.fileName)
+        let manifest = try loadManifest(at: manifestURL)
+        let existingSettings = try? Data(contentsOf: settingsURL)
+        let mutation = try AntigravityHookInstaller.uninstallSettingsJSON(
+            existingData: existingSettings,
+            managedCommand: manifest?.hookCommand
+        )
+
+        if mutation.changed, fileManager.fileExists(atPath: settingsURL.path) {
+            try backupFile(at: settingsURL)
+        }
+
+        if let contents = mutation.contents {
+            try contents.write(to: settingsURL, options: .atomic)
+        } else if fileManager.fileExists(atPath: settingsURL.path) {
+            try fileManager.removeItem(at: settingsURL)
+        }
+
+        if fileManager.fileExists(atPath: manifestURL.path) {
+            try fileManager.removeItem(at: manifestURL)
+        }
+
+        return try status()
+    }
+
+    private func loadManifest(at url: URL) throws -> AntigravityHookInstallerManifest? {
+        guard fileManager.fileExists(atPath: url.path) else { return nil }
+
+        let data = try Data(contentsOf: url)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(AntigravityHookInstallerManifest.self, from: data)
+    }
+
+    private func resolvedHooksBinaryURL(explicitURL: URL?) -> URL? {
+        if let explicitURL {
+            return explicitURL.standardizedFileURL
+        }
+
+        guard fileManager.isExecutableFile(atPath: managedHooksBinaryURL.path) else {
+            return nil
+        }
+
+        return managedHooksBinaryURL
+    }
+
+    private func backupFile(at url: URL) throws {
+        guard fileManager.fileExists(atPath: url.path) else { return }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let timestamp = formatter.string(from: .now).replacingOccurrences(of: ":", with: "-")
+        let backupURL = url.appendingPathExtension("backup.\(timestamp)")
+        if fileManager.fileExists(atPath: backupURL.path) {
+            try fileManager.removeItem(at: backupURL)
+        }
+        try fileManager.copyItem(at: url, to: backupURL)
+    }
+}
+
+public typealias GeminiHookInstallationManager = AntigravityHookInstallationManager

--- a/Sources/OpenIslandCore/AntigravityHookInstaller.swift
+++ b/Sources/OpenIslandCore/AntigravityHookInstaller.swift
@@ -1,0 +1,179 @@
+import Foundation
+
+public struct AntigravityHookInstallerManifest: Equatable, Codable, Sendable {
+    public static let fileName = "open-island-antigravity-hooks-install.json"
+
+    public var hookCommand: String
+    public var installedAt: Date
+
+    public init(hookCommand: String, installedAt: Date = .now) {
+        self.hookCommand = hookCommand
+        self.installedAt = installedAt
+    }
+}
+
+public typealias GeminiHookInstallerManifest = AntigravityHookInstallerManifest
+
+public struct AntigravityHookFileMutation: Equatable, Sendable {
+    public var contents: Data?
+    public var changed: Bool
+    public var managedHooksPresent: Bool
+
+    public init(contents: Data?, changed: Bool, managedHooksPresent: Bool) {
+        self.contents = contents
+        self.changed = changed
+        self.managedHooksPresent = managedHooksPresent
+    }
+}
+
+public typealias GeminiHookFileMutation = AntigravityHookFileMutation
+
+public enum AntigravityHookInstallerError: Error, LocalizedError {
+    case invalidSettingsJSON
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidSettingsJSON:
+            "The existing Antigravity settings.json is not valid JSON."
+        }
+    }
+}
+
+public typealias GeminiHookInstallerError = AntigravityHookInstallerError
+
+public enum AntigravityHookInstaller {
+    private static let eventSpecs: [(name: String, matcher: String?)] = [
+        ("SessionStart", "*"),
+        ("SessionEnd", "*"),
+        ("BeforeAgent", "*"),
+        ("AfterAgent", "*"),
+        ("Notification", "*"),
+    ]
+
+    public static func hookCommand(for binaryPath: String) -> String {
+        "\(shellQuote(binaryPath)) --source antigravity"
+    }
+
+    public static func installSettingsJSON(
+        existingData: Data?,
+        hookCommand: String
+    ) throws -> AntigravityHookFileMutation {
+        var rootObject = try loadRootObject(from: existingData)
+        var hooksObject = rootObject["hooks"] as? [String: Any] ?? [:]
+
+        for spec in eventSpecs {
+            var groups = hooksObject[spec.name] as? [[String: Any]] ?? []
+            groups = groups.filter { !isManagedGroup($0, managedCommand: hookCommand) }
+            groups.append(managedGroup(matcher: spec.matcher, hookCommand: hookCommand))
+            hooksObject[spec.name] = groups
+        }
+
+        rootObject["hooks"] = hooksObject
+        let data = try serialize(rootObject)
+        return AntigravityHookFileMutation(
+            contents: data,
+            changed: data != existingData,
+            managedHooksPresent: true
+        )
+    }
+
+    public static func uninstallSettingsJSON(
+        existingData: Data?,
+        managedCommand: String?
+    ) throws -> AntigravityHookFileMutation {
+        guard let existingData else {
+            return AntigravityHookFileMutation(contents: nil, changed: false, managedHooksPresent: false)
+        }
+
+        var rootObject = try loadRootObject(from: existingData)
+        var hooksObject = rootObject["hooks"] as? [String: Any] ?? [:]
+        var mutated = false
+
+        for spec in eventSpecs {
+            let groups = hooksObject[spec.name] as? [[String: Any]] ?? []
+            let filtered = groups.filter { !isManagedGroup($0, managedCommand: managedCommand) }
+            if filtered.count != groups.count {
+                mutated = true
+            }
+
+            if filtered.isEmpty {
+                hooksObject.removeValue(forKey: spec.name)
+            } else {
+                hooksObject[spec.name] = filtered
+            }
+        }
+
+        if hooksObject.isEmpty {
+            rootObject.removeValue(forKey: "hooks")
+        } else {
+            rootObject["hooks"] = hooksObject
+        }
+
+        let contents = rootObject.isEmpty ? nil : try serialize(rootObject)
+        return AntigravityHookFileMutation(
+            contents: contents,
+            changed: mutated || contents != existingData,
+            managedHooksPresent: mutated
+        )
+    }
+
+    private static func loadRootObject(from data: Data?) throws -> [String: Any] {
+        guard let data else { return [:] }
+
+        let object = try JSONSerialization.jsonObject(with: data)
+        guard let rootObject = object as? [String: Any] else {
+            throw AntigravityHookInstallerError.invalidSettingsJSON
+        }
+
+        return rootObject
+    }
+
+    private static func serialize(_ object: [String: Any]) throws -> Data {
+        try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys])
+    }
+
+    private static func managedGroup(matcher: String?, hookCommand: String) -> [String: Any] {
+        let hook: [String: Any] = [
+            "type": "command",
+            "command": hookCommand,
+            "name": "Open Island"
+        ]
+
+        var group: [String: Any] = [
+            "hooks": [hook]
+        ]
+
+        if let matcher {
+            group["matcher"] = matcher
+        }
+
+        return group
+    }
+
+    private static func isManagedGroup(_ group: [String: Any], managedCommand: String?) -> Bool {
+        guard let hooks = group["hooks"] as? [[String: Any]] else {
+            return false
+        }
+
+        return hooks.contains { hook in
+            guard let command = hook["command"] as? String else { return false }
+            if let managedCommand, command == managedCommand {
+                return true
+            }
+            return isOpenIslandAntigravityHookCommand(command)
+        }
+    }
+
+    private static func isOpenIslandAntigravityHookCommand(_ command: String) -> Bool {
+        let normalized = command.lowercased()
+        return (normalized.contains("openislandhooks") || normalized.contains("vibeislandhooks"))
+            && (normalized.contains("antigravity") || normalized.contains("gemini"))
+    }
+
+    private static func shellQuote(_ string: String) -> String {
+        guard !string.isEmpty else { return "''" }
+        return "'\(string.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+}
+
+public typealias GeminiHookInstaller = AntigravityHookInstaller

--- a/Sources/OpenIslandCore/AntigravityHooks.swift
+++ b/Sources/OpenIslandCore/AntigravityHooks.swift
@@ -1,0 +1,551 @@
+import Foundation
+
+public enum AntigravityHookEventName: String, Codable, Sendable {
+    case sessionStart = "SessionStart"
+    case sessionEnd = "SessionEnd"
+    case beforeAgent = "BeforeAgent"
+    case afterAgent = "AfterAgent"
+    case notification = "Notification"
+}
+
+public typealias GeminiHookEventName = AntigravityHookEventName
+
+public struct AntigravityHookPayload: Equatable, Codable, Sendable {
+    public var cwd: String
+    public var hookEventName: AntigravityHookEventName
+    public var sessionID: String
+    public var transcriptPath: String?
+    public var timestamp: String?
+    public var prompt: String?
+    public var promptResponse: String?
+    public var source: String?
+    public var reason: String?
+    public var notificationType: String?
+    public var message: String?
+    public var details: CodexHookJSONValue?
+    public var stopHookActive: Bool?
+    public var terminalApp: String?
+    public var terminalSessionID: String?
+    public var terminalTTY: String?
+    public var terminalTitle: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case cwd
+        case hookEventName = "hook_event_name"
+        case sessionID = "session_id"
+        case transcriptPath = "transcript_path"
+        case timestamp
+        case prompt
+        case promptResponse = "prompt_response"
+        case source
+        case reason
+        case notificationType = "notification_type"
+        case message
+        case details
+        case stopHookActive = "stop_hook_active"
+        case terminalApp = "terminal_app"
+        case terminalSessionID = "terminal_session_id"
+        case terminalTTY = "terminal_tty"
+        case terminalTitle = "terminal_title"
+    }
+
+    public init(
+        cwd: String,
+        hookEventName: AntigravityHookEventName,
+        sessionID: String,
+        transcriptPath: String? = nil,
+        timestamp: String? = nil,
+        prompt: String? = nil,
+        promptResponse: String? = nil,
+        source: String? = nil,
+        reason: String? = nil,
+        notificationType: String? = nil,
+        message: String? = nil,
+        details: CodexHookJSONValue? = nil,
+        stopHookActive: Bool? = nil,
+        terminalApp: String? = nil,
+        terminalSessionID: String? = nil,
+        terminalTTY: String? = nil,
+        terminalTitle: String? = nil
+    ) {
+        self.cwd = cwd
+        self.hookEventName = hookEventName
+        self.sessionID = sessionID
+        self.transcriptPath = transcriptPath
+        self.timestamp = timestamp
+        self.prompt = prompt
+        self.promptResponse = promptResponse
+        self.source = source
+        self.reason = reason
+        self.notificationType = notificationType
+        self.message = message
+        self.details = details
+        self.stopHookActive = stopHookActive
+        self.terminalApp = terminalApp
+        self.terminalSessionID = terminalSessionID
+        self.terminalTTY = terminalTTY
+        self.terminalTitle = terminalTitle
+    }
+}
+
+public typealias GeminiHookPayload = AntigravityHookPayload
+
+public struct AntigravitySessionMetadata: Equatable, Codable, Sendable {
+    public var transcriptPath: String?
+    public var initialUserPrompt: String?
+    public var lastUserPrompt: String?
+    public var lastAssistantMessage: String?
+    public var lastAssistantMessageBody: String?
+
+    public init(
+        transcriptPath: String? = nil,
+        initialUserPrompt: String? = nil,
+        lastUserPrompt: String? = nil,
+        lastAssistantMessage: String? = nil,
+        lastAssistantMessageBody: String? = nil
+    ) {
+        self.transcriptPath = transcriptPath
+        self.initialUserPrompt = initialUserPrompt
+        self.lastUserPrompt = lastUserPrompt
+        self.lastAssistantMessage = lastAssistantMessage
+        self.lastAssistantMessageBody = lastAssistantMessageBody
+    }
+
+    public var isEmpty: Bool {
+        transcriptPath == nil
+            && initialUserPrompt == nil
+            && lastUserPrompt == nil
+            && lastAssistantMessage == nil
+            && lastAssistantMessageBody == nil
+    }
+}
+
+public typealias GeminiSessionMetadata = AntigravitySessionMetadata
+
+public extension AntigravityHookPayload {
+    var workspaceName: String {
+        WorkspaceNameResolver.workspaceName(for: cwd)
+    }
+
+    var sessionTitle: String {
+        "Antigravity CLI · \(workspaceName)"
+    }
+
+    var defaultJumpTarget: JumpTarget {
+        JumpTarget(
+            terminalApp: terminalApp ?? "Terminal",
+            workspaceName: workspaceName,
+            paneTitle: terminalTitle ?? "Antigravity \(sessionID.prefix(8))",
+            workingDirectory: cwd,
+            terminalSessionID: terminalSessionID,
+            terminalTTY: terminalTTY
+        )
+    }
+
+    var defaultAntigravityMetadata: AntigravitySessionMetadata {
+        AntigravitySessionMetadata(
+            transcriptPath: transcriptPath,
+            initialUserPrompt: prompt ?? promptPreview,
+            lastUserPrompt: prompt ?? promptPreview,
+            lastAssistantMessage: promptResponsePreview ?? promptResponse,
+            lastAssistantMessageBody: preserveNewlinesClipped(promptResponse, limit: 8000)
+        )
+    }
+
+    var defaultGeminiMetadata: GeminiSessionMetadata {
+        defaultAntigravityMetadata
+    }
+
+    private func preserveNewlinesClipped(_ value: String?, limit: Int) -> String? {
+        guard let value = value, !value.isEmpty else {
+            return nil
+        }
+
+        if value.count <= limit {
+            return value
+        }
+
+        return String(value.suffix(limit))
+    }
+
+    var implicitSummary: String {
+        switch hookEventName {
+        case .sessionStart:
+            switch source?.lowercased() {
+            case "resume":
+                return "Resumed Antigravity CLI session in \(workspaceName)."
+            case "clear":
+                return "Cleared Antigravity CLI session in \(workspaceName)."
+            default:
+                return "Started Antigravity CLI session in \(workspaceName)."
+            }
+        case .sessionEnd:
+            return "Antigravity CLI session ended in \(workspaceName)."
+        case .beforeAgent:
+            return promptPreview.map { "Prompt: \($0)" } ?? "Antigravity CLI started a new turn in \(workspaceName)."
+        case .afterAgent:
+            return promptResponsePreview ?? "Antigravity CLI completed a turn in \(workspaceName)."
+        case .notification:
+            return notificationSummary
+        }
+    }
+
+    var promptPreview: String? {
+        clipped(prompt)
+    }
+
+    var promptResponsePreview: String? {
+        clipped(promptResponse)
+    }
+
+    var notificationSummary: String {
+        clipped(message) ?? "Antigravity CLI sent a notification."
+    }
+
+    var renderedDetails: String? {
+        guard let details else {
+            return nil
+        }
+
+        return clipped(stringValue(for: details), limit: 160)
+    }
+
+    func withRuntimeContext(environment: [String: String]) -> AntigravityHookPayload {
+        withRuntimeContext(
+            environment: environment,
+            currentTTYProvider: { currentTTY() },
+            terminalLocatorProvider: { terminalLocator(for: $0) }
+        )
+    }
+
+    func withRuntimeContext(
+        environment: [String: String],
+        currentTTYProvider: () -> String?,
+        terminalLocatorProvider: (String) -> (sessionID: String?, tty: String?, title: String?)
+    ) -> AntigravityHookPayload {
+        var payload = self
+
+        if payload.terminalApp == nil {
+            payload.terminalApp = inferTerminalApp(from: environment)
+        }
+
+        if payload.terminalTTY == nil {
+            payload.terminalTTY = currentTTYProvider()
+        }
+
+        let useLocator: Bool
+        if isCmuxTerminalApp(payload.terminalApp) || isZellijTerminalApp(payload.terminalApp) {
+            useLocator = false
+        } else if let terminalApp = payload.terminalApp, isGhosttyTerminalApp(terminalApp) {
+            switch payload.hookEventName {
+            case .sessionStart, .beforeAgent, .notification:
+                useLocator = true
+            case .sessionEnd, .afterAgent:
+                payload.terminalSessionID = nil
+                payload.terminalTitle = nil
+                useLocator = false
+            }
+        } else {
+            useLocator = shouldUseFocusedTerminalLocator(for: payload.terminalApp ?? "")
+        }
+
+        if useLocator, let terminalApp = payload.terminalApp {
+            let locator = terminalLocatorProvider(terminalApp)
+            if payload.terminalSessionID == nil {
+                payload.terminalSessionID = locator.sessionID
+            }
+            if payload.terminalTTY == nil {
+                payload.terminalTTY = locator.tty
+            }
+            if payload.terminalTitle == nil {
+                payload.terminalTitle = locator.title
+            }
+        }
+
+        return payload
+    }
+
+    private static let noLocatorTerminalApps: Set<String> = [
+        "cmux", "kaku", "wezterm", "zellij",
+        "vs code", "vs code insiders", "cursor", "windsurf", "trae",
+        "intellij idea", "webstorm", "pycharm", "goland", "clion",
+        "rubymine", "phpstorm", "rider", "rustrover"
+    ]
+
+    private func clipped(_ value: String?, limit: Int = 110) -> String? {
+        guard let value else {
+            return nil
+        }
+
+        let collapsed = value
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\t", with: " ")
+            .split(separator: " ", omittingEmptySubsequences: true)
+            .joined(separator: " ")
+
+        guard collapsed.count > limit else {
+            return collapsed
+        }
+
+        let endIndex = collapsed.index(collapsed.startIndex, offsetBy: limit - 1)
+        return "\(collapsed[..<endIndex])…"
+    }
+
+    private func stringValue(for value: CodexHookJSONValue) -> String {
+        switch value {
+        case let .string(text):
+            return text
+        case let .number(number):
+            return String(number)
+        case let .boolean(flag):
+            return flag ? "true" : "false"
+        case .null:
+            return "null"
+        case let .array(items):
+            let rendered = items.map(stringValue(for:)).joined(separator: ", ")
+            return "[\(rendered)]"
+        case let .object(object):
+            let rendered = object
+                .keys
+                .sorted()
+                .map { key in
+                    let value = object[key].map(stringValue(for:)) ?? "null"
+                    return "\(key): \(value)"
+                }
+                .joined(separator: ", ")
+            return "{\(rendered)}"
+        }
+    }
+
+    private func shouldUseFocusedTerminalLocator(for terminalApp: String) -> Bool {
+        let lower = terminalApp.lowercased()
+        if lower.contains("ghostty") || lower.contains("jetbrains") {
+            return false
+        }
+        return !Self.noLocatorTerminalApps.contains(lower)
+    }
+
+    private func isGhosttyTerminalApp(_ terminalApp: String?) -> Bool {
+        guard let app = terminalApp?.lowercased() else { return false }
+        return app.contains("ghostty")
+    }
+
+    private func isCmuxTerminalApp(_ terminalApp: String?) -> Bool {
+        terminalApp?.lowercased() == "cmux"
+    }
+
+    private func isZellijTerminalApp(_ terminalApp: String?) -> Bool {
+        terminalApp?.lowercased() == "zellij"
+    }
+
+    private func inferTerminalApp(from environment: [String: String]) -> String? {
+        if environment["ITERM_SESSION_ID"] != nil || environment["LC_TERMINAL"] == "iTerm2" {
+            return "iTerm"
+        }
+
+        if environment["CMUX_WORKSPACE_ID"] != nil || environment["CMUX_SOCKET_PATH"] != nil {
+            return "cmux"
+        }
+
+        if environment["ZELLIJ"] != nil {
+            return "Zellij"
+        }
+
+        if environment["GHOSTTY_RESOURCES_DIR"] != nil {
+            return "Ghostty"
+        }
+
+        if environment["WARP_IS_LOCAL_SHELL_SESSION"] != nil {
+            return "Warp"
+        }
+
+        let termProgram = environment["TERM_PROGRAM"]?.lowercased()
+        switch termProgram {
+        case .some("apple_terminal"):
+            return "Terminal"
+        case .some("iterm.app"), .some("iterm2"):
+            return "iTerm"
+        case let value? where value.contains("ghostty"):
+            return "Ghostty"
+        case let value? where value.contains("warp"):
+            return "Warp"
+        case let value? where value.contains("wezterm"):
+            return "WezTerm"
+        case .some("kaku"):
+            return "Kaku"
+        case .some("vscode"):
+            return "VS Code"
+        case .some("vscode-insiders"):
+            return "VS Code Insiders"
+        case .some("windsurf"):
+            return "Windsurf"
+        case .some("trae"):
+            return "Trae"
+        default:
+            break
+        }
+
+        if let terminalEmulator = environment["TERMINAL_EMULATOR"]?.lowercased(),
+           terminalEmulator.contains("jetbrains") {
+            if let bundleID = environment["__CFBundleIdentifier"]?.lowercased() {
+                if bundleID.contains("webstorm") { return "WebStorm" }
+                if bundleID.contains("pycharm") { return "PyCharm" }
+                if bundleID.contains("goland") { return "GoLand" }
+                if bundleID.contains("clion") { return "CLion" }
+                if bundleID.contains("rubymine") { return "RubyMine" }
+                if bundleID.contains("phpstorm") { return "PhpStorm" }
+                if bundleID.contains("rider") { return "Rider" }
+                if bundleID.contains("rustrover") { return "RustRover" }
+            }
+            return "JetBrains"
+        }
+
+        return nil
+    }
+
+    private func currentTTY() -> String? {
+        if let tty = commandOutput(executablePath: "/usr/bin/tty", arguments: []),
+           !tty.contains("not a tty") {
+            return tty
+        }
+
+        return parentProcessTTY()
+    }
+
+    private func parentProcessTTY() -> String? {
+        let ppid = getppid()
+        guard let raw = commandOutput(executablePath: "/bin/ps", arguments: ["-p", "\(ppid)", "-o", "tty="]) else {
+            return nil
+        }
+
+        let tty = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !tty.isEmpty, tty != "??", tty != "-" else {
+            return nil
+        }
+
+        return tty.hasPrefix("/dev/") ? tty : "/dev/\(tty)"
+    }
+
+    private func terminalLocator(for terminalApp: String) -> (sessionID: String?, tty: String?, title: String?) {
+        let normalized = terminalApp.lowercased()
+
+        if normalized.contains("iterm") {
+            let values = osascriptValues(script: Self.terminalLocatorAppleScript(for: "iTerm"))
+            return (
+                sessionID: values[safe: 0],
+                tty: values[safe: 1],
+                title: values[safe: 2]
+            )
+        }
+
+        if normalized == "cmux" {
+            return (sessionID: nil, tty: nil, title: nil)
+        }
+
+        if normalized.contains("ghostty") {
+            let values = osascriptValues(script: Self.terminalLocatorAppleScript(for: "Ghostty"))
+            return (
+                sessionID: values[safe: 0],
+                tty: nil,
+                title: values[safe: 2]
+            )
+        }
+
+        if normalized.contains("terminal") {
+            let values = osascriptValues(script: Self.terminalLocatorAppleScript(for: "Terminal"))
+            return (
+                sessionID: nil,
+                tty: values[safe: 0],
+                title: values[safe: 1]
+            )
+        }
+
+        return (nil, nil, nil)
+    }
+
+    static func terminalLocatorAppleScript(for terminalApp: String) -> String {
+        switch terminalApp {
+        case "iTerm":
+            """
+            tell application "iTerm"
+                if not (it is running) then return ""
+                tell current session of current window
+                    return (id as text) & (ASCII character 31) & (tty as text) & (ASCII character 31) & (name as text)
+                end tell
+            end tell
+            """
+        case "Ghostty":
+            """
+            tell application "Ghostty"
+                if not (it is running) then return ""
+                tell focused terminal of selected tab of front window
+                    return (id as text) & (ASCII character 31) & (working directory as text) & (ASCII character 31) & (name as text)
+                end tell
+            end tell
+            """
+        case "Terminal":
+            """
+            tell application "Terminal"
+                if not (it is running) then return ""
+                tell selected tab of front window
+                    return (tty as text) & (ASCII character 31) & (custom title as text)
+                end tell
+            end tell
+            """
+        default:
+            ""
+        }
+    }
+
+    private func osascriptValues(script: String) -> [String] {
+        guard let raw = commandOutput(executablePath: "/usr/bin/osascript", arguments: ["-e", script]) else {
+            return []
+        }
+
+        let separator = String(UnicodeScalar(31)!)
+        return raw
+            .components(separatedBy: separator)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+    }
+
+    private func commandOutput(executablePath: String, arguments: [String]) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+
+        let outputPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return nil
+        }
+
+        let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        guard !data.isEmpty else {
+            return nil
+        }
+
+        return String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+private extension CodexHookJSONValue {
+    var stringValue: String? {
+        if case let .string(value) = self {
+            value
+        } else {
+            nil
+        }
+    }
+}
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -467,7 +467,10 @@ public final class BridgeServer: @unchecked Sendable {
             handleCursorHook(payload, from: clientID)
 
         case let .processGeminiHook(payload):
-            handleGeminiHook(payload, from: clientID)
+            handleAntigravityHook(payload, from: clientID)
+
+        case let .processAntigravityHook(payload):
+            handleAntigravityHook(payload, from: clientID)
         }
     }
 
@@ -1298,7 +1301,7 @@ public final class BridgeServer: @unchecked Sendable {
         }
     }
 
-    private func handleGeminiHook(_ payload: GeminiHookPayload, from clientID: UUID) {
+    private func handleAntigravityHook(_ payload: AntigravityHookPayload, from clientID: UUID) {
         switch payload.hookEventName {
         case .sessionStart:
             emit(
@@ -1306,22 +1309,22 @@ public final class BridgeServer: @unchecked Sendable {
                     SessionStarted(
                         sessionID: payload.sessionID,
                         title: payload.sessionTitle,
-                        tool: .geminiCLI,
+                        tool: .antigravityCLI,
                         origin: .live,
                         initialPhase: .completed,
                         summary: payload.implicitSummary,
                         timestamp: .now,
                         jumpTarget: payload.defaultJumpTarget,
-                        geminiMetadata: payload.defaultGeminiMetadata.isEmpty ? nil : payload.defaultGeminiMetadata
+                        antigravityMetadata: payload.defaultAntigravityMetadata.isEmpty ? nil : payload.defaultAntigravityMetadata
                     )
                 )
             )
             send(.response(.acknowledged), to: clientID)
 
         case .beforeAgent:
-            ensureGeminiSessionExists(for: payload)
-            synchronizeGeminiJumpTarget(for: payload)
-            synchronizeGeminiMetadata(for: payload)
+            ensureAntigravitySessionExists(for: payload)
+            synchronizeAntigravityJumpTarget(for: payload)
+            synchronizeAntigravityMetadata(for: payload)
             emit(
                 .activityUpdated(
                     SessionActivityUpdated(
@@ -1335,9 +1338,9 @@ public final class BridgeServer: @unchecked Sendable {
             send(.response(.acknowledged), to: clientID)
 
         case .afterAgent:
-            ensureGeminiSessionExists(for: payload)
-            synchronizeGeminiJumpTarget(for: payload)
-            synchronizeGeminiMetadata(for: payload)
+            ensureAntigravitySessionExists(for: payload)
+            synchronizeAntigravityJumpTarget(for: payload)
+            synchronizeAntigravityMetadata(for: payload)
             emit(
                 .sessionCompleted(
                     SessionCompleted(
@@ -1350,14 +1353,14 @@ public final class BridgeServer: @unchecked Sendable {
             send(.response(.acknowledged), to: clientID)
 
         case .sessionEnd:
-            ensureGeminiSessionExists(for: payload)
-            synchronizeGeminiJumpTarget(for: payload)
-            synchronizeGeminiMetadata(for: payload)
+            ensureAntigravitySessionExists(for: payload)
+            synchronizeAntigravityJumpTarget(for: payload)
+            synchronizeAntigravityMetadata(for: payload)
             emit(
                 .sessionCompleted(
                     SessionCompleted(
                         sessionID: payload.sessionID,
-                        summary: payload.reason.map { "Gemini CLI session ended: \($0)." } ?? payload.implicitSummary,
+                        summary: payload.reason.map { "Antigravity CLI session ended: \($0)." } ?? payload.implicitSummary,
                         timestamp: .now,
                         isInterrupt: true,
                         isSessionEnd: true
@@ -1367,9 +1370,9 @@ public final class BridgeServer: @unchecked Sendable {
             send(.response(.acknowledged), to: clientID)
 
         case .notification:
-            ensureGeminiSessionExists(for: payload)
-            synchronizeGeminiJumpTarget(for: payload)
-            synchronizeGeminiMetadata(for: payload)
+            ensureAntigravitySessionExists(for: payload)
+            synchronizeAntigravityJumpTarget(for: payload)
+            synchronizeAntigravityMetadata(for: payload)
 
             let currentPhase = localState.session(id: payload.sessionID)?.phase ?? .completed
             emit(
@@ -1387,7 +1390,11 @@ public final class BridgeServer: @unchecked Sendable {
         }
     }
 
-    private func ensureGeminiSessionExists(for payload: GeminiHookPayload) {
+    private func handleGeminiHook(_ payload: GeminiHookPayload, from clientID: UUID) {
+        handleAntigravityHook(payload, from: clientID)
+    }
+
+    private func ensureAntigravitySessionExists(for payload: AntigravityHookPayload) {
         guard !hasSession(id: payload.sessionID) else {
             return
         }
@@ -1397,19 +1404,23 @@ public final class BridgeServer: @unchecked Sendable {
                 SessionStarted(
                     sessionID: payload.sessionID,
                     title: payload.sessionTitle,
-                    tool: .geminiCLI,
+                    tool: .antigravityCLI,
                     origin: .live,
                     initialPhase: .completed,
                     summary: payload.hookEventName == .notification ? payload.notificationSummary : payload.implicitSummary,
                     timestamp: .now,
                     jumpTarget: payload.defaultJumpTarget,
-                    geminiMetadata: payload.defaultGeminiMetadata.isEmpty ? nil : payload.defaultGeminiMetadata
+                    antigravityMetadata: payload.defaultAntigravityMetadata.isEmpty ? nil : payload.defaultAntigravityMetadata
                 )
             )
         )
     }
 
-    private func synchronizeGeminiJumpTarget(for payload: GeminiHookPayload) {
+    private func ensureGeminiSessionExists(for payload: GeminiHookPayload) {
+        ensureAntigravitySessionExists(for: payload)
+    }
+
+    private func synchronizeAntigravityJumpTarget(for payload: AntigravityHookPayload) {
         guard let existingSession = localState.session(id: payload.sessionID) else {
             return
         }
@@ -1434,36 +1445,45 @@ public final class BridgeServer: @unchecked Sendable {
         )
     }
 
-    private func synchronizeGeminiMetadata(for payload: GeminiHookPayload) {
+    private func synchronizeGeminiJumpTarget(for payload: GeminiHookPayload) {
+        synchronizeAntigravityJumpTarget(for: payload)
+    }
+
+    private func synchronizeAntigravityMetadata(for payload: AntigravityHookPayload) {
         guard let existingSession = localState.session(id: payload.sessionID) else {
             return
         }
 
-        let update = payload.defaultGeminiMetadata
-        let merged = GeminiSessionMetadata(
-            transcriptPath: update.transcriptPath ?? existingSession.geminiMetadata?.transcriptPath,
-            initialUserPrompt: existingSession.geminiMetadata?.initialUserPrompt ?? update.initialUserPrompt ?? update.lastUserPrompt,
-            lastUserPrompt: update.lastUserPrompt ?? existingSession.geminiMetadata?.lastUserPrompt,
-            lastAssistantMessage: update.lastAssistantMessage ?? existingSession.geminiMetadata?.lastAssistantMessage,
-            lastAssistantMessageBody: update.lastAssistantMessageBody ?? existingSession.geminiMetadata?.lastAssistantMessageBody
+        let update = payload.defaultAntigravityMetadata
+        let existingMeta = existingSession.antigravityMetadata ?? existingSession.geminiMetadata
+        let merged = AntigravitySessionMetadata(
+            transcriptPath: update.transcriptPath ?? existingMeta?.transcriptPath,
+            initialUserPrompt: existingMeta?.initialUserPrompt ?? update.initialUserPrompt ?? update.lastUserPrompt,
+            lastUserPrompt: update.lastUserPrompt ?? existingMeta?.lastUserPrompt,
+            lastAssistantMessage: update.lastAssistantMessage ?? existingMeta?.lastAssistantMessage,
+            lastAssistantMessageBody: update.lastAssistantMessageBody ?? existingMeta?.lastAssistantMessageBody
         )
         guard !merged.isEmpty else {
             return
         }
 
-        guard existingSession.geminiMetadata != merged else {
+        guard existingMeta != merged else {
             return
         }
 
         emit(
-            .geminiSessionMetadataUpdated(
-                GeminiSessionMetadataUpdated(
+            .antigravitySessionMetadataUpdated(
+                AntigravitySessionMetadataUpdated(
                     sessionID: payload.sessionID,
-                    geminiMetadata: merged,
+                    antigravityMetadata: merged,
                     timestamp: .now
                 )
             )
         )
+    }
+
+    private func synchronizeGeminiMetadata(for payload: GeminiHookPayload) {
+        synchronizeAntigravityMetadata(for: payload)
     }
 
     private func clearStaleCursorInteractionIfNeeded(for sessionID: String) {

--- a/Sources/OpenIslandCore/BridgeTransport.swift
+++ b/Sources/OpenIslandCore/BridgeTransport.swift
@@ -89,6 +89,7 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
     case processOpenCodeHook(OpenCodeHookPayload)
     case processCursorHook(CursorHookPayload)
     case processGeminiHook(GeminiHookPayload)
+    case processAntigravityHook(AntigravityHookPayload)
 
     private enum CodingKeys: String, CodingKey {
         case type

--- a/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
+++ b/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
@@ -17,13 +17,14 @@ struct OpenIslandHooksCLI {
         case codebuddy
         case cursor
         case gemini
+        case antigravity
         case kimi
 
         var isClaudeFormat: Bool {
             switch self {
             case .claude, .qoder, .qwen, .factory, .droid, .codebuddy, .kimi:
                 return true
-            case .codex, .cursor, .gemini:
+            case .codex, .cursor, .gemini, .antigravity:
                 return false
             }
         }
@@ -101,12 +102,12 @@ struct OpenIslandHooksCLI {
                     FileHandle.standardOutput.write(output)
                     FileHandle.standardOutput.write(Data("\n".utf8))
                 }
-            case .gemini:
+            case .gemini, .antigravity:
                 let payload = try decoder
-                    .decode(GeminiHookPayload.self, from: input)
+                    .decode(AntigravityHookPayload.self, from: input)
                     .withRuntimeContext(environment: ProcessInfo.processInfo.environment)
 
-                _ = try? client.send(.processGeminiHook(payload), timeout: 45)
+                _ = try? client.send(.processAntigravityHook(payload), timeout: 45)
             }
         } catch {
             // Hooks should fail open so the CLI continues working even if the bridge is unavailable.

--- a/Sources/OpenIslandSetup/OpenIslandSetupCLI.swift
+++ b/Sources/OpenIslandSetup/OpenIslandSetupCLI.swift
@@ -28,12 +28,16 @@ private struct SetupCommand {
         case installKimi
         case uninstallKimi
         case statusKimi
+        case installAntigravity
+        case uninstallAntigravity
+        case statusAntigravity
     }
 
     let action: Action
     let codexDirectory: URL
     let claudeDirectory: URL
     let kimiDirectory: URL
+    let antigravityDirectory: URL
     let hooksBinary: URL?
 
     init(arguments: [String]) throws {
@@ -48,6 +52,7 @@ private struct SetupCommand {
         var codexDirectory = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".codex", isDirectory: true)
         var claudeDirectory = ClaudeConfigDirectory.resolved()
         var kimiDirectory = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".kimi", isDirectory: true)
+        var antigravityDirectory = AntigravityHookInstallationManager.defaultAntigravityDirectory()
 
         var index = 1
         while index < arguments.count {
@@ -80,6 +85,13 @@ private struct SetupCommand {
                 }
                 kimiDirectory = URL(fileURLWithPath: arguments[index]).standardizedFileURL
 
+            case "--antigravity-dir":
+                index += 1
+                guard index < arguments.count else {
+                    throw SetupError.missingValue("--antigravity-dir")
+                }
+                antigravityDirectory = URL(fileURLWithPath: arguments[index]).standardizedFileURL
+
             default:
                 throw SetupError.unexpectedArgument(arguments[index])
             }
@@ -87,13 +99,14 @@ private struct SetupCommand {
             index += 1
         }
 
-        if (action == .install || action == .installClaude || action == .installKimi), hooksBinary == nil {
+        if (action == .install || action == .installClaude || action == .installKimi || action == .installAntigravity), hooksBinary == nil {
             hooksBinary = HooksBinaryLocator.locate()
         }
 
         self.codexDirectory = codexDirectory
         self.claudeDirectory = claudeDirectory
         self.kimiDirectory = kimiDirectory
+        self.antigravityDirectory = antigravityDirectory
         self.hooksBinary = hooksBinary
     }
 
@@ -117,6 +130,12 @@ private struct SetupCommand {
             try uninstallKimi()
         case .statusKimi:
             try statusKimi()
+        case .installAntigravity:
+            try installAntigravity()
+        case .uninstallAntigravity:
+            try uninstallAntigravity()
+        case .statusAntigravity:
+            try statusAntigravity()
         }
     }
 
@@ -252,6 +271,44 @@ private struct SetupCommand {
             print("Manifest: missing")
         }
     }
+
+    private func installAntigravity() throws {
+        guard let hooksBinary else {
+            throw SetupError.usage
+        }
+
+        let manager = AntigravityHookInstallationManager(antigravityDirectory: antigravityDirectory)
+        let status = try manager.install(hooksBinaryURL: hooksBinary)
+
+        print("Installed Open Island Antigravity hooks.")
+        print("Antigravity dir: \(status.antigravityDirectory.path)")
+        print("Hooks binary: \(hooksBinary.path)")
+    }
+
+    private func uninstallAntigravity() throws {
+        let manager = AntigravityHookInstallationManager(antigravityDirectory: antigravityDirectory)
+        let status = try manager.uninstall()
+
+        print("Removed Open Island Antigravity hooks.")
+        print("Antigravity dir: \(status.antigravityDirectory.path)")
+    }
+
+    private func statusAntigravity() throws {
+        let manager = AntigravityHookInstallationManager(antigravityDirectory: antigravityDirectory)
+        let status = try manager.status(hooksBinaryURL: hooksBinary)
+
+        print("Antigravity dir: \(status.antigravityDirectory.path)")
+        print("Managed hooks present: \(status.managedHooksPresent ? "yes" : "no")")
+        if let hooksBinary {
+            print("Hooks binary: \(hooksBinary.path)")
+        }
+        if let manifest = status.manifest {
+            print("Manifest: present")
+            print("Hook command: \(manifest.hookCommand)")
+        } else {
+            print("Manifest: missing")
+        }
+    }
 }
 
 private enum SetupError: Error, LocalizedError {
@@ -273,6 +330,9 @@ private enum SetupError: Error, LocalizedError {
               swift run OpenIslandSetup installKimi [--hooks-binary /abs/path/to/OpenIslandHooks] [--kimi-dir /abs/path/to/.kimi]
               swift run OpenIslandSetup uninstallKimi [--kimi-dir /abs/path/to/.kimi]
               swift run OpenIslandSetup statusKimi [--hooks-binary /abs/path/to/OpenIslandHooks] [--kimi-dir /abs/path/to/.kimi]
+              swift run OpenIslandSetup installAntigravity [--hooks-binary /abs/path/to/OpenIslandHooks] [--antigravity-dir /abs/path/to/.antigravity]
+              swift run OpenIslandSetup uninstallAntigravity [--antigravity-dir /abs/path/to/.antigravity]
+              swift run OpenIslandSetup statusAntigravity [--hooks-binary /abs/path/to/OpenIslandHooks] [--antigravity-dir /abs/path/to/.antigravity]
             """
         case let .missingValue(flag):
             "Missing value for \(flag)"

--- a/Tests/OpenIslandCoreTests/AntigravityHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/AntigravityHooksTests.swift
@@ -1,0 +1,105 @@
+import Dispatch
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+struct AntigravityHooksTests {
+    @Test
+    func antigravityHookPayloadDecodesNotification() throws {
+        let json = """
+        {
+          "cwd": "/tmp/worktree",
+          "hook_event_name": "Notification",
+          "session_id": "antigravity-session-1",
+          "message": "Antigravity CLI requires permission to continue.",
+          "notification_type": "ToolPermission",
+          "details": {
+            "tool_name": "run_shell_command",
+            "file_path": "/tmp/worktree/package.json"
+          }
+        }
+        """.data(using: .utf8)!
+
+        let payload = try JSONDecoder().decode(AntigravityHookPayload.self, from: json)
+
+        #expect(payload.hookEventName == .notification)
+        #expect(payload.notificationSummary == "Antigravity CLI requires permission to continue.")
+        #expect(payload.renderedDetails == "{file_path: /tmp/worktree/package.json, tool_name: run_shell_command}")
+    }
+
+    @Test
+    func antigravityHookInstallerInstallsIntoEmptySettingsFile() throws {
+        let mutation = try AntigravityHookInstaller.installSettingsJSON(
+            existingData: nil,
+            hookCommand: "/usr/local/bin/OpenIslandHooks --source antigravity"
+        )
+
+        #expect(mutation.changed)
+        #expect(mutation.managedHooksPresent)
+
+        let data = try #require(mutation.contents)
+        let object = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let hooks = object["hooks"] as! [String: Any]
+
+        #expect(hooks.keys.contains("SessionStart"))
+        #expect(hooks.keys.contains("SessionEnd"))
+        #expect(hooks.keys.contains("BeforeAgent"))
+        #expect(hooks.keys.contains("AfterAgent"))
+        #expect(hooks.keys.contains("Notification"))
+    }
+
+    @Test
+    func antigravityNotificationBecomesActivityUpdate() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+
+        let hookClient = BridgeCommandClient(socketURL: socketURL)
+        let payload = AntigravityHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .notification,
+            sessionID: "antigravity-session-1",
+            message: "Antigravity CLI completed step."
+        )
+
+        let response = try hookClient.send(.processAntigravityHook(payload))
+        #expect(response == .acknowledged)
+
+        let receivedEvent = try await withTimeout(seconds: 2.0) {
+            for await event in stream {
+                if case let .activityUpdated(activity) = event, activity.sessionID == "antigravity-session-1" {
+                    return event
+                }
+            }
+            return nil
+        }
+
+        guard case let .activityUpdated(activity)? = receivedEvent else {
+            Issue.record("Expected activityUpdated for antigravity notification")
+            return
+        }
+
+        #expect(activity.summary == "Antigravity CLI completed step.")
+    }
+}
+
+private func withTimeout<T: Sendable>(seconds: Double, body: @escaping @Sendable () async throws -> T) async throws -> T? {
+    try await withThrowingTaskGroup(of: T?.self) { group in
+        group.addTask {
+            try await body()
+        }
+        group.addTask {
+            try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            return nil
+        }
+
+        let result = try await group.next()
+        group.cancelAll()
+        return result ?? nil
+    }
+}

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -254,20 +254,20 @@ Setting `interrupt: true` terminates the current agent turn immediately.
 
 ---
 
-## Gemini CLI Hooks (`--source gemini`)
+## Antigravity CLI Hooks (`--source antigravity`)
 
-**Payload type**: `GeminiHookPayload`  
-**Source**: [`Sources/OpenIslandCore/GeminiHooks.swift`](../Sources/OpenIslandCore/GeminiHooks.swift)
+**Payload type**: `AntigravityHookPayload`  
+**Source**: [`Sources/OpenIslandCore/AntigravityHooks.swift`](../Sources/OpenIslandCore/AntigravityHooks.swift)
 
 ### Events
 
 | `hook_event_name` | When it fires | Current OpenIsland behavior |
 |---|---|---|
-| `SessionStart` | Session starts or resumes | Creates or restores the Gemini session, title, jump target, and transcript metadata |
-| `BeforeAgent` | Gemini starts handling a prompt / turn | Marks the session running, updates prompt text, refreshes terminal metadata |
-| `AfterAgent` | Gemini finishes a turn | Marks the turn completed and emits a completion card |
-| `SessionEnd` | Gemini reports the session ended | Marks the hook-managed session ended and removes it from active visibility |
-| `Notification` | Gemini emits a notification message | Updates the session summary / activity text without blocking the agent |
+| `SessionStart` | Session starts or resumes | Creates or restores the Antigravity session, title, jump target, and transcript metadata |
+| `BeforeAgent` | Antigravity starts handling a prompt / turn | Marks the session running, updates prompt text, refreshes terminal metadata |
+| `AfterAgent` | Antigravity finishes a turn | Marks the turn completed and emits a completion card |
+| `SessionEnd` | Antigravity reports the session ended | Marks the hook-managed session ended and removes it from active visibility |
+| `Notification` | Antigravity emits a notification message | Updates the session summary / activity text without blocking the agent |
 
 ### Common payload fields
 
@@ -276,16 +276,16 @@ Setting `interrupt: true` terminates the current agent turn immediately.
 | `cwd` | `cwd` | Working directory |
 | `hook_event_name` | `hookEventName` | Event type |
 | `session_id` | `sessionID` | Session identifier |
-| `transcript_path` | `transcriptPath` | Gemini transcript file path |
+| `transcript_path` | `transcriptPath` | Antigravity transcript file path |
 | `timestamp` | `timestamp` | Hook timestamp |
 | `prompt` | `prompt` | User prompt text |
-| `prompt_response` | `promptResponse` | Gemini response text |
+| `prompt_response` | `promptResponse` | Antigravity response text |
 | `source` | `source` | Session start source |
 | `reason` | `reason` | Session-end reason |
 | `notification_type` | `notificationType` | Notification category |
 | `message` | `message` | Notification message |
 | `details` | `details` | Structured notification payload |
-| `stop_hook_active` | `stopHookActive` | Whether Gemini stop hook support is active |
+| `stop_hook_active` | `stopHookActive` | Whether Antigravity stop hook support is active |
 | `terminal_app` | `terminalApp` | Terminal name |
 | `terminal_session_id` | `terminalSessionID` | Terminal session identifier |
 | `terminal_tty` | `terminalTTY` | TTY device path |
@@ -293,17 +293,16 @@ Setting `interrupt: true` terminates the current agent turn immediately.
 
 ### Current feature coverage
 
-- Session lifecycle ingestion for Gemini CLI via `OpenIslandHooks --source gemini`
-- Session list and island visibility updates from Gemini hook events
+- Session lifecycle ingestion for Antigravity CLI via `OpenIslandHooks --source antigravity`
+- Session list and island visibility updates from Antigravity hook events
 - Prompt / response metadata capture for completion cards and session details
 - Terminal jump metadata enrichment for Terminal.app, iTerm2, Ghostty, and other supported terminals
-- Process-assisted liveness matching so active Gemini CLI sessions can stay visible even when hook traffic is sparse
+- Process-assisted liveness matching so active Antigravity CLI sessions (`antigravity` / `agy`) stay visible even when hook traffic is sparse
 
 ### Current limitations
 
-- Gemini hooks are currently treated as fire-and-forget. OpenIsland does not send Gemini-specific approval or modification directives back to stdout.
-- Gemini hook payloads sometimes include a duplicated copy of the final response body, often with whitespace-only differences. OpenIsland applies a best-effort compatibility pass before rendering completion content, but the result is not guaranteed to be perfect for every response shape.
-- Gemini support is currently limited to the hook events and UI/session behaviors listed above. It does not yet match the richer permission / interaction flows available for Claude Code or OpenCode.
+- Antigravity hooks are currently treated as fire-and-forget. OpenIsland does not send Antigravity-specific approval or modification directives back to stdout.
+- Antigravity support is currently limited to the hook events and UI/session behaviors listed above.
 
 ---
 
@@ -315,7 +314,7 @@ Setting `interrupt: true` terminates the current agent turn immediately.
 | Codex | All other managed events | **45 seconds** |
 | Claude Code | `PermissionRequest` | **24 hours** (awaits human approval) |
 | Claude Code | All other events | **45 seconds** |
-| Gemini CLI | All events | Bridge default |
+| Antigravity CLI | All events | Bridge default |
 
 ---
 

--- a/docs/product.md
+++ b/docs/product.md
@@ -29,7 +29,7 @@ CLI coding agents are powerful, but they pull attention away from the editor and
 | **Qwen Code** | Supported | Claude Code fork — same hook format, config at `~/.qwen/settings.json` |
 | **Factory** | Supported | Claude Code fork — same hook format, config at `~/.factory/settings.json` |
 | **CodeBuddy** | Supported | Claude Code fork — same hook format, config at `~/.codebuddy/settings.json` |
-| **Gemini CLI** | Supported | Hook integration (`SessionStart`, `BeforeAgent`, `AfterAgent`, `SessionEnd`, `Notification`), session tracking, terminal jump metadata, completion-card compatibility handling |
+| **Antigravity CLI** | Supported | Hook integration (`SessionStart`, `BeforeAgent`, `AfterAgent`, `SessionEnd`, `Notification`), session tracking, terminal jump metadata, completion-card compatibility handling |
 | **Kimi CLI** | Supported | Hook integration via `~/.kimi/config.toml` `[[hooks]]` (Moonshot AI). Kimi's hook payload is byte-compatible with Claude Code, so runtime reuses the Claude decode path; a dedicated TOML installer preserves user-authored hooks |
 
 ## Supported Terminals

--- a/scripts/open-island-hooks.py
+++ b/scripts/open-island-hooks.py
@@ -267,6 +267,10 @@ def main():
             command = {"type": "processOpenCodeHook", "openCodeHook": payload}
             timeout = 86400 if payload.get("hook_event_name") == "PermissionRequest" else 45
             encoder = encode_opencode_stdout
+        elif source in ("gemini", "antigravity"):
+            command = {"type": "processAntigravityHook", "antigravityHook": payload}
+            timeout = 45
+            encoder = lambda resp: None
         else:
             command = {"type": "processCodexHook", "codexHook": payload}
             timeout = 45

--- a/scripts/setup-antigravity.py
+++ b/scripts/setup-antigravity.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+Setup helper for Open Island Antigravity CLI hooks on Windows / Cross-platform.
+
+Usage:
+    python scripts/setup-antigravity.py install
+    python scripts/setup-antigravity.py status
+    python scripts/setup-antigravity.py uninstall
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+def get_antigravity_dir() -> Path:
+    home = Path.home()
+    primary = home / ".antigravity"
+    fallback = home / ".gemini"
+    if primary.exists():
+        return primary
+    if fallback.exists():
+        return fallback
+    return primary
+
+def get_hook_command() -> str:
+    script_path = Path(__file__).parent.resolve() / "open-island-hooks.py"
+    py_exec = sys.executable or "python"
+    return f'"{py_exec}" "{script_path}" --source antigravity'
+
+EVENTS = ["SessionStart", "SessionEnd", "BeforeAgent", "AfterAgent", "Notification"]
+
+def status():
+    ag_dir = get_antigravity_dir()
+    settings_file = ag_dir / "settings.json"
+    print(f"Antigravity dir: {ag_dir}")
+    print(f"Settings file: {settings_file}")
+    
+    if not settings_file.exists():
+        print("Managed hooks present: no (settings.json missing)")
+        return False
+        
+    try:
+        with open(settings_file, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        hooks = data.get("hooks", {})
+        cmd = get_hook_command()
+        
+        present = True
+        for ev in EVENTS:
+            groups = hooks.get(ev, [])
+            found = False
+            for group in groups:
+                for hook in group.get("hooks", []):
+                    c = hook.get("command", "")
+                    if "open-island-hooks" in c or "antigravity" in c:
+                        found = True
+                        break
+            if not found:
+                present = False
+                break
+                
+        print(f"Managed hooks present: {'yes' if present else 'no'}")
+        return present
+    except Exception as e:
+        print(f"Error checking status: {e}")
+        return False
+
+def install():
+    ag_dir = get_antigravity_dir()
+    ag_dir.mkdir(parents=True, exist_ok=True)
+    settings_file = ag_dir / "settings.json"
+    
+    data = {}
+    if settings_file.exists():
+        try:
+            with open(settings_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except Exception:
+            data = {}
+            
+    hooks = data.get("hooks", {})
+    cmd = get_hook_command()
+    
+    for ev in EVENTS:
+        groups = hooks.get(ev, [])
+        # filter existing open-island hooks
+        new_groups = []
+        for g in groups:
+            h_list = g.get("hooks", [])
+            filtered_h = [h for h in h_list if "open-island" not in h.get("command", "") and "vibe-island" not in h.get("command", "")]
+            if filtered_h:
+                g["hooks"] = filtered_h
+                new_groups.append(g)
+        
+        # add managed group
+        new_groups.append({
+            "matcher": "*",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": cmd,
+                    "name": "Open Island"
+                }
+            ]
+        })
+        hooks[ev] = new_groups
+        
+    data["hooks"] = hooks
+    
+    with open(settings_file, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, sort_keys=True)
+        
+    print("Installed Open Island Antigravity hooks.")
+    print(f"Target file: {settings_file}")
+    print(f"Hook command: {cmd}")
+
+def uninstall():
+    ag_dir = get_antigravity_dir()
+    settings_file = ag_dir / "settings.json"
+    if not settings_file.exists():
+        print("No settings.json found.")
+        return
+        
+    try:
+        with open(settings_file, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        hooks = data.get("hooks", {})
+        
+        for ev in EVENTS:
+            groups = hooks.get(ev, [])
+            new_groups = []
+            for g in groups:
+                h_list = g.get("hooks", [])
+                filtered_h = [h for h in h_list if "open-island" not in h.get("command", "") and "vibe-island" not in h.get("command", "")]
+                if filtered_h:
+                    g["hooks"] = filtered_h
+                    new_groups.append(g)
+            if new_groups:
+                hooks[ev] = new_groups
+            else:
+                hooks.pop(ev, None)
+                
+        if hooks:
+            data["hooks"] = hooks
+        else:
+            data.pop("hooks", None)
+            
+        with open(settings_file, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+            
+        print("Removed Open Island Antigravity hooks.")
+    except Exception as e:
+        print(f"Error during uninstall: {e}")
+
+def main():
+    args = sys.argv[1:]
+    cmd = args[0] if args else "status"
+    if cmd == "install":
+        install()
+    elif cmd == "uninstall":
+        uninstall()
+    else:
+        status()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Gemini CLI was discontinued; replaces its hook-based integration with Google's Antigravity CLI (same underlying hook schema: SessionStart, BeforeAgent, AfterAgent, SessionEnd, Notification).
- Adds AntigravityHooks, AntigravityHookInstaller, and AntigravityHookInstallationManager, wired into BridgeServer, AppModel, and HookInstallationCoordinator the same way other agents are.
- Settings UI, README support matrix, and docs/hooks.md updated to reflect Antigravity CLI instead of Gemini CLI.
- Adds a cross-platform Python setup helper (scripts/setup-antigravity.py) for installing/checking/removing the managed hooks in ~/.antigravity/settings.json (falls back to ~/.gemini/antigravity-cli/settings.json), since Antigravity CLI is also used from Windows.
- Adds AntigravityHooksTests covering payload decoding and installer behavior.

## Test plan
- [ ] swift build / swift test (no Swift toolchain available in this environment - needs to run on macOS before merge)
- [x] Verified README support matrix has no remaining Gemini CLI references
- [ ] Manual: install hooks via app Settings (or scripts/setup-antigravity.py install) and confirm SessionStart/Notification events reach Open Island from a live Antigravity CLI session


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Antigravity CLI, including session tracking, activity updates, terminal context, and notifications.
  * Added Antigravity hook installation, status, and removal options in Settings and setup tools.
  * Added support for installing hooks across supported lifecycle events.
* **Documentation**
  * Updated compatibility, integration, hook event, and setup documentation for Antigravity CLI.
* **Tests**
  * Added coverage for Antigravity payloads, hook installation, and activity updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->