### PR TITLE
feat: support Codex sessions over SSH remote bridge

### DIFF
--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -1114,7 +1114,7 @@ struct RemoteConnectionSection: View {
                     }
                 }
 
-                Text("Monitor Claude Code running on remote servers via SSH.")
+                Text("Monitor Claude Code and Codex running on remote servers via SSH.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
 

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -492,7 +492,8 @@ public final class BridgeServer: @unchecked Sendable {
                     summary: payload.implicitStartSummary,
                     timestamp: .now,
                     jumpTarget: payload.defaultJumpTarget,
-                    codexMetadata: payload.defaultCodexMetadata.isEmpty ? nil : payload.defaultCodexMetadata
+                    codexMetadata: payload.defaultCodexMetadata.isEmpty ? nil : payload.defaultCodexMetadata,
+                    isRemote: payload.remote == true
                 )
             )
 
@@ -1833,7 +1834,8 @@ public final class BridgeServer: @unchecked Sendable {
                     summary: payload.implicitStartSummary,
                     timestamp: .now,
                     jumpTarget: payload.defaultJumpTarget,
-                    codexMetadata: payload.defaultCodexMetadata.isEmpty ? nil : payload.defaultCodexMetadata
+                    codexMetadata: payload.defaultCodexMetadata.isEmpty ? nil : payload.defaultCodexMetadata,
+                    isRemote: payload.remote == true
                 )
             )
         )

--- a/Sources/OpenIslandCore/CodexHooks.swift
+++ b/Sources/OpenIslandCore/CodexHooks.swift
@@ -141,6 +141,8 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
     public var prompt: String?
     public var stopHookActive: Bool?
     public var lastAssistantMessage: String?
+    /// Set to `true` by the Python hook client to indicate a remote (SSH) session.
+    public var remote: Bool?
 
     private enum CodingKeys: String, CodingKey {
         case cwd
@@ -163,6 +165,7 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
         case prompt
         case stopHookActive = "stop_hook_active"
         case lastAssistantMessage = "last_assistant_message"
+        case remote
     }
 
     public init(
@@ -185,7 +188,8 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
         toolResponse: CodexHookJSONValue? = nil,
         prompt: String? = nil,
         stopHookActive: Bool? = nil,
-        lastAssistantMessage: String? = nil
+        lastAssistantMessage: String? = nil,
+        remote: Bool? = nil
     ) {
         self.cwd = cwd
         self.hookEventName = hookEventName
@@ -207,6 +211,7 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
         self.prompt = prompt
         self.stopHookActive = stopHookActive
         self.lastAssistantMessage = lastAssistantMessage
+        self.remote = remote
     }
 
     public init(from decoder: any Decoder) throws {
@@ -231,6 +236,7 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
         prompt = try container.decodeIfPresent(String.self, forKey: .prompt)
         stopHookActive = try container.decodeIfPresent(Bool.self, forKey: .stopHookActive)
         lastAssistantMessage = try container.decodeIfPresent(String.self, forKey: .lastAssistantMessage)
+        remote = try container.decodeIfPresent(Bool.self, forKey: .remote)
     }
 }
 

--- a/Tests/OpenIslandAppTests/ForegroundTerminalSessionProbeTests.swift
+++ b/Tests/OpenIslandAppTests/ForegroundTerminalSessionProbeTests.swift
@@ -1,8 +1,9 @@
-import XCTest
+import Testing
 @testable import OpenIslandApp
 import OpenIslandCore
 
-final class ForegroundTerminalSessionProbeTests: XCTestCase {
+struct ForegroundTerminalSessionProbeTests {
+    @Test
     func testMatchesGhosttyFrontmostTerminalBySessionID() async {
         let probe = ForegroundTerminalSessionProbe(
             frontmostBundleIdentifierProvider: { "com.mitchellh.ghostty" },
@@ -18,9 +19,10 @@ final class ForegroundTerminalSessionProbeTests: XCTestCase {
             )
         )
 
-        XCTAssertTrue(matches)
+        #expect(matches)
     }
 
+    @Test
     func testMatchesTerminalFrontmostTabByTTY() async {
         let probe = ForegroundTerminalSessionProbe(
             frontmostBundleIdentifierProvider: { "com.apple.Terminal" },
@@ -36,9 +38,10 @@ final class ForegroundTerminalSessionProbeTests: XCTestCase {
             )
         )
 
-        XCTAssertTrue(matches)
+        #expect(matches)
     }
 
+    @Test
     func testMatchesITermFrontmostSessionByTTYFallback() async {
         let probe = ForegroundTerminalSessionProbe(
             frontmostBundleIdentifierProvider: { "com.googlecode.iterm2" },
@@ -55,9 +58,10 @@ final class ForegroundTerminalSessionProbeTests: XCTestCase {
             )
         )
 
-        XCTAssertTrue(matches)
+        #expect(matches)
     }
 
+    @Test
     func testReturnsFalseForUnsupportedFrontmostApp() async {
         let probe = ForegroundTerminalSessionProbe(
             frontmostBundleIdentifierProvider: { "com.example.Editor" },
@@ -73,6 +77,6 @@ final class ForegroundTerminalSessionProbeTests: XCTestCase {
             )
         )
 
-        XCTAssertFalse(matches)
+        #expect(!matches)
     }
 }

--- a/Tests/OpenIslandAppTests/KeystrokeInjectorTests.swift
+++ b/Tests/OpenIslandAppTests/KeystrokeInjectorTests.swift
@@ -1,20 +1,22 @@
-import XCTest
+import Testing
 @testable import OpenIslandApp
 
-final class KeystrokeInjectorTests: XCTestCase {
+struct KeystrokeInjectorTests {
+    @Test
     func testDefaultInjectorPostsCmdShiftRightBracketWithoutCrashing() {
         // We can't observe actual OS-level CGEvent delivery in a unit test,
         // but constructing and posting the event without throwing/crashing
         // covers the init-time correctness of the keycode and flags.
         let injector = DefaultKeystrokeInjector()
-        injector.sendCmdShiftRightBracket()  // no XCTAssert — if this crashes the test fails
+        injector.sendCmdShiftRightBracket()  // no assertion — if this crashes the test fails
     }
 
+    @Test
     func testSpyKeystrokerRecordsCalls() {
         let spy = KeystrokeInjectorSpy()
         spy.sendCmdShiftRightBracket()
         spy.sendCmdShiftRightBracket()
-        XCTAssertEqual(spy.callCount, 2)
+        #expect(spy.callCount == 2)
     }
 }
 

--- a/Tests/OpenIslandAppTests/TerminalJumpServiceTests.swift
+++ b/Tests/OpenIslandAppTests/TerminalJumpServiceTests.swift
@@ -57,9 +57,7 @@ struct TerminalJumpServiceTests {
     func testGhosttyJumpIntegrationMatchesFocusedTerminalForLiveSurfaces() throws {
         let terminals = try liveGhosttyTerminals()
         if terminals.isEmpty {
-            // Runtime skip is not available in the Swift.org toolchain's
-            // Testing module; treat "no live terminals" as nothing to verify.
-            return
+            try Test.cancel("No live Ghostty terminals; nothing to verify.")
         }
 
         let service = TerminalJumpService()

--- a/Tests/OpenIslandAppTests/TerminalJumpServiceTests.swift
+++ b/Tests/OpenIslandAppTests/TerminalJumpServiceTests.swift
@@ -1,9 +1,9 @@
-import XCTest
+import Testing
 @testable import OpenIslandApp
 import OpenIslandCore
 import Foundation
 
-final class TerminalJumpServiceTests: XCTestCase {
+struct TerminalJumpServiceTests {
     private final class OpenedArgumentsBox: @unchecked Sendable {
         var values: [[String]] = []
     }
@@ -12,6 +12,7 @@ final class TerminalJumpServiceTests: XCTestCase {
         var values: [(String, [String])] = []
     }
 
+    @Test
     func testGhosttyJumpScriptActivatesWindowAndRetriesFocusUntilItSticks() {
         let target = JumpTarget(
             terminalApp: "Ghostty",
@@ -23,19 +24,20 @@ final class TerminalJumpServiceTests: XCTestCase {
 
         let script = TerminalJumpService().ghosttyJumpScript(for: target)
 
-        XCTAssertTrue(script.contains("activate"))
-        XCTAssertTrue(script.contains("activate window targetWindow"))
-        XCTAssertTrue(script.contains("select tab targetTab"))
-        XCTAssertTrue(script.contains("focus targetTerminal"))
-        XCTAssertTrue(script.contains("repeat 3 times"))
-        XCTAssertTrue(script.contains("delay 0.04"))
-        XCTAssertTrue(script.contains("delay 0.08"))
-        XCTAssertTrue(script.contains("focused terminal of selected tab of front window"))
-        XCTAssertTrue(script.contains("repeat with aWindow in windows"))
-        XCTAssertTrue(script.contains("repeat with aTab in tabs of aWindow"))
-        XCTAssertTrue(script.contains("repeat with aTerminal in terminals of aTab"))
+        #expect(script.contains("activate"))
+        #expect(script.contains("activate window targetWindow"))
+        #expect(script.contains("select tab targetTab"))
+        #expect(script.contains("focus targetTerminal"))
+        #expect(script.contains("repeat 3 times"))
+        #expect(script.contains("delay 0.04"))
+        #expect(script.contains("delay 0.08"))
+        #expect(script.contains("focused terminal of selected tab of front window"))
+        #expect(script.contains("repeat with aWindow in windows"))
+        #expect(script.contains("repeat with aTab in tabs of aWindow"))
+        #expect(script.contains("repeat with aTerminal in terminals of aTab"))
     }
 
+    @Test
     func testGhosttyJumpScriptFallsBackToWorkingDirectoryAndTitle() {
         let target = JumpTarget(
             terminalApp: "Ghostty",
@@ -46,19 +48,18 @@ final class TerminalJumpServiceTests: XCTestCase {
 
         let script = TerminalJumpService().ghosttyJumpScript(for: target)
 
-        XCTAssertTrue(script.contains("(working directory of aTerminal as text) is \"/Users/wangruobing/Personal/open-island\""))
-        XCTAssertTrue(script.contains("(name of aTerminal as text) contains \"codex ~/p/open-island\""))
-        XCTAssertTrue(script.contains("if \"\" is \"\" then"))
+        #expect(script.contains("(working directory of aTerminal as text) is \"/Users/wangruobing/Personal/open-island\""))
+        #expect(script.contains("(name of aTerminal as text) contains \"codex ~/p/open-island\""))
+        #expect(script.contains("if \"\" is \"\" then"))
     }
 
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["OPEN_ISLAND_RUN_GHOSTTY_JUMP_INTEGRATION"] == "1"))
     func testGhosttyJumpIntegrationMatchesFocusedTerminalForLiveSurfaces() throws {
-        guard ProcessInfo.processInfo.environment["OPEN_ISLAND_RUN_GHOSTTY_JUMP_INTEGRATION"] == "1" else {
-            throw XCTSkip("Set OPEN_ISLAND_RUN_GHOSTTY_JUMP_INTEGRATION=1 to run live Ghostty jump verification.")
-        }
-
         let terminals = try liveGhosttyTerminals()
         if terminals.isEmpty {
-            throw XCTSkip("No live Ghostty terminals were found.")
+            // Runtime skip is not available in the Swift.org toolchain's
+            // Testing module; treat "no live terminals" as nothing to verify.
+            return
         }
 
         let service = TerminalJumpService()
@@ -87,13 +88,14 @@ final class TerminalJumpServiceTests: XCTestCase {
                 Thread.sleep(forTimeInterval: 0.25)
             }
 
-            XCTAssertTrue(
+            #expect(
                 matched,
                 "Ghostty jump did not settle on \(terminal.id). lastResult=\(lastResult) lastFocusedID=\(lastFocusedID)"
             )
         }
     }
 
+    @Test
     func testGhosttyJumpDoesNotOpenNewTabWhenPreciseTargetMissesInRunningApp() throws {
         let openedArguments = OpenedArgumentsBox()
         let service = TerminalJumpService(
@@ -119,10 +121,11 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Activated Ghostty. Exact pane targeting could not find the live terminal.")
-        XCTAssertEqual(openedArguments.values, [["-b", "com.mitchellh.ghostty"]])
+        #expect(result == "Activated Ghostty. Exact pane targeting could not find the live terminal.")
+        #expect(openedArguments.values == [["-b", "com.mitchellh.ghostty"]])
     }
 
+    @Test
     func testCursorJumpActivatesRunningAppWithoutWorkspaceReuse() throws {
         let openedArguments = OpenedArgumentsBox()
         let service = TerminalJumpService(
@@ -148,10 +151,11 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Activated Cursor.")
-        XCTAssertEqual(openedArguments.values, [["-b", "com.todesktop.230313mzl4w4u92"]])
+        #expect(result == "Activated Cursor.")
+        #expect(openedArguments.values == [["-b", "com.todesktop.230313mzl4w4u92"]])
     }
 
+    @Test
     func testCursorJumpFallsBackToWorkspaceWhenAppNotRunning() throws {
         let openedArguments = OpenedArgumentsBox()
         let service = TerminalJumpService(
@@ -175,10 +179,11 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Focused the matching Cursor workspace.")
-        XCTAssertTrue(openedArguments.values.isEmpty)
+        #expect(result == "Focused the matching Cursor workspace.")
+        #expect(openedArguments.values.isEmpty)
     }
 
+    @Test
     func testWarpJumpReturnsImmediatelyWhenAlreadyOnTargetPane() throws {
         let openedArguments = OpenedArgumentsBox()
         let keystroker = KeystrokeInjectorSpy()
@@ -207,11 +212,12 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Focused the matching Warp tab.")
-        XCTAssertEqual(keystroker.callCount, 0)
-        XCTAssertEqual(openedArguments.values, [["-b", "dev.warp.Warp-Stable"]])
+        #expect(result == "Focused the matching Warp tab.")
+        #expect(keystroker.callCount == 0)
+        #expect(openedArguments.values == [["-b", "dev.warp.Warp-Stable"]])
     }
 
+    @Test
     func testWarpJumpCyclesThroughTabsUntilTargetIsFocused() throws {
         let openedArguments = OpenedArgumentsBox()
         let keystroker = KeystrokeInjectorSpy()
@@ -247,11 +253,12 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Focused the matching Warp tab.")
-        XCTAssertEqual(keystroker.callCount, 2)
-        XCTAssertEqual(openedArguments.values, [["-b", "dev.warp.Warp-Stable"]])
+        #expect(result == "Focused the matching Warp tab.")
+        #expect(keystroker.callCount == 2)
+        #expect(openedArguments.values == [["-b", "dev.warp.Warp-Stable"]])
     }
 
+    @Test
     func testWarpJumpCapsOutAfterTabCountPlusTwoAndReturnsBestEffortMessage() throws {
         let keystroker = KeystrokeInjectorSpy()
         let service = TerminalJumpService(
@@ -277,10 +284,11 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Activated Warp but could not confirm precision focus.")
-        XCTAssertEqual(keystroker.callCount, 5)  // tabCount (3) + 2
+        #expect(result == "Activated Warp but could not confirm precision focus.")
+        #expect(keystroker.callCount == 5)  // tabCount (3) + 2
     }
 
+    @Test
     func testWarpJumpWithNilWarpPaneUUIDFallsBackToAppActivation() throws {
         let keystroker = KeystrokeInjectorSpy()
         let openedArguments = OpenedArgumentsBox()
@@ -307,11 +315,12 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Activated Warp. No precise pane mapping available.")
-        XCTAssertEqual(keystroker.callCount, 0)
-        XCTAssertEqual(openedArguments.values, [["-b", "dev.warp.Warp-Stable"]])
+        #expect(result == "Activated Warp. No precise pane mapping available.")
+        #expect(keystroker.callCount == 0)
+        #expect(openedArguments.values == [["-b", "dev.warp.Warp-Stable"]])
     }
 
+    @Test
     func testUnknownTerminalAppFallsBackToFinderInsteadOfFirstInstalledTerminal() throws {
         let openedArguments = OpenedArgumentsBox()
         // Pretend iTerm is installed. Without the "unknown" guard in
@@ -338,13 +347,14 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(openedArguments.values, [["/tmp"]])
-        XCTAssertTrue(
+        #expect(openedArguments.values == [["/tmp"]])
+        #expect(
             result.contains("Finder"),
             "Expected Finder fallback, got: \(result)"
         )
     }
 
+    @Test
     func testTraeJumpActivatesRunningTraeCNApp() throws {
         let openedArguments = OpenedArgumentsBox()
         let service = TerminalJumpService(
@@ -369,10 +379,11 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Activated Trae.")
-        XCTAssertEqual(openedArguments.values, [["-b", "cn.trae.app"]])
+        #expect(result == "Activated Trae.")
+        #expect(openedArguments.values == [["-b", "cn.trae.app"]])
     }
 
+    @Test
     func testTraeCNJumpPrefersCNBundleWhenBothTraeVariantsExist() throws {
         let openedArguments = OpenedArgumentsBox()
         let service = TerminalJumpService(
@@ -403,10 +414,11 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Activated Trae. Exact pane targeting is still best-effort.")
-        XCTAssertEqual(openedArguments.values, [["-b", "cn.trae.app"]])
+        #expect(result == "Activated Trae. Exact pane targeting is still best-effort.")
+        #expect(openedArguments.values == [["-b", "cn.trae.app"]])
     }
 
+    @Test
     func testCodexAppJumpActivatesCodexDesktopApp() throws {
         let openedArguments = OpenedArgumentsBox()
         let service = TerminalJumpService(
@@ -431,10 +443,11 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Activated Codex.app.")
-        XCTAssertEqual(openedArguments.values, [["-b", "com.openai.codex"]])
+        #expect(result == "Activated Codex.app.")
+        #expect(openedArguments.values == [["-b", "com.openai.codex"]])
     }
 
+    @Test
     func testCodexAppJumpOpensSpecificThreadWhenThreadIDProvided() throws {
         let openedArguments = OpenedArgumentsBox()
         let service = TerminalJumpService(
@@ -461,10 +474,11 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Focused the Codex.app conversation.")
-        XCTAssertEqual(openedArguments.values, [["codex://threads/\(threadID)"]])
+        #expect(result == "Focused the Codex.app conversation.")
+        #expect(openedArguments.values == [["codex://threads/\(threadID)"]])
     }
 
+    @Test
     func testTraeCNJumpFallsBackToWorkspaceViaTraeCLI() throws {
         let openedArguments = OpenedArgumentsBox()
         let processInvocations = ProcessInvocationBox()
@@ -492,11 +506,11 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Focused the matching Trae workspace.")
-        XCTAssertTrue(openedArguments.values.isEmpty)
-        XCTAssertEqual(processInvocations.values.count, 1)
-        XCTAssertEqual(processInvocations.values.first?.0, "trae")
-        XCTAssertEqual(processInvocations.values.first?.1, ["-r", "/Users/test/open-vibe-island"])
+        #expect(result == "Focused the matching Trae workspace.")
+        #expect(openedArguments.values.isEmpty)
+        #expect(processInvocations.values.count == 1)
+        #expect(processInvocations.values.first?.0 == "trae")
+        #expect(processInvocations.values.first?.1 == ["-r", "/Users/test/open-vibe-island"])
     }
 }
 
@@ -585,8 +599,11 @@ private func runAppleScript(_ script: String) throws -> String {
     guard task.terminationStatus == 0 else {
         let stderr = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        XCTFail(stderr.isEmpty ? "AppleScript command failed." : stderr)
-        throw NSError(domain: "TerminalJumpServiceTests", code: Int(task.terminationStatus))
+        throw NSError(
+            domain: "TerminalJumpServiceTests",
+            code: Int(task.terminationStatus),
+            userInfo: [NSLocalizedDescriptionKey: stderr.isEmpty ? "AppleScript command failed." : stderr]
+        )
     }
 
     return output

--- a/Tests/OpenIslandCoreTests/CodexRemoteSessionTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexRemoteSessionTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+/// Pins Codex SSH-remote support. The Python hook client
+/// (`scripts/open-island-hooks.py`) marks every bridge payload with
+/// `remote: true`; the Codex decode + bridge path must surface that as
+/// `isRemote` on the session so the UI shows the SSH badge and
+/// process-liveness checks skip sessions whose process lives on a
+/// remote machine.
+struct CodexRemoteSessionTests {
+    @Test
+    func codexSessionStartWithRemoteFlagCreatesRemoteSession() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let payload = CodexHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .sessionStart,
+            model: "gpt-5-codex",
+            permissionMode: .default,
+            sessionID: "codex-remote-1",
+            transcriptPath: nil,
+            remote: true
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(.processCodexHook(payload))
+
+        var iterator = stream.makeAsyncIterator()
+        let startedEvent = try await nextEvent(from: &iterator)
+
+        #expect(startedEvent.sessionStarted?.isRemote == true)
+    }
+
+    @Test
+    func codexSessionStartWithoutRemoteFlagCreatesLocalSession() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let payload = CodexHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .sessionStart,
+            model: "gpt-5-codex",
+            permissionMode: .default,
+            sessionID: "codex-local-1",
+            transcriptPath: nil
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(.processCodexHook(payload))
+
+        var iterator = stream.makeAsyncIterator()
+        let startedEvent = try await nextEvent(from: &iterator)
+
+        #expect(startedEvent.sessionStarted?.isRemote == false)
+    }
+
+    @Test
+    func codexHookPayloadDecodesRemoteFlag() throws {
+        let withRemote = """
+        {
+          "cwd": "/tmp/demo",
+          "hook_event_name": "SessionStart",
+          "model": "gpt-5-codex",
+          "permission_mode": "default",
+          "session_id": "s-remote",
+          "transcript_path": null,
+          "remote": true
+        }
+        """.data(using: .utf8)!
+
+        let remotePayload = try JSONDecoder().decode(CodexHookPayload.self, from: withRemote)
+        #expect(remotePayload.remote == true)
+
+        let withoutRemote = """
+        {
+          "cwd": "/tmp/demo",
+          "hook_event_name": "SessionStart",
+          "model": "gpt-5-codex",
+          "permission_mode": "default",
+          "session_id": "s-local",
+          "transcript_path": null
+        }
+        """.data(using: .utf8)!
+
+        let localPayload = try JSONDecoder().decode(CodexHookPayload.self, from: withoutRemote)
+        #expect(localPayload.remote == nil)
+    }
+}
+
+private enum CodexRemoteSessionTestError: Error {
+    case streamEnded
+}
+
+private func nextEvent(
+    from iterator: inout AsyncThrowingStream<AgentEvent, Error>.AsyncIterator
+) async throws -> AgentEvent {
+    guard let event = try await iterator.next() else {
+        throw CodexRemoteSessionTestError.streamEnded
+    }
+
+    return event
+}
+
+private extension AgentEvent {
+    var sessionStarted: SessionStarted? {
+        if case let .sessionStarted(payload) = self {
+            payload
+        } else {
+            nil
+        }
+    }
+}

--- a/Tests/OpenIslandCoreTests/OpenCodeSessionRegistryTests.swift
+++ b/Tests/OpenIslandCoreTests/OpenCodeSessionRegistryTests.swift
@@ -1,22 +1,19 @@
-import XCTest
+import Foundation
+import Testing
 import OpenIslandCore
 
-final class OpenCodeSessionRegistryTests: XCTestCase {
-    var tempFileURL: URL!
-
-    override func setUp() {
-        super.setUp()
-        tempFileURL = FileManager.default.temporaryDirectory
+struct OpenCodeSessionRegistryTests {
+    private func makeTempFileURL() -> URL {
+        FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
             .appendingPathExtension("json")
     }
 
-    override func tearDown() {
-        try? FileManager.default.removeItem(at: tempFileURL)
-        super.tearDown()
-    }
-
+    @Test
     func testSaveAndLoad() throws {
+        let tempFileURL = makeTempFileURL()
+        defer { try? FileManager.default.removeItem(at: tempFileURL) }
+
         let registry = OpenCodeSessionRegistry(fileURL: tempFileURL)
         let records = [
             OpenCodeTrackedSessionRecord(
@@ -37,14 +34,18 @@ final class OpenCodeSessionRegistryTests: XCTestCase {
         try registry.save(records)
         let loaded = try registry.load()
 
-        XCTAssertEqual(loaded.count, 1)
-        XCTAssertEqual(loaded[0].sessionID, "opencode-1")
-        XCTAssertEqual(loaded[0].openCodeMetadata?.initialUserPrompt, "Hello")
+        #expect(loaded.count == 1)
+        #expect(loaded[0].sessionID == "opencode-1")
+        #expect(loaded[0].openCodeMetadata?.initialUserPrompt == "Hello")
     }
 
+    @Test
     func testLoadEmpty() throws {
+        let tempFileURL = makeTempFileURL()
+        defer { try? FileManager.default.removeItem(at: tempFileURL) }
+
         let registry = OpenCodeSessionRegistry(fileURL: tempFileURL)
         let loaded = try registry.load()
-        XCTAssertEqual(loaded.count, 0)
+        #expect(loaded.count == 0)
     }
 }

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -72,6 +72,7 @@ The `CodexHookPayload` model and `BridgeServer` can parse richer events (`PreToo
 | `model` | `model` | Model name |
 | `permission_mode` | `permissionMode` | `default` / `acceptEdits` / `plan` / `dontAsk` / `bypassPermissions` |
 | `transcript_path` | `transcriptPath` | JSONL transcript file path |
+| `remote` | `remote` | `true` when the Python hook client marks an SSH remote session |
 | `terminal_app` | `terminalApp` | Terminal name (`Terminal`, `Ghostty`, `iTerm`, …) |
 | `terminal_session_id` | `terminalSessionID` | Terminal session identifier |
 | `terminal_tty` | `terminalTTY` | TTY device path |

--- a/docs/ssh-setup.md
+++ b/docs/ssh-setup.md
@@ -1,6 +1,6 @@
-# SSH Remote Claude Code Setup
+# SSH Remote Setup (Claude Code & Codex)
 
-Connect Open Island to Claude Code running on a remote server over SSH.
+Connect Open Island to Claude Code and Codex running on a remote server over SSH.
 
 ## How it works
 
@@ -14,7 +14,8 @@ macOS (local)                         Remote server
                                    │  hooks.py          │
                                    │        ▲           │
                                    │        │           │
-                                   │  Claude Code       │
+                                   │  Claude Code /     │
+                                   │  Codex             │
                                    └────────────────────┘
 ```
 
@@ -25,7 +26,7 @@ SSH's `RemoteForward` tunnels the Unix socket from your Mac to the remote server
 - Open Island running on your Mac
 - SSH access to the remote server
 - Python 3.6+ on the remote server
-- Claude Code installed on the remote server
+- Claude Code and/or Codex installed on the remote server
 
 ## Quick setup
 
@@ -38,7 +39,8 @@ Run the automated setup script:
 This will:
 1. Copy `open-island-hooks.py` to the remote server (`~/.local/bin/`)
 2. Configure Claude Code hooks in `~/.claude/settings.json` on the remote
-3. Print the SSH config snippet you need
+3. Configure Codex hooks in `~/.codex/hooks.json` on the remote
+4. Print the SSH config snippet you need
 
 ## Manual setup
 
@@ -89,11 +91,41 @@ Or connect directly with:
 ssh -R /tmp/open-island-$(id -u).sock:/tmp/open-island-$(id -u).sock user@myserver
 ```
 
-### 4. Verify
+### 4. Configure Codex hooks on the remote
+
+Edit `~/.codex/hooks.json` on the remote server:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [{ "type": "command", "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-501.sock python3 ~/.local/bin/open-island-hooks.py --source codex", "timeout": 45 }]
+      }
+    ],
+    "UserPromptSubmit": [
+      { "hooks": [{ "type": "command", "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-501.sock python3 ~/.local/bin/open-island-hooks.py --source codex", "timeout": 45 }] }
+    ],
+    "PermissionRequest": [
+      { "hooks": [{ "type": "command", "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-501.sock python3 ~/.local/bin/open-island-hooks.py --source codex", "timeout": 3600 }] }
+    ],
+    "Stop": [
+      { "hooks": [{ "type": "command", "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-501.sock python3 ~/.local/bin/open-island-hooks.py --source codex", "timeout": 45 }] }
+    ]
+  }
+}
+```
+
+Replace `501` with your local UID (`id -u`). Codex may require a manual
+trust review before running the hooks: open `/hooks` inside Codex CLI and
+approve the Open Island entries.
+
+### 5. Verify
 
 1. Make sure Open Island is running on your Mac
 2. SSH to the remote with socket forwarding enabled
-3. Run Claude Code on the remote — sessions should appear in the Open Island overlay
+3. Run Claude Code or Codex on the remote — sessions should appear in the Open Island overlay
 
 ## Important: sshd configuration
 

--- a/docs/ssh-setup.md
+++ b/docs/ssh-setup.md
@@ -121,6 +121,12 @@ Replace `501` with your local UID (`id -u`). Codex may require a manual
 trust review before running the hooks: open `/hooks` inside Codex CLI and
 approve the Open Island entries.
 
+> **Important:** Codex silently skips hooks that have not been approved yet.
+> If you start an SSH task before running the trust review, no events reach
+> Open Island. After approving the entries, restart any Codex SSH remote
+> session that was already running so the remote app-server reloads the
+> trusted hook state.
+
 ### 5. Verify
 
 1. Make sure Open Island is running on your Mac
@@ -136,6 +142,13 @@ StreamLocalBindUnlink yes
 ```
 
 Without this, reconnecting after a dropped SSH session will fail with "Address already in use" because the old socket file is still on disk.
+
+> **Note:** the forwarded socket is re-created by the most recent SSH
+> connection that carries the `RemoteForward`. Closing that connection can
+> remove the socket path even while an older Codex SSH remote session is still
+> connected, leaving its forward orphaned. Keep one stable tunnel session
+> open, or disconnect and reconnect the Codex SSH remote session, so hooks can
+> always reach the local app.
 
 ## Mac-to-Mac Setup (Different UIDs)
 

--- a/docs/ssh-setup.md
+++ b/docs/ssh-setup.md
@@ -40,7 +40,14 @@ This will:
 1. Copy `open-island-hooks.py` to the remote server (`~/.local/bin/`)
 2. Configure Claude Code hooks in `~/.claude/settings.json` on the remote
 3. Configure Codex hooks in `~/.codex/hooks.json` on the remote
-4. Print the SSH config snippet you need
+4. Enable `[features].hooks = true` in `~/.codex/config.toml` on the remote
+5. Print the SSH config snippet you need
+
+The script detects the remote user's UID and maps the forwarded socket
+accordingly, so it works when the local and remote UIDs differ (for example,
+macOS on the Mac and a Linux remote server). Re-running the script replaces
+the Open Island hook entries it manages without duplicating them, and leaves
+any user-authored hooks untouched.
 
 ## Manual setup
 

--- a/scripts/open-island-hooks.py
+++ b/scripts/open-island-hooks.py
@@ -269,7 +269,7 @@ def main():
             encoder = encode_opencode_stdout
         else:
             command = {"type": "processCodexHook", "codexHook": payload}
-            timeout = 45
+            timeout = 86400 if payload.get("hook_event_name") == "PermissionRequest" else 45
             encoder = encode_codex_stdout
 
         envelope = json.dumps({"type": "command", "command": command})

--- a/scripts/remote-setup.sh
+++ b/scripts/remote-setup.sh
@@ -3,8 +3,8 @@
 # Open Island — remote SSH setup
 #
 # Deploys the Python hook client to a remote server and configures
-# Claude Code to use it.  Also prints the SSH config snippet needed
-# for Unix socket forwarding.
+# Claude Code and Codex to use it.  Also prints the SSH config snippet
+# needed for Unix socket forwarding.
 #
 # Usage:
 #   ./scripts/remote-setup.sh user@host
@@ -12,7 +12,7 @@
 # Prerequisites:
 #   - SSH access to the remote host
 #   - Python 3.6+ on the remote host
-#   - Claude Code installed on the remote host
+#   - Claude Code and/or Codex installed on the remote host
 
 set -euo pipefail
 
@@ -96,7 +96,83 @@ print('Updated ' + settings_path)
 \"" <<< "$HOOKS_JSON"
 
 echo ""
+echo "==> Configuring Codex hooks on $REMOTE ..."
+# Codex hooks.json uses the same forwarded socket; the remote hook client
+# marks payloads as remote so the app keeps the session alive.
+CODEX_HOOK_CMD="OPEN_ISLAND_SOCKET_PATH=/tmp/$SOCKET_NAME python3 ~/.local/bin/open-island-hooks.py --source codex"
+CODEX_HOOKS_JSON=$(cat <<ENDJSON
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [{"type": "command", "command": "$CODEX_HOOK_CMD", "timeout": 45}]
+      }
+    ],
+    "UserPromptSubmit": [
+      {"hooks": [{"type": "command", "command": "$CODEX_HOOK_CMD", "timeout": 45}]}
+    ],
+    "PermissionRequest": [
+      {"hooks": [{"type": "command", "command": "$CODEX_HOOK_CMD", "timeout": 3600}]}
+    ],
+    "Stop": [
+      {"hooks": [{"type": "command", "command": "$CODEX_HOOK_CMD", "timeout": 45}]}
+    ]
+  }
+}
+ENDJSON
+)
+
+# Merge into existing hooks.json on remote (or create new), preserving
+# user-authored hook groups for the same events.
+ssh "$REMOTE" "python3 -c \"
+import json, os, sys
+
+hooks_path = os.path.expanduser('~/.codex/hooks.json')
+os.makedirs(os.path.dirname(hooks_path), exist_ok=True)
+
+existing = {}
+if os.path.exists(hooks_path):
+    with open(hooks_path) as f:
+        existing = json.load(f)
+
+new_hooks = json.loads(sys.stdin.read())
+
+if 'hooks' not in existing:
+    existing['hooks'] = {}
+
+def existing_commands(event):
+    commands = set()
+    for group in existing['hooks'].get(event, []):
+        for hook in group.get('hooks', []):
+            if isinstance(hook, dict) and hook.get('command'):
+                commands.add(hook['command'])
+    return commands
+
+for event, groups in new_hooks['hooks'].items():
+    cur = existing['hooks'].get(event, [])
+    known = existing_commands(event)
+    for group in groups:
+        commands = [h.get('command') for h in group.get('hooks', []) if isinstance(h, dict)]
+        if commands and all(c in known for c in commands):
+            continue
+        cur.append(group)
+        for c in commands:
+            known.add(c)
+    existing['hooks'][event] = cur
+
+with open(hooks_path, 'w') as f:
+    json.dump(existing, f, indent=2)
+    f.write('\n')
+
+print('Updated ' + hooks_path)
+\"" <<< "$CODEX_HOOKS_JSON"
+
+echo ""
 echo "==> Done!"
+echo ""
+echo "Codex may require a manual trust review before running the hooks:"
+echo "open \`/hooks\` inside Codex CLI and approve the Open Island entries."
 echo ""
 echo "IMPORTANT: Ensure the remote sshd has 'StreamLocalBindUnlink yes' in"
 echo "/etc/ssh/sshd_config — otherwise reconnecting will fail with"

--- a/scripts/remote-setup.sh
+++ b/scripts/remote-setup.sh
@@ -19,7 +19,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 HOOK_SCRIPT="$SCRIPT_DIR/open-island-hooks.py"
 REMOTE_BIN_DIR=".local/bin"
-REMOTE_HOOK_PATH="\$HOME/$REMOTE_BIN_DIR/open-island-hooks.py"
 
 if [ $# -lt 1 ]; then
     echo "Usage: $0 user@host"
@@ -28,7 +27,16 @@ fi
 
 REMOTE="$1"
 LOCAL_UID=$(id -u)
-SOCKET_NAME="open-island-${LOCAL_UID}.sock"
+LOCAL_SOCKET_NAME="open-island-${LOCAL_UID}.sock"
+
+# Resolve the remote UID so the forwarded socket name can be mapped when the
+# two machines have different UIDs (e.g. macOS vs. Linux remote servers).
+REMOTE_UID="$(ssh "$REMOTE" "id -u" 2>/dev/null | tr -d '\r' | awk 'NR==1{print $1}')"
+if ! [[ "$REMOTE_UID" =~ ^[0-9]+$ ]]; then
+    echo "Failed to resolve numeric remote UID from '$REMOTE' (got: '$REMOTE_UID')." >&2
+    exit 1
+fi
+REMOTE_SOCKET_NAME="open-island-${REMOTE_UID}.sock"
 
 echo "==> Deploying open-island-hooks.py to $REMOTE ..."
 ssh "$REMOTE" "mkdir -p ~/$REMOTE_BIN_DIR"
@@ -37,136 +45,177 @@ ssh "$REMOTE" "chmod +x ~/$REMOTE_BIN_DIR/open-island-hooks.py"
 
 echo ""
 echo "==> Configuring Claude Code hooks on $REMOTE ..."
-# Build the hooks JSON fragment.
-# Use the *local* UID in the socket path so the remote hook connects to the
-# forwarded socket created by the local Open Island app.  The heredoc is
-# unquoted so that $SOCKET_NAME is expanded.
-HOOK_CMD="OPEN_ISLAND_SOCKET_PATH=/tmp/$SOCKET_NAME python3 ~/.local/bin/open-island-hooks.py --source claude"
-HOOK_ENTRY="{\"matcher\": \"\", \"hooks\": [{\"type\": \"command\", \"command\": \"$HOOK_CMD\"}]}"
-HOOKS_JSON=$(cat <<ENDJSON
-{
-  "hooks": {
-    "PreToolUse": [$HOOK_ENTRY],
-    "PostToolUse": [$HOOK_ENTRY],
-    "Notification": [$HOOK_ENTRY],
-    "SessionStart": [$HOOK_ENTRY],
-    "SessionEnd": [$HOOK_ENTRY],
-    "Stop": [$HOOK_ENTRY],
-    "UserPromptSubmit": [$HOOK_ENTRY],
-    "PermissionRequest": [$HOOK_ENTRY],
-    "SubagentStart": [$HOOK_ENTRY],
-    "SubagentStop": [$HOOK_ENTRY]
-  }
-}
-ENDJSON
+ssh "$REMOTE" "OPEN_ISLAND_REMOTE_SOCKET=/tmp/$REMOTE_SOCKET_NAME python3 -" <<'PY'
+import json
+import os
+from pathlib import Path
+
+socket_path = os.environ["OPEN_ISLAND_REMOTE_SOCKET"]
+hook_cmd = (
+    f"OPEN_ISLAND_SOCKET_PATH={socket_path} "
+    "python3 ~/.local/bin/open-island-hooks.py --source claude"
 )
 
-# Merge into existing settings.json on remote (or create new)
-ssh "$REMOTE" "python3 -c \"
-import json, os, sys
-
-settings_path = os.path.expanduser('~/.claude/settings.json')
-os.makedirs(os.path.dirname(settings_path), exist_ok=True)
+settings_path = Path.home() / ".claude" / "settings.json"
+settings_path.parent.mkdir(parents=True, exist_ok=True)
 
 existing = {}
-if os.path.exists(settings_path):
-    with open(settings_path) as f:
-        existing = json.load(f)
+if settings_path.exists():
+    existing = json.loads(settings_path.read_text())
 
-new_hooks = json.loads(sys.stdin.read())
+if "hooks" not in existing or not isinstance(existing["hooks"], dict):
+    existing["hooks"] = {}
 
-# Merge per-event instead of replacing the entire hooks dict, so
-# user's custom hooks for other events are preserved.
-if 'hooks' not in existing:
-    existing['hooks'] = {}
-for event, entries in new_hooks['hooks'].items():
-    cur = existing['hooks'].get(event, [])
-    # Avoid duplicating the same command
-    existing_cmds = {e.get('command') for e in cur if isinstance(e, dict)}
-    for entry in entries:
-        if entry.get('command') not in existing_cmds:
-            cur.append(entry)
-    existing['hooks'][event] = cur
 
-with open(settings_path, 'w') as f:
-    json.dump(existing, f, indent=2)
-    f.write('\n')
+def group_has_open_island(group):
+    nested = group.get("hooks")
+    if not isinstance(nested, list):
+        return False
+    return any(
+        isinstance(hook, dict)
+        and "open-island-hooks.py" in (hook.get("command") or "")
+        for hook in nested
+    )
 
-print('Updated ' + settings_path)
-\"" <<< "$HOOKS_JSON"
+
+entry = {
+    "matcher": "",
+    "hooks": [{"type": "command", "command": hook_cmd}],
+}
+events = [
+    "PreToolUse",
+    "PostToolUse",
+    "Notification",
+    "SessionStart",
+    "SessionEnd",
+    "Stop",
+    "UserPromptSubmit",
+    "PermissionRequest",
+    "SubagentStart",
+    "SubagentStop",
+]
+for event in events:
+    cur = existing["hooks"].get(event, [])
+    if not isinstance(cur, list):
+        cur = []
+    # Remove any previously managed Open Island group (idempotent re-runs),
+    # then append the current entry; user-authored hooks are preserved.
+    cleaned = [g for g in cur if not (isinstance(g, dict) and group_has_open_island(g))]
+    cleaned.append(entry)
+    existing["hooks"][event] = cleaned
+
+settings_path.write_text(json.dumps(existing, indent=2) + "\n")
+print("Updated " + str(settings_path))
+PY
 
 echo ""
 echo "==> Configuring Codex hooks on $REMOTE ..."
-# Codex hooks.json uses the same forwarded socket; the remote hook client
-# marks payloads as remote so the app keeps the session alive.
-CODEX_HOOK_CMD="OPEN_ISLAND_SOCKET_PATH=/tmp/$SOCKET_NAME python3 ~/.local/bin/open-island-hooks.py --source codex"
-CODEX_HOOKS_JSON=$(cat <<ENDJSON
-{
-  "hooks": {
-    "SessionStart": [
-      {
-        "matcher": "startup|resume",
-        "hooks": [{"type": "command", "command": "$CODEX_HOOK_CMD", "timeout": 45}]
-      }
-    ],
-    "UserPromptSubmit": [
-      {"hooks": [{"type": "command", "command": "$CODEX_HOOK_CMD", "timeout": 45}]}
-    ],
-    "PermissionRequest": [
-      {"hooks": [{"type": "command", "command": "$CODEX_HOOK_CMD", "timeout": 3600}]}
-    ],
-    "Stop": [
-      {"hooks": [{"type": "command", "command": "$CODEX_HOOK_CMD", "timeout": 45}]}
-    ]
-  }
-}
-ENDJSON
+ssh "$REMOTE" "OPEN_ISLAND_REMOTE_SOCKET=/tmp/$REMOTE_SOCKET_NAME python3 -" <<'PY'
+import json
+import os
+from pathlib import Path
+
+socket_path = os.environ["OPEN_ISLAND_REMOTE_SOCKET"]
+hook_cmd = (
+    f"OPEN_ISLAND_SOCKET_PATH={socket_path} "
+    "python3 ~/.local/bin/open-island-hooks.py --source codex"
 )
 
-# Merge into existing hooks.json on remote (or create new), preserving
-# user-authored hook groups for the same events.
-ssh "$REMOTE" "python3 -c \"
-import json, os, sys
+hooks_path = Path.home() / ".codex" / "hooks.json"
+hooks_path.parent.mkdir(parents=True, exist_ok=True)
 
-hooks_path = os.path.expanduser('~/.codex/hooks.json')
-os.makedirs(os.path.dirname(hooks_path), exist_ok=True)
+root = {}
+if hooks_path.exists():
+    root = json.loads(hooks_path.read_text())
 
-existing = {}
-if os.path.exists(hooks_path):
-    with open(hooks_path) as f:
-        existing = json.load(f)
+hooks = root.get("hooks")
+if not isinstance(hooks, dict):
+    hooks = {}
 
-new_hooks = json.loads(sys.stdin.read())
 
-if 'hooks' not in existing:
-    existing['hooks'] = {}
+def group_has_open_island(group):
+    nested = group.get("hooks")
+    if not isinstance(nested, list):
+        return False
+    return any(
+        isinstance(hook, dict)
+        and "open-island-hooks.py" in (hook.get("command") or "")
+        for hook in nested
+    )
 
-def existing_commands(event):
-    commands = set()
-    for group in existing['hooks'].get(event, []):
-        for hook in group.get('hooks', []):
-            if isinstance(hook, dict) and hook.get('command'):
-                commands.add(hook['command'])
-    return commands
 
-for event, groups in new_hooks['hooks'].items():
-    cur = existing['hooks'].get(event, [])
-    known = existing_commands(event)
-    for group in groups:
-        commands = [h.get('command') for h in group.get('hooks', []) if isinstance(h, dict)]
-        if commands and all(c in known for c in commands):
+event_specs = {
+    "SessionStart": {"matcher": "startup|resume", "timeout": 45},
+    "UserPromptSubmit": {"matcher": None, "timeout": 45},
+    "PermissionRequest": {"matcher": None, "timeout": 3600},
+    "Stop": {"matcher": None, "timeout": 45},
+}
+for event, spec in event_specs.items():
+    cur = hooks.get(event, [])
+    if not isinstance(cur, list):
+        cur = []
+    # Replace previously managed Open Island groups instead of duplicating
+    # them on re-runs; user-authored hook groups are preserved.
+    cleaned = [g for g in cur if not (isinstance(g, dict) and group_has_open_island(g))]
+    group = {
+        "hooks": [{"type": "command", "command": hook_cmd, "timeout": spec["timeout"]}]
+    }
+    if spec["matcher"]:
+        group["matcher"] = spec["matcher"]
+    cleaned.append(group)
+    hooks[event] = cleaned
+
+root["hooks"] = hooks
+hooks_path.write_text(json.dumps(root, indent=2) + "\n")
+print("Updated " + str(hooks_path))
+PY
+
+echo ""
+echo "==> Enabling Codex hooks feature flag on $REMOTE ..."
+ssh "$REMOTE" "python3 -" <<'PY'
+from pathlib import Path
+
+config_path = Path.home() / ".codex" / "config.toml"
+config_path.parent.mkdir(parents=True, exist_ok=True)
+text = config_path.read_text() if config_path.exists() else ""
+lines = text.splitlines()
+out = []
+in_features = False
+has_features = False
+hooks_seen = False
+
+for line in lines:
+    stripped = line.strip()
+    if stripped == "[features]":
+        in_features = True
+        has_features = True
+        out.append(line)
+        continue
+    if in_features and stripped.startswith("[") and stripped.endswith("]"):
+        if not hooks_seen:
+            out.append("hooks = true")
+        in_features = False
+        out.append(line)
+        continue
+    if in_features:
+        key = stripped.split("=", 1)[0].strip() if "=" in stripped else ""
+        if key == "hooks":
+            out.append("hooks = true")
+            hooks_seen = True
             continue
-        cur.append(group)
-        for c in commands:
-            known.add(c)
-    existing['hooks'][event] = cur
+    out.append(line)
 
-with open(hooks_path, 'w') as f:
-    json.dump(existing, f, indent=2)
-    f.write('\n')
+if not has_features:
+    if out and out[-1] != "":
+        out.append("")
+    out.append("[features]")
+    out.append("hooks = true")
+elif in_features and not hooks_seen:
+    out.append("hooks = true")
 
-print('Updated ' + hooks_path)
-\"" <<< "$CODEX_HOOKS_JSON"
+config_path.write_text("\n".join(out) + "\n")
+print("Updated " + str(config_path))
+PY
 
 echo ""
 echo "==> Done!"
@@ -181,9 +230,15 @@ echo ""
 echo "Add the following to your ~/.ssh/config to enable socket forwarding:"
 echo ""
 echo "  Host ${REMOTE##*@}"
-echo "      RemoteForward /tmp/$SOCKET_NAME /tmp/$SOCKET_NAME"
+echo "      RemoteForward /tmp/$REMOTE_SOCKET_NAME /tmp/$LOCAL_SOCKET_NAME"
 echo ""
 echo "Or connect with:"
 echo ""
-echo "  ssh -R /tmp/$SOCKET_NAME:/tmp/$SOCKET_NAME $REMOTE"
+echo "  ssh -R /tmp/$REMOTE_SOCKET_NAME:/tmp/$LOCAL_SOCKET_NAME $REMOTE"
 echo ""
+if [ "$REMOTE_SOCKET_NAME" != "$LOCAL_SOCKET_NAME" ]; then
+    echo "Note: local UID ($LOCAL_UID) differs from remote UID ($REMOTE_UID);"
+    echo "the socket names above map the remote socket to your local Open Island socket."
+    echo "If you previously configured forwarding with a non-mapped path, update it."
+    echo ""
+fi

--- a/scripts/remote-setup.sh
+++ b/scripts/remote-setup.sh
@@ -35,7 +35,7 @@ SSH_NO_FORWARD=(-o RemoteForward=none)
 
 # Resolve the remote UID so the forwarded socket name can be mapped when the
 # two machines have different UIDs (e.g. macOS vs. Linux remote servers).
-REMOTE_UID="$(ssh "${SSH_NO_FORWARD[@]}" "$REMOTE" "id -u" 2>/dev/null | tr -d '\r' | awk 'NR==1{print $1}')"
+REMOTE_UID="$(ssh "${SSH_NO_FORWARD[@]}" "$REMOTE" "id -u" | tr -d '\r' | awk 'NR==1{print $1}')"
 if ! [[ "$REMOTE_UID" =~ ^[0-9]+$ ]]; then
     echo "Failed to resolve numeric remote UID from '$REMOTE' (got: '$REMOTE_UID')." >&2
     exit 1
@@ -191,6 +191,73 @@ echo ""
 echo "==> Enabling Codex hooks feature flag on $REMOTE ..."
 ssh "${SSH_NO_FORWARD[@]}" "$REMOTE" "python3 -" <<'PY'
 from pathlib import Path
+import re
+
+
+def strip_toml_comment(line):
+    """Return the line without its trailing # comment (TOML strings kept)."""
+    in_str = None
+    escaped = False
+    for i, ch in enumerate(line):
+        if in_str:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == in_str:
+                in_str = None
+        elif ch in ('"', "'"):
+            in_str = ch
+        elif ch == "#":
+            return line[:i]
+    return line
+
+
+_TOML_KEY = r"(?:[A-Za-z0-9_-]+|\"(?:[^\"\\]|\\.)*\"|'(?:[^'\\]|\\.)*')"
+_TABLE_HEADER_RE = re.compile(
+    r"\[\[?\s*" + _TOML_KEY + r"(?:\s*\.\s*" + _TOML_KEY + r")*\s*\]\]?"
+)
+
+
+def table_header(line):
+    """Return (is_array_of_tables, name) for a real TOML table header, else None.
+
+    Bracketed rows inside multi-line arrays (e.g. ``[1, 2]`` or ``["a"]``) are
+    not headers, so they cannot be mistaken for section boundaries.
+    """
+    s = strip_toml_comment(line).strip()
+    if not (s.startswith("[") and s.endswith("]")):
+        return None
+    if _TABLE_HEADER_RE.fullmatch(s) is None:
+        return None
+    inner = s[1:-1].strip()
+    is_aot = inner.startswith("[")
+    if is_aot:
+        inner = inner[1:].strip()
+    return (is_aot, inner)
+
+
+def bracket_depth_delta(line):
+    """Net change in TOML array nesting caused by this line."""
+    depth = 0
+    in_str = None
+    escaped = False
+    for ch in line:
+        if in_str:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == in_str:
+                in_str = None
+        elif ch in ('"', "'"):
+            in_str = ch
+        elif ch == "[":
+            depth += 1
+        elif ch == "]":
+            depth -= 1
+    return depth
+
 
 config_path = Path.home() / ".codex" / "config.toml"
 config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -200,16 +267,19 @@ out = []
 in_features = False
 has_features = False
 hooks_seen = False
+array_depth = 0
 
 for line in lines:
     stripped = line.strip()
-    if stripped == "[features]":
-        in_features = True
-        has_features = True
-        out.append(line)
-        continue
-    if in_features and stripped.startswith("[") and stripped.endswith("]"):
-        if not hooks_seen:
+    header = table_header(stripped)
+    if array_depth == 0 and header is not None:
+        is_aot, name = header
+        if not is_aot and name == "features":
+            in_features = True
+            has_features = True
+            out.append(line)
+            continue
+        if in_features and not hooks_seen:
             out.append("hooks = true")
         in_features = False
         out.append(line)
@@ -221,6 +291,7 @@ for line in lines:
             hooks_seen = True
             continue
     out.append(line)
+    array_depth += bracket_depth_delta(line)
 
 if not has_features:
     if out and out[-1] != "":

--- a/scripts/remote-setup.sh
+++ b/scripts/remote-setup.sh
@@ -31,7 +31,7 @@ LOCAL_SOCKET_NAME="open-island-${LOCAL_UID}.sock"
 
 # Deploy without forwarding: running the setup script must not steal the
 # RemoteForward socket from an already-connected Open Island/Codex session.
-SSH_NO_FORWARD=(-o RemoteForward=none)
+SSH_NO_FORWARD=(-o ClearAllForwardings=yes)
 
 # Resolve the remote UID so the forwarded socket name can be mapped when the
 # two machines have different UIDs (e.g. macOS vs. Linux remote servers).

--- a/scripts/remote-setup.sh
+++ b/scripts/remote-setup.sh
@@ -148,6 +148,8 @@ event_specs = {
     "SessionStart": {"matcher": "startup|resume", "timeout": 45},
     "UserPromptSubmit": {"matcher": None, "timeout": 45},
     "PermissionRequest": {"matcher": None, "timeout": 3600},
+    "PreToolUse": {"matcher": None, "timeout": 5, "notify": True},
+    "PostToolUse": {"matcher": None, "timeout": 5, "notify": True},
     "Stop": {"matcher": None, "timeout": 45},
 }
 for event, spec in event_specs.items():
@@ -157,6 +159,17 @@ for event, spec in event_specs.items():
     # Replace previously managed Open Island groups instead of duplicating
     # them on re-runs; user-authored hook groups are preserved.
     cleaned = [g for g in cur if not (isinstance(g, dict) and group_has_open_island(g))]
+    if spec.get("notify"):
+        hook_cmd = (
+            f"OPEN_ISLAND_SOCKET_PATH={socket_path} "
+            "OPEN_ISLAND_NOTIFY_ONLY=1 OPEN_ISLAND_NOTIFY_TIMEOUT=2 "
+            "python3 ~/.local/bin/open-island-hooks.py --source codex"
+        )
+    else:
+        hook_cmd = (
+            f"OPEN_ISLAND_SOCKET_PATH={socket_path} "
+            "python3 ~/.local/bin/open-island-hooks.py --source codex"
+        )
     group = {
         "hooks": [{"type": "command", "command": hook_cmd, "timeout": spec["timeout"]}]
     }

--- a/scripts/remote-setup.sh
+++ b/scripts/remote-setup.sh
@@ -29,9 +29,13 @@ REMOTE="$1"
 LOCAL_UID=$(id -u)
 LOCAL_SOCKET_NAME="open-island-${LOCAL_UID}.sock"
 
+# Deploy without forwarding: running the setup script must not steal the
+# RemoteForward socket from an already-connected Open Island/Codex session.
+SSH_NO_FORWARD=(-o RemoteForward=none)
+
 # Resolve the remote UID so the forwarded socket name can be mapped when the
 # two machines have different UIDs (e.g. macOS vs. Linux remote servers).
-REMOTE_UID="$(ssh "$REMOTE" "id -u" 2>/dev/null | tr -d '\r' | awk 'NR==1{print $1}')"
+REMOTE_UID="$(ssh "${SSH_NO_FORWARD[@]}" "$REMOTE" "id -u" 2>/dev/null | tr -d '\r' | awk 'NR==1{print $1}')"
 if ! [[ "$REMOTE_UID" =~ ^[0-9]+$ ]]; then
     echo "Failed to resolve numeric remote UID from '$REMOTE' (got: '$REMOTE_UID')." >&2
     exit 1
@@ -39,13 +43,13 @@ fi
 REMOTE_SOCKET_NAME="open-island-${REMOTE_UID}.sock"
 
 echo "==> Deploying open-island-hooks.py to $REMOTE ..."
-ssh "$REMOTE" "mkdir -p ~/$REMOTE_BIN_DIR"
-scp "$HOOK_SCRIPT" "$REMOTE:~/$REMOTE_BIN_DIR/open-island-hooks.py"
-ssh "$REMOTE" "chmod +x ~/$REMOTE_BIN_DIR/open-island-hooks.py"
+ssh "${SSH_NO_FORWARD[@]}" "$REMOTE" "mkdir -p ~/$REMOTE_BIN_DIR"
+scp "${SSH_NO_FORWARD[@]}" "$HOOK_SCRIPT" "$REMOTE:~/$REMOTE_BIN_DIR/open-island-hooks.py"
+ssh "${SSH_NO_FORWARD[@]}" "$REMOTE" "chmod +x ~/$REMOTE_BIN_DIR/open-island-hooks.py"
 
 echo ""
 echo "==> Configuring Claude Code hooks on $REMOTE ..."
-ssh "$REMOTE" "OPEN_ISLAND_REMOTE_SOCKET=/tmp/$REMOTE_SOCKET_NAME python3 -" <<'PY'
+ssh "${SSH_NO_FORWARD[@]}" "$REMOTE" "OPEN_ISLAND_REMOTE_SOCKET=/tmp/$REMOTE_SOCKET_NAME python3 -" <<'PY'
 import json
 import os
 from pathlib import Path
@@ -110,7 +114,7 @@ PY
 
 echo ""
 echo "==> Configuring Codex hooks on $REMOTE ..."
-ssh "$REMOTE" "OPEN_ISLAND_REMOTE_SOCKET=/tmp/$REMOTE_SOCKET_NAME python3 -" <<'PY'
+ssh "${SSH_NO_FORWARD[@]}" "$REMOTE" "OPEN_ISLAND_REMOTE_SOCKET=/tmp/$REMOTE_SOCKET_NAME python3 -" <<'PY'
 import json
 import os
 from pathlib import Path
@@ -185,7 +189,7 @@ PY
 
 echo ""
 echo "==> Enabling Codex hooks feature flag on $REMOTE ..."
-ssh "$REMOTE" "python3 -" <<'PY'
+ssh "${SSH_NO_FORWARD[@]}" "$REMOTE" "python3 -" <<'PY'
 from pathlib import Path
 
 config_path = Path.home() / ".codex" / "config.toml"


### PR DESCRIPTION
## Summary

Extends the SSH remote bridge so Codex sessions running on a remote server (including via Codex Desktop's SSH remote / `codex app-server`) appear in Open Island, matching the existing Claude Code remote flow.

## Changes

- `feat: support Codex sessions over SSH remote bridge` (a1ac4a7)
  - Portability hook client (`scripts/open-island-hooks.py`) supports `--source codex`
  - `CodexHookPayload` carries a `remote` flag set by the Python hook client
  - Codex `SessionStart` / `ensureSessionExists` sessions are marked `isRemote`
  - `scripts/remote-setup.sh` deploys and merges Codex hooks on the remote
  - Settings copy updated to mention Codex alongside Claude Code
- `test: migrate remaining XCTest suites to Swift Testing` (ef69115)
- `docs: note hook trust timing and tunnel ownership for Codex SSH remote` (7cf872f)

## Verification

- Remote `codex exec` and Codex Desktop SSH remote sessions create sessions in Open Island (verified end-to-end over the `RemoteForward` Unix socket tunnel)
- Hook events receive `acknowledged` bridge responses; session persisted in `session-terminals.json`
- Existing Swift Testing suites pass in the repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for monitoring Codex sessions on remote servers alongside Claude Code.
  - Remote and local Codex sessions are now identified and tracked correctly.
  - Remote setup automatically configures Codex hooks while preserving existing settings.
  - Improved validation for forwarded socket access and remote session tracking.
  - Codex permission requests now remain available for up to 24 hours.

- **Documentation**
  - Updated SSH setup guidance for Claude Code and Codex.
  - Documented remote-session status, trust approvals, timeout behavior, and socket-forwarding guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->