### PR TITLE
feat: add Grok Build / Grok CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Think of it as an open-source [Vibe Island](https://vibeisland.app/) — **free,
 
 ## Supported Agents & Terminals
 
-**10 agents**: Claude Code, Codex, Cursor, Gemini CLI, Kimi CLI, OpenCode, Qoder, Qwen Code, Factory, CodeBuddy
+**11 agents**: Claude Code, Codex, Cursor, Gemini CLI, Grok Build, Kimi CLI, OpenCode, Qoder, Qwen Code, Factory, CodeBuddy
 
 **15+ terminals & IDEs**: Terminal.app, Ghostty, iTerm2, WezTerm, Zellij, tmux, cmux, Kaku, VS Code, Cursor, Windsurf, Trae, Zed, JetBrains IDEs (IDEA, WebStorm, PyCharm, GoLand, CLion, RubyMine, PhpStorm, Rider, RustRover)
 
@@ -73,6 +73,7 @@ Think of it as an open-source [Vibe Island](https://vibeisland.app/) — **free,
 | **Cursor** | Supported | Hook integration via `~/.cursor/hooks.json`, session tracking, workspace jump-back |
 | **Gemini CLI** | Supported | Hook integration via `~/.gemini/settings.json`, session tracking, fire-and-forget events |
 | **Kimi CLI** | Supported | Hook integration via `~/.kimi/config.toml` `[[hooks]]`, session tracking, permission flow (reuses Claude payload) |
+| **Grok Build** | Supported | Hook integration via `~/.grok/hooks/open-island.json`, session tracking, terminal jump-back (camelCase payload) |
 
 ### Terminals & IDEs
 
@@ -279,6 +280,14 @@ Developers who already live in the terminal and want a better way to work with c
   swift run OpenIslandSetup installKimi    # write [[hooks]] entries into ~/.kimi/config.toml
   swift run OpenIslandSetup statusKimi     # report whether managed hooks are present
   swift run OpenIslandSetup uninstallKimi  # remove managed entries, preserve user-authored [[hooks]]
+  ```
+
+- **Grok Build** — Hook-based integration via `~/.grok/hooks/open-island.json` (xAI Grok CLI / TUI). Grok emits camelCase hook envelopes (`sessionId`, `hookEventName`, `toolResult`) and accepts PascalCase or snake_case event names. Open Island uses a dedicated `--source grok` path for decode + lifecycle mapping (session visibility, activity, turn completion, terminal jump-back). Managed install registers the full supported lifecycle event set; tool events are observation-only (no PreToolUse blocking yet). Settings reports installed only when every required event is present with an Open Island command (Vibe Island hooks do not count). Manage installation from the Settings window, or via CLI:
+
+  ```sh
+  swift run OpenIslandSetup installGrok    # write ~/.grok/hooks/open-island.json
+  swift run OpenIslandSetup statusGrok     # report whether managed hooks are present
+  swift run OpenIslandSetup uninstallGrok  # remove managed open-island.json + manifest
   ```
 
 ### Terminal Support

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Think of it as an open-source [Vibe Island](https://vibeisland.app/) — **free,
 | **Cursor** | Supported | Hook integration via `~/.cursor/hooks.json`, session tracking, workspace jump-back |
 | **Gemini CLI** | Supported | Hook integration via `~/.gemini/settings.json`, session tracking, fire-and-forget events |
 | **Kimi CLI** | Supported | Hook integration via `~/.kimi/config.toml` `[[hooks]]`, session tracking, permission flow (reuses Claude payload) |
-| **Grok Build** | Supported | Hook integration via `~/.grok/hooks/open-island.json`, session tracking, terminal jump-back (camelCase payload) |
+| **Grok Build** | Supported | Hook integration via `~/.grok/hooks/open-island.json`, session tracking, terminal jump-back, fire-and-forget events (no permission round-trip yet; camelCase payload) |
 
 ### Terminals & IDEs
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Think of it as an open-source [Vibe Island](https://vibeisland.app/) — **free,
 
 ## Supported Agents & Terminals
 
-**10 agents**: Claude Code, Codex, Cursor, Gemini CLI, Kimi CLI, OpenCode, Qoder, Qwen Code, Factory, CodeBuddy
+**11 agents**: Claude Code, Codex, Cursor, Gemini CLI, Grok Build, Kimi CLI, OpenCode, Qoder, Qwen Code, Factory, CodeBuddy
 
 **15+ terminals & IDEs**: Terminal.app, Ghostty, iTerm2, WezTerm, Zellij, tmux, cmux, Kaku, VS Code, Cursor, Windsurf, Trae, JetBrains IDEs (IDEA, WebStorm, PyCharm, GoLand, CLion, RubyMine, PhpStorm, Rider, RustRover)
 
@@ -73,6 +73,7 @@ Think of it as an open-source [Vibe Island](https://vibeisland.app/) — **free,
 | **Cursor** | Supported | Hook integration via `~/.cursor/hooks.json`, session tracking, workspace jump-back |
 | **Gemini CLI** | Supported | Hook integration via `~/.gemini/settings.json`, session tracking, fire-and-forget events |
 | **Kimi CLI** | Supported | Hook integration via `~/.kimi/config.toml` `[[hooks]]`, session tracking, permission flow (reuses Claude payload) |
+| **Grok Build** | Supported | Hook integration via `~/.grok/hooks/open-island.json`, session tracking, terminal jump-back (camelCase payload) |
 
 ### Terminals & IDEs
 
@@ -277,6 +278,14 @@ Developers who already live in the terminal and want a better way to work with c
   swift run OpenIslandSetup installKimi    # write [[hooks]] entries into ~/.kimi/config.toml
   swift run OpenIslandSetup statusKimi     # report whether managed hooks are present
   swift run OpenIslandSetup uninstallKimi  # remove managed entries, preserve user-authored [[hooks]]
+  ```
+
+- **Grok Build** — Hook-based integration via `~/.grok/hooks/open-island.json` (xAI Grok CLI / TUI). Grok emits camelCase hook envelopes (`sessionId`, `hookEventName`, `toolResult`) and accepts PascalCase or snake_case event names. Open Island uses a dedicated `--source grok` path for decode + lifecycle mapping (session visibility, activity, turn completion, terminal jump-back). Managed install registers the full supported lifecycle event set; tool events are observation-only (no PreToolUse blocking yet). Settings reports installed only when every required event is present with an Open Island command (Vibe Island hooks do not count). Manage installation from the Settings window, or via CLI:
+
+  ```sh
+  swift run OpenIslandSetup installGrok    # write ~/.grok/hooks/open-island.json
+  swift run OpenIslandSetup statusGrok     # report whether managed hooks are present
+  swift run OpenIslandSetup uninstallGrok  # remove managed open-island.json + manifest
   ```
 
 ### Terminal Support

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -72,7 +72,7 @@ Open Island 驻留在 Mac 的**刘海区域**（或顶部栏），为你的 AI c
 | **Cursor** | 已支持 | Hook 集成，通过 `~/.cursor/hooks.json` 配置，会话追踪，工作区跳转 |
 | **Gemini CLI** | 已支持 | Hook 集成，通过 `~/.gemini/settings.json` 配置，会话追踪，fire-and-forget 事件 |
 | **Kimi CLI** | 已支持 | Hook 集成，通过 `~/.kimi/config.toml` 的 `[[hooks]]` 数组配置，会话追踪，复用 Claude payload 协议 |
-| **Grok Build** | 已支持 | Hook 集成，写入 `~/.grok/hooks/open-island.json`，会话追踪与终端跳回（camelCase payload） |
+| **Grok Build** | 已支持 | Hook 集成，写入 `~/.grok/hooks/open-island.json`，会话追踪与终端跳回，fire-and-forget 事件（暂无权限拦截；camelCase payload） |
 
 ### 终端和 IDE
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -50,7 +50,7 @@ Open Island 驻留在 Mac 的**刘海区域**（或顶部栏），为你的 AI c
 
 ## 支持的 Agents 和终端
 
-**10 个 Agents**：Claude Code、Codex、Cursor、Gemini CLI、Kimi CLI、OpenCode、Qoder、Qwen Code、Factory、CodeBuddy
+**11 个 Agents**：Claude Code、Codex、Cursor、Gemini CLI、Grok Build、Kimi CLI、OpenCode、Qoder、Qwen Code、Factory、CodeBuddy
 
 **15+ 终端和 IDE**：Terminal.app、Ghostty、iTerm2、WezTerm、Zellij、tmux、cmux、Kaku、VS Code、Cursor、Windsurf、Trae、Zed、JetBrains 全家桶（IDEA、WebStorm、PyCharm、GoLand、CLion、RubyMine、PhpStorm、Rider、RustRover）
 
@@ -72,6 +72,7 @@ Open Island 驻留在 Mac 的**刘海区域**（或顶部栏），为你的 AI c
 | **Cursor** | 已支持 | Hook 集成，通过 `~/.cursor/hooks.json` 配置，会话追踪，工作区跳转 |
 | **Gemini CLI** | 已支持 | Hook 集成，通过 `~/.gemini/settings.json` 配置，会话追踪，fire-and-forget 事件 |
 | **Kimi CLI** | 已支持 | Hook 集成，通过 `~/.kimi/config.toml` 的 `[[hooks]]` 数组配置，会话追踪，复用 Claude payload 协议 |
+| **Grok Build** | 已支持 | Hook 集成，写入 `~/.grok/hooks/open-island.json`，会话追踪与终端跳回（camelCase payload） |
 
 ### 终端和 IDE
 
@@ -281,6 +282,14 @@ AI coding 正在成为日常开发流程的一部分，但围绕它的控制层�
   swift run OpenIslandSetup installKimi    # 把受管 [[hooks]] 条目写入 ~/.kimi/config.toml
   swift run OpenIslandSetup statusKimi     # 查看受管 hooks 是否已安装
   swift run OpenIslandSetup uninstallKimi  # 移除受管条目，保留用户自定义的 [[hooks]]
+  ```
+
+- **Grok Build** — 基于 hook 的集成，写入 `~/.grok/hooks/open-island.json`（xAI Grok CLI / TUI）。Grok 使用 camelCase 字段（`sessionId`、`hookEventName`、`toolResult`），事件名同时接受 PascalCase 与 snake_case。Open Island 通过独立的 `--source grok` 路径完成解码与会话生命周期映射（可见性、活动状态、turn 完成、终端跳回）。受管安装注册完整支持的生命周期事件集合；工具事件为观察模式（尚未实现 PreToolUse 拦截）。仅当所有必需事件均挂载 Open Island 命令时，Settings 才显示已安装（Vibe Island 的 hooks 不计入）。可在设置窗口安装，或通过 CLI：
+
+  ```sh
+  swift run OpenIslandSetup installGrok    # 写入 ~/.grok/hooks/open-island.json
+  swift run OpenIslandSetup statusGrok     # 查看受管 hooks 是否已安装
+  swift run OpenIslandSetup uninstallGrok  # 移除 open-island.json 与 manifest
   ```
 
 ### 终端支持

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -50,7 +50,7 @@ Open Island 驻留在 Mac 的**刘海区域**（或顶部栏），为你的 AI c
 
 ## 支持的 Agents 和终端
 
-**10 个 Agents**：Claude Code、Codex、Cursor、Gemini CLI、Kimi CLI、OpenCode、Qoder、Qwen Code、Factory、CodeBuddy
+**11 个 Agents**：Claude Code、Codex、Cursor、Gemini CLI、Grok Build、Kimi CLI、OpenCode、Qoder、Qwen Code、Factory、CodeBuddy
 
 **15+ 终端和 IDE**：Terminal.app、Ghostty、iTerm2、WezTerm、Zellij、tmux、cmux、Kaku、VS Code、Cursor、Windsurf、Trae、JetBrains 全家桶（IDEA、WebStorm、PyCharm、GoLand、CLion、RubyMine、PhpStorm、Rider、RustRover）
 
@@ -72,6 +72,7 @@ Open Island 驻留在 Mac 的**刘海区域**（或顶部栏），为你的 AI c
 | **Cursor** | 已支持 | Hook 集成，通过 `~/.cursor/hooks.json` 配置，会话追踪，工作区跳转 |
 | **Gemini CLI** | 已支持 | Hook 集成，通过 `~/.gemini/settings.json` 配置，会话追踪，fire-and-forget 事件 |
 | **Kimi CLI** | 已支持 | Hook 集成，通过 `~/.kimi/config.toml` 的 `[[hooks]]` 数组配置，会话追踪，复用 Claude payload 协议 |
+| **Grok Build** | 已支持 | Hook 集成，写入 `~/.grok/hooks/open-island.json`，会话追踪与终端跳回（camelCase payload） |
 
 ### 终端和 IDE
 
@@ -279,6 +280,14 @@ AI coding 正在成为日常开发流程的一部分，但围绕它的控制层�
   swift run OpenIslandSetup installKimi    # 把受管 [[hooks]] 条目写入 ~/.kimi/config.toml
   swift run OpenIslandSetup statusKimi     # 查看受管 hooks 是否已安装
   swift run OpenIslandSetup uninstallKimi  # 移除受管条目，保留用户自定义的 [[hooks]]
+  ```
+
+- **Grok Build** — 基于 hook 的集成，写入 `~/.grok/hooks/open-island.json`（xAI Grok CLI / TUI）。Grok 使用 camelCase 字段（`sessionId`、`hookEventName`、`toolResult`），事件名同时接受 PascalCase 与 snake_case。Open Island 通过独立的 `--source grok` 路径完成解码与会话生命周期映射（可见性、活动状态、turn 完成、终端跳回）。受管安装注册完整支持的生命周期事件集合；工具事件为观察模式（尚未实现 PreToolUse 拦截）。仅当所有必需事件均挂载 Open Island 命令时，Settings 才显示已安装（Vibe Island 的 hooks 不计入）。可在设置窗口安装，或通过 CLI：
+
+  ```sh
+  swift run OpenIslandSetup installGrok    # 写入 ~/.grok/hooks/open-island.json
+  swift run OpenIslandSetup statusGrok     # 查看受管 hooks 是否已安装
+  swift run OpenIslandSetup uninstallGrok  # 移除 open-island.json 与 manifest
   ```
 
 ### 终端支持

--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -215,6 +215,23 @@ struct ActiveAgentProcessDiscovery {
                 ))
                 continue
             }
+
+            if isGrokProcess(command: process.command) {
+                let claimKey = "grok:\(process.pid)"
+                guard claimedKeys.insert(claimKey).inserted else {
+                    continue
+                }
+
+                let lsofOutput = lsofOutput(pid: process.pid)
+                snapshots.append(ProcessSnapshot(
+                    tool: .grokBuild,
+                    sessionID: nil,
+                    workingDirectory: lsofOutput.flatMap(workingDirectory(from:)),
+                    terminalTTY: process.terminalTTY,
+                    terminalApp: terminalApp(for: process, processesByPID: processesByPID)
+                ))
+                continue
+            }
         }
 
         return snapshots
@@ -780,6 +797,23 @@ struct ActiveAgentProcessDiscovery {
         }
 
         return firstToken == "kimi" || firstToken.hasSuffix("/kimi")
+    }
+
+    /// Matches the Grok Build / Grok CLI entry-point (`grok` under `~/.grok/bin`
+    /// or on PATH). Avoids matching incidental paths that merely contain the
+    /// substring "grok".
+    private func isGrokProcess(command: String) -> Bool {
+        let lowered = command.lowercased()
+        guard let firstToken = lowered.split(separator: " ").first.map(String.init) else {
+            return false
+        }
+
+        let binaryName = (firstToken as NSString).lastPathComponent
+        guard binaryName == "grok" else {
+            return false
+        }
+
+        return firstToken == "grok" || firstToken.hasSuffix("/grok")
     }
 
     /// Returns `true` when the given `ps` command string belongs to a Claude Code process.

--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -215,6 +215,23 @@ struct ActiveAgentProcessDiscovery {
                 ))
                 continue
             }
+
+            if isGrokProcess(command: process.command) {
+                let claimKey = "grok:\(process.pid)"
+                guard claimedKeys.insert(claimKey).inserted else {
+                    continue
+                }
+
+                let lsofOutput = lsofOutput(pid: process.pid)
+                snapshots.append(ProcessSnapshot(
+                    tool: .grokBuild,
+                    sessionID: nil,
+                    workingDirectory: lsofOutput.flatMap(workingDirectory(from:)),
+                    terminalTTY: process.terminalTTY,
+                    terminalApp: terminalApp(for: process, processesByPID: processesByPID)
+                ))
+                continue
+            }
         }
 
         return snapshots
@@ -767,6 +784,23 @@ struct ActiveAgentProcessDiscovery {
         }
 
         return firstToken == "kimi" || firstToken.hasSuffix("/kimi")
+    }
+
+    /// Matches the Grok Build / Grok CLI entry-point (`grok` under `~/.grok/bin`
+    /// or on PATH). Avoids matching incidental paths that merely contain the
+    /// substring "grok".
+    private func isGrokProcess(command: String) -> Bool {
+        let lowered = command.lowercased()
+        guard let firstToken = lowered.split(separator: " ").first.map(String.init) else {
+            return false
+        }
+
+        let binaryName = (firstToken as NSString).lastPathComponent
+        guard binaryName == "grok" else {
+            return false
+        }
+
+        return firstToken == "grok" || firstToken.hasSuffix("/grok")
     }
 
     /// Returns `true` when the given `ps` command string belongs to a Claude Code process.

--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -228,6 +228,8 @@ extension AgentSession {
             return "Cursor"
         case .kimiCLI:
             return "Kimi"
+        case .grokBuild:
+            return "Grok"
         }
     }
 

--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -222,6 +222,8 @@ extension AgentSession {
             return "Cursor"
         case .kimiCLI:
             return "Kimi"
+        case .grokBuild:
+            return "Grok"
         }
     }
 

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -139,6 +139,11 @@ final class AppModel {
     var kimiHookStatus: KimiHookInstallationStatus? { hooks.kimiHookStatus }
     var kimiHookStatusTitle: String { hooks.kimiHookStatusTitle }
     var kimiHookStatusSummary: String { hooks.kimiHookStatusSummary }
+    var grokHooksInstalled: Bool { hooks.grokHooksInstalled }
+    var isGrokHookSetupBusy: Bool { hooks.isGrokHookSetupBusy }
+    var grokHookStatus: GrokHookInstallationStatus? { hooks.grokHookStatus }
+    var grokHookStatusTitle: String { hooks.grokHookStatusTitle }
+    var grokHookStatusSummary: String { hooks.grokHookStatusSummary }
     var codexHookStatusTitle: String { hooks.codexHookStatusTitle }
     var codexHookStatusSummary: String { hooks.codexHookStatusSummary }
 
@@ -165,6 +170,7 @@ final class AppModel {
             || hooks.openCodePluginInstalled
             || hooks.geminiHooksInstalled
             || hooks.kimiHooksInstalled
+            || hooks.grokHooksInstalled
     }
     func refreshCodexHookStatus() { hooks.refreshCodexHookStatus() }
     func refreshClaudeHookStatus() { hooks.refreshClaudeHookStatus() }
@@ -195,6 +201,9 @@ final class AppModel {
     func refreshKimiHookStatus() { hooks.refreshKimiHookStatus() }
     func installKimiHooks() { hooks.installKimiHooks() }
     func uninstallKimiHooks() { hooks.uninstallKimiHooks() }
+    func refreshGrokHookStatus() { hooks.refreshGrokHookStatus() }
+    func installGrokHooks() { hooks.installGrokHooks() }
+    func uninstallGrokHooks() { hooks.uninstallGrokHooks() }
     func installClaudeUsageBridge() { hooks.installClaudeUsageBridge() }
     func uninstallClaudeUsageBridge() { hooks.uninstallClaudeUsageBridge() }
     func updateClaudeConfigDirectory(to newDirectory: URL?) { hooks.updateClaudeConfigDirectory(to: newDirectory) }
@@ -1676,6 +1685,7 @@ final class AppModel {
                 if self.hooks.shouldAutoInstall(.cursor) { self.installCursorHooks() }
                 if self.hooks.shouldAutoInstall(.gemini) { self.installGeminiHooks() }
                 if self.hooks.shouldAutoInstall(.kimi) { self.installKimiHooks() }
+                if self.hooks.shouldAutoInstall(.grok) { self.installGrokHooks() }
                 if self.hooks.shouldAutoInstall(.claudeUsageBridge) { self.installClaudeUsageBridge() }
 
                 // Run health checks after install to detect stale paths, conflicts, etc.

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1113,6 +1113,9 @@ final class AppModel {
             hooks.refreshCCForkHookStatuses()
             hooks.refreshOpenCodePluginStatus()
             hooks.refreshCursorHookStatus()
+            hooks.refreshGeminiHookStatus()
+            hooks.refreshKimiHookStatus()
+            hooks.refreshGrokHookStatus()
             hooks.refreshClaudeUsageState()
             hooks.startClaudeUsageMonitoringIfNeeded()
             if showCodexUsage {

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1113,8 +1113,6 @@ final class AppModel {
             hooks.refreshCCForkHookStatuses()
             hooks.refreshOpenCodePluginStatus()
             hooks.refreshCursorHookStatus()
-            hooks.refreshGeminiHookStatus()
-            hooks.refreshKimiHookStatus()
             hooks.refreshGrokHookStatus()
             hooks.refreshClaudeUsageState()
             hooks.startClaudeUsageMonitoringIfNeeded()

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -137,6 +137,11 @@ final class AppModel {
     var kimiHookStatus: KimiHookInstallationStatus? { hooks.kimiHookStatus }
     var kimiHookStatusTitle: String { hooks.kimiHookStatusTitle }
     var kimiHookStatusSummary: String { hooks.kimiHookStatusSummary }
+    var grokHooksInstalled: Bool { hooks.grokHooksInstalled }
+    var isGrokHookSetupBusy: Bool { hooks.isGrokHookSetupBusy }
+    var grokHookStatus: GrokHookInstallationStatus? { hooks.grokHookStatus }
+    var grokHookStatusTitle: String { hooks.grokHookStatusTitle }
+    var grokHookStatusSummary: String { hooks.grokHookStatusSummary }
     var codexHookStatusTitle: String { hooks.codexHookStatusTitle }
     var codexHookStatusSummary: String { hooks.codexHookStatusSummary }
 
@@ -163,6 +168,7 @@ final class AppModel {
             || hooks.openCodePluginInstalled
             || hooks.geminiHooksInstalled
             || hooks.kimiHooksInstalled
+            || hooks.grokHooksInstalled
     }
     func refreshCodexHookStatus() { hooks.refreshCodexHookStatus() }
     func refreshClaudeHookStatus() { hooks.refreshClaudeHookStatus() }
@@ -193,6 +199,9 @@ final class AppModel {
     func refreshKimiHookStatus() { hooks.refreshKimiHookStatus() }
     func installKimiHooks() { hooks.installKimiHooks() }
     func uninstallKimiHooks() { hooks.uninstallKimiHooks() }
+    func refreshGrokHookStatus() { hooks.refreshGrokHookStatus() }
+    func installGrokHooks() { hooks.installGrokHooks() }
+    func uninstallGrokHooks() { hooks.uninstallGrokHooks() }
     func installClaudeUsageBridge() { hooks.installClaudeUsageBridge() }
     func uninstallClaudeUsageBridge() { hooks.uninstallClaudeUsageBridge() }
     func updateClaudeConfigDirectory(to newDirectory: URL?) { hooks.updateClaudeConfigDirectory(to: newDirectory) }
@@ -1649,6 +1658,7 @@ final class AppModel {
                 if self.hooks.shouldAutoInstall(.cursor) { self.installCursorHooks() }
                 if self.hooks.shouldAutoInstall(.gemini) { self.installGeminiHooks() }
                 if self.hooks.shouldAutoInstall(.kimi) { self.installKimiHooks() }
+                if self.hooks.shouldAutoInstall(.grok) { self.installGrokHooks() }
                 if self.hooks.shouldAutoInstall(.claudeUsageBridge) { self.installClaudeUsageBridge() }
 
                 // Run health checks after install to detect stale paths, conflicts, etc.

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -1098,6 +1098,9 @@ final class AppModel {
             hooks.refreshCCForkHookStatuses()
             hooks.refreshOpenCodePluginStatus()
             hooks.refreshCursorHookStatus()
+            hooks.refreshGeminiHookStatus()
+            hooks.refreshKimiHookStatus()
+            hooks.refreshGrokHookStatus()
             hooks.refreshClaudeUsageState()
             hooks.startClaudeUsageMonitoringIfNeeded()
             if showCodexUsage {

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -22,6 +22,7 @@ final class HookInstallationCoordinator {
     var cursorHookStatus: CursorHookInstallationStatus?
     var geminiHookStatus: GeminiHookInstallationStatus?
     var kimiHookStatus: KimiHookInstallationStatus?
+    var grokHookStatus: GrokHookInstallationStatus?
     var claudeStatusLineStatus: ClaudeStatusLineInstallationStatus?
     var claudeUsageSnapshot: ClaudeUsageSnapshot?
     var codexUsageSnapshot: CodexUsageSnapshot?
@@ -36,6 +37,7 @@ final class HookInstallationCoordinator {
     var isCursorHookSetupBusy = false
     var isGeminiHookSetupBusy = false
     var isKimiHookSetupBusy = false
+    var isGrokHookSetupBusy = false
     var isClaudeUsageSetupBusy = false
 
     @ObservationIgnored
@@ -84,6 +86,9 @@ final class HookInstallationCoordinator {
 
     @ObservationIgnored
     private let kimiHookInstallationManager = KimiHookInstallationManager()
+
+    @ObservationIgnored
+    private let grokHookInstallationManager = GrokHookInstallationManager()
 
     /// Computed so it always reflects the latest `ClaudeConfigDirectory` setting.
     private var claudeStatusLineInstallationManager: ClaudeStatusLineInstallationManager {
@@ -143,6 +148,10 @@ final class HookInstallationCoordinator {
 
     var kimiHooksInstalled: Bool {
         kimiHookStatus?.managedHooksPresent == true
+    }
+
+    var grokHooksInstalled: Bool {
+        grokHookStatus?.managedHooksPresent == true
     }
 
     var claudeUsageInstalled: Bool {
@@ -376,6 +385,34 @@ final class HookInstallationCoordinator {
         }
 
         return "no managed Kimi hooks"
+    }
+
+    var grokHookStatusTitle: String {
+        if grokHooksInstalled {
+            return "Grok hooks installed"
+        }
+
+        if hooksBinaryURL == nil {
+            return "Hook binary not found"
+        }
+
+        return "Grok hooks not installed"
+    }
+
+    var grokHookStatusSummary: String {
+        guard grokHookStatus != nil else {
+            return "Reading ~/.grok/hooks/open-island.json."
+        }
+
+        if grokHooksInstalled {
+            return "managed hooks present"
+        }
+
+        if hooksBinaryURL == nil {
+            return "Build OpenIslandHooks before installing."
+        }
+
+        return "no managed Grok hooks"
     }
 
     var codexHookStatusTitle: String {
@@ -692,6 +729,16 @@ final class HookInstallationCoordinator {
                     self.onStatusMessage?("Failed to read Kimi hook status: \(error.localizedDescription)")
                 }
             }
+
+            group.addTask { @MainActor [weak self] in
+                guard let self else { return }
+                do {
+                    let status = try self.grokHookInstallationManager.status(hooksBinaryURL: self.hooksBinaryURL)
+                    self.grokHookStatus = status
+                } catch {
+                    self.onStatusMessage?("Failed to read Grok hook status: \(error.localizedDescription)")
+                }
+            }
         }
     }
 
@@ -743,6 +790,19 @@ final class HookInstallationCoordinator {
                 self.kimiHookStatus = status
             } catch {
                 self.onStatusMessage?("Failed to read Kimi hook status: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    func refreshGrokHookStatus() {
+        Task { [weak self] in
+            guard let self else { return }
+
+            do {
+                let status = try self.grokHookInstallationManager.status(hooksBinaryURL: self.hooksBinaryURL)
+                self.grokHookStatus = status
+            } catch {
+                self.onStatusMessage?("Failed to read Grok hook status: \(error.localizedDescription)")
             }
         }
     }
@@ -817,6 +877,7 @@ final class HookInstallationCoordinator {
         case .openCode: return !openCodePluginInstalled
         case .gemini: return !geminiHooksInstalled
         case .kimi: return !kimiHooksInstalled
+        case .grok: return !grokHooksInstalled
         case .claudeUsageBridge: return !claudeUsageInstalled
         }
     }
@@ -841,6 +902,7 @@ final class HookInstallationCoordinator {
             case .openCode: return openCodePluginInstalled
             case .gemini: return geminiHooksInstalled
             case .kimi: return kimiHooksInstalled
+            case .grok: return grokHooksInstalled
             case .claudeUsageBridge: return claudeUsageInstalled
             }
         }
@@ -1048,6 +1110,23 @@ final class HookInstallationCoordinator {
 
     func uninstallKimiHooks() {
         updateKimiHooks(userMessage: "Removing Kimi hooks.", intent: .uninstalled) { manager in
+            try manager.uninstall()
+        }
+    }
+
+    func installGrokHooks() {
+        guard let hooksBinaryURL else {
+            onStatusMessage?("Could not find a local OpenIslandHooks binary. Build the package first.")
+            return
+        }
+
+        updateGrokHooks(userMessage: "Installing Grok hooks.", intent: .installed) { manager in
+            try manager.install(hooksBinaryURL: hooksBinaryURL)
+        }
+    }
+
+    func uninstallGrokHooks() {
+        updateGrokHooks(userMessage: "Removing Grok hooks.", intent: .uninstalled) { manager in
             try manager.uninstall()
         }
     }
@@ -1260,6 +1339,34 @@ final class HookInstallationCoordinator {
                 }
             } catch {
                 self.onStatusMessage?("Kimi hook update failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func updateGrokHooks(
+        userMessage: String,
+        intent: AgentHookIntent,
+        operation: @escaping (GrokHookInstallationManager) throws -> GrokHookInstallationStatus
+    ) {
+        isGrokHookSetupBusy = true
+        onStatusMessage?(userMessage)
+
+        Task { [weak self] in
+            guard let self else { return }
+
+            defer { self.isGrokHookSetupBusy = false }
+
+            do {
+                let status = try operation(self.grokHookInstallationManager)
+                self.grokHookStatus = status
+                self.intentStore.setIntent(intent, for: .grok)
+                if status.managedHooksPresent {
+                    self.onStatusMessage?("Grok hooks are installed and ready.")
+                } else {
+                    self.onStatusMessage?("Grok hooks are not installed.")
+                }
+            } catch {
+                self.onStatusMessage?("Grok hook update failed: \(error.localizedDescription)")
             }
         }
     }

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -22,6 +22,7 @@ final class HookInstallationCoordinator {
     var cursorHookStatus: CursorHookInstallationStatus?
     var geminiHookStatus: GeminiHookInstallationStatus?
     var kimiHookStatus: KimiHookInstallationStatus?
+    var grokHookStatus: GrokHookInstallationStatus?
     var claudeStatusLineStatus: ClaudeStatusLineInstallationStatus?
     var claudeUsageSnapshot: ClaudeUsageSnapshot?
     var codexUsageSnapshot: CodexUsageSnapshot?
@@ -36,6 +37,7 @@ final class HookInstallationCoordinator {
     var isCursorHookSetupBusy = false
     var isGeminiHookSetupBusy = false
     var isKimiHookSetupBusy = false
+    var isGrokHookSetupBusy = false
     var isClaudeUsageSetupBusy = false
 
     @ObservationIgnored
@@ -84,6 +86,9 @@ final class HookInstallationCoordinator {
 
     @ObservationIgnored
     private let kimiHookInstallationManager = KimiHookInstallationManager()
+
+    @ObservationIgnored
+    private let grokHookInstallationManager = GrokHookInstallationManager()
 
     /// Computed so it always reflects the latest `ClaudeConfigDirectory` setting.
     private var claudeStatusLineInstallationManager: ClaudeStatusLineInstallationManager {
@@ -143,6 +148,10 @@ final class HookInstallationCoordinator {
 
     var kimiHooksInstalled: Bool {
         kimiHookStatus?.managedHooksPresent == true
+    }
+
+    var grokHooksInstalled: Bool {
+        grokHookStatus?.managedHooksPresent == true
     }
 
     var claudeUsageInstalled: Bool {
@@ -376,6 +385,34 @@ final class HookInstallationCoordinator {
         }
 
         return "no managed Kimi hooks"
+    }
+
+    var grokHookStatusTitle: String {
+        if grokHooksInstalled {
+            return "Grok hooks installed"
+        }
+
+        if hooksBinaryURL == nil {
+            return "Hook binary not found"
+        }
+
+        return "Grok hooks not installed"
+    }
+
+    var grokHookStatusSummary: String {
+        guard grokHookStatus != nil else {
+            return "Reading ~/.grok/hooks/open-island.json."
+        }
+
+        if grokHooksInstalled {
+            return "managed hooks present"
+        }
+
+        if hooksBinaryURL == nil {
+            return "Build OpenIslandHooks before installing."
+        }
+
+        return "no managed Grok hooks"
     }
 
     var codexHookStatusTitle: String {
@@ -689,6 +726,16 @@ final class HookInstallationCoordinator {
                     self.onStatusMessage?("Failed to read Kimi hook status: \(error.localizedDescription)")
                 }
             }
+
+            group.addTask { @MainActor [weak self] in
+                guard let self else { return }
+                do {
+                    let status = try self.grokHookInstallationManager.status(hooksBinaryURL: self.hooksBinaryURL)
+                    self.grokHookStatus = status
+                } catch {
+                    self.onStatusMessage?("Failed to read Grok hook status: \(error.localizedDescription)")
+                }
+            }
         }
     }
 
@@ -740,6 +787,19 @@ final class HookInstallationCoordinator {
                 self.kimiHookStatus = status
             } catch {
                 self.onStatusMessage?("Failed to read Kimi hook status: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    func refreshGrokHookStatus() {
+        Task { [weak self] in
+            guard let self else { return }
+
+            do {
+                let status = try self.grokHookInstallationManager.status(hooksBinaryURL: self.hooksBinaryURL)
+                self.grokHookStatus = status
+            } catch {
+                self.onStatusMessage?("Failed to read Grok hook status: \(error.localizedDescription)")
             }
         }
     }
@@ -814,6 +874,7 @@ final class HookInstallationCoordinator {
         case .openCode: return !openCodePluginInstalled
         case .gemini: return !geminiHooksInstalled
         case .kimi: return !kimiHooksInstalled
+        case .grok: return !grokHooksInstalled
         case .claudeUsageBridge: return !claudeUsageInstalled
         }
     }
@@ -838,6 +899,7 @@ final class HookInstallationCoordinator {
             case .openCode: return openCodePluginInstalled
             case .gemini: return geminiHooksInstalled
             case .kimi: return kimiHooksInstalled
+            case .grok: return grokHooksInstalled
             case .claudeUsageBridge: return claudeUsageInstalled
             }
         }
@@ -1045,6 +1107,23 @@ final class HookInstallationCoordinator {
 
     func uninstallKimiHooks() {
         updateKimiHooks(userMessage: "Removing Kimi hooks.", intent: .uninstalled) { manager in
+            try manager.uninstall()
+        }
+    }
+
+    func installGrokHooks() {
+        guard let hooksBinaryURL else {
+            onStatusMessage?("Could not find a local OpenIslandHooks binary. Build the package first.")
+            return
+        }
+
+        updateGrokHooks(userMessage: "Installing Grok hooks.", intent: .installed) { manager in
+            try manager.install(hooksBinaryURL: hooksBinaryURL)
+        }
+    }
+
+    func uninstallGrokHooks() {
+        updateGrokHooks(userMessage: "Removing Grok hooks.", intent: .uninstalled) { manager in
             try manager.uninstall()
         }
     }
@@ -1257,6 +1336,34 @@ final class HookInstallationCoordinator {
                 }
             } catch {
                 self.onStatusMessage?("Kimi hook update failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func updateGrokHooks(
+        userMessage: String,
+        intent: AgentHookIntent,
+        operation: @escaping (GrokHookInstallationManager) throws -> GrokHookInstallationStatus
+    ) {
+        isGrokHookSetupBusy = true
+        onStatusMessage?(userMessage)
+
+        Task { [weak self] in
+            guard let self else { return }
+
+            defer { self.isGrokHookSetupBusy = false }
+
+            do {
+                let status = try operation(self.grokHookInstallationManager)
+                self.grokHookStatus = status
+                self.intentStore.setIntent(intent, for: .grok)
+                if status.managedHooksPresent {
+                    self.onStatusMessage?("Grok hooks are installed and ready.")
+                } else {
+                    self.onStatusMessage?("Grok hooks are not installed.")
+                }
+            } catch {
+                self.onStatusMessage?("Grok hook update failed: \(error.localizedDescription)")
             }
         }
     }

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -510,6 +510,43 @@ final class ProcessMonitoringCoordinator {
             }
         }
 
+        // Grok sessions are hook-managed. Process discovery sees a `grok`
+        // binary but cannot recover Grok's session UUID from ps/lsof.
+        // Prefer TTY / CWD matches when unique; otherwise use a conservative
+        // fallback (same idea as Kimi): while any Grok process is alive, keep
+        // non-ended Grok sessions in the alive set so the hook-managed
+        // processNotSeenCount path does not kill them after ~6s.
+        // Explicit SessionEnd still wins — ended sessions are skipped here and
+        // ignored by SessionState.markProcessLiveness once isSessionEnded.
+        let grokProcesses = activeProcesses.filter { $0.tool == .grokBuild }
+        let trackedGrokSessions = sessions.filter {
+            $0.tool == .grokBuild && !$0.isDemoSession && !$0.isSessionEnded
+        }
+        var claimedGrokSessionIDs: Set<String> = []
+        var hasUnmatchedGrokProcess = false
+
+        for process in grokProcesses {
+            switch uniqueTrackedGrokSession(
+                for: process,
+                sessions: trackedGrokSessions,
+                claimedSessionIDs: claimedGrokSessionIDs
+            ) {
+            case .matched(let matched):
+                aliveIDs.insert(matched.id)
+                claimedGrokSessionIDs.insert(matched.id)
+            case .ambiguous:
+                hasUnmatchedGrokProcess = true
+            case .rejectedConflict:
+                break
+            }
+        }
+
+        if hasUnmatchedGrokProcess || (!grokProcesses.isEmpty && claimedGrokSessionIDs.isEmpty) {
+            for session in trackedGrokSessions where !claimedGrokSessionIDs.contains(session.id) {
+                aliveIDs.insert(session.id)
+            }
+        }
+
         // Cursor sessions: prefer concrete cursor-agent processes when they
         // are visible (Cursor CLI / integrated terminal), then fall back to
         // app-level liveness for IDE-only hook sessions where there is no
@@ -607,6 +644,59 @@ final class ProcessMonitoringCoordinator {
         case matched(AgentSession)
         case ambiguous
         case rejectedConflict
+    }
+
+    /// Same matching strategy as OpenCode: unique TTY (+ optional CWD check),
+    /// then unique CWD. No blind single-session attach without a signal.
+    private func uniqueTrackedGrokSession(
+        for process: ActiveProcessSnapshot,
+        sessions: [AgentSession],
+        claimedSessionIDs: Set<String>
+    ) -> OpenCodeMatchResult {
+        let unclaimedSessions = sessions.filter { !claimedSessionIDs.contains($0.id) }
+        guard !unclaimedSessions.isEmpty else {
+            return .ambiguous
+        }
+
+        if let terminalTTY = normalizedTTYForMatching(process.terminalTTY) {
+            let candidates = unclaimedSessions.filter {
+                normalizedTTYForMatching($0.jumpTarget?.terminalTTY) == terminalTTY
+            }
+            if candidates.count == 1 {
+                let candidate = candidates[0]
+                if let processCWD = normalizedPathForMatching(process.workingDirectory),
+                   let sessionCWD = normalizedPathForMatching(candidate.jumpTarget?.workingDirectory),
+                   processCWD != sessionCWD {
+                    return .rejectedConflict
+                }
+                return .matched(candidate)
+            }
+            if !candidates.isEmpty {
+                if let processCWD = normalizedPathForMatching(process.workingDirectory) {
+                    let cwdCandidates = candidates.filter {
+                        normalizedPathForMatching($0.jumpTarget?.workingDirectory) == processCWD
+                    }
+                    if cwdCandidates.count == 1 {
+                        return .matched(cwdCandidates[0])
+                    }
+                }
+                return .ambiguous
+            }
+        }
+
+        if let processCWD = normalizedPathForMatching(process.workingDirectory) {
+            let workspaceMatches = unclaimedSessions.filter {
+                normalizedPathForMatching($0.jumpTarget?.workingDirectory) == processCWD
+            }
+            if workspaceMatches.count == 1 {
+                return .matched(workspaceMatches[0])
+            }
+            if !workspaceMatches.isEmpty {
+                return .ambiguous
+            }
+        }
+
+        return .ambiguous
     }
 
     private func uniqueTrackedOpenCodeSession(
@@ -1479,6 +1569,8 @@ final class ProcessMonitoringCoordinator {
             return "Cursor \(session.id.prefix(8))"
         case .kimiCLI:
             return "Kimi \(session.id.prefix(8))"
+        case .grokBuild:
+            return "Grok \(session.id.prefix(8))"
         }
     }
 }

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -509,6 +509,43 @@ final class ProcessMonitoringCoordinator {
             }
         }
 
+        // Grok sessions are hook-managed. Process discovery sees a `grok`
+        // binary but cannot recover Grok's session UUID from ps/lsof.
+        // Prefer TTY / CWD matches when unique; otherwise use a conservative
+        // fallback (same idea as Kimi): while any Grok process is alive, keep
+        // non-ended Grok sessions in the alive set so the hook-managed
+        // processNotSeenCount path does not kill them after ~6s.
+        // Explicit SessionEnd still wins — ended sessions are skipped here and
+        // ignored by SessionState.markProcessLiveness once isSessionEnded.
+        let grokProcesses = activeProcesses.filter { $0.tool == .grokBuild }
+        let trackedGrokSessions = sessions.filter {
+            $0.tool == .grokBuild && !$0.isDemoSession && !$0.isSessionEnded
+        }
+        var claimedGrokSessionIDs: Set<String> = []
+        var hasUnmatchedGrokProcess = false
+
+        for process in grokProcesses {
+            switch uniqueTrackedGrokSession(
+                for: process,
+                sessions: trackedGrokSessions,
+                claimedSessionIDs: claimedGrokSessionIDs
+            ) {
+            case .matched(let matched):
+                aliveIDs.insert(matched.id)
+                claimedGrokSessionIDs.insert(matched.id)
+            case .ambiguous:
+                hasUnmatchedGrokProcess = true
+            case .rejectedConflict:
+                break
+            }
+        }
+
+        if hasUnmatchedGrokProcess || (!grokProcesses.isEmpty && claimedGrokSessionIDs.isEmpty) {
+            for session in trackedGrokSessions where !claimedGrokSessionIDs.contains(session.id) {
+                aliveIDs.insert(session.id)
+            }
+        }
+
         // Cursor sessions: prefer concrete cursor-agent processes when they
         // are visible (Cursor CLI / integrated terminal), then fall back to
         // app-level liveness for IDE-only hook sessions where there is no
@@ -581,6 +618,59 @@ final class ProcessMonitoringCoordinator {
         case matched(AgentSession)
         case ambiguous
         case rejectedConflict
+    }
+
+    /// Same matching strategy as OpenCode: unique TTY (+ optional CWD check),
+    /// then unique CWD. No blind single-session attach without a signal.
+    private func uniqueTrackedGrokSession(
+        for process: ActiveProcessSnapshot,
+        sessions: [AgentSession],
+        claimedSessionIDs: Set<String>
+    ) -> OpenCodeMatchResult {
+        let unclaimedSessions = sessions.filter { !claimedSessionIDs.contains($0.id) }
+        guard !unclaimedSessions.isEmpty else {
+            return .ambiguous
+        }
+
+        if let terminalTTY = normalizedTTYForMatching(process.terminalTTY) {
+            let candidates = unclaimedSessions.filter {
+                normalizedTTYForMatching($0.jumpTarget?.terminalTTY) == terminalTTY
+            }
+            if candidates.count == 1 {
+                let candidate = candidates[0]
+                if let processCWD = normalizedPathForMatching(process.workingDirectory),
+                   let sessionCWD = normalizedPathForMatching(candidate.jumpTarget?.workingDirectory),
+                   processCWD != sessionCWD {
+                    return .rejectedConflict
+                }
+                return .matched(candidate)
+            }
+            if !candidates.isEmpty {
+                if let processCWD = normalizedPathForMatching(process.workingDirectory) {
+                    let cwdCandidates = candidates.filter {
+                        normalizedPathForMatching($0.jumpTarget?.workingDirectory) == processCWD
+                    }
+                    if cwdCandidates.count == 1 {
+                        return .matched(cwdCandidates[0])
+                    }
+                }
+                return .ambiguous
+            }
+        }
+
+        if let processCWD = normalizedPathForMatching(process.workingDirectory) {
+            let workspaceMatches = unclaimedSessions.filter {
+                normalizedPathForMatching($0.jumpTarget?.workingDirectory) == processCWD
+            }
+            if workspaceMatches.count == 1 {
+                return .matched(workspaceMatches[0])
+            }
+            if !workspaceMatches.isEmpty {
+                return .ambiguous
+            }
+        }
+
+        return .ambiguous
     }
 
     private func uniqueTrackedOpenCodeSession(
@@ -1440,6 +1530,8 @@ final class ProcessMonitoringCoordinator {
             return "Cursor \(session.id.prefix(8))"
         case .kimiCLI:
             return "Kimi \(session.id.prefix(8))"
+        case .grokBuild:
+            return "Grok \(session.id.prefix(8))"
         }
     }
 }

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -425,6 +425,7 @@ struct SetupSettingsPane: View {
     @State private var confirmingUninstallCursor = false
     @State private var confirmingUninstallGemini = false
     @State private var confirmingUninstallKimi = false
+    @State private var confirmingUninstallGrok = false
     @State private var confirmingUninstallClaudeUsage = false
 
     private var lang: LanguageManager { model.lang }
@@ -609,6 +610,24 @@ struct SetupSettingsPane: View {
                 } message: {
                     Text("This will remove Open Island hooks from ~/.kimi/config.toml.")
                 }
+
+                hookRow(
+                    name: "Grok Build",
+                    installed: model.grokHooksInstalled,
+                    busy: model.isGrokHookSetupBusy,
+                    requiresBinary: true,
+                    configLocationURL: model.grokHookStatus?.hooksURL,
+                    installAction: { model.installGrokHooks() },
+                    uninstallAction: { confirmingUninstallGrok = true }
+                )
+                .alert(lang.t("settings.general.uninstallConfirmTitle"), isPresented: $confirmingUninstallGrok) {
+                    Button(lang.t("settings.general.uninstallConfirmAction"), role: .destructive) {
+                        model.uninstallGrokHooks()
+                    }
+                    Button(lang.t("settings.general.cancel"), role: .cancel) {}
+                } message: {
+                    Text("This will remove Open Island hooks from ~/.grok/hooks/open-island.json.")
+                }
             }
 
             Section {
@@ -686,6 +705,7 @@ struct SetupSettingsPane: View {
                     if !model.cursorHooksInstalled { model.installCursorHooks() }
                     if !model.geminiHooksInstalled { model.installGeminiHooks() }
                     if !model.kimiHooksInstalled { model.installKimiHooks() }
+                    if !model.grokHooksInstalled { model.installGrokHooks() }
                     if !model.claudeUsageInstalled { model.installClaudeUsageBridge() }
                 }
                 .disabled(model.hooksBinaryURL == nil || allReady)
@@ -747,7 +767,8 @@ struct SetupSettingsPane: View {
     private var allReady: Bool {
         model.claudeHooksInstalled && model.codexHooksInstalled && model.openCodePluginInstalled
             && model.qoderHooksInstalled && model.qwenCodeHooksInstalled && model.factoryHooksInstalled && model.codebuddyHooksInstalled
-            && model.cursorHooksInstalled && model.geminiHooksInstalled && model.kimiHooksInstalled && model.claudeUsageInstalled
+            && model.cursorHooksInstalled && model.geminiHooksInstalled && model.kimiHooksInstalled
+            && model.grokHooksInstalled && model.claudeUsageInstalled
     }
 
     @ViewBuilder

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -418,6 +418,7 @@ struct SetupSettingsPane: View {
     @State private var confirmingUninstallCursor = false
     @State private var confirmingUninstallGemini = false
     @State private var confirmingUninstallKimi = false
+    @State private var confirmingUninstallGrok = false
     @State private var confirmingUninstallClaudeUsage = false
 
     private var lang: LanguageManager { model.lang }
@@ -602,6 +603,24 @@ struct SetupSettingsPane: View {
                 } message: {
                     Text("This will remove Open Island hooks from ~/.kimi/config.toml.")
                 }
+
+                hookRow(
+                    name: "Grok Build",
+                    installed: model.grokHooksInstalled,
+                    busy: model.isGrokHookSetupBusy,
+                    requiresBinary: true,
+                    configLocationURL: model.grokHookStatus?.hooksURL,
+                    installAction: { model.installGrokHooks() },
+                    uninstallAction: { confirmingUninstallGrok = true }
+                )
+                .alert(lang.t("settings.general.uninstallConfirmTitle"), isPresented: $confirmingUninstallGrok) {
+                    Button(lang.t("settings.general.uninstallConfirmAction"), role: .destructive) {
+                        model.uninstallGrokHooks()
+                    }
+                    Button(lang.t("settings.general.cancel"), role: .cancel) {}
+                } message: {
+                    Text("This will remove Open Island hooks from ~/.grok/hooks/open-island.json.")
+                }
             }
 
             Section {
@@ -679,6 +698,7 @@ struct SetupSettingsPane: View {
                     if !model.cursorHooksInstalled { model.installCursorHooks() }
                     if !model.geminiHooksInstalled { model.installGeminiHooks() }
                     if !model.kimiHooksInstalled { model.installKimiHooks() }
+                    if !model.grokHooksInstalled { model.installGrokHooks() }
                     if !model.claudeUsageInstalled { model.installClaudeUsageBridge() }
                 }
                 .disabled(model.hooksBinaryURL == nil || allReady)
@@ -740,7 +760,8 @@ struct SetupSettingsPane: View {
     private var allReady: Bool {
         model.claudeHooksInstalled && model.codexHooksInstalled && model.openCodePluginInstalled
             && model.qoderHooksInstalled && model.qwenCodeHooksInstalled && model.factoryHooksInstalled && model.codebuddyHooksInstalled
-            && model.cursorHooksInstalled && model.geminiHooksInstalled && model.kimiHooksInstalled && model.claudeUsageInstalled
+            && model.cursorHooksInstalled && model.geminiHooksInstalled && model.kimiHooksInstalled
+            && model.grokHooksInstalled && model.claudeUsageInstalled
     }
 
     @ViewBuilder

--- a/Sources/OpenIslandCore/AgentHookIntent.swift
+++ b/Sources/OpenIslandCore/AgentHookIntent.swift
@@ -27,5 +27,6 @@ public enum AgentIdentifier: String, Codable, Sendable, CaseIterable {
     case openCode
     case gemini
     case kimi
+    case grok
     case claudeUsageBridge
 }

--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -11,6 +11,7 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
     case codebuddy
     case cursor
     case kimiCLI
+    case grokBuild
 
     public var displayName: String {
         switch self {
@@ -34,6 +35,8 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
             "Cursor"
         case .kimiCLI:
             "Kimi CLI"
+        case .grokBuild:
+            "Grok"
         }
     }
 
@@ -59,6 +62,8 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
             "CURSOR"
         case .kimiCLI:
             "KIMI"
+        case .grokBuild:
+            "GROK"
         }
     }
 
@@ -87,6 +92,7 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
         case .factory:    "#6e9fff"
         case .codebuddy:  "#fca5a5"
         case .kimiCLI:    "#fde047"
+        case .grokBuild:  "#22d3ee"
         }
     }
 }
@@ -508,7 +514,7 @@ public extension AgentSession {
     }
 
     var isTrackedLiveSession: Bool {
-        !isDemoSession && (tool == .codex || tool == .claudeCode || tool == .geminiCLI || tool == .openCode || tool == .qoder || tool == .qwenCode || tool == .factory || tool == .codebuddy || tool == .cursor || tool == .kimiCLI)
+        !isDemoSession && (tool == .codex || tool == .claudeCode || tool == .geminiCLI || tool == .openCode || tool == .qoder || tool == .qwenCode || tool == .factory || tool == .codebuddy || tool == .cursor || tool == .kimiCLI || tool == .grokBuild)
     }
 
     var isTrackedLiveCodexSession: Bool {

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -1458,8 +1458,10 @@ public final class BridgeServer: @unchecked Sendable {
         case .stopCancelled:
             // Fires *instead of* Stop when a turn ends without completing
             // (user interrupt, declined permission, --max-turns, no-progress
-            // bail-out). Settle the turn like a genuine Stop but flag it as an
-            // interrupt so the island does not surface it as actionable.
+            // bail-out). Settle the turn like a genuine Stop. A cancellation
+            // the user caused is flagged as an interrupt so the island does
+            // not pop for something they just did; a runtime bail-out
+            // (`cancelledBy == "runtime"`, e.g. max turns) is worth surfacing.
             ensureGrokSessionExists(for: payload)
             synchronizeGrokJumpTarget(for: payload)
             emit(
@@ -1468,7 +1470,7 @@ public final class BridgeServer: @unchecked Sendable {
                         sessionID: payload.sessionID,
                         summary: payload.implicitSummary,
                         timestamp: .now,
-                        isInterrupt: true
+                        isInterrupt: payload.isUserInitiatedCancellation
                     )
                 )
             )

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -1370,7 +1370,7 @@ public final class BridgeServer: @unchecked Sendable {
             // Fire-and-forget: Grok fails open without a decision on stdout.
             send(.response(.acknowledged), to: clientID)
 
-        case .postToolUse, .subagentStart, .subagentStop, .preCompact, .postCompact, .notification:
+        case .postToolUse, .subagentStart, .subagentStop, .preCompact, .postCompact:
             ensureGrokSessionExists(for: payload)
             synchronizeGrokJumpTarget(for: payload)
             let currentPhase = localState.session(id: payload.sessionID)?.phase ?? .running
@@ -1384,6 +1384,39 @@ public final class BridgeServer: @unchecked Sendable {
                     )
                 )
             )
+            send(.response(.acknowledged), to: clientID)
+
+        case .notification:
+            ensureGrokSessionExists(for: payload)
+            synchronizeGrokJumpTarget(for: payload)
+            let currentPhase = localState.session(id: payload.sessionID)?.phase ?? .running
+            if payload.isIdlePromptNotification {
+                // `idle_prompt` is Grok's backstop for turns that reported none
+                // of the Stop-family events: settle a still-running session.
+                // Once already completed, leave the Stop summary untouched.
+                if currentPhase != .completed {
+                    emit(
+                        .sessionCompleted(
+                            SessionCompleted(
+                                sessionID: payload.sessionID,
+                                summary: payload.implicitSummary,
+                                timestamp: .now
+                            )
+                        )
+                    )
+                }
+            } else {
+                emit(
+                    .activityUpdated(
+                        SessionActivityUpdated(
+                            sessionID: payload.sessionID,
+                            summary: payload.implicitSummary,
+                            phase: currentPhase == .completed ? .completed : .running,
+                            timestamp: .now
+                        )
+                    )
+                )
+            }
             send(.response(.acknowledged), to: clientID)
 
         case .permissionDenied, .postToolUseFailure, .stopFailure:

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -477,6 +477,9 @@ public final class BridgeServer: @unchecked Sendable {
 
         case let .processGeminiHook(payload):
             handleGeminiHook(payload, from: clientID)
+
+        case let .processGrokHook(payload):
+            handleGrokHook(payload, from: clientID)
         }
     }
 
@@ -1307,6 +1310,183 @@ public final class BridgeServer: @unchecked Sendable {
             )
             send(.response(.acknowledged), to: clientID)
         }
+    }
+
+    private func handleGrokHook(_ payload: GrokHookPayload, from clientID: UUID) {
+        // SessionStart always re-opens; every other event ignores ended sessions
+        // so late hooks cannot rewrite phase/summary after SessionEnd.
+        if payload.hookEventName != .sessionStart,
+           localState.session(id: payload.sessionID)?.isSessionEnded == true {
+            send(.response(.acknowledged), to: clientID)
+            return
+        }
+
+        switch payload.hookEventName {
+        case .sessionStart:
+            emit(
+                .sessionStarted(
+                    SessionStarted(
+                        sessionID: payload.sessionID,
+                        title: payload.sessionTitle,
+                        tool: .grokBuild,
+                        origin: .live,
+                        initialPhase: .completed,
+                        summary: payload.implicitSummary,
+                        timestamp: .now,
+                        jumpTarget: payload.defaultJumpTarget
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .userPromptSubmit:
+            ensureGrokSessionExists(for: payload)
+            synchronizeGrokJumpTarget(for: payload)
+            emit(
+                .activityUpdated(
+                    SessionActivityUpdated(
+                        sessionID: payload.sessionID,
+                        summary: payload.implicitSummary,
+                        phase: .running,
+                        timestamp: .now
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .preToolUse:
+            ensureGrokSessionExists(for: payload)
+            synchronizeGrokJumpTarget(for: payload)
+            emit(
+                .activityUpdated(
+                    SessionActivityUpdated(
+                        sessionID: payload.sessionID,
+                        summary: payload.implicitSummary,
+                        phase: .running,
+                        timestamp: .now
+                    )
+                )
+            )
+            // Fire-and-forget: Grok fails open without a decision on stdout.
+            send(.response(.acknowledged), to: clientID)
+
+        case .postToolUse, .subagentStart, .subagentStop, .preCompact, .postCompact, .notification, .permissionDenied:
+            ensureGrokSessionExists(for: payload)
+            synchronizeGrokJumpTarget(for: payload)
+            let currentPhase = localState.session(id: payload.sessionID)?.phase ?? .running
+            emit(
+                .activityUpdated(
+                    SessionActivityUpdated(
+                        sessionID: payload.sessionID,
+                        summary: payload.implicitSummary,
+                        phase: currentPhase == .completed ? .completed : .running,
+                        timestamp: .now
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .postToolUseFailure, .stopFailure:
+            ensureGrokSessionExists(for: payload)
+            synchronizeGrokJumpTarget(for: payload)
+            emit(
+                .activityUpdated(
+                    SessionActivityUpdated(
+                        sessionID: payload.sessionID,
+                        summary: payload.implicitSummary,
+                        phase: .completed,
+                        timestamp: .now
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .stop:
+            ensureGrokSessionExists(for: payload)
+            synchronizeGrokJumpTarget(for: payload)
+            // Ignore observe-only session-end Stop fires (reason != end_turn).
+            if payload.isGenuineTurnStop {
+                emit(
+                    .sessionCompleted(
+                        SessionCompleted(
+                            sessionID: payload.sessionID,
+                            summary: payload.implicitSummary,
+                            timestamp: .now
+                        )
+                    )
+                )
+            }
+            send(.response(.acknowledged), to: clientID)
+
+        case .sessionEnd:
+            ensureGrokSessionExists(for: payload)
+            synchronizeGrokJumpTarget(for: payload)
+            emit(
+                .sessionCompleted(
+                    SessionCompleted(
+                        sessionID: payload.sessionID,
+                        summary: payload.implicitSummary,
+                        timestamp: .now,
+                        isInterrupt: true,
+                        isSessionEnd: true
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+        }
+    }
+
+    /// Ensures a Grok session row exists for non-`SessionStart` events.
+    ///
+    /// Policy: if a session with this ID already exists — including after
+    /// `SessionEnd` — do **not** recreate it from tool/prompt/stop events.
+    /// Only `SessionStart` (which always emits `sessionStarted`) may re-open
+    /// an ended session. This prevents late hooks or process-liveness churn
+    /// from resurrecting terminated sessions.
+    private func ensureGrokSessionExists(for payload: GrokHookPayload) {
+        if localState.session(id: payload.sessionID) != nil {
+            return
+        }
+
+        emit(
+            .sessionStarted(
+                SessionStarted(
+                    sessionID: payload.sessionID,
+                    title: payload.sessionTitle,
+                    tool: .grokBuild,
+                    origin: .live,
+                    initialPhase: .completed,
+                    summary: payload.implicitSummary,
+                    timestamp: .now,
+                    jumpTarget: payload.defaultJumpTarget
+                )
+            )
+        )
+    }
+
+    private func synchronizeGrokJumpTarget(for payload: GrokHookPayload) {
+        guard let existingSession = localState.session(id: payload.sessionID) else {
+            return
+        }
+
+        let jumpTarget = Self.mergeJumpTargetPreservingExistingResolvedFields(
+            incoming: payload.defaultJumpTarget,
+            existing: existingSession.jumpTarget
+        )
+
+        guard existingSession.jumpTarget != jumpTarget else {
+            return
+        }
+
+        emit(
+            .jumpTargetUpdated(
+                JumpTargetUpdated(
+                    sessionID: payload.sessionID,
+                    jumpTarget: jumpTarget,
+                    timestamp: .now
+                )
+            )
+        )
     }
 
     private func handleGeminiHook(_ payload: GeminiHookPayload, from clientID: UUID) {
@@ -2299,6 +2479,11 @@ public final class BridgeServer: @unchecked Sendable {
                 taskCreationCount: pendingTaskCreations.count
             )
         }
+    }
+
+    /// Test-only accessor for the bridge's local session state after hook events.
+    func sessionStateSnapshotForTests() -> SessionState {
+        queue.sync { localState }
     }
 
     /// Clears all active subagents from the session.

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -1418,6 +1418,25 @@ public final class BridgeServer: @unchecked Sendable {
             }
             send(.response(.acknowledged), to: clientID)
 
+        case .stopCancelled:
+            // Fires *instead of* Stop when a turn ends without completing
+            // (user interrupt, declined permission, --max-turns, no-progress
+            // bail-out). Settle the turn like a genuine Stop but flag it as an
+            // interrupt so the island does not surface it as actionable.
+            ensureGrokSessionExists(for: payload)
+            synchronizeGrokJumpTarget(for: payload)
+            emit(
+                .sessionCompleted(
+                    SessionCompleted(
+                        sessionID: payload.sessionID,
+                        summary: payload.implicitSummary,
+                        timestamp: .now,
+                        isInterrupt: true
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
         case .sessionEnd:
             ensureGrokSessionExists(for: payload)
             synchronizeGrokJumpTarget(for: payload)

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -2482,8 +2482,13 @@ public final class BridgeServer: @unchecked Sendable {
     }
 
     /// Test-only accessor for the bridge's local session state after hook events.
+    /// Reuses the `queueKey` guard from `stop()` so a caller already on the
+    /// bridge queue reads directly instead of deadlocking in `queue.sync`.
     func sessionStateSnapshotForTests() -> SessionState {
-        queue.sync { localState }
+        if DispatchQueue.getSpecific(key: queueKey) != nil {
+            return localState
+        }
+        return queue.sync { localState }
     }
 
     /// Clears all active subagents from the session.

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -1370,7 +1370,7 @@ public final class BridgeServer: @unchecked Sendable {
             // Fire-and-forget: Grok fails open without a decision on stdout.
             send(.response(.acknowledged), to: clientID)
 
-        case .postToolUse, .subagentStart, .subagentStop, .preCompact, .postCompact, .notification, .permissionDenied:
+        case .postToolUse, .subagentStart, .subagentStop, .preCompact, .postCompact, .notification:
             ensureGrokSessionExists(for: payload)
             synchronizeGrokJumpTarget(for: payload)
             let currentPhase = localState.session(id: payload.sessionID)?.phase ?? .running
@@ -1386,7 +1386,7 @@ public final class BridgeServer: @unchecked Sendable {
             )
             send(.response(.acknowledged), to: clientID)
 
-        case .postToolUseFailure, .stopFailure:
+        case .permissionDenied, .postToolUseFailure, .stopFailure:
             ensureGrokSessionExists(for: payload)
             synchronizeGrokJumpTarget(for: payload)
             emit(

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -1370,7 +1370,11 @@ public final class BridgeServer: @unchecked Sendable {
             // Fire-and-forget: Grok fails open without a decision on stdout.
             send(.response(.acknowledged), to: clientID)
 
-        case .postToolUse, .subagentStart, .subagentStop, .preCompact, .postCompact:
+        // PermissionDenied fires for both a user Reject (a StopCancelled with
+        // permission_rejected follows) and a configured PolicyDeny rule (the
+        // model is told the tool was skipped and keeps working), so it must
+        // not settle the turn on its own.
+        case .postToolUse, .subagentStart, .subagentStop, .preCompact, .postCompact, .permissionDenied:
             ensureGrokSessionExists(for: payload)
             synchronizeGrokJumpTarget(for: payload)
             let currentPhase = localState.session(id: payload.sessionID)?.phase ?? .running
@@ -1419,7 +1423,7 @@ public final class BridgeServer: @unchecked Sendable {
             }
             send(.response(.acknowledged), to: clientID)
 
-        case .permissionDenied, .postToolUseFailure, .stopFailure:
+        case .postToolUseFailure, .stopFailure:
             ensureGrokSessionExists(for: payload)
             synchronizeGrokJumpTarget(for: payload)
             emit(

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -1359,7 +1359,7 @@ public final class BridgeServer: @unchecked Sendable {
             // Fire-and-forget: Grok fails open without a decision on stdout.
             send(.response(.acknowledged), to: clientID)
 
-        case .postToolUse, .subagentStart, .subagentStop, .preCompact, .postCompact, .notification, .permissionDenied:
+        case .postToolUse, .subagentStart, .subagentStop, .preCompact, .postCompact, .notification:
             ensureGrokSessionExists(for: payload)
             synchronizeGrokJumpTarget(for: payload)
             let currentPhase = localState.session(id: payload.sessionID)?.phase ?? .running
@@ -1375,7 +1375,7 @@ public final class BridgeServer: @unchecked Sendable {
             )
             send(.response(.acknowledged), to: clientID)
 
-        case .postToolUseFailure, .stopFailure:
+        case .permissionDenied, .postToolUseFailure, .stopFailure:
             ensureGrokSessionExists(for: payload)
             synchronizeGrokJumpTarget(for: payload)
             emit(

--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -468,6 +468,9 @@ public final class BridgeServer: @unchecked Sendable {
 
         case let .processGeminiHook(payload):
             handleGeminiHook(payload, from: clientID)
+
+        case let .processGrokHook(payload):
+            handleGrokHook(payload, from: clientID)
         }
     }
 
@@ -1296,6 +1299,183 @@ public final class BridgeServer: @unchecked Sendable {
             )
             send(.response(.acknowledged), to: clientID)
         }
+    }
+
+    private func handleGrokHook(_ payload: GrokHookPayload, from clientID: UUID) {
+        // SessionStart always re-opens; every other event ignores ended sessions
+        // so late hooks cannot rewrite phase/summary after SessionEnd.
+        if payload.hookEventName != .sessionStart,
+           localState.session(id: payload.sessionID)?.isSessionEnded == true {
+            send(.response(.acknowledged), to: clientID)
+            return
+        }
+
+        switch payload.hookEventName {
+        case .sessionStart:
+            emit(
+                .sessionStarted(
+                    SessionStarted(
+                        sessionID: payload.sessionID,
+                        title: payload.sessionTitle,
+                        tool: .grokBuild,
+                        origin: .live,
+                        initialPhase: .completed,
+                        summary: payload.implicitSummary,
+                        timestamp: .now,
+                        jumpTarget: payload.defaultJumpTarget
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .userPromptSubmit:
+            ensureGrokSessionExists(for: payload)
+            synchronizeGrokJumpTarget(for: payload)
+            emit(
+                .activityUpdated(
+                    SessionActivityUpdated(
+                        sessionID: payload.sessionID,
+                        summary: payload.implicitSummary,
+                        phase: .running,
+                        timestamp: .now
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .preToolUse:
+            ensureGrokSessionExists(for: payload)
+            synchronizeGrokJumpTarget(for: payload)
+            emit(
+                .activityUpdated(
+                    SessionActivityUpdated(
+                        sessionID: payload.sessionID,
+                        summary: payload.implicitSummary,
+                        phase: .running,
+                        timestamp: .now
+                    )
+                )
+            )
+            // Fire-and-forget: Grok fails open without a decision on stdout.
+            send(.response(.acknowledged), to: clientID)
+
+        case .postToolUse, .subagentStart, .subagentStop, .preCompact, .postCompact, .notification, .permissionDenied:
+            ensureGrokSessionExists(for: payload)
+            synchronizeGrokJumpTarget(for: payload)
+            let currentPhase = localState.session(id: payload.sessionID)?.phase ?? .running
+            emit(
+                .activityUpdated(
+                    SessionActivityUpdated(
+                        sessionID: payload.sessionID,
+                        summary: payload.implicitSummary,
+                        phase: currentPhase == .completed ? .completed : .running,
+                        timestamp: .now
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .postToolUseFailure, .stopFailure:
+            ensureGrokSessionExists(for: payload)
+            synchronizeGrokJumpTarget(for: payload)
+            emit(
+                .activityUpdated(
+                    SessionActivityUpdated(
+                        sessionID: payload.sessionID,
+                        summary: payload.implicitSummary,
+                        phase: .completed,
+                        timestamp: .now
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+
+        case .stop:
+            ensureGrokSessionExists(for: payload)
+            synchronizeGrokJumpTarget(for: payload)
+            // Ignore observe-only session-end Stop fires (reason != end_turn).
+            if payload.isGenuineTurnStop {
+                emit(
+                    .sessionCompleted(
+                        SessionCompleted(
+                            sessionID: payload.sessionID,
+                            summary: payload.implicitSummary,
+                            timestamp: .now
+                        )
+                    )
+                )
+            }
+            send(.response(.acknowledged), to: clientID)
+
+        case .sessionEnd:
+            ensureGrokSessionExists(for: payload)
+            synchronizeGrokJumpTarget(for: payload)
+            emit(
+                .sessionCompleted(
+                    SessionCompleted(
+                        sessionID: payload.sessionID,
+                        summary: payload.implicitSummary,
+                        timestamp: .now,
+                        isInterrupt: true,
+                        isSessionEnd: true
+                    )
+                )
+            )
+            send(.response(.acknowledged), to: clientID)
+        }
+    }
+
+    /// Ensures a Grok session row exists for non-`SessionStart` events.
+    ///
+    /// Policy: if a session with this ID already exists — including after
+    /// `SessionEnd` — do **not** recreate it from tool/prompt/stop events.
+    /// Only `SessionStart` (which always emits `sessionStarted`) may re-open
+    /// an ended session. This prevents late hooks or process-liveness churn
+    /// from resurrecting terminated sessions.
+    private func ensureGrokSessionExists(for payload: GrokHookPayload) {
+        if localState.session(id: payload.sessionID) != nil {
+            return
+        }
+
+        emit(
+            .sessionStarted(
+                SessionStarted(
+                    sessionID: payload.sessionID,
+                    title: payload.sessionTitle,
+                    tool: .grokBuild,
+                    origin: .live,
+                    initialPhase: .completed,
+                    summary: payload.implicitSummary,
+                    timestamp: .now,
+                    jumpTarget: payload.defaultJumpTarget
+                )
+            )
+        )
+    }
+
+    private func synchronizeGrokJumpTarget(for payload: GrokHookPayload) {
+        guard let existingSession = localState.session(id: payload.sessionID) else {
+            return
+        }
+
+        let jumpTarget = Self.mergeJumpTargetPreservingExistingResolvedFields(
+            incoming: payload.defaultJumpTarget,
+            existing: existingSession.jumpTarget
+        )
+
+        guard existingSession.jumpTarget != jumpTarget else {
+            return
+        }
+
+        emit(
+            .jumpTargetUpdated(
+                JumpTargetUpdated(
+                    sessionID: payload.sessionID,
+                    jumpTarget: jumpTarget,
+                    timestamp: .now
+                )
+            )
+        )
     }
 
     private func handleGeminiHook(_ payload: GeminiHookPayload, from clientID: UUID) {
@@ -2199,6 +2379,11 @@ public final class BridgeServer: @unchecked Sendable {
                 taskCreationCount: pendingTaskCreations.count
             )
         }
+    }
+
+    /// Test-only accessor for the bridge's local session state after hook events.
+    func sessionStateSnapshotForTests() -> SessionState {
+        queue.sync { localState }
     }
 
     /// Clears all active subagents from the session.

--- a/Sources/OpenIslandCore/BridgeTransport.swift
+++ b/Sources/OpenIslandCore/BridgeTransport.swift
@@ -89,6 +89,7 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
     case processOpenCodeHook(OpenCodeHookPayload)
     case processCursorHook(CursorHookPayload)
     case processGeminiHook(GeminiHookPayload)
+    case processGrokHook(GrokHookPayload)
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -102,6 +103,7 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
         case openCodeHook
         case cursorHook
         case geminiHook
+        case grokHook
     }
 
     private enum CommandType: String, Codable {
@@ -114,6 +116,7 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
         case processOpenCodeHook
         case processCursorHook
         case processGeminiHook
+        case processGrokHook
     }
 
     public init(from decoder: any Decoder) throws {
@@ -148,6 +151,8 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
             self = .processCursorHook(try container.decode(CursorHookPayload.self, forKey: .cursorHook))
         case .processGeminiHook:
             self = .processGeminiHook(try container.decode(GeminiHookPayload.self, forKey: .geminiHook))
+        case .processGrokHook:
+            self = .processGrokHook(try container.decode(GrokHookPayload.self, forKey: .grokHook))
         }
     }
 
@@ -185,6 +190,9 @@ public enum BridgeCommand: Equatable, Codable, Sendable {
         case let .processGeminiHook(payload):
             try container.encode(CommandType.processGeminiHook, forKey: .type)
             try container.encode(payload, forKey: .geminiHook)
+        case let .processGrokHook(payload):
+            try container.encode(CommandType.processGrokHook, forKey: .type)
+            try container.encode(payload, forKey: .grokHook)
         }
     }
 }

--- a/Sources/OpenIslandCore/GrokHookInstallationManager.swift
+++ b/Sources/OpenIslandCore/GrokHookInstallationManager.swift
@@ -58,7 +58,8 @@ public final class GrokHookInstallationManager: @unchecked Sendable {
     public func status(hooksBinaryURL: URL? = nil) throws -> GrokHookInstallationStatus {
         let resolvedBinaryURL = resolvedHooksBinaryURL(explicitURL: hooksBinaryURL)
         let hooksData = try? Data(contentsOf: hooksURL)
-        let manifest = try loadManifest(at: manifestURL)
+        // Corrupt/partial manifests must not block status reads — treat as absent.
+        let manifest = loadManifest(at: manifestURL)
         let managedCommand = manifest?.hookCommand
             ?? resolvedBinaryURL.map { GrokHookInstaller.hookCommand(for: $0.path) }
 
@@ -101,14 +102,10 @@ public final class GrokHookInstallationManager: @unchecked Sendable {
             }
         }
 
-        let previousManifest = try loadManifest(at: manifestURL)
+        // Rewrite manifest whenever the command changes or the previous
+        // file was missing/corrupt (loadManifest returns nil in both cases).
+        let previousManifest = loadManifest(at: manifestURL)
         if previousManifest?.hookCommand != command {
-            let manifest = GrokHookInstallerManifest(hookCommand: command)
-            let encoder = JSONEncoder()
-            encoder.dateEncodingStrategy = .iso8601
-            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-            try encoder.encode(manifest).write(to: manifestURL, options: .atomic)
-        } else if !fileManager.fileExists(atPath: manifestURL.path) {
             let manifest = GrokHookInstallerManifest(hookCommand: command)
             let encoder = JSONEncoder()
             encoder.dateEncodingStrategy = .iso8601
@@ -137,12 +134,16 @@ public final class GrokHookInstallationManager: @unchecked Sendable {
         return try status()
     }
 
-    private func loadManifest(at url: URL) throws -> GrokHookInstallerManifest? {
-        guard fileManager.fileExists(atPath: url.path) else { return nil }
-        let data = try Data(contentsOf: url)
+    /// Returns nil when the file is missing or unreadable/corrupt so status
+    /// and reinstall can still proceed.
+    private func loadManifest(at url: URL) -> GrokHookInstallerManifest? {
+        guard fileManager.fileExists(atPath: url.path),
+              let data = try? Data(contentsOf: url) else {
+            return nil
+        }
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        return try decoder.decode(GrokHookInstallerManifest.self, from: data)
+        return try? decoder.decode(GrokHookInstallerManifest.self, from: data)
     }
 
     private func resolvedHooksBinaryURL(explicitURL: URL?) -> URL? {

--- a/Sources/OpenIslandCore/GrokHookInstallationManager.swift
+++ b/Sources/OpenIslandCore/GrokHookInstallationManager.swift
@@ -1,0 +1,172 @@
+import Foundation
+
+public struct GrokHookInstallationStatus: Equatable, Sendable {
+    public var grokDirectory: URL
+    public var hooksDirectory: URL
+    public var hooksURL: URL
+    public var manifestURL: URL
+    public var hooksBinaryURL: URL?
+    public var managedHooksPresent: Bool
+    public var manifest: GrokHookInstallerManifest?
+
+    public init(
+        grokDirectory: URL,
+        hooksDirectory: URL,
+        hooksURL: URL,
+        manifestURL: URL,
+        hooksBinaryURL: URL?,
+        managedHooksPresent: Bool,
+        manifest: GrokHookInstallerManifest?
+    ) {
+        self.grokDirectory = grokDirectory
+        self.hooksDirectory = hooksDirectory
+        self.hooksURL = hooksURL
+        self.manifestURL = manifestURL
+        self.hooksBinaryURL = hooksBinaryURL
+        self.managedHooksPresent = managedHooksPresent
+        self.manifest = manifest
+    }
+}
+
+public final class GrokHookInstallationManager: @unchecked Sendable {
+    public let grokDirectory: URL
+    public let managedHooksBinaryURL: URL
+    private let fileManager: FileManager
+
+    public init(
+        grokDirectory: URL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".grok", isDirectory: true),
+        managedHooksBinaryURL: URL = ManagedHooksBinary.defaultURL(),
+        fileManager: FileManager = .default
+    ) {
+        self.grokDirectory = grokDirectory
+        self.managedHooksBinaryURL = managedHooksBinaryURL.standardizedFileURL
+        self.fileManager = fileManager
+    }
+
+    public var hooksDirectory: URL {
+        grokDirectory.appendingPathComponent("hooks", isDirectory: true)
+    }
+
+    public var hooksURL: URL {
+        hooksDirectory.appendingPathComponent(GrokHookInstaller.managedHooksFileName)
+    }
+
+    public var manifestURL: URL {
+        grokDirectory.appendingPathComponent(GrokHookInstallerManifest.fileName)
+    }
+
+    public func status(hooksBinaryURL: URL? = nil) throws -> GrokHookInstallationStatus {
+        let resolvedBinaryURL = resolvedHooksBinaryURL(explicitURL: hooksBinaryURL)
+        let hooksData = try? Data(contentsOf: hooksURL)
+        let manifest = try loadManifest(at: manifestURL)
+        let managedCommand = manifest?.hookCommand
+            ?? resolvedBinaryURL.map { GrokHookInstaller.hookCommand(for: $0.path) }
+
+        return GrokHookInstallationStatus(
+            grokDirectory: grokDirectory,
+            hooksDirectory: hooksDirectory,
+            hooksURL: hooksURL,
+            manifestURL: manifestURL,
+            hooksBinaryURL: resolvedBinaryURL,
+            managedHooksPresent: GrokHookInstaller.managedHooksPresent(
+                in: hooksData,
+                managedCommand: managedCommand
+            ),
+            manifest: manifest
+        )
+    }
+
+    @discardableResult
+    public func install(hooksBinaryURL: URL) throws -> GrokHookInstallationStatus {
+        try fileManager.createDirectory(at: hooksDirectory, withIntermediateDirectories: true)
+
+        let installedBinaryURL = try ManagedHooksBinary.install(
+            from: hooksBinaryURL,
+            to: managedHooksBinaryURL,
+            fileManager: fileManager
+        )
+        let command = GrokHookInstaller.hookCommand(for: installedBinaryURL.path)
+        let existingData = try? Data(contentsOf: hooksURL)
+        let mutation = try GrokHookInstaller.installHooksJSON(
+            existingData: existingData,
+            hookCommand: command
+        )
+
+        if mutation.changed {
+            if fileManager.fileExists(atPath: hooksURL.path) {
+                try backupFile(at: hooksURL)
+            }
+            if let contents = mutation.contents {
+                try contents.write(to: hooksURL, options: .atomic)
+            }
+        }
+
+        let previousManifest = try loadManifest(at: manifestURL)
+        if previousManifest?.hookCommand != command {
+            let manifest = GrokHookInstallerManifest(hookCommand: command)
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            try encoder.encode(manifest).write(to: manifestURL, options: .atomic)
+        } else if !fileManager.fileExists(atPath: manifestURL.path) {
+            let manifest = GrokHookInstallerManifest(hookCommand: command)
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            try encoder.encode(manifest).write(to: manifestURL, options: .atomic)
+        }
+
+        return try status(hooksBinaryURL: installedBinaryURL)
+    }
+
+    @discardableResult
+    public func uninstall() throws -> GrokHookInstallationStatus {
+        if fileManager.fileExists(atPath: hooksURL.path) {
+            let existingData = try? Data(contentsOf: hooksURL)
+            guard GrokHookInstaller.isOpenIslandOwnedManagedFile(existingData) else {
+                throw GrokHookInstallerError.managedFileNotOwnedByOpenIsland
+            }
+            try backupFile(at: hooksURL)
+            try fileManager.removeItem(at: hooksURL)
+        }
+
+        if fileManager.fileExists(atPath: manifestURL.path) {
+            try fileManager.removeItem(at: manifestURL)
+        }
+
+        return try status()
+    }
+
+    private func loadManifest(at url: URL) throws -> GrokHookInstallerManifest? {
+        guard fileManager.fileExists(atPath: url.path) else { return nil }
+        let data = try Data(contentsOf: url)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(GrokHookInstallerManifest.self, from: data)
+    }
+
+    private func resolvedHooksBinaryURL(explicitURL: URL?) -> URL? {
+        if let explicitURL {
+            return explicitURL.standardizedFileURL
+        }
+
+        guard fileManager.isExecutableFile(atPath: managedHooksBinaryURL.path) else {
+            return nil
+        }
+
+        return managedHooksBinaryURL
+    }
+
+    private func backupFile(at url: URL) throws {
+        guard fileManager.fileExists(atPath: url.path) else { return }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let timestamp = formatter.string(from: .now).replacingOccurrences(of: ":", with: "-")
+        let backupURL = url.appendingPathExtension("backup.\(timestamp)")
+        if fileManager.fileExists(atPath: backupURL.path) {
+            try fileManager.removeItem(at: backupURL)
+        }
+        try fileManager.copyItem(at: url, to: backupURL)
+    }
+}

--- a/Sources/OpenIslandCore/GrokHookInstaller.swift
+++ b/Sources/OpenIslandCore/GrokHookInstaller.swift
@@ -1,0 +1,219 @@
+import Foundation
+
+public struct GrokHookInstallerManifest: Equatable, Codable, Sendable {
+    public static let fileName = "open-island-grok-hooks-install.json"
+
+    public var hookCommand: String
+    public var installedAt: Date
+
+    public init(hookCommand: String, installedAt: Date = .now) {
+        self.hookCommand = hookCommand
+        self.installedAt = installedAt
+    }
+}
+
+public struct GrokHookFileMutation: Equatable, Sendable {
+    public var contents: Data?
+    public var changed: Bool
+    public var managedHooksPresent: Bool
+
+    public init(contents: Data?, changed: Bool, managedHooksPresent: Bool) {
+        self.contents = contents
+        self.changed = changed
+        self.managedHooksPresent = managedHooksPresent
+    }
+}
+
+public enum GrokHookInstallerError: Error, LocalizedError, Equatable {
+    case managedFileNotOwnedByOpenIsland
+
+    public var errorDescription: String? {
+        switch self {
+        case .managedFileNotOwnedByOpenIsland:
+            "Refusing to uninstall \(GrokHookInstaller.managedHooksFileName): the file is not an Open Island managed Grok hooks file."
+        }
+    }
+}
+
+/// Installs Open Island's managed Grok Build hooks as a dedicated file under
+/// `~/.grok/hooks/open-island.json`.
+///
+/// Grok discovers every `*.json` in `~/.grok/hooks/`, so writing a dedicated
+/// managed file (matching the commercial Vibe Island layout) avoids mutating
+/// user-authored hooks and makes uninstall a simple delete of *our* file only.
+public enum GrokHookInstaller {
+    public static let managedHooksFileName = "open-island.json"
+    public static let managedTimeout = 45
+
+    /// Full managed event set claimed by the product (must stay in sync with
+    /// `GrokHookEventName` / `BridgeServer.handleGrokHook` / docs).
+    ///
+    /// Lifecycle-focused install. PreToolUse is observation-only (fail-open
+    /// without a deny decision on stdout), so a 45s timeout does not block the
+    /// agent when the bridge is unhealthy.
+    public static let requiredEventSpecs: [(name: String, matcher: String?, timeout: Int?)] = [
+        ("SessionStart", nil, managedTimeout),
+        ("SessionEnd", nil, managedTimeout),
+        ("UserPromptSubmit", nil, managedTimeout),
+        ("Stop", nil, managedTimeout),
+        ("StopFailure", nil, managedTimeout),
+        ("Notification", "*", managedTimeout),
+        ("PreToolUse", "*", managedTimeout),
+        ("PostToolUse", "*", managedTimeout),
+        ("PostToolUseFailure", "*", managedTimeout),
+        ("SubagentStart", nil, managedTimeout),
+        ("SubagentStop", nil, managedTimeout),
+        ("PermissionDenied", nil, managedTimeout),
+        ("PreCompact", nil, managedTimeout),
+        ("PostCompact", nil, managedTimeout),
+    ]
+
+    public static var requiredEventNames: [String] {
+        requiredEventSpecs.map(\.name)
+    }
+
+    public static func hookCommand(for binaryPath: String) -> String {
+        "\(shellQuote(binaryPath)) --source grok"
+    }
+
+    public static func installHooksJSON(
+        existingData: Data? = nil,
+        hookCommand: String
+    ) throws -> GrokHookFileMutation {
+        var hooksObject: [String: Any] = [:]
+
+        for spec in requiredEventSpecs {
+            hooksObject[spec.name] = [
+                managedGroup(matcher: spec.matcher, timeout: spec.timeout, hookCommand: hookCommand),
+            ]
+        }
+
+        let rootObject: [String: Any] = ["hooks": hooksObject]
+        let data = try serialize(rootObject)
+        let changed = data != existingData
+
+        return GrokHookFileMutation(
+            contents: data,
+            changed: changed,
+            managedHooksPresent: true
+        )
+    }
+
+    /// Managed integration is present only when **every** required event is
+    /// registered with an Open Island Grok command hook.
+    ///
+    /// Commercial Vibe Island commands (`vibe-island-bridge --source grok`) do
+    /// **not** count as Open Island installed.
+    public static func managedHooksPresent(in data: Data?, managedCommand: String?) -> Bool {
+        guard let data,
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let hooks = object["hooks"] as? [String: Any] else {
+            return false
+        }
+
+        for eventName in requiredEventNames {
+            guard let groups = hooks[eventName] as? [Any],
+                  eventHasOpenIslandManagedCommand(
+                      in: groups,
+                      managedCommand: managedCommand
+                  ) else {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    /// True when the file contains at least one recognizably Open Island Grok
+    /// hook command. Used to refuse silent deletion of user-replaced content.
+    public static func isOpenIslandOwnedManagedFile(_ data: Data?) -> Bool {
+        guard let data,
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let hooks = object["hooks"] as? [String: Any] else {
+            return false
+        }
+
+        return hooks.values.contains { value in
+            let groups = value as? [Any] ?? []
+            return eventHasOpenIslandManagedCommand(in: groups, managedCommand: nil)
+        }
+    }
+
+    private static func eventHasOpenIslandManagedCommand(
+        in groups: [Any],
+        managedCommand: String?
+    ) -> Bool {
+        for item in groups {
+            guard let group = item as? [String: Any],
+                  let hooks = group["hooks"] as? [Any] else {
+                continue
+            }
+
+            for hook in hooks {
+                guard let hook = hook as? [String: Any],
+                      let command = hook["command"] as? String else {
+                    continue
+                }
+
+                // Prefer type == command when present; older/malformed files may omit it.
+                if let type = hook["type"] as? String, type != "command" {
+                    continue
+                }
+
+                if isOpenIslandManagedGrokCommand(command, managedCommand: managedCommand) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    /// Open Island only — never treat Vibe Island as our install.
+    private static func isOpenIslandManagedGrokCommand(
+        _ command: String,
+        managedCommand: String?
+    ) -> Bool {
+        if let managedCommand, command == managedCommand {
+            return true
+        }
+
+        let normalized = command.lowercased()
+        guard normalized.contains("--source grok") else {
+            return false
+        }
+
+        return normalized.contains("openislandhooks")
+            || normalized.contains("open-island-bridge")
+    }
+
+    private static func managedGroup(
+        matcher: String?,
+        timeout: Int?,
+        hookCommand: String
+    ) -> [String: Any] {
+        var hook: [String: Any] = [
+            "type": "command",
+            "command": hookCommand,
+        ]
+        if let timeout {
+            hook["timeout"] = timeout
+        }
+
+        var group: [String: Any] = [
+            "hooks": [hook],
+        ]
+        if let matcher {
+            group["matcher"] = matcher
+        }
+        return group
+    }
+
+    private static func serialize(_ object: [String: Any]) throws -> Data {
+        try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys])
+    }
+
+    private static func shellQuote(_ string: String) -> String {
+        guard !string.isEmpty else { return "''" }
+        return "'\(string.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+}

--- a/Sources/OpenIslandCore/GrokHookInstaller.swift
+++ b/Sources/OpenIslandCore/GrokHookInstaller.swift
@@ -57,6 +57,7 @@ public enum GrokHookInstaller {
         ("UserPromptSubmit", nil, managedTimeout),
         ("Stop", nil, managedTimeout),
         ("StopFailure", nil, managedTimeout),
+        ("StopCancelled", nil, managedTimeout),
         ("Notification", "*", managedTimeout),
         ("PreToolUse", "*", managedTimeout),
         ("PostToolUse", "*", managedTimeout),

--- a/Sources/OpenIslandCore/GrokHooks.swift
+++ b/Sources/OpenIslandCore/GrokHooks.swift
@@ -353,6 +353,15 @@ public extension GrokHookPayload {
     ///   → observe-only; do not emit sessionCompleted for the turn.
     /// - `reason` omitted → treat as genuine turn completion for older Grok
     ///   builds that do not populate the field (fail-open toward visibility).
+    /// `StopCancelled` reports who ended the turn. Anything the user did
+    /// (Ctrl+C, declining a permission) is an interrupt; `"runtime"` means
+    /// Grok itself bailed out (`max_turns`, `no_progress`) and the user has
+    /// not seen it yet. Missing/unknown values are treated as user-initiated.
+    public var isUserInitiatedCancellation: Bool {
+        guard hookEventName == .stopCancelled else { return false }
+        return cancelledBy != "runtime"
+    }
+
     var isGenuineTurnStop: Bool {
         guard hookEventName == .stop else { return false }
         if let reason {

--- a/Sources/OpenIslandCore/GrokHooks.swift
+++ b/Sources/OpenIslandCore/GrokHooks.swift
@@ -326,11 +326,11 @@ public extension GrokHookPayload {
             payload.terminalApp = inferTerminalApp(from: environment)
         }
 
-        if payload.terminalApp == "cmux", payload.terminalSessionID == nil {
+        if isCmuxTerminalApp(payload.terminalApp), payload.terminalSessionID == nil {
             payload.terminalSessionID = environment["CMUX_SURFACE_ID"]
         }
 
-        if payload.terminalApp?.lowercased() == "zellij", payload.terminalSessionID == nil {
+        if isZellijTerminalApp(payload.terminalApp), payload.terminalSessionID == nil {
             let paneID = environment["ZELLIJ_PANE_ID"] ?? ""
             let sessionName = environment["ZELLIJ_SESSION_NAME"] ?? ""
             if !paneID.isEmpty {

--- a/Sources/OpenIslandCore/GrokHooks.swift
+++ b/Sources/OpenIslandCore/GrokHooks.swift
@@ -66,6 +66,9 @@ public struct GrokHookPayload: Equatable, Codable, Sendable {
     public var workspaceRoot: String?
     public var permissionMode: String?
     public var timestamp: String?
+    /// Envelope-level prompt identifier (`promptId`). Decoded so a later
+    /// change can ignore stale-prompt reports; no behaviour depends on it yet.
+    public var promptID: String?
     public var toolName: String?
     public var toolInput: CodexHookJSONValue?
     public var toolUseID: String?
@@ -96,6 +99,7 @@ public struct GrokHookPayload: Equatable, Codable, Sendable {
         case workspaceRoot
         case permissionMode
         case timestamp
+        case promptID = "promptId"
         case toolName
         case toolInput
         case toolUseID = "toolUseId"
@@ -127,6 +131,7 @@ public struct GrokHookPayload: Equatable, Codable, Sendable {
         workspaceRoot: String? = nil,
         permissionMode: String? = nil,
         timestamp: String? = nil,
+        promptID: String? = nil,
         toolName: String? = nil,
         toolInput: CodexHookJSONValue? = nil,
         toolUseID: String? = nil,
@@ -156,6 +161,7 @@ public struct GrokHookPayload: Equatable, Codable, Sendable {
         self.workspaceRoot = workspaceRoot
         self.permissionMode = permissionMode
         self.timestamp = timestamp
+        self.promptID = promptID
         self.toolName = toolName
         self.toolInput = toolInput
         self.toolUseID = toolUseID
@@ -190,6 +196,7 @@ public struct GrokHookPayload: Equatable, Codable, Sendable {
         workspaceRoot = try container.decodeIfPresent(String.self, forKey: .workspaceRoot)
         permissionMode = try container.decodeIfPresent(String.self, forKey: .permissionMode)
         timestamp = try container.decodeIfPresent(String.self, forKey: .timestamp)
+        promptID = try container.decodeIfPresent(String.self, forKey: .promptID)
         toolName = try container.decodeIfPresent(String.self, forKey: .toolName)
         toolInput = try container.decodeIfPresent(CodexHookJSONValue.self, forKey: .toolInput)
         toolUseID = try container.decodeIfPresent(String.self, forKey: .toolUseID)

--- a/Sources/OpenIslandCore/GrokHooks.swift
+++ b/Sources/OpenIslandCore/GrokHooks.swift
@@ -290,7 +290,20 @@ public extension GrokHookPayload {
     }
 
     var notificationSummary: String {
-        clipped(message) ?? "Grok sent a notification."
+        if isIdlePromptNotification {
+            return clipped(message) ?? "Grok is idle in \(workspaceName)."
+        }
+        return clipped(message) ?? "Grok sent a notification."
+    }
+
+    /// True for `Notification` events with `notificationType == "idle_prompt"`.
+    ///
+    /// Grok fires `idle_prompt` after any turn end followed by sustained
+    /// idleness; the upstream guide names it as the backstop for turns that
+    /// reported none of the Stop-family events.
+    var isIdlePromptNotification: Bool {
+        hookEventName == .notification
+            && notificationType?.lowercased() == "idle_prompt"
     }
 
     /// Fallback summary for `StopCancelled` when Grok did not attach a partial

--- a/Sources/OpenIslandCore/GrokHooks.swift
+++ b/Sources/OpenIslandCore/GrokHooks.swift
@@ -14,6 +14,7 @@ public enum GrokHookEventName: String, Codable, Sendable, CaseIterable {
     case postToolUseFailure = "PostToolUseFailure"
     case stop = "Stop"
     case stopFailure = "StopFailure"
+    case stopCancelled = "StopCancelled"
     case notification = "Notification"
     case subagentStart = "SubagentStart"
     case subagentStop = "SubagentStop"
@@ -42,6 +43,7 @@ public enum GrokHookEventName: String, Codable, Sendable, CaseIterable {
         case "posttoolusefailure": self = .postToolUseFailure
         case "stop": self = .stop
         case "stopfailure": self = .stopFailure
+        case "stopcancelled": self = .stopCancelled
         case "notification": self = .notification
         case "subagentstart": self = .subagentStart
         case "subagentstop", "subagentend": self = .subagentStop
@@ -72,6 +74,9 @@ public struct GrokHookPayload: Equatable, Codable, Sendable {
     public var lastAssistantMessage: String?
     public var stopHookActive: Bool?
     public var reason: String?
+    public var cancelledBy: String?
+    public var cancelTrigger: String?
+    public var reasonDetails: String?
     public var source: String?
     public var message: String?
     public var notificationType: String?
@@ -99,6 +104,9 @@ public struct GrokHookPayload: Equatable, Codable, Sendable {
         case lastAssistantMessage
         case stopHookActive
         case reason
+        case cancelledBy
+        case cancelTrigger
+        case reasonDetails
         case source
         case message
         case notificationType
@@ -127,6 +135,9 @@ public struct GrokHookPayload: Equatable, Codable, Sendable {
         lastAssistantMessage: String? = nil,
         stopHookActive: Bool? = nil,
         reason: String? = nil,
+        cancelledBy: String? = nil,
+        cancelTrigger: String? = nil,
+        reasonDetails: String? = nil,
         source: String? = nil,
         message: String? = nil,
         notificationType: String? = nil,
@@ -153,6 +164,9 @@ public struct GrokHookPayload: Equatable, Codable, Sendable {
         self.lastAssistantMessage = lastAssistantMessage
         self.stopHookActive = stopHookActive
         self.reason = reason
+        self.cancelledBy = cancelledBy
+        self.cancelTrigger = cancelTrigger
+        self.reasonDetails = reasonDetails
         self.source = source
         self.message = message
         self.notificationType = notificationType
@@ -184,6 +198,9 @@ public struct GrokHookPayload: Equatable, Codable, Sendable {
         lastAssistantMessage = try container.decodeIfPresent(String.self, forKey: .lastAssistantMessage)
         stopHookActive = try container.decodeIfPresent(Bool.self, forKey: .stopHookActive)
         reason = try container.decodeIfPresent(String.self, forKey: .reason)
+        cancelledBy = try container.decodeIfPresent(String.self, forKey: .cancelledBy)
+        cancelTrigger = try container.decodeIfPresent(String.self, forKey: .cancelTrigger)
+        reasonDetails = try container.decodeIfPresent(String.self, forKey: .reasonDetails)
         source = try container.decodeIfPresent(String.self, forKey: .source)
         message = try container.decodeIfPresent(String.self, forKey: .message)
         notificationType = try container.decodeIfPresent(String.self, forKey: .notificationType)
@@ -246,6 +263,8 @@ public extension GrokHookPayload {
         case .stopFailure:
             return error.map { "Grok turn failed: \($0)" }
                 ?? "Grok failed to finish a turn in \(workspaceName)."
+        case .stopCancelled:
+            return lastAssistantMessagePreview ?? stopCancelledFallbackSummary
         case .notification:
             return notificationSummary
         case .subagentStart:
@@ -272,6 +291,25 @@ public extension GrokHookPayload {
 
     var notificationSummary: String {
         clipped(message) ?? "Grok sent a notification."
+    }
+
+    /// Fallback summary for `StopCancelled` when Grok did not attach a partial
+    /// assistant message. Keyed on the upstream `reason` values
+    /// (`user_interrupt`, `permission_rejected`, `permission_cancelled`,
+    /// `max_turns`, `no_progress`, `unknown`).
+    var stopCancelledFallbackSummary: String {
+        switch reason {
+        case "user_interrupt":
+            return "Grok turn interrupted in \(workspaceName)."
+        case "permission_rejected", "permission_cancelled":
+            return "Grok turn stopped: permission not granted in \(workspaceName)."
+        case "max_turns":
+            return "Grok turn stopped: max turns reached in \(workspaceName)."
+        case "no_progress":
+            return "Grok turn stopped: no progress in \(workspaceName)."
+        default:
+            return "Grok turn cancelled in \(workspaceName)."
+        }
     }
 
     var toolInputPreview: String? {

--- a/Sources/OpenIslandCore/GrokHooks.swift
+++ b/Sources/OpenIslandCore/GrokHooks.swift
@@ -1,0 +1,606 @@
+import Foundation
+
+/// Grok Build / Grok CLI hook event names.
+///
+/// Grok registers hooks with PascalCase names (`SessionStart`) but may emit
+/// either PascalCase or snake_case values in the stdin envelope
+/// (`session_start`). Decoding normalizes both forms.
+public enum GrokHookEventName: String, Codable, Sendable, CaseIterable {
+    case sessionStart = "SessionStart"
+    case sessionEnd = "SessionEnd"
+    case userPromptSubmit = "UserPromptSubmit"
+    case preToolUse = "PreToolUse"
+    case postToolUse = "PostToolUse"
+    case postToolUseFailure = "PostToolUseFailure"
+    case stop = "Stop"
+    case stopFailure = "StopFailure"
+    case notification = "Notification"
+    case subagentStart = "SubagentStart"
+    case subagentStop = "SubagentStop"
+    case preCompact = "PreCompact"
+    case postCompact = "PostCompact"
+    case permissionDenied = "PermissionDenied"
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        if let exact = GrokHookEventName(rawValue: raw) {
+            self = exact
+            return
+        }
+
+        let normalized = raw
+            .replacingOccurrences(of: "_", with: "")
+            .lowercased()
+
+        switch normalized {
+        case "sessionstart": self = .sessionStart
+        case "sessionend": self = .sessionEnd
+        case "userpromptsubmit": self = .userPromptSubmit
+        case "pretooluse": self = .preToolUse
+        case "posttooluse": self = .postToolUse
+        case "posttoolusefailure": self = .postToolUseFailure
+        case "stop": self = .stop
+        case "stopfailure": self = .stopFailure
+        case "notification": self = .notification
+        case "subagentstart": self = .subagentStart
+        case "subagentstop", "subagentend": self = .subagentStop
+        case "precompact": self = .preCompact
+        case "postcompact": self = .postCompact
+        case "permissiondenied": self = .permissionDenied
+        default:
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unknown Grok hook event name: \(raw)"
+            )
+        }
+    }
+}
+
+public struct GrokHookPayload: Equatable, Codable, Sendable {
+    public var cwd: String
+    public var hookEventName: GrokHookEventName
+    public var sessionID: String
+    public var workspaceRoot: String?
+    public var permissionMode: String?
+    public var timestamp: String?
+    public var toolName: String?
+    public var toolInput: CodexHookJSONValue?
+    public var toolUseID: String?
+    public var toolResult: CodexHookJSONValue?
+    public var prompt: String?
+    public var lastAssistantMessage: String?
+    public var stopHookActive: Bool?
+    public var reason: String?
+    public var source: String?
+    public var message: String?
+    public var notificationType: String?
+    public var error: String?
+    public var errorDetails: String?
+    public var agentType: String?
+    public var agentID: String?
+    public var terminalApp: String?
+    public var terminalSessionID: String?
+    public var terminalTTY: String?
+    public var terminalTitle: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case cwd
+        case hookEventName
+        case sessionID = "sessionId"
+        case workspaceRoot
+        case permissionMode
+        case timestamp
+        case toolName
+        case toolInput
+        case toolUseID = "toolUseId"
+        case toolResult
+        case prompt
+        case lastAssistantMessage
+        case stopHookActive
+        case reason
+        case source
+        case message
+        case notificationType
+        case error
+        case errorDetails
+        case agentType
+        case agentID = "agentId"
+        case terminalApp
+        case terminalSessionID
+        case terminalTTY
+        case terminalTitle
+    }
+
+    public init(
+        cwd: String,
+        hookEventName: GrokHookEventName,
+        sessionID: String,
+        workspaceRoot: String? = nil,
+        permissionMode: String? = nil,
+        timestamp: String? = nil,
+        toolName: String? = nil,
+        toolInput: CodexHookJSONValue? = nil,
+        toolUseID: String? = nil,
+        toolResult: CodexHookJSONValue? = nil,
+        prompt: String? = nil,
+        lastAssistantMessage: String? = nil,
+        stopHookActive: Bool? = nil,
+        reason: String? = nil,
+        source: String? = nil,
+        message: String? = nil,
+        notificationType: String? = nil,
+        error: String? = nil,
+        errorDetails: String? = nil,
+        agentType: String? = nil,
+        agentID: String? = nil,
+        terminalApp: String? = nil,
+        terminalSessionID: String? = nil,
+        terminalTTY: String? = nil,
+        terminalTitle: String? = nil
+    ) {
+        self.cwd = cwd
+        self.hookEventName = hookEventName
+        self.sessionID = sessionID
+        self.workspaceRoot = workspaceRoot
+        self.permissionMode = permissionMode
+        self.timestamp = timestamp
+        self.toolName = toolName
+        self.toolInput = toolInput
+        self.toolUseID = toolUseID
+        self.toolResult = toolResult
+        self.prompt = prompt
+        self.lastAssistantMessage = lastAssistantMessage
+        self.stopHookActive = stopHookActive
+        self.reason = reason
+        self.source = source
+        self.message = message
+        self.notificationType = notificationType
+        self.error = error
+        self.errorDetails = errorDetails
+        self.agentType = agentType
+        self.agentID = agentID
+        self.terminalApp = terminalApp
+        self.terminalSessionID = terminalSessionID
+        self.terminalTTY = terminalTTY
+        self.terminalTitle = terminalTitle
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        hookEventName = try container.decode(GrokHookEventName.self, forKey: .hookEventName)
+        sessionID = try container.decode(String.self, forKey: .sessionID)
+        cwd = try container.decodeIfPresent(String.self, forKey: .cwd)
+            ?? container.decodeIfPresent(String.self, forKey: .workspaceRoot)
+            ?? ""
+        workspaceRoot = try container.decodeIfPresent(String.self, forKey: .workspaceRoot)
+        permissionMode = try container.decodeIfPresent(String.self, forKey: .permissionMode)
+        timestamp = try container.decodeIfPresent(String.self, forKey: .timestamp)
+        toolName = try container.decodeIfPresent(String.self, forKey: .toolName)
+        toolInput = try container.decodeIfPresent(CodexHookJSONValue.self, forKey: .toolInput)
+        toolUseID = try container.decodeIfPresent(String.self, forKey: .toolUseID)
+        toolResult = try container.decodeIfPresent(CodexHookJSONValue.self, forKey: .toolResult)
+        prompt = try container.decodeIfPresent(String.self, forKey: .prompt)
+        lastAssistantMessage = try container.decodeIfPresent(String.self, forKey: .lastAssistantMessage)
+        stopHookActive = try container.decodeIfPresent(Bool.self, forKey: .stopHookActive)
+        reason = try container.decodeIfPresent(String.self, forKey: .reason)
+        source = try container.decodeIfPresent(String.self, forKey: .source)
+        message = try container.decodeIfPresent(String.self, forKey: .message)
+        notificationType = try container.decodeIfPresent(String.self, forKey: .notificationType)
+        error = try container.decodeIfPresent(String.self, forKey: .error)
+        errorDetails = try container.decodeIfPresent(String.self, forKey: .errorDetails)
+        agentType = try container.decodeIfPresent(String.self, forKey: .agentType)
+        agentID = try container.decodeIfPresent(String.self, forKey: .agentID)
+        terminalApp = try container.decodeIfPresent(String.self, forKey: .terminalApp)
+        terminalSessionID = try container.decodeIfPresent(String.self, forKey: .terminalSessionID)
+        terminalTTY = try container.decodeIfPresent(String.self, forKey: .terminalTTY)
+        terminalTitle = try container.decodeIfPresent(String.self, forKey: .terminalTitle)
+    }
+}
+
+public extension GrokHookPayload {
+    var workspaceName: String {
+        WorkspaceNameResolver.workspaceName(for: cwd.isEmpty ? (workspaceRoot ?? "") : cwd)
+    }
+
+    var sessionTitle: String {
+        "Grok · \(workspaceName)"
+    }
+
+    var defaultJumpTarget: JumpTarget {
+        JumpTarget(
+            terminalApp: terminalApp ?? "Terminal",
+            workspaceName: workspaceName,
+            paneTitle: terminalTitle ?? "Grok \(sessionID.prefix(8))",
+            workingDirectory: cwd.isEmpty ? workspaceRoot : cwd,
+            terminalSessionID: terminalSessionID,
+            terminalTTY: terminalTTY
+        )
+    }
+
+    var implicitSummary: String {
+        switch hookEventName {
+        case .sessionStart:
+            switch source?.lowercased() {
+            case "resume":
+                return "Resumed Grok session in \(workspaceName)."
+            default:
+                return "Started Grok session in \(workspaceName)."
+            }
+        case .sessionEnd:
+            return reason.map { "Grok session ended: \($0)." }
+                ?? "Grok session ended in \(workspaceName)."
+        case .userPromptSubmit:
+            return promptPreview.map { "Prompt: \($0)" }
+                ?? "Grok received a new prompt in \(workspaceName)."
+        case .preToolUse:
+            return "Grok is preparing \(toolName ?? "a tool") in \(workspaceName)."
+        case .postToolUse:
+            return "Grok finished \(toolName ?? "a tool") in \(workspaceName)."
+        case .postToolUseFailure:
+            return error.map { "Grok tool failed: \($0)" }
+                ?? "Grok hit a tool error in \(workspaceName)."
+        case .stop:
+            return lastAssistantMessagePreview
+                ?? "Grok completed a turn in \(workspaceName)."
+        case .stopFailure:
+            return error.map { "Grok turn failed: \($0)" }
+                ?? "Grok failed to finish a turn in \(workspaceName)."
+        case .notification:
+            return notificationSummary
+        case .subagentStart:
+            return agentType.map { "Started \($0) subagent." }
+                ?? "Started Grok subagent in \(workspaceName)."
+        case .subagentStop:
+            return "Finished Grok subagent in \(workspaceName)."
+        case .preCompact:
+            return "Grok is compacting the conversation in \(workspaceName)."
+        case .postCompact:
+            return "Grok finished compacting the conversation in \(workspaceName)."
+        case .permissionDenied:
+            return "Grok permission was denied in \(workspaceName)."
+        }
+    }
+
+    var promptPreview: String? {
+        clipped(prompt)
+    }
+
+    var lastAssistantMessagePreview: String? {
+        clipped(lastAssistantMessage)
+    }
+
+    var notificationSummary: String {
+        clipped(message) ?? "Grok sent a notification."
+    }
+
+    var toolInputPreview: String? {
+        if case let .object(obj) = toolInput {
+            let keyPriority = ["command", "file_path", "target_file", "pattern", "query", "prompt", "description", "url"]
+            for key in keyPriority {
+                if case let .string(val)? = obj[key], !val.isEmpty {
+                    return clipped(val)
+                }
+            }
+        }
+        return clipped(stringValue(for: toolInput))
+    }
+
+    /// True when this Stop is a genuine turn completion rather than the
+    /// observe-only fire that Grok emits at session end.
+    ///
+    /// Decision (tested):
+    /// - `reason == "end_turn"` → genuine turn completion.
+    /// - `reason` present and not `"end_turn"` (e.g. `shutdown`, `channel_closed`)
+    ///   → observe-only; do not emit sessionCompleted for the turn.
+    /// - `reason` omitted → treat as genuine turn completion for older Grok
+    ///   builds that do not populate the field (fail-open toward visibility).
+    var isGenuineTurnStop: Bool {
+        guard hookEventName == .stop else { return false }
+        if let reason {
+            return reason == "end_turn"
+        }
+        return true
+    }
+
+    func withRuntimeContext(environment: [String: String]) -> GrokHookPayload {
+        withRuntimeContext(
+            environment: environment,
+            currentTTYProvider: { currentTTY() },
+            terminalLocatorProvider: { terminalLocator(for: $0) }
+        )
+    }
+
+    func withRuntimeContext(
+        environment: [String: String],
+        currentTTYProvider: () -> String?,
+        terminalLocatorProvider: (String) -> (sessionID: String?, tty: String?, title: String?)
+    ) -> GrokHookPayload {
+        var payload = self
+
+        if payload.cwd.isEmpty, let workspaceRoot = payload.workspaceRoot {
+            payload.cwd = workspaceRoot
+        }
+
+        if payload.terminalApp == nil {
+            payload.terminalApp = inferTerminalApp(from: environment)
+        }
+
+        if payload.terminalApp == "cmux", payload.terminalSessionID == nil {
+            payload.terminalSessionID = environment["CMUX_SURFACE_ID"]
+        }
+
+        if payload.terminalApp?.lowercased() == "zellij", payload.terminalSessionID == nil {
+            let paneID = environment["ZELLIJ_PANE_ID"] ?? ""
+            let sessionName = environment["ZELLIJ_SESSION_NAME"] ?? ""
+            if !paneID.isEmpty {
+                payload.terminalSessionID = "\(paneID):\(sessionName)"
+            }
+        }
+
+        if payload.terminalTTY == nil {
+            payload.terminalTTY = currentTTYProvider()
+        }
+
+        let useLocator: Bool
+        if isCmuxTerminalApp(payload.terminalApp) || isZellijTerminalApp(payload.terminalApp) {
+            useLocator = false
+        } else if let terminalApp = payload.terminalApp, isGhosttyTerminalApp(terminalApp) {
+            switch payload.hookEventName {
+            case .sessionStart, .userPromptSubmit, .notification:
+                useLocator = true
+            default:
+                payload.terminalSessionID = nil
+                payload.terminalTitle = nil
+                useLocator = false
+            }
+        } else {
+            useLocator = shouldUseFocusedTerminalLocator(for: payload.terminalApp ?? "")
+        }
+
+        if useLocator, let terminalApp = payload.terminalApp {
+            let locator = terminalLocatorProvider(terminalApp)
+            if payload.terminalSessionID == nil {
+                payload.terminalSessionID = locator.sessionID
+            }
+            if payload.terminalTTY == nil {
+                payload.terminalTTY = locator.tty
+            }
+            if payload.terminalTitle == nil {
+                payload.terminalTitle = locator.title
+            }
+        }
+
+        return payload
+    }
+
+    private static let noLocatorTerminalApps: Set<String> = [
+        "cmux", "kaku", "wezterm", "zellij",
+        "vs code", "vs code insiders", "cursor", "windsurf", "trae",
+        "intellij idea", "webstorm", "pycharm", "goland", "clion",
+        "rubymine", "phpstorm", "rider", "rustrover",
+    ]
+
+    private func clipped(_ value: String?, limit: Int = 110) -> String? {
+        guard let value else { return nil }
+
+        let collapsed = value
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\t", with: " ")
+            .split(separator: " ", omittingEmptySubsequences: true)
+            .joined(separator: " ")
+
+        guard !collapsed.isEmpty else { return nil }
+        guard collapsed.count > limit else { return collapsed }
+
+        let endIndex = collapsed.index(collapsed.startIndex, offsetBy: limit - 1)
+        return "\(collapsed[..<endIndex])…"
+    }
+
+    private func stringValue(for value: CodexHookJSONValue?) -> String? {
+        guard let value else { return nil }
+        switch value {
+        case let .string(text): return text
+        case let .number(number): return String(number)
+        case let .boolean(flag): return flag ? "true" : "false"
+        case .null: return "null"
+        case let .array(items):
+            return "[\(items.compactMap { stringValue(for: $0) }.joined(separator: ", "))]"
+        case let .object(object):
+            let rendered = object.keys.sorted().map { key in
+                "\(key): \(stringValue(for: object[key]) ?? "null")"
+            }.joined(separator: ", ")
+            return "{\(rendered)}"
+        }
+    }
+
+    private func shouldUseFocusedTerminalLocator(for terminalApp: String) -> Bool {
+        let lower = terminalApp.lowercased()
+        if lower.contains("ghostty") || lower.contains("jetbrains") {
+            return false
+        }
+        return !Self.noLocatorTerminalApps.contains(lower)
+    }
+
+    private func isGhosttyTerminalApp(_ terminalApp: String?) -> Bool {
+        terminalApp?.lowercased().contains("ghostty") == true
+    }
+
+    private func isCmuxTerminalApp(_ terminalApp: String?) -> Bool {
+        terminalApp?.lowercased() == "cmux"
+    }
+
+    private func isZellijTerminalApp(_ terminalApp: String?) -> Bool {
+        terminalApp?.lowercased() == "zellij"
+    }
+
+    private func inferTerminalApp(from environment: [String: String]) -> String? {
+        if environment["CMUX_WORKSPACE_ID"] != nil || environment["CMUX_SOCKET_PATH"] != nil {
+            return "cmux"
+        }
+        if environment["ZELLIJ"] != nil {
+            return "Zellij"
+        }
+
+        if let termProgram = environment["TERM_PROGRAM"]?.lowercased(), !termProgram.isEmpty {
+            switch termProgram {
+            case "apple_terminal": return "Terminal"
+            case "iterm.app", "iterm2": return "iTerm"
+            case let value where value.contains("warp"): return "Warp"
+            case let value where value.contains("ghostty"): return "Ghostty"
+            case "kaku": return "Kaku"
+            case "wezterm": return "WezTerm"
+            case "vscode":
+                if environment["CURSOR_TRACE_ID"] != nil { return "Cursor" }
+                return "VS Code"
+            case "vscode-insiders": return "VS Code Insiders"
+            case "windsurf": return "Windsurf"
+            case "trae": return "Trae"
+            default: break
+            }
+        }
+
+        if environment["ITERM_SESSION_ID"] != nil || environment["LC_TERMINAL"] == "iTerm2" {
+            return "iTerm"
+        }
+        if environment["WARP_IS_LOCAL_SHELL_SESSION"] != nil {
+            return "Warp"
+        }
+        if environment["GHOSTTY_RESOURCES_DIR"] != nil {
+            return "Ghostty"
+        }
+
+        if let terminalEmulator = environment["TERMINAL_EMULATOR"]?.lowercased(),
+           terminalEmulator.contains("jetbrains") {
+            if let bundleID = environment["__CFBundleIdentifier"]?.lowercased() {
+                if bundleID.contains("webstorm") { return "WebStorm" }
+                if bundleID.contains("pycharm") { return "PyCharm" }
+                if bundleID.contains("goland") { return "GoLand" }
+                if bundleID.contains("clion") { return "CLion" }
+                if bundleID.contains("rubymine") { return "RubyMine" }
+                if bundleID.contains("phpstorm") { return "PhpStorm" }
+                if bundleID.contains("rider") { return "Rider" }
+                if bundleID.contains("rustrover") { return "RustRover" }
+                if bundleID.contains("intellij") { return "IntelliJ IDEA" }
+            }
+            return "IntelliJ IDEA"
+        }
+
+        return nil
+    }
+
+    private func currentTTY() -> String? {
+        if let tty = commandOutput(executablePath: "/usr/bin/tty", arguments: []),
+           !tty.contains("not a tty") {
+            return tty
+        }
+        return parentProcessTTY()
+    }
+
+    private func parentProcessTTY() -> String? {
+        let ppid = getppid()
+        guard let raw = commandOutput(executablePath: "/bin/ps", arguments: ["-p", "\(ppid)", "-o", "tty="]) else {
+            return nil
+        }
+
+        let tty = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !tty.isEmpty, tty != "??", tty != "-" else {
+            return nil
+        }
+
+        return tty.hasPrefix("/dev/") ? tty : "/dev/\(tty)"
+    }
+
+    private func terminalLocator(for terminalApp: String) -> (sessionID: String?, tty: String?, title: String?) {
+        let normalized = terminalApp.lowercased()
+
+        if normalized.contains("iterm") {
+            let values = osascriptValues(script: """
+            tell application "iTerm"
+                if not (it is running) then return ""
+                tell current session of current window
+                    return (id as text) & (ASCII character 31) & (tty as text) & (ASCII character 31) & (name as text)
+                end tell
+            end tell
+            """)
+            return (sessionID: values[safe: 0], tty: values[safe: 1], title: values[safe: 2])
+        }
+
+        if normalized == "cmux" {
+            return (sessionID: nil, tty: nil, title: nil)
+        }
+
+        if normalized.contains("ghostty") {
+            let values = osascriptValues(script: """
+            tell application "Ghostty"
+                if not (it is running) then return ""
+                tell focused terminal of selected tab of front window
+                    return (id as text) & (ASCII character 31) & (working directory as text) & (ASCII character 31) & (name as text)
+                end tell
+            end tell
+            """)
+            return (sessionID: values[safe: 0], tty: nil, title: values[safe: 2])
+        }
+
+        if normalized.contains("terminal") {
+            let values = osascriptValues(script: """
+            tell application "Terminal"
+                if not (it is running) then return ""
+                tell selected tab of front window
+                    return (tty as text) & (ASCII character 31) & (custom title as text)
+                end tell
+            end tell
+            """)
+            return (sessionID: nil, tty: values[safe: 0], title: values[safe: 1])
+        }
+
+        return (nil, nil, nil)
+    }
+
+    private func osascriptValues(script: String) -> [String] {
+        guard let raw = commandOutput(executablePath: "/usr/bin/osascript", arguments: ["-e", script]) else {
+            return []
+        }
+
+        let separator = String(UnicodeScalar(31)!)
+        return raw
+            .components(separatedBy: separator)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+    }
+
+    private func commandOutput(executablePath: String, arguments: [String]) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+
+        let outputPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return nil
+        }
+
+        guard process.terminationStatus == 0 else {
+            return nil
+        }
+
+        let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        guard let output = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !output.isEmpty else {
+            return nil
+        }
+
+        return output
+    }
+}
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}

--- a/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
+++ b/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
@@ -18,12 +18,13 @@ struct OpenIslandHooksCLI {
         case cursor
         case gemini
         case kimi
+        case grok
 
         var isClaudeFormat: Bool {
             switch self {
             case .claude, .qoder, .qwen, .factory, .droid, .codebuddy, .kimi:
                 return true
-            case .codex, .cursor, .gemini:
+            case .codex, .cursor, .gemini, .grok:
                 return false
             }
         }
@@ -107,6 +108,12 @@ struct OpenIslandHooksCLI {
                     .withRuntimeContext(environment: ProcessInfo.processInfo.environment)
 
                 _ = try? client.send(.processGeminiHook(payload), timeout: 45)
+            case .grok:
+                let payload = try decoder
+                    .decode(GrokHookPayload.self, from: input)
+                    .withRuntimeContext(environment: ProcessInfo.processInfo.environment)
+
+                _ = try? client.send(.processGrokHook(payload), timeout: 45)
             }
         } catch {
             // Hooks should fail open so the CLI continues working even if the bridge is unavailable.

--- a/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
+++ b/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
@@ -113,7 +113,11 @@ struct OpenIslandHooksCLI {
                     .decode(GrokHookPayload.self, from: input)
                     .withRuntimeContext(environment: ProcessInfo.processInfo.environment)
 
-                _ = try? client.send(.processGrokHook(payload), timeout: 45)
+                // Client timeout slightly under managed hook timeout (45s) so
+                // the hook can exit fail-open before Grok kills it.
+                if (try? client.send(.processGrokHook(payload), timeout: 40)) == nil {
+                    logStderr("bridge unavailable for grok hook (\(payload.hookEventName.rawValue))")
+                }
             }
         } catch {
             // Hooks should fail open so the CLI continues working even if the bridge is unavailable.

--- a/Sources/OpenIslandSetup/OpenIslandSetupCLI.swift
+++ b/Sources/OpenIslandSetup/OpenIslandSetupCLI.swift
@@ -28,12 +28,16 @@ private struct SetupCommand {
         case installKimi
         case uninstallKimi
         case statusKimi
+        case installGrok
+        case uninstallGrok
+        case statusGrok
     }
 
     let action: Action
     let codexDirectory: URL
     let claudeDirectory: URL
     let kimiDirectory: URL
+    let grokDirectory: URL
     let hooksBinary: URL?
 
     init(arguments: [String]) throws {
@@ -48,6 +52,7 @@ private struct SetupCommand {
         var codexDirectory = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".codex", isDirectory: true)
         var claudeDirectory = ClaudeConfigDirectory.resolved()
         var kimiDirectory = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".kimi", isDirectory: true)
+        var grokDirectory = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".grok", isDirectory: true)
 
         var index = 1
         while index < arguments.count {
@@ -80,6 +85,13 @@ private struct SetupCommand {
                 }
                 kimiDirectory = URL(fileURLWithPath: arguments[index]).standardizedFileURL
 
+            case "--grok-dir":
+                index += 1
+                guard index < arguments.count else {
+                    throw SetupError.missingValue("--grok-dir")
+                }
+                grokDirectory = URL(fileURLWithPath: arguments[index]).standardizedFileURL
+
             default:
                 throw SetupError.unexpectedArgument(arguments[index])
             }
@@ -87,13 +99,14 @@ private struct SetupCommand {
             index += 1
         }
 
-        if (action == .install || action == .installClaude || action == .installKimi), hooksBinary == nil {
+        if (action == .install || action == .installClaude || action == .installKimi || action == .installGrok), hooksBinary == nil {
             hooksBinary = HooksBinaryLocator.locate()
         }
 
         self.codexDirectory = codexDirectory
         self.claudeDirectory = claudeDirectory
         self.kimiDirectory = kimiDirectory
+        self.grokDirectory = grokDirectory
         self.hooksBinary = hooksBinary
     }
 
@@ -117,6 +130,12 @@ private struct SetupCommand {
             try uninstallKimi()
         case .statusKimi:
             try statusKimi()
+        case .installGrok:
+            try installGrok()
+        case .uninstallGrok:
+            try uninstallGrok()
+        case .statusGrok:
+            try statusGrok()
         }
     }
 
@@ -252,6 +271,49 @@ private struct SetupCommand {
             print("Manifest: missing")
         }
     }
+
+    private func installGrok() throws {
+        guard let hooksBinary else {
+            throw SetupError.usage
+        }
+
+        let manager = GrokHookInstallationManager(grokDirectory: grokDirectory)
+        let status = try manager.install(hooksBinaryURL: hooksBinary)
+
+        print("Installed Open Island Grok hooks.")
+        print("Grok dir: \(status.grokDirectory.path)")
+        print("Hooks file: \(status.hooksURL.path)")
+        print("Hooks binary: \(hooksBinary.path)")
+    }
+
+    private func uninstallGrok() throws {
+        let manager = GrokHookInstallationManager(grokDirectory: grokDirectory)
+        let status = try manager.uninstall()
+
+        print("Removed Open Island Grok hooks.")
+        print("Grok dir: \(status.grokDirectory.path)")
+        if FileManager.default.fileExists(atPath: status.hooksURL.path) {
+            print("Note: hooks file still present.")
+        }
+    }
+
+    private func statusGrok() throws {
+        let manager = GrokHookInstallationManager(grokDirectory: grokDirectory)
+        let status = try manager.status(hooksBinaryURL: hooksBinary)
+
+        print("Grok dir: \(status.grokDirectory.path)")
+        print("Hooks file: \(status.hooksURL.path)")
+        print("Managed hooks present: \(status.managedHooksPresent ? "yes" : "no")")
+        if let hooksBinary {
+            print("Hooks binary: \(hooksBinary.path)")
+        }
+        if let manifest = status.manifest {
+            print("Manifest: present")
+            print("Hook command: \(manifest.hookCommand)")
+        } else {
+            print("Manifest: missing")
+        }
+    }
 }
 
 private enum SetupError: Error, LocalizedError {
@@ -273,6 +335,9 @@ private enum SetupError: Error, LocalizedError {
               swift run OpenIslandSetup installKimi [--hooks-binary /abs/path/to/OpenIslandHooks] [--kimi-dir /abs/path/to/.kimi]
               swift run OpenIslandSetup uninstallKimi [--kimi-dir /abs/path/to/.kimi]
               swift run OpenIslandSetup statusKimi [--hooks-binary /abs/path/to/OpenIslandHooks] [--kimi-dir /abs/path/to/.kimi]
+              swift run OpenIslandSetup installGrok [--hooks-binary /abs/path/to/OpenIslandHooks] [--grok-dir /abs/path/to/.grok]
+              swift run OpenIslandSetup uninstallGrok [--grok-dir /abs/path/to/.grok]
+              swift run OpenIslandSetup statusGrok [--hooks-binary /abs/path/to/OpenIslandHooks] [--grok-dir /abs/path/to/.grok]
             """
         case let .missingValue(flag):
             "Missing value for \(flag)"

--- a/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
+++ b/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
@@ -111,6 +111,7 @@ struct AgentSessionPresentationTests {
             (.codebuddy, "CodeBuddy"),
             (.cursor, "Cursor"),
             (.kimiCLI, "Kimi"),
+            (.grokBuild, "Grok"),
         ]
         #expect(expectedNames.map { $0.0.rawValue }.sorted() == AgentTool.allCases.map(\.rawValue).sorted())
 

--- a/Tests/OpenIslandAppTests/GrokProcessLivenessTests.swift
+++ b/Tests/OpenIslandAppTests/GrokProcessLivenessTests.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Testing
+@testable import OpenIslandApp
+@testable import OpenIslandCore
+
+@MainActor
+struct GrokProcessLivenessTests {
+    @Test
+    func anyGrokProcessKeepsUnmatchedNonEndedSessionsAlive() {
+        let coordinator = ProcessMonitoringCoordinator()
+        var session = AgentSession(
+            id: "grok-uuid-1",
+            title: "Grok · work",
+            tool: .grokBuild,
+            phase: .running,
+            summary: "Working",
+            updatedAt: .now,
+            jumpTarget: JumpTarget(
+                terminalApp: "Terminal",
+                workspaceName: "work",
+                paneTitle: "Grok",
+                workingDirectory: "/tmp/work",
+                terminalTTY: "/dev/ttys099"
+            )
+        )
+        session.isHookManaged = true
+        session.isSessionEnded = false
+
+        coordinator.stateAccessor = { SessionState(sessions: [session]) }
+
+        // Process has no sessionID and a different TTY → no unique match.
+        let processes = [
+            ActiveAgentProcessDiscovery.ProcessSnapshot(
+                tool: .grokBuild,
+                sessionID: nil,
+                workingDirectory: "/tmp/other",
+                terminalTTY: "/dev/ttys001"
+            ),
+        ]
+
+        let alive = coordinator.sessionIDsWithAliveProcesses(
+            activeProcesses: processes,
+            isCodexAppRunning: false
+        )
+        #expect(alive.contains("grok-uuid-1"))
+    }
+
+    @Test
+    func uniqueTTYMatchClaimsSingleGrokSession() {
+        let coordinator = ProcessMonitoringCoordinator()
+        var session = AgentSession(
+            id: "grok-uuid-tty",
+            title: "Grok · work",
+            tool: .grokBuild,
+            phase: .running,
+            summary: "Working",
+            updatedAt: .now,
+            jumpTarget: JumpTarget(
+                terminalApp: "Terminal",
+                workspaceName: "work",
+                paneTitle: "Grok",
+                workingDirectory: "/tmp/work",
+                terminalTTY: "/dev/ttys042"
+            )
+        )
+        session.isHookManaged = true
+
+        coordinator.stateAccessor = { SessionState(sessions: [session]) }
+
+        let processes = [
+            ActiveAgentProcessDiscovery.ProcessSnapshot(
+                tool: .grokBuild,
+                sessionID: nil,
+                workingDirectory: "/tmp/work",
+                terminalTTY: "/dev/ttys042"
+            ),
+        ]
+
+        let alive = coordinator.sessionIDsWithAliveProcesses(
+            activeProcesses: processes,
+            isCodexAppRunning: false
+        )
+        #expect(alive == ["grok-uuid-tty"])
+    }
+
+    @Test
+    func endedGrokSessionIsNotKeptAliveByProcessPresence() {
+        let coordinator = ProcessMonitoringCoordinator()
+        var session = AgentSession(
+            id: "grok-uuid-ended",
+            title: "Grok · work",
+            tool: .grokBuild,
+            phase: .completed,
+            summary: "Done",
+            updatedAt: .now,
+            jumpTarget: JumpTarget(
+                terminalApp: "Terminal",
+                workspaceName: "work",
+                paneTitle: "Grok",
+                workingDirectory: "/tmp/work",
+                terminalTTY: "/dev/ttys042"
+            )
+        )
+        session.isHookManaged = true
+        session.isSessionEnded = true
+
+        coordinator.stateAccessor = { SessionState(sessions: [session]) }
+
+        let processes = [
+            ActiveAgentProcessDiscovery.ProcessSnapshot(
+                tool: .grokBuild,
+                sessionID: nil,
+                workingDirectory: "/tmp/work",
+                terminalTTY: "/dev/ttys042"
+            ),
+        ]
+
+        let alive = coordinator.sessionIDsWithAliveProcesses(
+            activeProcesses: processes,
+            isCodexAppRunning: false
+        )
+        #expect(!alive.contains("grok-uuid-ended"))
+    }
+
+    @Test
+    func noGrokProcessLeavesSessionOutOfAliveSet() {
+        let coordinator = ProcessMonitoringCoordinator()
+        var session = AgentSession(
+            id: "grok-uuid-orphan",
+            title: "Grok · work",
+            tool: .grokBuild,
+            phase: .running,
+            summary: "Working",
+            updatedAt: .now
+        )
+        session.isHookManaged = true
+
+        coordinator.stateAccessor = { SessionState(sessions: [session]) }
+
+        let alive = coordinator.sessionIDsWithAliveProcesses(
+            activeProcesses: [],
+            isCodexAppRunning: false
+        )
+        #expect(!alive.contains("grok-uuid-orphan"))
+    }
+}

--- a/Tests/OpenIslandCoreTests/GrokHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/GrokHooksTests.swift
@@ -1,0 +1,557 @@
+import Dispatch
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+struct GrokHooksTests {
+    private let openIslandCommand = "'/usr/local/bin/OpenIslandHooks' --source grok"
+    private let vibeCommand = "'/Users/me/.vibe-island/bin/vibe-island-bridge' --source grok"
+
+    // MARK: - Decode
+
+    @Test
+    func grokHookPayloadDecodesCamelCaseEnvelope() throws {
+        let json = """
+        {
+          "hookEventName": "pre_tool_use",
+          "sessionId": "grok-session-1",
+          "cwd": "/tmp/worktree",
+          "workspaceRoot": "/tmp/worktree",
+          "permissionMode": "default",
+          "toolName": "run_terminal_command",
+          "toolInput": { "command": "npm test" },
+          "toolUseId": "tool-1",
+          "timestamp": "2026-08-01T12:00:00Z"
+        }
+        """.data(using: .utf8)!
+
+        let payload = try JSONDecoder().decode(GrokHookPayload.self, from: json)
+
+        #expect(payload.hookEventName == .preToolUse)
+        #expect(payload.sessionID == "grok-session-1")
+        #expect(payload.toolName == "run_terminal_command")
+        #expect(payload.toolUseID == "tool-1")
+        #expect(payload.sessionTitle == "Grok · worktree")
+        #expect(payload.implicitSummary.contains("run_terminal_command"))
+    }
+
+    @Test
+    func workspaceRootFallbackWhenCwdMissing() throws {
+        let json = """
+        {
+          "hookEventName": "SessionStart",
+          "sessionId": "grok-cwd-fallback",
+          "workspaceRoot": "/tmp/from-workspace-root"
+        }
+        """.data(using: .utf8)!
+
+        let payload = try JSONDecoder().decode(GrokHookPayload.self, from: json)
+        #expect(payload.cwd == "/tmp/from-workspace-root")
+        #expect(payload.workspaceName == "from-workspace-root")
+    }
+
+    @Test
+    func grokHookEventNameAcceptsPascalCaseAndSnakeCase() throws {
+        let cases: [(String, GrokHookEventName)] = [
+            ("SessionStart", .sessionStart),
+            ("session_start", .sessionStart),
+            ("UserPromptSubmit", .userPromptSubmit),
+            ("user_prompt_submit", .userPromptSubmit),
+            ("PreToolUse", .preToolUse),
+            ("pre_tool_use", .preToolUse),
+            ("Stop", .stop),
+            ("stop", .stop),
+            ("PermissionDenied", .permissionDenied),
+            ("permission_denied", .permissionDenied),
+            ("PostCompact", .postCompact),
+            ("post_compact", .postCompact),
+            ("subagent_end", .subagentStop),
+        ]
+
+        for (raw, expected) in cases {
+            let decoded = try JSONDecoder().decode(
+                GrokHookEventName.self,
+                from: Data("\"\(raw)\"".utf8)
+            )
+            #expect(decoded == expected, "raw \(raw)")
+        }
+    }
+
+    @Test
+    func genuineTurnStopFiltersSessionEndFire() {
+        let turnEnd = GrokHookPayload(
+            cwd: "/tmp",
+            hookEventName: .stop,
+            sessionID: "s1",
+            reason: "end_turn"
+        )
+        let sessionEndFire = GrokHookPayload(
+            cwd: "/tmp",
+            hookEventName: .stop,
+            sessionID: "s1",
+            reason: "shutdown"
+        )
+        let missingReason = GrokHookPayload(
+            cwd: "/tmp",
+            hookEventName: .stop,
+            sessionID: "s1"
+        )
+
+        #expect(turnEnd.isGenuineTurnStop)
+        #expect(!sessionEndFire.isGenuineTurnStop)
+        // Missing reason: treat as genuine turn completion (older Grok builds).
+        #expect(missingReason.isGenuineTurnStop)
+    }
+
+    // MARK: - Installer
+
+    @Test
+    func managedInstallEmitsCompleteRequiredEventSet() throws {
+        let mutation = try GrokHookInstaller.installHooksJSON(hookCommand: openIslandCommand)
+        #expect(mutation.changed)
+        #expect(mutation.managedHooksPresent)
+
+        let data = try #require(mutation.contents)
+        let object = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let hooks = object["hooks"] as! [String: Any]
+        let installedKeys = Set(hooks.keys)
+        let expectedKeys = Set(GrokHookInstaller.requiredEventNames)
+
+        #expect(installedKeys == expectedKeys)
+        #expect(
+            GrokHookInstaller.managedHooksPresent(in: data, managedCommand: openIslandCommand)
+        )
+    }
+
+    @Test
+    func installIsIdempotentWhenContentUnchanged() throws {
+        let first = try GrokHookInstaller.installHooksJSON(hookCommand: openIslandCommand)
+        let firstData = try #require(first.contents)
+        #expect(first.changed)
+
+        let second = try GrokHookInstaller.installHooksJSON(
+            existingData: firstData,
+            hookCommand: openIslandCommand
+        )
+        #expect(second.changed == false)
+        #expect(second.contents == firstData)
+    }
+
+    @Test
+    func completeManagedJSONReportsInstalled() throws {
+        let data = try #require(
+            try GrokHookInstaller.installHooksJSON(hookCommand: openIslandCommand).contents
+        )
+        #expect(GrokHookInstaller.managedHooksPresent(in: data, managedCommand: openIslandCommand))
+        #expect(GrokHookInstaller.isOpenIslandOwnedManagedFile(data))
+    }
+
+    @Test
+    func missingCriticalEventReportsNotInstalled() throws {
+        var root: [String: Any] = ["hooks": [:]]
+        var hooks: [String: Any] = [:]
+        for name in GrokHookInstaller.requiredEventNames where name != "SessionEnd" {
+            hooks[name] = [[
+                "hooks": [[
+                    "type": "command",
+                    "command": openIslandCommand,
+                ]],
+            ]]
+        }
+        root["hooks"] = hooks
+        let data = try JSONSerialization.data(withJSONObject: root)
+
+        #expect(
+            GrokHookInstaller.managedHooksPresent(in: data, managedCommand: openIslandCommand) == false
+        )
+    }
+
+    @Test
+    func unrelatedCommandReportsNotInstalled() throws {
+        var hooks: [String: Any] = [:]
+        for name in GrokHookInstaller.requiredEventNames {
+            hooks[name] = [[
+                "hooks": [[
+                    "type": "command",
+                    "command": "echo unrelated",
+                ]],
+            ]]
+        }
+        let data = try JSONSerialization.data(withJSONObject: ["hooks": hooks])
+        #expect(GrokHookInstaller.managedHooksPresent(in: data, managedCommand: openIslandCommand) == false)
+        #expect(GrokHookInstaller.isOpenIslandOwnedManagedFile(data) == false)
+    }
+
+    @Test
+    func vibeIslandOnlyCommandDoesNotCountAsOpenIslandInstalled() throws {
+        var hooks: [String: Any] = [:]
+        for name in GrokHookInstaller.requiredEventNames {
+            hooks[name] = [[
+                "hooks": [[
+                    "type": "command",
+                    "command": vibeCommand,
+                ]],
+            ]]
+        }
+        let data = try JSONSerialization.data(withJSONObject: ["hooks": hooks])
+        #expect(GrokHookInstaller.managedHooksPresent(in: data, managedCommand: openIslandCommand) == false)
+        #expect(GrokHookInstaller.isOpenIslandOwnedManagedFile(data) == false)
+    }
+
+    @Test
+    func installationManagerInstallUninstallAndRefusesForeignFile() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-grok-install-\(UUID().uuidString)", isDirectory: true)
+        let binDir = tmp.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
+
+        let fakeHooks = binDir.appendingPathComponent("OpenIslandHooks")
+        try Data("#!/bin/sh\n".utf8).write(to: fakeHooks)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fakeHooks.path)
+
+        let managedBinary = binDir.appendingPathComponent("managed-OpenIslandHooks")
+        let grokDir = tmp.appendingPathComponent("grok", isDirectory: true)
+        let manager = GrokHookInstallationManager(
+            grokDirectory: grokDir,
+            managedHooksBinaryURL: managedBinary
+        )
+
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let installed = try manager.install(hooksBinaryURL: fakeHooks)
+        #expect(installed.managedHooksPresent)
+        #expect(FileManager.default.fileExists(atPath: installed.hooksURL.path))
+
+        let again = try manager.install(hooksBinaryURL: fakeHooks)
+        #expect(again.managedHooksPresent)
+
+        let uninstalled = try manager.uninstall()
+        #expect(uninstalled.managedHooksPresent == false)
+        #expect(FileManager.default.fileExists(atPath: installed.hooksURL.path) == false)
+
+        // User-replaced foreign content must not be deleted.
+        try FileManager.default.createDirectory(at: manager.hooksDirectory, withIntermediateDirectories: true)
+        try Data("{\"hooks\":{}}".utf8).write(to: manager.hooksURL)
+        #expect(throws: GrokHookInstallerError.managedFileNotOwnedByOpenIsland) {
+            try manager.uninstall()
+        }
+        #expect(FileManager.default.fileExists(atPath: manager.hooksURL.path))
+    }
+
+    // MARK: - Bridge lifecycle
+
+    @Test
+    func grokSessionStartAndStopFlowThroughBridge() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        let startPayload = GrokHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .sessionStart,
+            sessionID: "grok-session-bridge"
+        )
+        let stopPayload = GrokHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .stop,
+            sessionID: "grok-session-bridge",
+            lastAssistantMessage: "All done.",
+            reason: "end_turn"
+        )
+
+        _ = try BridgeCommandClient(socketURL: socketURL).send(.processGrokHook(startPayload))
+        _ = try BridgeCommandClient(socketURL: socketURL).send(.processGrokHook(stopPayload))
+
+        var iterator = stream.makeAsyncIterator()
+        let event = try await nextMatchingGrokEvent(from: &iterator, maxEvents: 8) { event in
+            if case .sessionCompleted = event {
+                return true
+            }
+            return false
+        }
+
+        guard case let .sessionCompleted(payload) = event else {
+            Issue.record("Expected Grok stop session completion")
+            return
+        }
+
+        #expect(payload.sessionID == "grok-session-bridge")
+        #expect(payload.summary == "All done.")
+        #expect(payload.isSessionEnd != true)
+        #expect(server.sessionStateSnapshotForTests().session(id: "grok-session-bridge")?.isSessionEnded != true)
+    }
+
+    @Test
+    func nonTurnStopDoesNotCompleteTurn() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .sessionStart,
+                    sessionID: "grok-non-turn-stop"
+                )
+            )
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .userPromptSubmit,
+                    sessionID: "grok-non-turn-stop",
+                    prompt: "hi"
+                )
+            )
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .stop,
+                    sessionID: "grok-non-turn-stop",
+                    reason: "shutdown"
+                )
+            )
+        )
+
+        let session = try #require(server.sessionStateSnapshotForTests().session(id: "grok-non-turn-stop"))
+        #expect(session.phase == .running)
+        #expect(session.isSessionEnded == false)
+    }
+
+    @Test
+    func postToolUseFailureDoesNotLeaveSessionRunning() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .sessionStart,
+                    sessionID: "grok-tool-fail"
+                )
+            )
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .postToolUseFailure,
+                    sessionID: "grok-tool-fail",
+                    toolName: "run_terminal_command",
+                    error: "exit 1"
+                )
+            )
+        )
+
+        let session = try #require(server.sessionStateSnapshotForTests().session(id: "grok-tool-fail"))
+        #expect(session.phase == .completed)
+        #expect(session.isSessionEnded == false)
+    }
+
+    @Test
+    func stopFailureDoesNotLeaveSessionRunning() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .sessionStart,
+                    sessionID: "grok-stop-fail"
+                )
+            )
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .stopFailure,
+                    sessionID: "grok-stop-fail",
+                    error: "rate_limit"
+                )
+            )
+        )
+
+        let session = try #require(server.sessionStateSnapshotForTests().session(id: "grok-stop-fail"))
+        #expect(session.phase == .completed)
+    }
+
+    @Test
+    func grokSessionEndMarksSessionEnded() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .sessionStart,
+                    sessionID: "grok-session-end"
+                )
+            )
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .sessionEnd,
+                    sessionID: "grok-session-end",
+                    reason: "user_exit"
+                )
+            )
+        )
+
+        let session = try #require(server.sessionStateSnapshotForTests().session(id: "grok-session-end"))
+        #expect(session.isSessionEnded == true)
+        #expect(session.phase == .completed)
+    }
+
+    @Test
+    func lateEventAfterSessionEndDoesNotResurrectSession() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let client = BridgeCommandClient(socketURL: socketURL)
+        _ = try client.send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .sessionStart,
+                    sessionID: "grok-ended"
+                )
+            )
+        )
+        _ = try client.send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .sessionEnd,
+                    sessionID: "grok-ended"
+                )
+            )
+        )
+        _ = try client.send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .userPromptSubmit,
+                    sessionID: "grok-ended",
+                    prompt: "late prompt"
+                )
+            )
+        )
+
+        let session = try #require(server.sessionStateSnapshotForTests().session(id: "grok-ended"))
+        #expect(session.isSessionEnded == true)
+        // Summary must not be rewritten by late UserPromptSubmit recreation.
+        #expect(session.summary.contains("late prompt") == false)
+    }
+
+    // MARK: - Process liveness (SessionState contract)
+
+    @Test
+    func liveGrokProcessKeepsHookManagedSessionAcrossMissThreshold() {
+        var session = AgentSession(
+            id: "grok-live-1",
+            title: "Grok · demo",
+            tool: .grokBuild,
+            phase: .running,
+            summary: "Working",
+            updatedAt: Date(timeIntervalSince1970: 1_000)
+        )
+        session.isHookManaged = true
+        session.isProcessAlive = true
+        var state = SessionState(sessions: [session])
+
+        // Process monitoring reports the session as alive (Grok process present).
+        state.markProcessLiveness(aliveSessionIDs: ["grok-live-1"])
+        state.markProcessLiveness(aliveSessionIDs: ["grok-live-1"])
+        state.markProcessLiveness(aliveSessionIDs: ["grok-live-1"])
+        #expect(state.session(id: "grok-live-1")?.isSessionEnded == false)
+        #expect(state.session(id: "grok-live-1")?.isVisibleInIsland == true)
+    }
+
+    @Test
+    func missingGrokProcessEventuallyEndsHookManagedSessionWithoutSessionEnd() {
+        var session = AgentSession(
+            id: "grok-orphan-1",
+            title: "Grok · demo",
+            tool: .grokBuild,
+            phase: .running,
+            summary: "Working",
+            updatedAt: Date(timeIntervalSince1970: 1_000)
+        )
+        session.isHookManaged = true
+        session.isProcessAlive = true
+        var state = SessionState(sessions: [session])
+
+        state.markProcessLiveness(aliveSessionIDs: [])
+        #expect(state.session(id: "grok-orphan-1")?.isSessionEnded == false)
+
+        state.markProcessLiveness(aliveSessionIDs: [])
+        #expect(state.session(id: "grok-orphan-1")?.isSessionEnded == true)
+        #expect(state.session(id: "grok-orphan-1")?.isVisibleInIsland == false)
+    }
+
+    @Test
+    func explicitlyEndedGrokSessionIsNotResurrectedByAliveProcessSet() {
+        var session = AgentSession(
+            id: "grok-ended-1",
+            title: "Grok · demo",
+            tool: .grokBuild,
+            phase: .completed,
+            summary: "Done",
+            updatedAt: Date(timeIntervalSince1970: 1_000)
+        )
+        session.isHookManaged = true
+        session.isSessionEnded = true
+        var state = SessionState(sessions: [session])
+
+        // Even if process discovery still reports the session id as "alive",
+        // ended sessions must stay ended.
+        state.markProcessLiveness(aliveSessionIDs: ["grok-ended-1"])
+        state.markProcessLiveness(aliveSessionIDs: ["grok-ended-1"])
+        #expect(state.session(id: "grok-ended-1")?.isSessionEnded == true)
+        #expect(state.session(id: "grok-ended-1")?.isVisibleInIsland == false)
+    }
+}
+
+// MARK: - Helpers
+
+private func nextMatchingGrokEvent(
+    from iterator: inout AsyncThrowingStream<AgentEvent, Error>.AsyncIterator,
+    maxEvents: Int,
+    match: (AgentEvent) -> Bool
+) async throws -> AgentEvent {
+    for _ in 0..<maxEvents {
+        guard let event = try await iterator.next() else {
+            break
+        }
+        if match(event) {
+            return event
+        }
+    }
+    Issue.record("Timed out waiting for matching Grok bridge event")
+    throw CancellationError()
+}

--- a/Tests/OpenIslandCoreTests/GrokHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/GrokHooksTests.swift
@@ -141,6 +141,17 @@ struct GrokHooksTests {
             cancelledBy: "runtime"
         )
         #expect(bare.implicitSummary == "Grok turn stopped: max turns reached in worktree.")
+        #expect(bare.isUserInitiatedCancellation == false)
+
+        let interrupted = GrokHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .stopCancelled,
+            sessionID: "grok-cancelled",
+            reason: "user_interrupt",
+            cancelledBy: "user"
+        )
+        #expect(interrupted.isUserInitiatedCancellation)
+        #expect(!GrokHookPayload(cwd: "/tmp", hookEventName: .stop, sessionID: "s", reason: "end_turn").isUserInitiatedCancellation)
     }
 
     @Test

--- a/Tests/OpenIslandCoreTests/GrokHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/GrokHooksTests.swift
@@ -451,6 +451,139 @@ struct GrokHooksTests {
     }
 
     @Test
+    func idlePromptNotificationSettlesRunningSession() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .sessionStart,
+                    sessionID: "grok-idle-prompt"
+                )
+            )
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .userPromptSubmit,
+                    sessionID: "grok-idle-prompt",
+                    prompt: "do the thing"
+                )
+            )
+        )
+        // No Stop-family event arrives; idle_prompt is the backstop.
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .notification,
+                    sessionID: "grok-idle-prompt",
+                    message: "Grok is waiting for input",
+                    notificationType: "idle_prompt"
+                )
+            )
+        )
+
+        let session = try #require(server.sessionStateSnapshotForTests().session(id: "grok-idle-prompt"))
+        #expect(session.phase == .completed)
+        #expect(session.summary == "Grok is waiting for input")
+        #expect(session.isSessionEnded == false)
+    }
+
+    @Test
+    func idlePromptNotificationPreservesCompletedStopSummary() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .sessionStart,
+                    sessionID: "grok-idle-after-stop"
+                )
+            )
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .stop,
+                    sessionID: "grok-idle-after-stop",
+                    lastAssistantMessage: "All done.",
+                    reason: "end_turn"
+                )
+            )
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .notification,
+                    sessionID: "grok-idle-after-stop",
+                    message: "Grok is waiting for input",
+                    notificationType: "idle_prompt"
+                )
+            )
+        )
+
+        let session = try #require(server.sessionStateSnapshotForTests().session(id: "grok-idle-after-stop"))
+        #expect(session.phase == .completed)
+        #expect(session.summary == "All done.")
+    }
+
+    @Test
+    func nonIdleNotificationKeepsSessionRunning() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .sessionStart,
+                    sessionID: "grok-permission-prompt"
+                )
+            )
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .userPromptSubmit,
+                    sessionID: "grok-permission-prompt",
+                    prompt: "do the thing"
+                )
+            )
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .notification,
+                    sessionID: "grok-permission-prompt",
+                    message: "Grok needs permission to run npm test",
+                    notificationType: "permission_prompt"
+                )
+            )
+        )
+
+        let session = try #require(server.sessionStateSnapshotForTests().session(id: "grok-permission-prompt"))
+        #expect(session.phase == .running)
+        #expect(session.summary == "Grok needs permission to run npm test")
+        #expect(session.isSessionEnded == false)
+    }
+
+    @Test
     func postToolUseFailureDoesNotLeaveSessionRunning() async throws {
         let socketURL = BridgeSocketLocation.uniqueTestURL()
         let server = BridgeServer(socketURL: socketURL)

--- a/Tests/OpenIslandCoreTests/GrokHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/GrokHooksTests.swift
@@ -106,6 +106,42 @@ struct GrokHooksTests {
     // MARK: - Installer
 
     @Test
+    func stopCancelledPayloadDecodesCancellationFields() throws {
+        for raw in ["StopCancelled", "stop_cancelled", "stopCancelled"] {
+            let json = """
+            {
+              "hookEventName": "\(raw)",
+              "sessionId": "grok-cancelled",
+              "cwd": "/tmp/worktree",
+              "reason": "user_interrupt",
+              "cancelledBy": "user",
+              "cancelTrigger": "ctrl_c",
+              "reasonDetails": "Interrupted by user",
+              "lastAssistantMessage": "Partial answer."
+            }
+            """.data(using: .utf8)!
+
+            let payload = try JSONDecoder().decode(GrokHookPayload.self, from: json)
+            #expect(payload.hookEventName == .stopCancelled, "raw \(raw)")
+            #expect(payload.reason == "user_interrupt")
+            #expect(payload.cancelledBy == "user")
+            #expect(payload.cancelTrigger == "ctrl_c")
+            #expect(payload.reasonDetails == "Interrupted by user")
+            #expect(payload.implicitSummary == "Partial answer.")
+            #expect(!payload.isGenuineTurnStop)
+        }
+
+        let bare = GrokHookPayload(
+            cwd: "/tmp/worktree",
+            hookEventName: .stopCancelled,
+            sessionID: "grok-cancelled",
+            reason: "max_turns",
+            cancelledBy: "runtime"
+        )
+        #expect(bare.implicitSummary == "Grok turn stopped: max turns reached in worktree.")
+    }
+
+    @Test
     func requiredEventSpecsCoverEveryHookEventName() {
         let registered = Set(GrokHookInstaller.requiredEventNames)
         let declared = Set(GrokHookEventName.allCases.map(\.rawValue))
@@ -343,6 +379,74 @@ struct GrokHooksTests {
 
         let session = try #require(server.sessionStateSnapshotForTests().session(id: "grok-non-turn-stop"))
         #expect(session.phase == .running)
+        #expect(session.isSessionEnded == false)
+    }
+
+    @Test
+    func stopCancelledCompletesTurnAsInterrupt() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+        try await observer.send(.registerClient(role: .observer))
+
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .sessionStart,
+                    sessionID: "grok-stop-cancelled"
+                )
+            )
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .userPromptSubmit,
+                    sessionID: "grok-stop-cancelled",
+                    prompt: "refactor everything"
+                )
+            )
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .stopCancelled,
+                    sessionID: "grok-stop-cancelled",
+                    lastAssistantMessage: "Partial answer.",
+                    reason: "user_interrupt",
+                    cancelledBy: "user",
+                    cancelTrigger: "ctrl_c"
+                )
+            )
+        )
+
+        var iterator = stream.makeAsyncIterator()
+        let event = try await nextMatchingGrokEvent(from: &iterator, maxEvents: 8) { event in
+            if case .sessionCompleted = event {
+                return true
+            }
+            return false
+        }
+
+        guard case let .sessionCompleted(payload) = event else {
+            Issue.record("Expected Grok StopCancelled session completion")
+            return
+        }
+
+        #expect(payload.sessionID == "grok-stop-cancelled")
+        #expect(payload.summary == "Partial answer.")
+        #expect(payload.isInterrupt == true)
+        #expect(payload.isSessionEnd != true)
+
+        let session = try #require(server.sessionStateSnapshotForTests().session(id: "grok-stop-cancelled"))
+        #expect(session.phase == .completed)
         #expect(session.isSessionEnded == false)
     }
 

--- a/Tests/OpenIslandCoreTests/GrokHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/GrokHooksTests.swift
@@ -617,7 +617,7 @@ struct GrokHooksTests {
     }
 
     @Test
-    func permissionDeniedCompletesTurn() async throws {
+    func permissionDeniedKeepsSessionRunningUntilStopCancelled() async throws {
         let socketURL = BridgeSocketLocation.uniqueTestURL()
         let server = BridgeServer(socketURL: socketURL)
         try server.start()
@@ -653,9 +653,27 @@ struct GrokHooksTests {
             )
         )
 
-        let session = try #require(server.sessionStateSnapshotForTests().session(id: "grok-perm-denied"))
-        #expect(session.phase == .completed)
-        #expect(session.isSessionEnded == false)
+        // A policy deny leaves the model working, so the turn stays running.
+        let afterDeny = try #require(server.sessionStateSnapshotForTests().session(id: "grok-perm-denied"))
+        #expect(afterDeny.phase == .running)
+        #expect(afterDeny.isSessionEnded == false)
+
+        // A user Reject is followed by StopCancelled, which settles the turn.
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .stopCancelled,
+                    sessionID: "grok-perm-denied",
+                    reason: "permission_rejected",
+                    cancelledBy: "user"
+                )
+            )
+        )
+
+        let afterCancel = try #require(server.sessionStateSnapshotForTests().session(id: "grok-perm-denied"))
+        #expect(afterCancel.phase == .completed)
+        #expect(afterCancel.isSessionEnded == false)
     }
 
     @Test

--- a/Tests/OpenIslandCoreTests/GrokHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/GrokHooksTests.swift
@@ -106,14 +106,21 @@ struct GrokHooksTests {
     // MARK: - Installer
 
     @Test
+    func requiredEventSpecsCoverEveryHookEventName() {
+        let registered = Set(GrokHookInstaller.requiredEventNames)
+        let declared = Set(GrokHookEventName.allCases.map(\.rawValue))
+        #expect(registered == declared)
+    }
+
+    @Test
     func managedInstallEmitsCompleteRequiredEventSet() throws {
         let mutation = try GrokHookInstaller.installHooksJSON(hookCommand: openIslandCommand)
         #expect(mutation.changed)
         #expect(mutation.managedHooksPresent)
 
         let data = try #require(mutation.contents)
-        let object = try JSONSerialization.jsonObject(with: data) as! [String: Any]
-        let hooks = object["hooks"] as! [String: Any]
+        let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let hooks = try #require(object["hooks"] as? [String: Any])
         let installedKeys = Set(hooks.keys)
         let expectedKeys = Set(GrokHookInstaller.requiredEventNames)
 
@@ -236,6 +243,16 @@ struct GrokHooksTests {
             try manager.uninstall()
         }
         #expect(FileManager.default.fileExists(atPath: manager.hooksURL.path))
+
+        // Corrupt manifest must not block status or reinstall.
+        try manager.install(hooksBinaryURL: fakeHooks)
+        try Data("{not-json".utf8).write(to: manager.manifestURL)
+        let statusDespiteCorruptManifest = try manager.status(hooksBinaryURL: fakeHooks)
+        #expect(statusDespiteCorruptManifest.managedHooksPresent)
+        #expect(statusDespiteCorruptManifest.manifest == nil)
+        let reinstalled = try manager.install(hooksBinaryURL: fakeHooks)
+        #expect(reinstalled.manifest?.hookCommand != nil)
+        #expect(reinstalled.managedHooksPresent)
     }
 
     // MARK: - Bridge lifecycle
@@ -358,6 +375,48 @@ struct GrokHooksTests {
         )
 
         let session = try #require(server.sessionStateSnapshotForTests().session(id: "grok-tool-fail"))
+        #expect(session.phase == .completed)
+        #expect(session.isSessionEnded == false)
+    }
+
+    @Test
+    func permissionDeniedCompletesTurn() async throws {
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+        try server.start()
+        defer { server.stop() }
+
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .sessionStart,
+                    sessionID: "grok-perm-denied"
+                )
+            )
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .userPromptSubmit,
+                    sessionID: "grok-perm-denied",
+                    prompt: "run something"
+                )
+            )
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processGrokHook(
+                GrokHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .permissionDenied,
+                    sessionID: "grok-perm-denied",
+                    toolName: "run_terminal_command"
+                )
+            )
+        )
+
+        let session = try #require(server.sessionStateSnapshotForTests().session(id: "grok-perm-denied"))
         #expect(session.phase == .completed)
         #expect(session.isSessionEnded == false)
     }

--- a/Tests/OpenIslandCoreTests/GrokHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/GrokHooksTests.swift
@@ -117,7 +117,8 @@ struct GrokHooksTests {
               "cancelledBy": "user",
               "cancelTrigger": "ctrl_c",
               "reasonDetails": "Interrupted by user",
-              "lastAssistantMessage": "Partial answer."
+              "lastAssistantMessage": "Partial answer.",
+              "promptId": "prompt-7"
             }
             """.data(using: .utf8)!
 
@@ -127,6 +128,7 @@ struct GrokHooksTests {
             #expect(payload.cancelledBy == "user")
             #expect(payload.cancelTrigger == "ctrl_c")
             #expect(payload.reasonDetails == "Interrupted by user")
+            #expect(payload.promptID == "prompt-7")
             #expect(payload.implicitSummary == "Partial answer.")
             #expect(!payload.isGenuineTurnStop)
         }

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -338,6 +338,7 @@ All of the following are registered in `~/.grok/hooks/open-island.json` by the m
 | `UserPromptSubmit` | — | Marks the session running and updates summary |
 | `Stop` | — | Completion when `reason == "end_turn"`; if `reason` is omitted, treat as turn completion; non-`end_turn` reasons are observe-only |
 | `StopFailure` | — | Activity update, phase `.completed` (session not ended) |
+| `StopCancelled` | — | Turn completion flagged `isInterrupt` — fires *instead of* `Stop` on a user interrupt (Ctrl+C / Esc), a declined or cancelled permission prompt, `--max-turns`, or a no-progress bail-out; summary is `lastAssistantMessage` when present, else derived from `reason` |
 | `Notification` | `*` | Activity update |
 | `PreToolUse` | `*` | Activity update, **fire-and-forget** (no deny directive; fail-open) |
 | `PostToolUse` | `*` | Activity update |
@@ -356,7 +357,8 @@ Managed status is **healthy only when every event above** is present with an Ope
 ### Wire format notes
 
 - Stdin JSON uses **camelCase** keys (`sessionId`, `hookEventName`, `toolName`, `toolResult`).
-- `hookEventName` may arrive as PascalCase (`PreToolUse`) or snake_case (`pre_tool_use`); both are accepted.
+- `hookEventName` may arrive as PascalCase (`PreToolUse`), snake_case (`pre_tool_use`) or camelCase (`preToolUse`); all are accepted.
+- `StopCancelled` carries `reason` (`user_interrupt`, `permission_rejected`, `permission_cancelled`, `max_turns`, `no_progress`, `unknown`), `cancelledBy` (`user` / `runtime` / `unknown`) and optional `cancelTrigger` / `reasonDetails` / `lastAssistantMessage`.
 - PreToolUse decision format (not used by the managed install yet): `{"decision":"allow"}` / `{"decision":"deny","reason":"..."}`.
 - Sessions also land under `~/.grok/sessions/<url-encoded-cwd>/<session-id>/` for offline discovery (not yet scanned by Open Island).
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -339,7 +339,7 @@ All of the following are registered in `~/.grok/hooks/open-island.json` by the m
 | `Stop` | — | Completion when `reason == "end_turn"`; if `reason` is omitted, treat as turn completion; non-`end_turn` reasons are observe-only |
 | `StopFailure` | — | Activity update, phase `.completed` (session not ended) |
 | `StopCancelled` | — | Turn completion flagged `isInterrupt` — fires *instead of* `Stop` on a user interrupt (Ctrl+C / Esc), a declined or cancelled permission prompt, `--max-turns`, or a no-progress bail-out; summary is `lastAssistantMessage` when present, else derived from `reason` |
-| `Notification` | `*` | Activity update |
+| `Notification` | `*` | Activity update; `notificationType == "idle_prompt"` settles a still-running session as completed (Grok's backstop for turns that reported no Stop-family event) and leaves an already-completed session untouched |
 | `PreToolUse` | `*` | Activity update, **fire-and-forget** (no deny directive; fail-open) |
 | `PostToolUse` | `*` | Activity update |
 | `PostToolUseFailure` | `*` | Activity update, phase `.completed` |

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,14 +1,14 @@
 # Hook System
 
-OpenIsland receives hook events from AI agents (Codex / Claude Code / Gemini CLI) via the `OpenIslandHooks` CLI. The CLI forwards payloads to the app over a Unix socket and, when necessary, writes a directive back to stdout so the agent can act on it (e.g. block a tool call).
+OpenIsland receives hook events from AI agents (Codex / Claude Code / Gemini CLI / Grok Build / …) via the `OpenIslandHooks` CLI. The CLI forwards payloads to the app over a Unix socket and, when necessary, writes a directive back to stdout so the agent can act on it (e.g. block a tool call).
 
 ## Architecture
 
 ```
-Agent (Codex / Claude Code / Gemini CLI)
+Agent (Codex / Claude Code / Gemini CLI / Grok Build / …)
   │  stdin: JSON payload
   ▼
-OpenIslandHooks CLI  (--source codex | --source claude | --source gemini)
+OpenIslandHooks CLI  (--source codex | --source claude | --source gemini | --source grok | …)
   │  Unix socket
   ▼
 BridgeServer → AppModel → UI
@@ -36,7 +36,7 @@ This is meant for per-process launches. Do not set it globally unless you want O
 
 ## Codex Hooks (`--source codex`)
 
-**Payload type**: `CodexHookPayload`  
+**Payload type**: `CodexHookPayload`
 **Source**: [`Sources/OpenIslandCore/CodexHooks.swift`](../Sources/OpenIslandCore/CodexHooks.swift)
 
 ### Events
@@ -134,7 +134,7 @@ All other Codex events require no stdout response.
 
 ## Claude Code Hooks (`--source claude`)
 
-**Payload type**: `ClaudeHookPayload`  
+**Payload type**: `ClaudeHookPayload`
 **Source**: [`Sources/OpenIslandCore/ClaudeHooks.swift`](../Sources/OpenIslandCore/ClaudeHooks.swift)
 
 ### Events
@@ -256,7 +256,7 @@ Setting `interrupt: true` terminates the current agent turn immediately.
 
 ## Gemini CLI Hooks (`--source gemini`)
 
-**Payload type**: `GeminiHookPayload`  
+**Payload type**: `GeminiHookPayload`
 **Source**: [`Sources/OpenIslandCore/GeminiHooks.swift`](../Sources/OpenIslandCore/GeminiHooks.swift)
 
 ### Events
@@ -316,6 +316,61 @@ Setting `interrupt: true` terminates the current agent turn immediately.
 | Claude Code | `PermissionRequest` | **24 hours** (awaits human approval) |
 | Claude Code | All other events | **45 seconds** |
 | Gemini CLI | All events | Bridge default |
+| Grok Build | All managed events | **45 seconds** |
+
+---
+
+## Grok Build Hooks (`--source grok`)
+
+**Payload type**: `GrokHookPayload`
+**Source**: [`Sources/OpenIslandCore/GrokHooks.swift`](../Sources/OpenIslandCore/GrokHooks.swift)
+
+Grok Build (Grok CLI / Grok TUI) discovers hooks from `~/.grok/hooks/*.json`. Open Island writes a dedicated managed file at `~/.grok/hooks/open-island.json`.
+
+### Events (managed install)
+
+All of the following are registered in `~/.grok/hooks/open-island.json` by the managed installer:
+
+| Event | Matcher | Current OpenIsland behavior |
+|---|---|---|
+| `SessionStart` | — | Creates / re-opens the Grok session, title, and jump target |
+| `SessionEnd` | — | Marks the hook-managed session ended (`isSessionEnd`) |
+| `UserPromptSubmit` | — | Marks the session running and updates summary |
+| `Stop` | — | Completion when `reason == "end_turn"`; if `reason` is omitted, treat as turn completion; non-`end_turn` reasons are observe-only |
+| `StopFailure` | — | Activity update, phase `.completed` (session not ended) |
+| `Notification` | `*` | Activity update |
+| `PreToolUse` | `*` | Activity update, **fire-and-forget** (no deny directive; fail-open) |
+| `PostToolUse` | `*` | Activity update |
+| `PostToolUseFailure` | `*` | Activity update, phase `.completed` |
+| `SubagentStart` / `SubagentStop` | — | Activity updates |
+| `PermissionDenied` | — | Activity update |
+| `PreCompact` / `PostCompact` | — | Activity updates |
+
+Managed status is **healthy only when every event above** is present with an Open Island Grok command. A Vibe Island-only command does **not** count as installed.
+
+### Lifecycle / liveness notes
+
+- Non-`SessionStart` events on an **already ended** session are acknowledged and ignored (no resurrection).
+- Process discovery cannot recover Grok session UUIDs. While a `grok` process is alive, Open Island keeps non-ended Grok sessions in the process-alive set (TTY/CWD match when unique; otherwise a conservative “any Grok process” fallback similar to Kimi). Explicit `SessionEnd` still ends the session.
+
+### Wire format notes
+
+- Stdin JSON uses **camelCase** keys (`sessionId`, `hookEventName`, `toolName`, `toolResult`).
+- `hookEventName` may arrive as PascalCase (`PreToolUse`) or snake_case (`pre_tool_use`); both are accepted.
+- PreToolUse decision format (not used by the managed install yet): `{"decision":"allow"}` / `{"decision":"deny","reason":"..."}`.
+- Sessions also land under `~/.grok/sessions/<url-encoded-cwd>/<session-id>/` for offline discovery (not yet scanned by Open Island).
+
+### Install / uninstall
+
+```bash
+swift run OpenIslandSetup installGrok
+swift run OpenIslandSetup statusGrok
+swift run OpenIslandSetup uninstallGrok
+```
+
+Or use **Settings → Setup → Grok Build** in the app.
+
+> If commercial Vibe Island is also installed, both may write under `~/.grok/hooks/`. Prefer one controller at a time.
 
 ---
 
@@ -340,9 +395,11 @@ For iTerm, Terminal, and Ghostty the process additionally runs an AppleScript qu
 
 | File | Responsibility |
 |---|---|
-| [`Sources/OpenIslandHooks/main.swift`](../Sources/OpenIslandHooks/main.swift) | Hook CLI entry point — routes to Codex, Claude, or Gemini path |
+| [`Sources/OpenIslandHooks/OpenIslandHooksCLI.swift`](../Sources/OpenIslandHooks/OpenIslandHooksCLI.swift) | Hook CLI entry point — routes to Codex, Claude, Gemini, Grok, … |
 | [`Sources/OpenIslandCore/CodexHooks.swift`](../Sources/OpenIslandCore/CodexHooks.swift) | Codex payload model, output encoder, terminal detection |
 | [`Sources/OpenIslandCore/ClaudeHooks.swift`](../Sources/OpenIslandCore/ClaudeHooks.swift) | Claude Code payload model, directive types, output encoder |
 | [`Sources/OpenIslandCore/GeminiHooks.swift`](../Sources/OpenIslandCore/GeminiHooks.swift) | Gemini CLI payload model, terminal detection, metadata helpers |
+| [`Sources/OpenIslandCore/GrokHooks.swift`](../Sources/OpenIslandCore/GrokHooks.swift) | Grok Build payload model, terminal detection, lifecycle summaries |
+| [`Sources/OpenIslandCore/GrokHookInstaller.swift`](../Sources/OpenIslandCore/GrokHookInstaller.swift) | Writes `~/.grok/hooks/open-island.json` |
 | [`Sources/OpenIslandCore/BridgeServer.swift`](../Sources/OpenIslandCore/BridgeServer.swift) | Unix socket server — handles incoming hook payloads |
 | [`Sources/OpenIslandCore/BridgeTransport.swift`](../Sources/OpenIslandCore/BridgeTransport.swift) | Protocol codec and envelope types |

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -358,6 +358,7 @@ Managed status is **healthy only when every event above** is present with an Ope
 
 - Stdin JSON uses **camelCase** keys (`sessionId`, `hookEventName`, `toolName`, `toolResult`).
 - `hookEventName` may arrive as PascalCase (`PreToolUse`), snake_case (`pre_tool_use`) or camelCase (`preToolUse`); all are accepted.
+- Envelopes may carry `promptId`; it is decoded as `promptID` but not acted on yet (reserved for ignoring stale-prompt reports).
 - `StopCancelled` carries `reason` (`user_interrupt`, `permission_rejected`, `permission_cancelled`, `max_turns`, `no_progress`, `unknown`), `cancelledBy` (`user` / `runtime` / `unknown`) and optional `cancelTrigger` / `reasonDetails` / `lastAssistantMessage`.
 - PreToolUse decision format (not used by the managed install yet): `{"decision":"allow"}` / `{"decision":"deny","reason":"..."}`.
 - Sessions also land under `~/.grok/sessions/<url-encoded-cwd>/<session-id>/` for offline discovery (not yet scanned by Open Island).

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -4,7 +4,7 @@ OpenIsland receives hook events from AI agents (Codex / Claude Code / Gemini CLI
 
 ## Architecture
 
-```
+```text
 Agent (Codex / Claude Code / Gemini CLI / Grok Build / …)
   │  stdin: JSON payload
   ▼

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -343,7 +343,7 @@ All of the following are registered in `~/.grok/hooks/open-island.json` by the m
 | `PostToolUse` | `*` | Activity update |
 | `PostToolUseFailure` | `*` | Activity update, phase `.completed` |
 | `SubagentStart` / `SubagentStop` | — | Activity updates |
-| `PermissionDenied` | — | Activity update |
+| `PermissionDenied` | — | Activity update, phase `.completed` (session not ended) |
 | `PreCompact` / `PostCompact` | — | Activity updates |
 
 Managed status is **healthy only when every event above** is present with an Open Island Grok command. A Vibe Island-only command does **not** count as installed.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -344,7 +344,7 @@ All of the following are registered in `~/.grok/hooks/open-island.json` by the m
 | `PostToolUse` | `*` | Activity update |
 | `PostToolUseFailure` | `*` | Activity update, phase `.completed` |
 | `SubagentStart` / `SubagentStop` | — | Activity updates |
-| `PermissionDenied` | — | Activity update, phase `.completed` (session not ended) |
+| `PermissionDenied` | — | Activity update; session stays running. Fires for both a user **Reject** (a `StopCancelled` with `permission_rejected` follows and settles the turn) and a configured **PolicyDeny** rule (the model is told the tool was skipped and keeps working) |
 | `PreCompact` / `PostCompact` | — | Activity updates |
 
 Managed status is **healthy only when every event above** is present with an Open Island Grok command. A Vibe Island-only command does **not** count as installed.


### PR DESCRIPTION
## Summary

Adds first-class **Grok Build / Grok CLI** support to Open Island:

- Managed hooks at `~/.grok/hooks/open-island.json` (`OpenIslandSetup installGrok` / Settings)
- Dedicated `--source grok` decode path for camelCase Grok hook envelopes
- Bridge lifecycle: session start/end, activity, turn completion, jump-back metadata
- Process-liveness matching so hook-managed Grok sessions are not aged out while `grok` is still running
- Installer health checks, idempotent reinstall, safe uninstall of Open Island–owned files only

Addresses the pre-merge review findings in process liveness, complete managed event set, install status accuracy, and ownership/idempotency.

## Fixes (pre-merge review)

1. **Process liveness** — TTY/CWD match when unique; otherwise Kimi-style “any Grok process keeps non-ended sessions alive”. Explicit `SessionEnd` is not resurrected.
2. **Managed events** — installer registers the full claimed set, including `PermissionDenied`, `PreCompact`, `PostCompact`.
3. **Install status** — healthy only when every required event has an Open Island Grok command; Vibe Island commands do **not** count as installed.
4. **Idempotent install / safe uninstall** — identical reinstall is `changed: false` (no extra backup); uninstall refuses non–Open Island content in `open-island.json`.
5. **Lifecycle policy** — non-`SessionStart` events on ended sessions are ignored; late hooks do not rewrite phase/summary.
6. **Brand color** — `#22d3ee` for visibility on dark island UI.

## Verification

```text
swift build --product OpenIslandHooks   # OK
swift build --product OpenIslandSetup   # OK
swift build --product OpenIslandApp     # OK
swift test --filter GrokHooksTests      # NOT RUN — environment has Command Line Tools only
                                        # (no Xcode; `import Testing` unavailable)
```

Isolated install smoke (temp `--grok-dir`):

- install → 14 events present (full required set)
- status → managed present yes
- second install → hooks dir still single managed file (idempotent)
- uninstall → managed present no

## Out of scope / follow-ups

- PreToolUse blocking approval UI (observation-only MVP)
- Cold-start discovery from `~/.grok/sessions/**`
- Usage/rate-limit panel for xAI
- Settings warning when commercial `vibe-island.json` is also present
- Hook health-check parity for Grok

## Test plan

- [ ] Xcode / CI: `swift test --filter GrokHooksTests`
- [ ] Xcode / CI: `swift test --filter GrokProcessLivenessTests`
- [ ] Settings → install Grok Build → confirm `~/.grok/hooks/open-island.json`
- [ ] Run `grok`, send a prompt, confirm island session + jump-back
- [ ] Quit Grok without SessionEnd → session eventually ages out
- [ ] SessionEnd → session disappears and is not resurrected by a lingering process
- [ ] Uninstall with a hand-edited foreign `open-island.json` → refuse delete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Grok Build sessions, activity tracking, lifecycle events, process detection, previews, notifications, terminal context, and branding.
  * Added Grok Build hook installation, status checks, uninstall controls, and “Install All” support.
  * Added setup commands for installing, checking, and removing Grok Build integration.

* **Documentation**
  * Updated English and Chinese documentation with Grok Build compatibility, setup instructions, event coverage, and CLI usage.
  * Updated the supported-agent count from 10 to 11.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->