### PR TITLE
feat: add notify-only Codex remote hooks and hide stale completed sessions

### DIFF
--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -346,6 +346,17 @@ extension AgentSession {
             && referenceDate.timeIntervalSince(islandActivityDate) >= threshold
     }
 
+    /// Sessions that are completed and stale for the island surface. Used to
+    /// hide long-finished sessions (for example remote Codex sessions that
+    /// never receive a SessionEnd hook) from the main island list.
+    func isHiddenIdleIslandSession(
+        at referenceDate: Date,
+        threshold: TimeInterval = Self.staleCompletedDisplayThreshold
+    ) -> Bool {
+        phase == .completed
+            && isStaleCompletedForIsland(at: referenceDate, threshold: threshold)
+    }
+
     private var spotlightRunningActivityText: String? {
         guard let currentTool = currentToolName?.trimmedForSurface,
               !currentTool.isEmpty else {

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1694,6 +1694,7 @@ final class AppModel {
 
         for session in rankedSessions where session.isVisibleInIsland {
             guard !session.isSubagentSession else { continue }
+            guard !session.isHiddenIdleIslandSession(at: now, threshold: completedStaleThreshold.seconds) else { continue }
 
             if let liveAttachmentKey = monitoring.liveAttachmentKey(for: session) {
                 guard claimedLiveAttachmentKeys.insert(liveAttachmentKey).inserted else {

--- a/Sources/OpenIslandApp/IslandSurface.swift
+++ b/Sources/OpenIslandApp/IslandSurface.swift
@@ -22,6 +22,8 @@ enum IslandSurface: Equatable {
 
     static func notificationSurface(for event: AgentEvent) -> IslandSurface? {
         switch event {
+        case let .activityUpdated(payload) where payload.phase == .running:
+            .sessionList(actionableSessionID: payload.sessionID)
         case let .permissionRequested(payload):
             .sessionList(actionableSessionID: payload.sessionID)
         case let .questionAsked(payload):
@@ -50,7 +52,7 @@ enum IslandSurface: Equatable {
         case .completed:
             return true
         case .running:
-            return false
+            return true
         }
     }
 }

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -523,6 +523,21 @@ public final class BridgeServer: @unchecked Sendable {
 
             let command = payload.commandPreview ?? "Bash command"
 
+            if payload.openIslandNotifyOnly == true {
+                emit(
+                    .activityUpdated(
+                        SessionActivityUpdated(
+                            sessionID: payload.sessionID,
+                            summary: "Running: \(command)",
+                            phase: .running,
+                            timestamp: .now
+                        )
+                    )
+                )
+                send(.response(.acknowledged), to: clientID)
+                return
+            }
+
             let approvalEvent = AgentEvent.permissionRequested(
                 PermissionRequested(
                     sessionID: payload.sessionID,

--- a/Sources/OpenIslandCore/CodexHooks.swift
+++ b/Sources/OpenIslandCore/CodexHooks.swift
@@ -141,6 +141,10 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
     public var prompt: String?
     public var stopHookActive: Bool?
     public var lastAssistantMessage: String?
+    /// Set by the remote Python hook client when `OPEN_ISLAND_NOTIFY_ONLY`
+    /// is enabled: tool-use events become running-activity notifications
+    /// instead of blocking approval requests on the remote agent.
+    public var openIslandNotifyOnly: Bool?
 
     private enum CodingKeys: String, CodingKey {
         case cwd
@@ -163,6 +167,7 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
         case prompt
         case stopHookActive = "stop_hook_active"
         case lastAssistantMessage = "last_assistant_message"
+        case openIslandNotifyOnly = "open_island_notify_only"
     }
 
     public init(
@@ -185,7 +190,8 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
         toolResponse: CodexHookJSONValue? = nil,
         prompt: String? = nil,
         stopHookActive: Bool? = nil,
-        lastAssistantMessage: String? = nil
+        lastAssistantMessage: String? = nil,
+        openIslandNotifyOnly: Bool? = nil
     ) {
         self.cwd = cwd
         self.hookEventName = hookEventName
@@ -207,6 +213,7 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
         self.prompt = prompt
         self.stopHookActive = stopHookActive
         self.lastAssistantMessage = lastAssistantMessage
+        self.openIslandNotifyOnly = openIslandNotifyOnly
     }
 
     public init(from decoder: any Decoder) throws {
@@ -231,6 +238,7 @@ public struct CodexHookPayload: Equatable, Codable, Sendable {
         prompt = try container.decodeIfPresent(String.self, forKey: .prompt)
         stopHookActive = try container.decodeIfPresent(Bool.self, forKey: .stopHookActive)
         lastAssistantMessage = try container.decodeIfPresent(String.self, forKey: .lastAssistantMessage)
+        openIslandNotifyOnly = try container.decodeIfPresent(Bool.self, forKey: .openIslandNotifyOnly)
     }
 }
 

--- a/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
+++ b/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
@@ -184,6 +184,35 @@ struct AgentSessionPresentationTests {
     }
 
     @Test
+    func completedStaleSessionsAreHiddenIdleButRunningSessionsAreNot() {
+        let referenceDate = Date(timeIntervalSince1970: 10_000)
+
+        let completed = AgentSession(
+            id: "session-completed",
+            title: "Codex · remote",
+            tool: .codex,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .completed,
+            summary: "Done",
+            updatedAt: referenceDate.addingTimeInterval(-301)
+        )
+        #expect(completed.isHiddenIdleIslandSession(at: referenceDate))
+
+        let running = AgentSession(
+            id: "session-running",
+            title: "Codex · remote",
+            tool: .codex,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Working",
+            updatedAt: referenceDate.addingTimeInterval(-3_600)
+        )
+        #expect(!running.isHiddenIdleIslandSession(at: referenceDate))
+    }
+
+    @Test
     func liveHeadlineUsesLatestPromptForAttachedSession() {
         let session = AgentSession(
             id: "session-1",

--- a/Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift
+++ b/Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift
@@ -111,7 +111,7 @@ struct AgentsGridRightSlotTests {
     func moreThanNineSessionsFoldIntoOverflow() {
         let model = AppModel()
         model.islandRightSlot = .agents
-        let now = Date(timeIntervalSince1970: 200_000)
+        let now = Date.now
 
         var sessions: [AgentSession] = []
         for i in 0..<12 {
@@ -142,7 +142,7 @@ struct AgentsGridRightSlotTests {
     func cellStateReflectsSessionPhase() {
         let model = AppModel()
         model.islandRightSlot = .agents
-        let now = Date(timeIntervalSince1970: 300_000)
+        let now = Date.now
 
         let running  = makeSession(id: "r", firstSeenAt: now,                         updatedAt: now, phase: .running)
         let waitingA = makeSession(

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -92,7 +92,7 @@ struct AppModelSessionListTests {
 
     @Test
     func islandListDeduplicatesSessionsSharingTheSameLiveGhosttyTerminal() {
-        let now = Date(timeIntervalSince1970: 2_000)
+        let now = Date.now
         let model = AppModel()
 
         var runningLive = AgentSession(
@@ -165,7 +165,7 @@ struct AppModelSessionListTests {
 
     @Test
     func islandListKeepsDistinctCodexAppThreadsInTheSameWorkspace() {
-        let now = Date(timeIntervalSince1970: 2_000)
+        let now = Date.now
         let model = AppModel()
 
         var firstThread = AgentSession(
@@ -263,7 +263,7 @@ struct AppModelSessionListTests {
     }
 
     @Test
-    func freshCompletedSessionsSortAheadOfV8StaleCompletedSessions() {
+    func islandListHidesStaleCompletedSessions() {
         let now = Date()
         let model = AppModel()
 
@@ -307,7 +307,8 @@ struct AppModelSessionListTests {
 
         model.state = SessionState(sessions: [staleCompleted, freshCompleted])
 
-        #expect(model.islandListSessions.map(\.id) == ["fresh-completed", "stale-completed"])
+        #expect(model.islandListSessions.map(\.id) == ["fresh-completed"])
+        #expect(model.recentSessions.map(\.id).contains("stale-completed"))
     }
 
     @Test

--- a/Tests/OpenIslandAppTests/IslandSurfaceTests.swift
+++ b/Tests/OpenIslandAppTests/IslandSurfaceTests.swift
@@ -59,7 +59,7 @@ struct IslandSurfaceTests {
     }
 
     @Test
-    func actionableSurfaceDoesNotMatchRunningState() {
+    func actionableSurfaceMatchesRunningState() {
         let session = AgentSession(
             id: "session-1",
             title: "Codex · repo",
@@ -71,7 +71,21 @@ struct IslandSurfaceTests {
         )
 
         let surface = IslandSurface.sessionList(actionableSessionID: "session-1")
-        #expect(!surface.matchesCurrentState(of: session))
+        #expect(surface.matchesCurrentState(of: session))
+    }
+
+    @Test
+    func runningActivityEventsRouteToActionableSurface() {
+        let event = AgentEvent.activityUpdated(
+            SessionActivityUpdated(
+                sessionID: "session-1",
+                summary: "Running: git status",
+                phase: .running,
+                timestamp: .now
+            )
+        )
+
+        #expect(IslandSurface.notificationSurface(for: event) == .sessionList(actionableSessionID: "session-1"))
     }
 
     @Test

--- a/Tests/OpenIslandCoreTests/CodexRemoteNotifyTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexRemoteNotifyTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+/// Pins the notify-only Codex hook path: when the remote Python hook client
+/// runs with `OPEN_ISLAND_NOTIFY_ONLY=1`, PreToolUse events must post a
+/// running-activity update instead of raising an approval request, so remote
+/// agents are not blocked by a Mac-side approval round-trip.
+struct CodexRemoteNotifyTests {
+    @Test
+    func notifyOnlyPreToolUsePostsActivityInsteadOfApproval() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let payload = CodexHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .preToolUse,
+            model: "gpt-5-codex",
+            permissionMode: .default,
+            sessionID: "codex-notify-1",
+            transcriptPath: "/tmp/rollout.json",
+            openIslandNotifyOnly: true
+        )
+        let response = try BridgeCommandClient(socketURL: socketURL).send(.processCodexHook(payload))
+        #expect(response == .acknowledged)
+
+        var iterator = stream.makeAsyncIterator()
+        let first = try await nextEvent(from: &iterator)
+        // ensureSessionExists emits a sessionStarted event first.
+        #expect(first.sessionStarted != nil)
+
+        let second = try await nextEvent(from: &iterator)
+        #expect(second.activityUpdated?.phase == .running)
+        #expect(second.activityUpdated?.summary == "Running: Bash command")
+    }
+
+    @Test
+    func codexHookPayloadDecodesNotifyOnlyFlag() throws {
+        let json = """
+        {
+          "cwd": "/tmp/demo",
+          "hook_event_name": "PreToolUse",
+          "model": "gpt-5-codex",
+          "permission_mode": "default",
+          "session_id": "s-notify",
+          "transcript_path": null,
+          "open_island_notify_only": true
+        }
+        """.data(using: .utf8)!
+
+        let payload = try JSONDecoder().decode(CodexHookPayload.self, from: json)
+        #expect(payload.openIslandNotifyOnly == true)
+    }
+}
+
+private enum CodexRemoteNotifyTestError: Error {
+    case streamEnded
+}
+
+private func nextEvent(
+    from iterator: inout AsyncThrowingStream<AgentEvent, Error>.AsyncIterator
+) async throws -> AgentEvent {
+    guard let event = try await iterator.next() else {
+        throw CodexRemoteNotifyTestError.streamEnded
+    }
+
+    return event
+}
+
+private extension AgentEvent {
+    var sessionStarted: SessionStarted? {
+        if case let .sessionStarted(payload) = self {
+            payload
+        } else {
+            nil
+        }
+    }
+
+    var activityUpdated: SessionActivityUpdated? {
+        if case let .activityUpdated(payload) = self {
+            payload
+        } else {
+            nil
+        }
+    }
+
+    var permissionRequested: PermissionRequested? {
+        if case let .permissionRequested(payload) = self {
+            payload
+        } else {
+            nil
+        }
+    }
+}

--- a/docs/ssh-setup.md
+++ b/docs/ssh-setup.md
@@ -89,11 +89,50 @@ Or connect directly with:
 ssh -R /tmp/open-island-$(id -u).sock:/tmp/open-island-$(id -u).sock user@myserver
 ```
 
-### 4. Verify
+### 4. Configure Codex hooks on the remote (optional)
+
+Codex reads hooks from `~/.codex/hooks.json` on the remote server. Use the
+notify-only mode for `PreToolUse` / `PostToolUse` so tool calls post a
+"Running: ..." activity without blocking the remote agent while it waits for
+an approval round-trip to your Mac:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [{ "type": "command", "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-501.sock python3 ~/.local/bin/open-island-hooks.py --source codex", "timeout": 45 }]
+      }
+    ],
+    "UserPromptSubmit": [
+      { "hooks": [{ "type": "command", "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-501.sock python3 ~/.local/bin/open-island-hooks.py --source codex", "timeout": 45 }] }
+    ],
+    "PermissionRequest": [
+      { "hooks": [{ "type": "command", "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-501.sock python3 ~/.local/bin/open-island-hooks.py --source codex", "timeout": 3600 }] }
+    ],
+    "PreToolUse": [
+      { "hooks": [{ "type": "command", "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-501.sock OPEN_ISLAND_NOTIFY_ONLY=1 OPEN_ISLAND_NOTIFY_TIMEOUT=2 python3 ~/.local/bin/open-island-hooks.py --source codex", "timeout": 5 }] }
+    ],
+    "PostToolUse": [
+      { "hooks": [{ "type": "command", "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-501.sock OPEN_ISLAND_NOTIFY_ONLY=1 OPEN_ISLAND_NOTIFY_TIMEOUT=2 python3 ~/.local/bin/open-island-hooks.py --source codex", "timeout": 5 }] }
+    ],
+    "Stop": [
+      { "hooks": [{ "type": "command", "command": "OPEN_ISLAND_SOCKET_PATH=/tmp/open-island-501.sock python3 ~/.local/bin/open-island-hooks.py --source codex", "timeout": 45 }] }
+    ]
+  }
+}
+```
+
+Replace `501` with your local UID (or the mapped remote UID described below).
+`PermissionRequest` still waits (up to an hour) for an Allow/Deny decision in
+Open Island; the notify-only entries return within a couple of seconds.
+
+### 5. Verify
 
 1. Make sure Open Island is running on your Mac
 2. SSH to the remote with socket forwarding enabled
-3. Run Claude Code on the remote — sessions should appear in the Open Island overlay
+3. Run Claude Code or Codex on the remote — sessions should appear in the Open Island overlay
 
 ## Important: sshd configuration
 

--- a/scripts/open-island-hooks.py
+++ b/scripts/open-island-hooks.py
@@ -122,7 +122,12 @@ def enrich_payload(payload, env):
 # Bridge socket communication
 # ---------------------------------------------------------------------------
 
-def send_command(envelope_json, timeout):
+def env_flag(env, name):
+    """Return whether an environment flag is enabled."""
+    return (env.get(name) or "").lower() in ("1", "true", "yes", "on")
+
+
+def send_command(envelope_json, timeout, wait_response=True):
     """Connect to bridge socket, send JSON line, return parsed response."""
     path = socket_path()
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -130,6 +135,8 @@ def send_command(envelope_json, timeout):
     try:
         sock.connect(path)
         sock.sendall(envelope_json.encode("utf-8") + b"\n")
+        if not wait_response:
+            return None
 
         buf = b""
         while True:
@@ -205,6 +212,16 @@ def encode_codex_stdout(response):
         output = {"decision": "block", "reason": directive.get("reason", "")}
         return json.dumps(output, sort_keys=True) + "\n"
 
+    if dtype == "permissionRequest":
+        output = {
+            "continue": True,
+            "hookSpecificOutput": {
+                "hookEventName": "PermissionRequest",
+                "decision": directive.get("decision", {}),
+            },
+        }
+        return json.dumps(output, sort_keys=True) + "\n"
+
     return None
 
 
@@ -269,12 +286,17 @@ def main():
             encoder = encode_opencode_stdout
         else:
             command = {"type": "processCodexHook", "codexHook": payload}
-            timeout = 45
+            timeout = 3600 if payload.get("hook_event_name") == "PermissionRequest" else 45
             encoder = encode_codex_stdout
+
+        notify_only = env_flag(env, "OPEN_ISLAND_NOTIFY_ONLY")
+        if notify_only:
+            payload["open_island_notify_only"] = True
+            timeout = int(env.get("OPEN_ISLAND_NOTIFY_TIMEOUT", "2"))
 
         envelope = json.dumps({"type": "command", "command": command})
 
-        response = send_command(envelope, timeout)
+        response = send_command(envelope, timeout, wait_response=not notify_only)
         if response is None:
             return
 


### PR DESCRIPTION
## Summary

Companion to #628: makes remote Codex sessions non-blocking and keeps the island list tidy.

- **Notify-only mode**: remote PreToolUse/PostToolUse hooks run with `OPEN_ISLAND_NOTIFY_ONLY=1` and post a `Running: ...` activity instead of waiting for a Mac-side approval round-trip; only `PermissionRequest` blocks (up to 3600s) for an Allow/Deny decision.
- **PermissionRequest decision passthrough**: the Python hook client now encodes `permissionRequest` directives so Allow/Deny decisions reach the remote Codex agent.
- **Stale completed sessions hidden**: long-finished sessions (e.g. remote Codex sessions with no SessionEnd hook) are hidden from the island list while remaining in recent sessions.

## Changes

- `scripts/open-island-hooks.py`: `env_flag`, `send_command(wait_response:)`, notify-only payload + timeout, codex `permissionRequest` encoding, 3600s PermissionRequest timeout
- `Sources/OpenIslandCore/CodexHooks.swift`: `openIslandNotifyOnly` payload field
- `Sources/OpenIslandCore/BridgeServer.swift`: PreToolUse notify-only branch (activity update + ack, no approval)
- `Sources/OpenIslandApp/IslandSurface.swift`: running activity events route to the notification surface
- `Sources/OpenIslandApp/AppModel.swift` + `AgentSession+Presentation.swift`: hide idle completed sessions from the island list
- `docs/ssh-setup.md`: Codex hooks.json example with notify-only entries
- Tests: notify-only bridge behavior, running-activity surface routing, stale-hiding, plus date fixes for two grid tests

## Verification

- `swift test`: all new tests pass; full-suite failures match the main-branch baseline (3 environment-sensitive AppModel tests + 1 concurrency flake)
- `python3 -m py_compile` + unit assertions for the hook client (deny/permissionRequest encoding, env flag parsing)
- Existing remote end-to-end path unchanged (SessionStart/UserPromptSubmit/PermissionRequest/Stop still ack)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Running activity now appears promptly in the session list with the correct active session.
  * Codex tool-use notifications can update activity without creating unnecessary approval prompts.
  * Added optional Codex hook setup for remote servers.

* **Bug Fixes**
  * Completed sessions that have been idle beyond the configured threshold are hidden from the active island while remaining available in recent sessions.

* **Documentation**
  * Expanded SSH setup guidance with Codex configuration and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->