### PR TITLE
fix: make Codex rollout rediscovery incremental

### DIFF
--- a/Sources/OpenIslandCore/CodexSessionTracking.swift
+++ b/Sources/OpenIslandCore/CodexSessionTracking.swift
@@ -342,6 +342,20 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
     private struct Candidate {
         var fileURL: URL
         var modifiedAt: Date
+        var fileSize: Int
+    }
+
+    /// Per-file incremental parse state. `snapshot`/`sessionMeta` only
+    /// reflect bytes up to `consumedOffset` — always the end of the last
+    /// complete line — so a partial trailing line is never folded in twice
+    /// when a later append completes it.
+    private struct ParseState {
+        var consumedOffset: Int
+        var snapshot: CodexRolloutSnapshot
+        var sessionMeta: SessionMeta?
+        var fileSize: Int
+        var modifiedAt: Date
+        var record: CodexTrackedSessionRecord?
     }
 
     private struct SessionMeta {
@@ -373,6 +387,10 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
     private let maxAge: TimeInterval
     private let maxFiles: Int
 
+    private let stateLock = NSLock()
+    private var parseStates: [String: ParseState] = [:]
+    private var scanInProgress = false
+
     public init(
         rootURL: URL = CodexRolloutDiscovery.defaultRootURL,
         fileManager: FileManager = .default,
@@ -386,10 +404,26 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
     }
 
     public func discoverRecentSessions(now: Date = .now) -> [CodexTrackedSessionRecord] {
+        // Re-entrancy guard: with a large active rollout a scan can outlast
+        // the caller's 10s rediscover throttle, and overlapping scans parse
+        // the same files on multiple threads at once.
+        stateLock.lock()
+        if scanInProgress {
+            stateLock.unlock()
+            return []
+        }
+        scanInProgress = true
+        stateLock.unlock()
+        defer {
+            stateLock.lock()
+            scanInProgress = false
+            stateLock.unlock()
+        }
+
         guard fileManager.fileExists(atPath: rootURL.path),
               let enumerator = fileManager.enumerator(
                 at: rootURL,
-                includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey],
+                includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey, .fileSizeKey],
                 options: [.skipsHiddenFiles]
               ) else {
             return []
@@ -405,7 +439,7 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             }
 
             guard let resourceValues = try? fileURL.resourceValues(
-                forKeys: [.contentModificationDateKey, .isRegularFileKey]
+                forKeys: [.contentModificationDateKey, .isRegularFileKey, .fileSizeKey]
             ),
             resourceValues.isRegularFile == true else {
                 continue
@@ -416,7 +450,11 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
                 continue
             }
 
-            candidates.append(Candidate(fileURL: fileURL, modifiedAt: modifiedAt))
+            candidates.append(Candidate(
+                fileURL: fileURL,
+                modifiedAt: modifiedAt,
+                fileSize: resourceValues.fileSize ?? 0
+            ))
         }
 
         let recentCandidates = candidates
@@ -429,11 +467,19 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             }
             .prefix(maxFiles)
 
+        // Drop parse state for files that fell out of the scan window so
+        // the cache stays bounded by `maxFiles`.
+        let candidatePaths = Set(recentCandidates.map { $0.fileURL.path })
+        stateLock.lock()
+        parseStates = parseStates.filter { candidatePaths.contains($0.key) }
+        stateLock.unlock()
+
         var recordsByID: [String: CodexTrackedSessionRecord] = [:]
         for candidate in recentCandidates {
             guard let record = discoverRecord(
                 fileURL: candidate.fileURL,
-                modifiedAt: candidate.modifiedAt
+                modifiedAt: candidate.modifiedAt,
+                fileSize: candidate.fileSize
             ) else {
                 continue
             }
@@ -456,27 +502,57 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
 
     private func discoverRecord(
         fileURL: URL,
-        modifiedAt: Date
+        modifiedAt: Date,
+        fileSize: Int
     ) -> CodexTrackedSessionRecord? {
-        // Stream the rollout line by line instead of slurping the whole
-        // file. Long-lived Codex sessions accumulate JSONL files of tens
-        // of MB; combined with the 10s rediscover throttle that meant a
-        // full-file `String(contentsOf:)` + `split` + `map(String.init)`
-        // every 10 seconds — high autorelease churn that pushed the app
-        // toward swap. Peak working set is now one chunk plus the
-        // accumulated `CodexRolloutSnapshot`.
+        // Rollouts are append-only folds, so parse them incrementally:
+        // cache the accumulated snapshot per file and only reduce bytes
+        // past `consumedOffset`. Re-reducing every recent rollout from
+        // byte 0 on each 10s rediscover pass pinned a core for hours once
+        // an active session's file grew past a few tens of MB (a single
+        // 80 MB rollout takes ~the whole 10s window to fold), and the
+        // resulting overlap stacked concurrent full parses on top.
+        let path = fileURL.path
+
+        stateLock.lock()
+        var state = parseStates[path]
+        stateLock.unlock()
+
+        if let cached = state, cached.fileSize == fileSize, cached.modifiedAt == modifiedAt {
+            return cached.record
+        }
+        if let cached = state, fileSize < cached.consumedOffset {
+            // Truncated or replaced in place — the cached fold no longer
+            // matches the bytes on disk.
+            state = nil
+        }
+
         guard let fileHandle = try? FileHandle(forReadingFrom: fileURL) else {
             return nil
         }
         defer { try? fileHandle.close() }
 
-        var snapshot = CodexRolloutSnapshot()
-        var sessionMeta: SessionMeta?
+        var snapshot = state?.snapshot ?? CodexRolloutSnapshot()
+        var sessionMeta = state?.sessionMeta
+        var startOffset = state?.consumedOffset ?? 0
+
+        if startOffset > 0 {
+            do {
+                try fileHandle.seek(toOffset: UInt64(startOffset))
+            } catch {
+                snapshot = CodexRolloutSnapshot()
+                sessionMeta = nil
+                startOffset = 0
+            }
+        }
+
         var buffer = Data()
+        var bytesRead = 0
 
         while let chunk = try? fileHandle.read(upToCount: Self.streamingChunkSize),
               !chunk.isEmpty {
             buffer.append(chunk)
+            bytesRead += chunk.count
             for line in extractCompleteLines(from: &buffer) {
                 CodexRolloutReducer.apply(line: line, to: &snapshot)
                 if sessionMeta == nil {
@@ -485,17 +561,52 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             }
         }
 
+        // Cache only the fold over complete lines; the leftover partial
+        // line is folded into a throwaway copy below so it can't be
+        // applied twice once a later append completes it.
+        let consumedOffset = startOffset + bytesRead - buffer.count
+
+        var recordSnapshot = snapshot
+        var recordMeta = sessionMeta
+
         // A trailing line without a final newline should still count.
         if !buffer.isEmpty {
             let trailing = String(decoding: buffer, as: UTF8.self)
             if !trailing.isEmpty {
-                CodexRolloutReducer.apply(line: trailing, to: &snapshot)
-                if sessionMeta == nil {
-                    sessionMeta = parseSessionMeta(fromLine: trailing)
+                CodexRolloutReducer.apply(line: trailing, to: &recordSnapshot)
+                if recordMeta == nil {
+                    recordMeta = parseSessionMeta(fromLine: trailing)
                 }
             }
         }
 
+        let record = makeRecord(
+            fileURL: fileURL,
+            modifiedAt: modifiedAt,
+            snapshot: recordSnapshot,
+            sessionMeta: recordMeta
+        )
+
+        stateLock.lock()
+        parseStates[path] = ParseState(
+            consumedOffset: consumedOffset,
+            snapshot: snapshot,
+            sessionMeta: sessionMeta,
+            fileSize: fileSize,
+            modifiedAt: modifiedAt,
+            record: record
+        )
+        stateLock.unlock()
+
+        return record
+    }
+
+    private func makeRecord(
+        fileURL: URL,
+        modifiedAt: Date,
+        snapshot: CodexRolloutSnapshot,
+        sessionMeta: SessionMeta?
+    ) -> CodexTrackedSessionRecord? {
         guard let sessionMeta else { return nil }
 
         let summary = snapshot.summary ?? sessionMeta.defaultSummary

--- a/Sources/OpenIslandCore/CodexSessionTracking.swift
+++ b/Sources/OpenIslandCore/CodexSessionTracking.swift
@@ -338,6 +338,12 @@ public enum CodexAppSessionReconciler {
     }
 }
 
+struct CodexRolloutDiscoveryDiagnostics: Equatable, Sendable {
+    var bytesRead = 0
+    var parsedFileCount = 0
+    var cacheHitCount = 0
+}
+
 public final class CodexRolloutDiscovery: @unchecked Sendable {
     private struct Candidate {
         var fileURL: URL
@@ -390,6 +396,11 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
     private let stateLock = NSLock()
     private var parseStates: [String: ParseState] = [:]
     private var scanInProgress = false
+    private var _lastScanDiagnostics = CodexRolloutDiscoveryDiagnostics()
+
+    var lastScanDiagnostics: CodexRolloutDiscoveryDiagnostics {
+        stateLock.withLock { _lastScanDiagnostics }
+    }
 
     public init(
         rootURL: URL = CodexRolloutDiscovery.defaultRootURL,
@@ -414,10 +425,12 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
         }
         scanInProgress = true
         stateLock.unlock()
+        var diagnostics = CodexRolloutDiscoveryDiagnostics()
         defer {
-            stateLock.lock()
-            scanInProgress = false
-            stateLock.unlock()
+            stateLock.withLock {
+                _lastScanDiagnostics = diagnostics
+                scanInProgress = false
+            }
         }
 
         guard fileManager.fileExists(atPath: rootURL.path),
@@ -479,7 +492,8 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             guard let record = discoverRecord(
                 fileURL: candidate.fileURL,
                 modifiedAt: candidate.modifiedAt,
-                fileSize: candidate.fileSize
+                fileSize: candidate.fileSize,
+                diagnostics: &diagnostics
             ) else {
                 continue
             }
@@ -503,7 +517,8 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
     private func discoverRecord(
         fileURL: URL,
         modifiedAt: Date,
-        fileSize: Int
+        fileSize: Int,
+        diagnostics: inout CodexRolloutDiscoveryDiagnostics
     ) -> CodexTrackedSessionRecord? {
         // Rollouts are append-only folds, so parse them incrementally:
         // cache the accumulated snapshot per file and only reduce bytes
@@ -519,6 +534,7 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
         stateLock.unlock()
 
         if let cached = state, cached.fileSize == fileSize, cached.modifiedAt == modifiedAt {
+            diagnostics.cacheHitCount += 1
             return cached.record
         }
         if let cached = state,
@@ -535,6 +551,7 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             return nil
         }
         defer { try? fileHandle.close() }
+        diagnostics.parsedFileCount += 1
 
         var snapshot = state?.snapshot ?? CodexRolloutSnapshot()
         var sessionMeta = state?.sessionMeta
@@ -557,6 +574,7 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
               !chunk.isEmpty {
             buffer.append(chunk)
             bytesRead += chunk.count
+            diagnostics.bytesRead += chunk.count
             for line in extractCompleteLines(from: &buffer) {
                 CodexRolloutReducer.apply(line: line, to: &snapshot)
                 if sessionMeta == nil {

--- a/Sources/OpenIslandCore/CodexSessionTracking.swift
+++ b/Sources/OpenIslandCore/CodexSessionTracking.swift
@@ -521,9 +521,13 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
         if let cached = state, cached.fileSize == fileSize, cached.modifiedAt == modifiedAt {
             return cached.record
         }
-        if let cached = state, fileSize < cached.consumedOffset {
-            // Truncated or replaced in place — the cached fold no longer
-            // matches the bytes on disk.
+        if let cached = state,
+           fileSize < cached.consumedOffset
+               || (fileSize == cached.fileSize && modifiedAt != cached.modifiedAt) {
+            // Truncated or rewritten in place — the cached fold no longer
+            // matches the bytes on disk. A same-size rewrite has no appended
+            // suffix to parse, so its changed modification date must also
+            // invalidate the snapshot.
             state = nil
         }
 

--- a/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
@@ -1325,6 +1325,158 @@ struct CodexSessionTrackingTests {
         #expect(records.first?.sessionID == "codex-session-trailing")
         #expect(records.first?.codexMetadata?.lastAssistantMessage == "Final line without newline.")
     }
+
+    @Test
+    func codexRolloutDiscoveryFoldsAppendedLinesIncrementally() throws {
+        // Pins the incremental re-scan path: a second discovery pass over a
+        // grown rollout must only fold the appended bytes, and a trailing
+        // partial line from the first pass must fold exactly once when a
+        // later append completes it. If the cached offset drifted into the
+        // partial line, the completed line would be parsed from mid-line
+        // garbage and the final assistant message would be lost.
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-discovery-incr-\(UUID().uuidString)", isDirectory: true)
+        let rolloutDirectoryURL = rootURL.appendingPathComponent("2026/04/02", isDirectory: true)
+        let rolloutURL = rolloutDirectoryURL.appendingPathComponent("rollout-incremental.jsonl")
+        let now = Date(timeIntervalSince1970: 1_743_555_200)
+
+        try FileManager.default.createDirectory(at: rolloutDirectoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let completedLine = rolloutLine(
+            timestamp: "2026-04-02T04:03:46.000Z",
+            type: "event_msg",
+            payload: [
+                "type": "agent_message",
+                "message": "Message completed across two scans.",
+            ]
+        )
+        let splitIndex = completedLine.index(completedLine.startIndex, offsetBy: completedLine.count / 2)
+
+        let firstChunk = [
+            sessionMetaLine(
+                sessionID: "codex-session-incremental",
+                timestamp: "2026-04-02T04:03:44.000Z",
+                cwd: "/Users/wangruobing/Personal/open-island"
+            ),
+            rolloutLine(
+                timestamp: "2026-04-02T04:03:45.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "user_message",
+                    "message": "Start the incremental scan.",
+                ]
+            ),
+        ].joined(separator: "\n").appending("\n").appending(String(completedLine[..<splitIndex]))
+
+        try firstChunk.write(to: rolloutURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.modificationDate: now], ofItemAtPath: rolloutURL.path)
+
+        let discovery = CodexRolloutDiscovery(
+            rootURL: rootURL,
+            fileManager: .default,
+            maxAge: 86_400,
+            maxFiles: 10
+        )
+
+        let firstPass = discovery.discoverRecentSessions(now: now)
+        #expect(firstPass.count == 1)
+        #expect(firstPass.first?.codexMetadata?.lastUserPrompt == "Start the incremental scan.")
+
+        let secondChunk = String(completedLine[splitIndex...]).appending("\n").appending(
+            rolloutLine(
+                timestamp: "2026-04-02T04:03:47.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "user_message",
+                    "message": "Appended after the first scan.",
+                ]
+            )
+        ).appending("\n")
+
+        let appendHandle = try FileHandle(forWritingTo: rolloutURL)
+        try appendHandle.seekToEnd()
+        try appendHandle.write(contentsOf: Data(secondChunk.utf8))
+        try appendHandle.close()
+        let later = now.addingTimeInterval(30)
+        try FileManager.default.setAttributes([.modificationDate: later], ofItemAtPath: rolloutURL.path)
+
+        let secondPass = discovery.discoverRecentSessions(now: later)
+        let freshPass = CodexRolloutDiscovery(
+            rootURL: rootURL,
+            fileManager: .default,
+            maxAge: 86_400,
+            maxFiles: 10
+        ).discoverRecentSessions(now: later)
+
+        #expect(secondPass.count == 1)
+        #expect(secondPass.first?.sessionID == "codex-session-incremental")
+        #expect(secondPass.first?.codexMetadata?.lastAssistantMessage == "Message completed across two scans.")
+        #expect(secondPass.first?.codexMetadata?.lastUserPrompt == "Appended after the first scan.")
+        #expect(secondPass.first == freshPass.first)
+    }
+
+    @Test
+    func codexRolloutDiscoveryReparsesTruncatedRollouts() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-discovery-trunc-\(UUID().uuidString)", isDirectory: true)
+        let rolloutDirectoryURL = rootURL.appendingPathComponent("2026/04/02", isDirectory: true)
+        let rolloutURL = rolloutDirectoryURL.appendingPathComponent("rollout-truncated.jsonl")
+        let now = Date(timeIntervalSince1970: 1_743_555_200)
+
+        try FileManager.default.createDirectory(at: rolloutDirectoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let longLines = [
+            sessionMetaLine(
+                sessionID: "codex-session-truncated",
+                timestamp: "2026-04-02T04:03:44.000Z",
+                cwd: "/Users/wangruobing/Personal/open-island"
+            ),
+            rolloutLine(
+                timestamp: "2026-04-02T04:03:45.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "agent_message",
+                    "message": "Original content before truncation, padded to outsize the rewrite. \(String(repeating: "x", count: 512))",
+                ]
+            ),
+        ]
+        try longLines.joined(separator: "\n").appending("\n").write(to: rolloutURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.modificationDate: now], ofItemAtPath: rolloutURL.path)
+
+        let discovery = CodexRolloutDiscovery(
+            rootURL: rootURL,
+            fileManager: .default,
+            maxAge: 86_400,
+            maxFiles: 10
+        )
+        _ = discovery.discoverRecentSessions(now: now)
+
+        let rewrittenLines = [
+            sessionMetaLine(
+                sessionID: "codex-session-truncated",
+                timestamp: "2026-04-02T04:03:44.000Z",
+                cwd: "/Users/wangruobing/Personal/open-island"
+            ),
+            rolloutLine(
+                timestamp: "2026-04-02T04:03:48.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "agent_message",
+                    "message": "Rewritten after truncation.",
+                ]
+            ),
+        ]
+        try rewrittenLines.joined(separator: "\n").appending("\n").write(to: rolloutURL, atomically: true, encoding: .utf8)
+        let later = now.addingTimeInterval(30)
+        try FileManager.default.setAttributes([.modificationDate: later], ofItemAtPath: rolloutURL.path)
+
+        let records = discovery.discoverRecentSessions(now: later)
+
+        #expect(records.count == 1)
+        #expect(records.first?.codexMetadata?.lastAssistantMessage == "Rewritten after truncation.")
+    }
 }
 
 private final class MissingTranscriptFileManager: FileManager, @unchecked Sendable {

--- a/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
@@ -1477,6 +1477,60 @@ struct CodexSessionTrackingTests {
         #expect(records.count == 1)
         #expect(records.first?.codexMetadata?.lastAssistantMessage == "Rewritten after truncation.")
     }
+
+    @Test
+    func codexRolloutDiscoveryReparsesSameSizeRewrites() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-discovery-rewrite-\(UUID().uuidString)", isDirectory: true)
+        let rolloutDirectoryURL = rootURL.appendingPathComponent("2026/04/02", isDirectory: true)
+        let rolloutURL = rolloutDirectoryURL.appendingPathComponent("rollout-rewritten.jsonl")
+        let now = Date(timeIntervalSince1970: 1_743_555_200)
+
+        try FileManager.default.createDirectory(at: rolloutDirectoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let originalBody = [
+            sessionMetaLine(
+                sessionID: "codex-session-rewritten",
+                timestamp: "2026-04-02T04:03:44.000Z",
+                cwd: "/Users/wangruobing/Personal/open-island"
+            ),
+            rolloutLine(
+                timestamp: "2026-04-02T04:03:45.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "agent_message",
+                    "message": "Original same-size content.",
+                ]
+            ),
+        ].joined(separator: "\n").appending("\n")
+        let replacementBody = originalBody.replacingOccurrences(
+            of: "Original same-size content.",
+            with: "Replaced same-size content."
+        )
+        #expect(originalBody.utf8.count == replacementBody.utf8.count)
+
+        try originalBody.write(to: rolloutURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.modificationDate: now], ofItemAtPath: rolloutURL.path)
+
+        let discovery = CodexRolloutDiscovery(
+            rootURL: rootURL,
+            fileManager: .default,
+            maxAge: 86_400,
+            maxFiles: 10
+        )
+        let originalRecords = discovery.discoverRecentSessions(now: now)
+        #expect(originalRecords.first?.codexMetadata?.lastAssistantMessage == "Original same-size content.")
+
+        try replacementBody.write(to: rolloutURL, atomically: true, encoding: .utf8)
+        let later = now.addingTimeInterval(30)
+        try FileManager.default.setAttributes([.modificationDate: later], ofItemAtPath: rolloutURL.path)
+
+        let rewrittenRecords = discovery.discoverRecentSessions(now: later)
+
+        #expect(rewrittenRecords.count == 1)
+        #expect(rewrittenRecords.first?.codexMetadata?.lastAssistantMessage == "Replaced same-size content.")
+    }
 }
 
 private final class MissingTranscriptFileManager: FileManager, @unchecked Sendable {

--- a/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
@@ -1531,6 +1531,79 @@ struct CodexSessionTrackingTests {
         #expect(rewrittenRecords.count == 1)
         #expect(rewrittenRecords.first?.codexMetadata?.lastAssistantMessage == "Replaced same-size content.")
     }
+
+    @Test
+    func codexRolloutDiscoveryReadsOnlyAppendedBytesAfterWarmup() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-discovery-read-volume-\(UUID().uuidString)", isDirectory: true)
+        let rolloutDirectoryURL = rootURL.appendingPathComponent("2026/04/02", isDirectory: true)
+        let rolloutURL = rolloutDirectoryURL.appendingPathComponent("rollout-read-volume.jsonl")
+        let now = Date(timeIntervalSince1970: 1_743_555_200)
+
+        try FileManager.default.createDirectory(at: rolloutDirectoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        var initialLines = [
+            sessionMetaLine(
+                sessionID: "codex-session-read-volume",
+                timestamp: "2026-04-02T04:03:44.000Z",
+                cwd: "/Users/wangruobing/Personal/open-island"
+            ),
+        ]
+        let padding = String(repeating: "x", count: 512)
+        for index in 0..<200 {
+            initialLines.append(rolloutLine(
+                timestamp: "2026-04-02T04:03:45.000Z",
+                type: "event_msg",
+                payload: [
+                    "type": "agent_message",
+                    "message": "padding \(index) \(padding)",
+                ]
+            ))
+        }
+        let initialBody = initialLines.joined(separator: "\n").appending("\n")
+        try initialBody.write(to: rolloutURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.modificationDate: now], ofItemAtPath: rolloutURL.path)
+
+        let discovery = CodexRolloutDiscovery(
+            rootURL: rootURL,
+            fileManager: .default,
+            maxAge: 86_400,
+            maxFiles: 10
+        )
+
+        _ = discovery.discoverRecentSessions(now: now)
+        #expect(discovery.lastScanDiagnostics.bytesRead == initialBody.utf8.count)
+        #expect(discovery.lastScanDiagnostics.parsedFileCount == 1)
+        #expect(discovery.lastScanDiagnostics.cacheHitCount == 0)
+
+        _ = discovery.discoverRecentSessions(now: now)
+        #expect(discovery.lastScanDiagnostics.bytesRead == 0)
+        #expect(discovery.lastScanDiagnostics.parsedFileCount == 0)
+        #expect(discovery.lastScanDiagnostics.cacheHitCount == 1)
+
+        let appendedLine = rolloutLine(
+            timestamp: "2026-04-02T04:03:46.000Z",
+            type: "event_msg",
+            payload: [
+                "type": "user_message",
+                "message": "Only this appended line should be read.",
+            ]
+        ).appending("\n")
+        let appendHandle = try FileHandle(forWritingTo: rolloutURL)
+        try appendHandle.seekToEnd()
+        try appendHandle.write(contentsOf: Data(appendedLine.utf8))
+        try appendHandle.close()
+        let later = now.addingTimeInterval(30)
+        try FileManager.default.setAttributes([.modificationDate: later], ofItemAtPath: rolloutURL.path)
+
+        let appendedRecords = discovery.discoverRecentSessions(now: later)
+
+        #expect(discovery.lastScanDiagnostics.bytesRead == appendedLine.utf8.count)
+        #expect(discovery.lastScanDiagnostics.parsedFileCount == 1)
+        #expect(discovery.lastScanDiagnostics.cacheHitCount == 0)
+        #expect(appendedRecords.first?.codexMetadata?.lastUserPrompt == "Only this appended line should be read.")
+    }
 }
 
 private final class MissingTranscriptFileManager: FileManager, @unchecked Sendable {


### PR DESCRIPTION
## Summary

- cache per-rollout parse state and fold only appended JSONL bytes during Codex rediscovery
- prevent overlapping rediscovery scans when a large rollout takes longer than the 10-second throttle
- preserve correctness for partial trailing lines, truncation, and same-size rewrites
- add deterministic diagnostics and regression coverage proving warm scans read zero unchanged bytes

## Root cause

The existing streaming reader bounded memory per chunk, but every periodic rediscovery still reparsed every recent rollout from byte zero. Large, long-lived Codex rollouts therefore caused recurring CPU work, disk reads, memory growth, and overlapping scans.

## Impact

On the same 15 recent rollout files (about 87 MB, largest about 37 MB):

- standalone warm rediscovery fell from about 11.2 seconds for a full fold to about 18–21 ms
- a 75-second app comparison against `origin/main` reduced total CPU time from 2124 ms to 450 ms
- after the first 20-second startup window, CPU work fell from 1746 ms to 33 ms and additional reads fell from 13.6 MB to 0
- end-of-run resident memory fell from about 456 MB to about 100 MB in this local sample

## Validation

- `swift build`
- 7 focused `CodexSessionTrackingTests` passed:
  - recent rollout discovery
  - cross-chunk streaming
  - trailing partial line
  - incremental append folding
  - truncation recovery
  - same-size rewrite invalidation
  - deterministic read-volume assertions
- matched 75-second baseline/optimized app runs with process rusage sampling
- 20-second stack samples confirmed the baseline rediscovery/watcher path dominates recurring work

Supersedes #606 while preserving the original contributor commit and authorship.

Related to #618 and #564.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session rollout discovery when files are appended, truncated, rewritten, or contain incomplete trailing lines.
  * Prevented duplicate records and stale results during repeated scans.
  * Improved scan reliability by preventing overlapping discovery operations.

* **Performance**
  * Reduced unnecessary file reading by reusing unchanged data and processing only newly appended content.

* **Diagnostics**
  * Added scan diagnostics to improve visibility into discovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->