### PR TITLE
feat: support Codex sessions over SSH remote bridge

### DIFF
--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -1114,7 +1114,7 @@ struct RemoteConnectionSection: View {
                     }
                 }
 
-                Text("Monitor Claude Code running on remote servers via SSH.")
+                Text("Monitor Claude Code and Codex running on remote servers via SSH.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
 

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -492,7 +492,8 @@ public final class BridgeServer: @unchecked Sendable {
                     summary: payload.implicitStartSummary,
                     timestamp: .now,
                     jumpTarget: payload.defaultJumpTarget,
-                    codexMetadata: payload.defaultCodexMetadata.isEmpty ? nil : payload.defaultCodexMetadata
+                    codexMetadata: payload.defaultCodexMetadata.isEmpty ? nil : payload.defaultCodexMetadata,
+                    isRemote: payload.remote == true
                 )
             )
 
@@ -1833,7 +1834,8 @@ public final class BridgeServer: @unchecked Sendable {
                     summary: payload.implicitStartSummary,
                     timestamp: .now,
                     jumpTarget: payload.defaultJumpTarget,
-                    codexMetadata: payload.defaultCodexMetadata.isEmpty ? nil : payload.defaultCodexMetadata
+                    codexMetadata: payload.defaultCodexMetadata.isEmpty ? nil : payload.defaultCodexMetadata,
+                    isRemote: payload.remote == true
                 )
             )
         )

--- a/Sources/OpenIslandCore/CodexHooks.swift
+++ b/Sources/OpenIslandCore/CodexHooks.swift
@@ -141,6 +141,8 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
     public var prompt: String?
     public var stopHookActive: Bool?
     public var lastAssistantMessage: String?
+    /// Set to `true` by the Python hook client to indicate a remote (SSH) session.
+    public var remote: Bool?
 
     private enum CodingKeys: String, CodingKey {
         case cwd
@@ -163,6 +165,7 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
         case prompt
         case stopHookActive = "stop_hook_active"
         case lastAssistantMessage = "last_assistant_message"
+        case remote
     }
 
     public init(
@@ -185,7 +188,8 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
         toolResponse: CodexHookJSONValue? = nil,
         prompt: String? = nil,
         stopHookActive: Bool? = nil,
-        lastAssistantMessage: String? = nil
+        lastAssistantMessage: String? = nil,
+        remote: Bool? = nil
     ) {
         self.cwd = cwd
         self.hookEventName = hookEventName
@@ -207,6 +211,7 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
         self.prompt = prompt
         self.stopHookActive = stopHookActive
         self.lastAssistantMessage = lastAssistantMessage
+        self.remote = remote
     }
 
     public init(from decoder: any Decoder) throws {
@@ -231,6 +236,7 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
         prompt = try container.decodeIfPresent(String.self, forKey: .prompt)
         stopHookActive = try container.decodeIfPresent(Bool.self, forKey: .stopHookActive)
         lastAssistantMessage = try container.decodeIfPresent(String.self, forKey: .lastAssistantMessage)
+        remote = try container.decodeIfPresent(Bool.self, forKey: .remote)
     }
 }
 

--- a/Tests/OpenIslandAppTests/ForegroundTerminalSessionProbeTests.swift
+++ b/Tests/OpenIslandAppTests/ForegroundTerminalSessionProbeTests.swift
@@ -1,8 +1,9 @@
-import XCTest
+import Testing
 @testable import OpenIslandApp
 import OpenIslandCore
 
-final class ForegroundTerminalSessionProbeTests: XCTestCase {
+struct ForegroundTerminalSessionProbeTests {
+    @Test
     func testMatchesGhosttyFrontmostTerminalBySessionID() async {
         let probe = ForegroundTerminalSessionProbe(
             frontmostBundleIdentifierProvider: { "com.mitchellh.ghostty" },
@@ -18,9 +19,10 @@ final class ForegroundTerminalSessionProbeTests: XCTestCase {
             )
         )
 
-        XCTAssertTrue(matches)
+        #expect(matches)
     }
 
+    @Test
     func testMatchesTerminalFrontmostTabByTTY() async {
         let probe = ForegroundTerminalSessionProbe(
             frontmostBundleIdentifierProvider: { "com.apple.Terminal" },
@@ -36,9 +38,10 @@ final class ForegroundTerminalSessionProbeTests: XCTestCase {
             )
         )
 
-        XCTAssertTrue(matches)
+        #expect(matches)
     }
 
+    @Test
     func testMatchesITermFrontmostSessionByTTYFallback() async {
         let probe = ForegroundTerminalSessionProbe(
             frontmostBundleIdentifierProvider: { "com.googlecode.iterm2" },
@@ -55,9 +58,10 @@ final class ForegroundTerminalSessionProbeTests: XCTestCase {
             )
         )
 
-        XCTAssertTrue(matches)
+        #expect(matches)
     }
 
+    @Test
     func testReturnsFalseForUnsupportedFrontmostApp() async {
         let probe = ForegroundTerminalSessionProbe(
             frontmostBundleIdentifierProvider: { "com.example.Editor" },
@@ -73,6 +77,6 @@ final class ForegroundTerminalSessionProbeTests: XCTestCase {
             )
         )
 
-        XCTAssertFalse(matches)
+        #expect(!matches)
     }
 }

--- a/Tests/OpenIslandAppTests/KeystrokeInjectorTests.swift
+++ b/Tests/OpenIslandAppTests/KeystrokeInjectorTests.swift
@@ -1,20 +1,22 @@
-import XCTest
+import Testing
 @testable import OpenIslandApp
 
-final class KeystrokeInjectorTests: XCTestCase {
+struct KeystrokeInjectorTests {
+    @Test
     func testDefaultInjectorPostsCmdShiftRightBracketWithoutCrashing() {
         // We can't observe actual OS-level CGEvent delivery in a unit test,
         // but constructing and posting the event without throwing/crashing
         // covers the init-time correctness of the keycode and flags.
         let injector = DefaultKeystrokeInjector()
-        injector.sendCmdShiftRightBracket()  // no XCTAssert — if this crashes the test fails
+        injector.sendCmdShiftRightBracket()  // no assertion — if this crashes the test fails
     }
 
+    @Test
     func testSpyKeystrokerRecordsCalls() {
         let spy = KeystrokeInjectorSpy()
         spy.sendCmdShiftRightBracket()
         spy.sendCmdShiftRightBracket()
-        XCTAssertEqual(spy.callCount, 2)
+        #expect(spy.callCount == 2)
     }
 }
 

--- a/Tests/OpenIslandAppTests/TerminalJumpServiceTests.swift
+++ b/Tests/OpenIslandAppTests/TerminalJumpServiceTests.swift
@@ -1,9 +1,9 @@
-import XCTest
+import Testing
 @testable import OpenIslandApp
 import OpenIslandCore
 import Foundation
 
-final class TerminalJumpServiceTests: XCTestCase {
+struct TerminalJumpServiceTests {
     private final class OpenedArgumentsBox: @unchecked Sendable {
         var values: [[String]] = []
     }
@@ -12,6 +12,7 @@ final class TerminalJumpServiceTests: XCTestCase {
         var values: [(String, [String])] = []
     }
 
+    @Test
     func testGhosttyJumpScriptActivatesWindowAndRetriesFocusUntilItSticks() {
         let target = JumpTarget(
             terminalApp: "Ghostty",
@@ -23,19 +24,20 @@ final class TerminalJumpServiceTests: XCTestCase {
 
         let script = TerminalJumpService().ghosttyJumpScript(for: target)
 
-        XCTAssertTrue(script.contains("activate"))
-        XCTAssertTrue(script.contains("activate window targetWindow"))
-        XCTAssertTrue(script.contains("select tab targetTab"))
-        XCTAssertTrue(script.contains("focus targetTerminal"))
-        XCTAssertTrue(script.contains("repeat 3 times"))
-        XCTAssertTrue(script.contains("delay 0.04"))
-        XCTAssertTrue(script.contains("delay 0.08"))
-        XCTAssertTrue(script.contains("focused terminal of selected tab of front window"))
-        XCTAssertTrue(script.contains("repeat with aWindow in windows"))
-        XCTAssertTrue(script.contains("repeat with aTab in tabs of aWindow"))
-        XCTAssertTrue(script.contains("repeat with aTerminal in terminals of aTab"))
+        #expect(script.contains("activate"))
+        #expect(script.contains("activate window targetWindow"))
+        #expect(script.contains("select tab targetTab"))
+        #expect(script.contains("focus targetTerminal"))
+        #expect(script.contains("repeat 3 times"))
+        #expect(script.contains("delay 0.04"))
+        #expect(script.contains("delay 0.08"))
+        #expect(script.contains("focused terminal of selected tab of front window"))
+        #expect(script.contains("repeat with aWindow in windows"))
+        #expect(script.contains("repeat with aTab in tabs of aWindow"))
+        #expect(script.contains("repeat with aTerminal in terminals of aTab"))
     }
 
+    @Test
     func testGhosttyJumpScriptFallsBackToWorkingDirectoryAndTitle() {
         let target = JumpTarget(
             terminalApp: "Ghostty",
@@ -46,19 +48,18 @@ final class TerminalJumpServiceTests: XCTestCase {
 
         let script = TerminalJumpService().ghosttyJumpScript(for: target)
 
-        XCTAssertTrue(script.contains("(working directory of aTerminal as text) is \"/Users/wangruobing/Personal/open-island\""))
-        XCTAssertTrue(script.contains("(name of aTerminal as text) contains \"codex ~/p/open-island\""))
-        XCTAssertTrue(script.contains("if \"\" is \"\" then"))
+        #expect(script.contains("(working directory of aTerminal as text) is \"/Users/wangruobing/Personal/open-island\""))
+        #expect(script.contains("(name of aTerminal as text) contains \"codex ~/p/open-island\""))
+        #expect(script.contains("if \"\" is \"\" then"))
     }
 
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["OPEN_ISLAND_RUN_GHOSTTY_JUMP_INTEGRATION"] == "1"))
     func testGhosttyJumpIntegrationMatchesFocusedTerminalForLiveSurfaces() throws {
-        guard ProcessInfo.processInfo.environment["OPEN_ISLAND_RUN_GHOSTTY_JUMP_INTEGRATION"] == "1" else {
-            throw XCTSkip("Set OPEN_ISLAND_RUN_GHOSTTY_JUMP_INTEGRATION=1 to run live Ghostty jump verification.")
-        }
-
         let terminals = try liveGhosttyTerminals()
         if terminals.isEmpty {
-            throw XCTSkip("No live Ghostty terminals were found.")
+            // Runtime skip is not available in the Swift.org toolchain's
+            // Testing module; treat "no live terminals" as nothing to verify.
+            return
         }
 
         let service = TerminalJumpService()
@@ -87,13 +88,14 @@ final class TerminalJumpServiceTests: XCTestCase {
                 Thread.sleep(forTimeInterval: 0.25)
             }
 
-            XCTAssertTrue(
+            #expect(
                 matched,
                 "Ghostty jump did not settle on \(terminal.id). lastResult=\(lastResult) lastFocusedID=\(lastFocusedID)"
             )
         }
     }
 
+    @Test
     func testGhosttyJumpDoesNotOpenNewTabWhenPreciseTargetMissesInRunningApp() throws {
         let openedArguments = OpenedArgumentsBox()
         let service = TerminalJumpService(
@@ -119,10 +121,11 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Activated Ghostty. Exact pane targeting could not find the live terminal.")
-        XCTAssertEqual(openedArguments.values, [["-b", "com.mitchellh.ghostty"]])
+        #expect(result == "Activated Ghostty. Exact pane targeting could not find the live terminal.")
+        #expect(openedArguments.values == [["-b", "com.mitchellh.ghostty"]])
     }
 
+    @Test
     func testCursorJumpActivatesRunningAppWithoutWorkspaceReuse() throws {
         let openedArguments = OpenedArgumentsBox()
         let service = TerminalJumpService(
@@ -148,10 +151,11 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Activated Cursor.")
-        XCTAssertEqual(openedArguments.values, [["-b", "com.todesktop.230313mzl4w4u92"]])
+        #expect(result == "Activated Cursor.")
+        #expect(openedArguments.values == [["-b", "com.todesktop.230313mzl4w4u92"]])
     }
 
+    @Test
     func testCursorJumpFallsBackToWorkspaceWhenAppNotRunning() throws {
         let openedArguments = OpenedArgumentsBox()
         let service = TerminalJumpService(
@@ -175,10 +179,11 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Focused the matching Cursor workspace.")
-        XCTAssertTrue(openedArguments.values.isEmpty)
+        #expect(result == "Focused the matching Cursor workspace.")
+        #expect(openedArguments.values.isEmpty)
     }
 
+    @Test
     func testWarpJumpReturnsImmediatelyWhenAlreadyOnTargetPane() throws {
         let openedArguments = OpenedArgumentsBox()
         let keystroker = KeystrokeInjectorSpy()
@@ -207,11 +212,12 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Focused the matching Warp tab.")
-        XCTAssertEqual(keystroker.callCount, 0)
-        XCTAssertEqual(openedArguments.values, [["-b", "dev.warp.Warp-Stable"]])
+        #expect(result == "Focused the matching Warp tab.")
+        #expect(keystroker.callCount == 0)
+        #expect(openedArguments.values == [["-b", "dev.warp.Warp-Stable"]])
     }
 
+    @Test
     func testWarpJumpCyclesThroughTabsUntilTargetIsFocused() throws {
         let openedArguments = OpenedArgumentsBox()
         let keystroker = KeystrokeInjectorSpy()
@@ -247,11 +253,12 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Focused the matching Warp tab.")
-        XCTAssertEqual(keystroker.callCount, 2)
-        XCTAssertEqual(openedArguments.values, [["-b", "dev.warp.Warp-Stable"]])
+        #expect(result == "Focused the matching Warp tab.")
+        #expect(keystroker.callCount == 2)
+        #expect(openedArguments.values == [["-b", "dev.warp.Warp-Stable"]])
     }
 
+    @Test
     func testWarpJumpCapsOutAfterTabCountPlusTwoAndReturnsBestEffortMessage() throws {
         let keystroker = KeystrokeInjectorSpy()
         let service = TerminalJumpService(
@@ -277,10 +284,11 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Activated Warp but could not confirm precision focus.")
-        XCTAssertEqual(keystroker.callCount, 5)  // tabCount (3) + 2
+        #expect(result == "Activated Warp but could not confirm precision focus.")
+        #expect(keystroker.callCount == 5)  // tabCount (3) + 2
     }
 
+    @Test
     func testWarpJumpWithNilWarpPaneUUIDFallsBackToAppActivation() throws {
         let keystroker = KeystrokeInjectorSpy()
         let openedArguments = OpenedArgumentsBox()
@@ -307,11 +315,12 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Activated Warp. No precise pane mapping available.")
-        XCTAssertEqual(keystroker.callCount, 0)
-        XCTAssertEqual(openedArguments.values, [["-b", "dev.warp.Warp-Stable"]])
+        #expect(result == "Activated Warp. No precise pane mapping available.")
+        #expect(keystroker.callCount == 0)
+        #expect(openedArguments.values == [["-b", "dev.warp.Warp-Stable"]])
     }
 
+    @Test
     func testUnknownTerminalAppFallsBackToFinderInsteadOfFirstInstalledTerminal() throws {
         let openedArguments = OpenedArgumentsBox()
         // Pretend iTerm is installed. Without the "unknown" guard in
@@ -338,13 +347,14 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(openedArguments.values, [["/tmp"]])
-        XCTAssertTrue(
+        #expect(openedArguments.values == [["/tmp"]])
+        #expect(
             result.contains("Finder"),
             "Expected Finder fallback, got: \(result)"
         )
     }
 
+    @Test
     func testTraeJumpActivatesRunningTraeCNApp() throws {
         let openedArguments = OpenedArgumentsBox()
         let service = TerminalJumpService(
@@ -369,10 +379,11 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Activated Trae.")
-        XCTAssertEqual(openedArguments.values, [["-b", "cn.trae.app"]])
+        #expect(result == "Activated Trae.")
+        #expect(openedArguments.values == [["-b", "cn.trae.app"]])
     }
 
+    @Test
     func testTraeCNJumpPrefersCNBundleWhenBothTraeVariantsExist() throws {
         let openedArguments = OpenedArgumentsBox()
         let service = TerminalJumpService(
@@ -403,10 +414,11 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Activated Trae. Exact pane targeting is still best-effort.")
-        XCTAssertEqual(openedArguments.values, [["-b", "cn.trae.app"]])
+        #expect(result == "Activated Trae. Exact pane targeting is still best-effort.")
+        #expect(openedArguments.values == [["-b", "cn.trae.app"]])
     }
 
+    @Test
     func testCodexAppJumpActivatesCodexDesktopApp() throws {
         let openedArguments = OpenedArgumentsBox()
         let service = TerminalJumpService(
@@ -431,10 +443,11 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Activated Codex.app.")
-        XCTAssertEqual(openedArguments.values, [["-b", "com.openai.codex"]])
+        #expect(result == "Activated Codex.app.")
+        #expect(openedArguments.values == [["-b", "com.openai.codex"]])
     }
 
+    @Test
     func testCodexAppJumpOpensSpecificThreadWhenThreadIDProvided() throws {
         let openedArguments = OpenedArgumentsBox()
         let service = TerminalJumpService(
@@ -461,10 +474,11 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Focused the Codex.app conversation.")
-        XCTAssertEqual(openedArguments.values, [["codex://threads/\(threadID)"]])
+        #expect(result == "Focused the Codex.app conversation.")
+        #expect(openedArguments.values == [["codex://threads/\(threadID)"]])
     }
 
+    @Test
     func testTraeCNJumpFallsBackToWorkspaceViaTraeCLI() throws {
         let openedArguments = OpenedArgumentsBox()
         let processInvocations = ProcessInvocationBox()
@@ -492,11 +506,11 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Focused the matching Trae workspace.")
-        XCTAssertTrue(openedArguments.values.isEmpty)
-        XCTAssertEqual(processInvocations.values.count, 1)
-        XCTAssertEqual(processInvocations.values.first?.0, "trae")
-        XCTAssertEqual(processInvocations.values.first?.1, ["-r", "/Users/test/open-vibe-island"])
+        #expect(result == "Focused the matching Trae workspace.")
+        #expect(openedArguments.values.isEmpty)
+        #expect(processInvocations.values.count == 1)
+        #expect(processInvocations.values.first?.0 == "trae")
+        #expect(processInvocations.values.first?.1 == ["-r", "/Users/test/open-vibe-island"])
     }
 }
 
@@ -585,8 +599,11 @@ private func runAppleScript(_ script: String) throws -> String {
     guard task.terminationStatus == 0 else {
         let stderr = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        XCTFail(stderr.isEmpty ? "AppleScript command failed." : stderr)
-        throw NSError(domain: "TerminalJumpServiceTests", code: Int(task.terminationStatus))
+        throw NSError(
+            domain: "TerminalJumpServiceTests",
+            code: Int(task.terminationStatus),
+            userInfo: [NSLocalizedDescriptionKey: stderr.isEmpty ? "AppleScript command failed." : stderr]
+        )
     }
 
     return output

--- a/Tests/OpenIslandCoreTests/CodexRemoteSessionTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexRemoteSessionTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+/// Pins Codex SSH-remote support. The Python hook client
+/// (`scripts/open-island-hooks.py`) marks every bridge payload with
+/// `remote: true`; the Codex decode + bridge path must surface that as
+/// `isRemote` on the session so the UI shows the SSH badge and
+/// process-liveness checks skip sessions whose process lives on a
+/// remote machine.
+struct CodexRemoteSessionTests {
+    @Test
+    func codexSessionStartWithRemoteFlagCreatesRemoteSession() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let payload = CodexHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .sessionStart,
+            model: "gpt-5-codex",
+            permissionMode: .default,
+            sessionID: "codex-remote-1",
+            transcriptPath: nil,
+            remote: true
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(.processCodexHook(payload))
+
+        var iterator = stream.makeAsyncIterator()
+        let startedEvent = try await nextEvent(from: &iterator)
+
+        #expect(startedEvent.sessionStarted?.isRemote == true)
+    }
+
+    @Test
+    func codexSessionStartWithoutRemoteFlagCreatesLocalSession() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let payload = CodexHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .sessionStart,
+            model: "gpt-5-codex",
+            permissionMode: .default,
+            sessionID: "codex-local-1",
+            transcriptPath: nil
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(.processCodexHook(payload))
+
+        var iterator = stream.makeAsyncIterator()
+        let startedEvent = try await nextEvent(from: &iterator)
+
+        #expect(startedEvent.sessionStarted?.isRemote == false)
+    }
+
+    @Test
+    func codexHookPayloadDecodesRemoteFlag() throws {
+        let withRemote = """
+        {
+          "cwd": "/tmp/demo",
+          "hook_event_name": "SessionStart",
+          "model": "gpt-5-codex",
+          "permission_mode": "default",
+          "session_id": "s-remote",
+          "transcript_path": null,
+          "remote": true
+        }
+        """.data(using: .utf8)!
+
+        let remotePayload = try JSONDecoder().decode(CodexHookPayload.self, from: withRemote)
+        #expect(remotePayload.remote == true)
+
+        let withoutRemote = """
+        {
+          "cwd": "/tmp/demo",
+          "hook_event_name": "SessionStart",
+          "model": "gpt-5-codex",
+          "permission_mode": "default",
+          "session_id": "s-local",
+          "transcript_path": null
+        }
+        """.data(using: .utf8)!
+
+        let localPayload = try JSONDecoder().decode(CodexHookPayload.self, from: withoutRemote)
+        #expect(localPayload.remote == nil)
+    }
+}
+
+private enum CodexRemoteSessionTestError: Error {
+    case streamEnded
+}
+
+private func nextEvent(
+    from iterator: inout AsyncThrowingStream<AgentEvent, Error>.AsyncIterator
+) async throws -> AgentEvent {
+    guard let event = try await iterator.next() else {
+        throw CodexRemoteSessionTestError.streamEnded
+    }
+
+    return event
+}
+
+private extension AgentEvent {
+    var sessionStarted: SessionStarted? {
+        if case let .sessionStarted(payload) = self {
+            payload
+        } else {
+            nil
+        }
+    }
+}

--- a/Tests/OpenIslandCoreTests/OpenCodeSessionRegistryTests.swift
+++ b/Tests/OpenIslandCoreTests/OpenCodeSessionRegistryTests.swift
@@ -1,22 +1,19 @@
-import XCTest
+import Foundation
+import Testing
 import OpenIslandCore
 
-final class OpenCodeSessionRegistryTests: XCTestCase {
-    var tempFileURL: URL!
-
-    override func setUp() {
-        super.setUp()
-        tempFileURL = FileManager.default.temporaryDirectory
+struct OpenCodeSessionRegistryTests {
+    private func makeTempFileURL() -> URL {
+        FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
             .appendingPathExtension("json")
     }
 
-    override func tearDown() {
-        try? FileManager.default.removeItem(at: tempFileURL)
-        super.tearDown()
-    }
-
+    @Test
     func testSaveAndLoad() throws {
+        let tempFileURL = makeTempFileURL()
+        defer { try? FileManager.default.removeItem(at: tempFileURL) }
+
         let registry = OpenCodeSessionRegistry(fileURL: tempFileURL)
         let records = [
             OpenCodeTrackedSessionRecord(
@@ -37,14 +34,18 @@ final class OpenCodeSessionRegistryTests: XCTestCase {
         try registry.save(records)
         let loaded = try registry.load()
 
-        XCTAssertEqual(loaded.count, 1)
-        XCTAssertEqual(loaded[0].sessionID, "opencode-1")
-        XCTAssertEqual(loaded[0].openCodeMetadata?.initialUserPrompt, "Hello")
+        #expect(loaded.count == 1)
+        #expect(loaded[0].sessionID == "opencode-1")
+        #expect(loaded[0].openCodeMetadata?.initialUserPrompt == "Hello")
     }
 
+    @Test
     func testLoadEmpty() throws {
+        let tempFileURL = makeTempFileURL()
+        defer { try? FileManager.default.removeItem(at: tempFileURL) }
+
         let registry = OpenCodeSessionRegistry(fileURL: tempFileURL)
         let loaded = try registry.load()
-        XCTAssertEqual(loaded.count, 0)
+        #expect(loaded.count == 0)
     }
 }

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -72,6 +72,7 @@ The `CodexHookPayload` model and `BridgeServer` can parse richer events (`PreToo
 | `model` | `model` | Model name |
 | `permission_mode` | `permissionMode` | `default` / `acceptEdits` / `plan` / `dontAsk` / `bypassPermissions` |
 | `transcript_path` | `transcriptPath` | JSONL transcript file path |
+| `remote` | `remote` | `true` when the Python hook client marks an SSH remote session |
 | `terminal_app` | `terminalApp` | Terminal name (`Terminal`, `Ghostty`, `iTerm`, …) |
 | `terminal_session_id` | `terminalSessionID` | Terminal session identifier |
 | `terminal_tty` | `terminalTTY` | TTY device path |

--- a/docs/ssh-setup.md
+++ b/docs/ssh-setup.md
@@ -1,6 +1,6 @@
-# SSH Remote Claude Code Setup
+# SSH Remote Setup (Claude Code & Codex)
 
-Connect Open Island to Claude Code running on a remote server over SSH.
+Connect Open Island to Claude Code and Codex running on a remote server over SSH.
 
 ## How it works
 
@@ -14,7 +14,8 @@ macOS (local)                         Remote server
                                    │  hooks.py          │
                                    │        ▲           │
                                    │        │           │
-                                   │  Claude Code       │
+                                   │  Claude Code /     │
+                                   │  Codex             │
                                    └────────────────────┘
 ```
 
@@ -25,7 +26,7 @@ SSH's `RemoteForward` tunnels the Unix socket from your Mac to the remote server
 - Open Island running on your Mac
 - SSH access to the remote server
 - Python 3.6+ on the remote server
-- Claude Code installed on the remote server
+- Claude Code and/or Codex installed on the remote server
 
 ## Quick setup
 
@@ -38,7 +39,8 @@ Run the automated setup script:
 This will:
 1. Copy `open-island-hooks.py` to the remote server (`~/.local/bin/`)
 2. Configure Claude Code hooks in `~/.claude/settings.json` on the remote
-3. Print the SSH config snippet you need
+3. Configure Codex hooks in `~/.codex/hooks.json` on the remote
+4. Print the SSH config snippet you need
 
 ## Manual setup
 
@@ -89,11 +91,41 @@ Or connect directly with:
 ssh -R /tmp/open-island-$(id -u).sock:/tmp/open-island-$(id -u).sock user@myserver
 ```
 
-### 4. Verify
+### 4. Configure Codex hooks on the remote
+
+Edit `~/.codex/hooks.json` on the remote server:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [{ "type": "command", "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-501.sock python3 ~/.local/bin/open-island-hooks.py --source codex", "timeout": 45 }]
+      }
+    ],
+    "UserPromptSubmit": [
+      { "hooks": [{ "type": "command", "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-501.sock python3 ~/.local/bin/open-island-hooks.py --source codex", "timeout": 45 }] }
+    ],
+    "PermissionRequest": [
+      { "hooks": [{ "type": "command", "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-501.sock python3 ~/.local/bin/open-island-hooks.py --source codex", "timeout": 3600 }] }
+    ],
+    "Stop": [
+      { "hooks": [{ "type": "command", "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-501.sock python3 ~/.local/bin/open-island-hooks.py --source codex", "timeout": 45 }] }
+    ]
+  }
+}
+```
+
+Replace `501` with your local UID (`id -u`). Codex may require a manual
+trust review before running the hooks: open `/hooks` inside Codex CLI and
+approve the Open Island entries.
+
+### 5. Verify
 
 1. Make sure Open Island is running on your Mac
 2. SSH to the remote with socket forwarding enabled
-3. Run Claude Code on the remote — sessions should appear in the Open Island overlay
+3. Run Claude Code or Codex on the remote — sessions should appear in the Open Island overlay
 
 ## Important: sshd configuration
 

--- a/docs/ssh-setup.md
+++ b/docs/ssh-setup.md
@@ -121,6 +121,12 @@ Replace `501` with your local UID (`id -u`). Codex may require a manual
 trust review before running the hooks: open `/hooks` inside Codex CLI and
 approve the Open Island entries.
 
+> **Important:** Codex silently skips hooks that have not been approved yet.
+> If you start an SSH task before running the trust review, no events reach
+> Open Island. After approving the entries, restart any Codex SSH remote
+> session that was already running so the remote app-server reloads the
+> trusted hook state.
+
 ### 5. Verify
 
 1. Make sure Open Island is running on your Mac
@@ -136,6 +142,13 @@ StreamLocalBindUnlink yes
 ```
 
 Without this, reconnecting after a dropped SSH session will fail with "Address already in use" because the old socket file is still on disk.
+
+> **Note:** the forwarded socket is re-created by the most recent SSH
+> connection that carries the `RemoteForward`. Closing that connection can
+> remove the socket path even while an older Codex SSH remote session is still
+> connected, leaving its forward orphaned. Keep one stable tunnel session
+> open, or disconnect and reconnect the Codex SSH remote session, so hooks can
+> always reach the local app.
 
 ## Mac-to-Mac Setup (Different UIDs)
 

--- a/scripts/remote-setup.sh
+++ b/scripts/remote-setup.sh
@@ -3,8 +3,8 @@
 # Open Island — remote SSH setup
 #
 # Deploys the Python hook client to a remote server and configures
-# Claude Code to use it.  Also prints the SSH config snippet needed
-# for Unix socket forwarding.
+# Claude Code and Codex to use it.  Also prints the SSH config snippet
+# needed for Unix socket forwarding.
 #
 # Usage:
 #   ./scripts/remote-setup.sh user@host
@@ -12,7 +12,7 @@
 # Prerequisites:
 #   - SSH access to the remote host
 #   - Python 3.6+ on the remote host
-#   - Claude Code installed on the remote host
+#   - Claude Code and/or Codex installed on the remote host
 
 set -euo pipefail
 
@@ -96,7 +96,83 @@ print('Updated ' + settings_path)
 \"" <<< "$HOOKS_JSON"
 
 echo ""
+echo "==> Configuring Codex hooks on $REMOTE ..."
+# Codex hooks.json uses the same forwarded socket; the remote hook client
+# marks payloads as remote so the app keeps the session alive.
+CODEX_HOOK_CMD="OPEN_ISLAND_SOCKET_PATH=/tmp/$SOCKET_NAME python3 ~/.local/bin/open-island-hooks.py --source codex"
+CODEX_HOOKS_JSON=$(cat <<ENDJSON
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [{"type": "command", "command": "$CODEX_HOOK_CMD", "timeout": 45}]
+      }
+    ],
+    "UserPromptSubmit": [
+      {"hooks": [{"type": "command", "command": "$CODEX_HOOK_CMD", "timeout": 45}]}
+    ],
+    "PermissionRequest": [
+      {"hooks": [{"type": "command", "command": "$CODEX_HOOK_CMD", "timeout": 3600}]}
+    ],
+    "Stop": [
+      {"hooks": [{"type": "command", "command": "$CODEX_HOOK_CMD", "timeout": 45}]}
+    ]
+  }
+}
+ENDJSON
+)
+
+# Merge into existing hooks.json on remote (or create new), preserving
+# user-authored hook groups for the same events.
+ssh "$REMOTE" "python3 -c \"
+import json, os, sys
+
+hooks_path = os.path.expanduser('~/.codex/hooks.json')
+os.makedirs(os.path.dirname(hooks_path), exist_ok=True)
+
+existing = {}
+if os.path.exists(hooks_path):
+    with open(hooks_path) as f:
+        existing = json.load(f)
+
+new_hooks = json.loads(sys.stdin.read())
+
+if 'hooks' not in existing:
+    existing['hooks'] = {}
+
+def existing_commands(event):
+    commands = set()
+    for group in existing['hooks'].get(event, []):
+        for hook in group.get('hooks', []):
+            if isinstance(hook, dict) and hook.get('command'):
+                commands.add(hook['command'])
+    return commands
+
+for event, groups in new_hooks['hooks'].items():
+    cur = existing['hooks'].get(event, [])
+    known = existing_commands(event)
+    for group in groups:
+        commands = [h.get('command') for h in group.get('hooks', []) if isinstance(h, dict)]
+        if commands and all(c in known for c in commands):
+            continue
+        cur.append(group)
+        for c in commands:
+            known.add(c)
+    existing['hooks'][event] = cur
+
+with open(hooks_path, 'w') as f:
+    json.dump(existing, f, indent=2)
+    f.write('\n')
+
+print('Updated ' + hooks_path)
+\"" <<< "$CODEX_HOOKS_JSON"
+
+echo ""
 echo "==> Done!"
+echo ""
+echo "Codex may require a manual trust review before running the hooks:"
+echo "open \`/hooks\` inside Codex CLI and approve the Open Island entries."
 echo ""
 echo "IMPORTANT: Ensure the remote sshd has 'StreamLocalBindUnlink yes' in"
 echo "/etc/ssh/sshd_config — otherwise reconnecting will fail with"


### PR DESCRIPTION
## Summary

Extends the SSH remote bridge so Codex sessions running on a remote server (including via Codex Desktop's SSH remote / `codex app-server`) appear in Open Island, matching the existing Claude Code remote flow.

## Changes

- `feat: support Codex sessions over SSH remote bridge` (a1ac4a7)
  - Portability hook client (`scripts/open-island-hooks.py`) supports `--source codex`
  - `CodexHookPayload` carries a `remote` flag set by the Python hook client
  - Codex `SessionStart` / `ensureSessionExists` sessions are marked `isRemote`
  - `scripts/remote-setup.sh` deploys and merges Codex hooks on the remote
  - Settings copy updated to mention Codex alongside Claude Code
- `test: migrate remaining XCTest suites to Swift Testing` (ef69115)
- `docs: note hook trust timing and tunnel ownership for Codex SSH remote` (7cf872f)

## Verification

- Remote `codex exec` and Codex Desktop SSH remote sessions create sessions in Open Island (verified end-to-end over the `RemoteForward` Unix socket tunnel)
- Hook events receive `acknowledged` bridge responses; session persisted in `session-terminals.json`
- Existing Swift Testing suites pass in the repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote session detection now supports both Claude Code and Codex.
  * Codex remote-session status is reflected in session events.
  * Remote setup can configure Codex hooks while preserving existing settings.

* **Documentation**
  * Updated SSH setup and hook documentation with Codex configuration, verification, and troubleshooting guidance.

* **Tests**
  * Added coverage for Codex remote and local session handling.
  * Migrated several test suites to Swift Testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->