### PR TITLE
feat: add detailed usage display mode

### DIFF
--- a/Sources/OpenIslandApp/AppModelTypes.swift
+++ b/Sources/OpenIslandApp/AppModelTypes.swift
@@ -66,8 +66,15 @@ struct IslandAppearancePreferences: Equatable, Sendable {
 enum IslandUsageDisplay: String, CaseIterable, Identifiable, Sendable {
     case hidden
     case compact
+    case detailed
 
     var id: String { rawValue }
+
+    /// Whether the opened island renders usage chips at all.
+    var showsUsage: Bool { self != .hidden }
+
+    /// Whether a usage chip lists every window instead of only the busiest one.
+    var showsAllWindows: Bool { self == .detailed }
 }
 
 enum IslandSessionStateIndicator: String, CaseIterable, Identifiable, Sendable {

--- a/Sources/OpenIslandApp/AppModelTypes.swift
+++ b/Sources/OpenIslandApp/AppModelTypes.swift
@@ -63,7 +63,7 @@ struct IslandAppearancePreferences: Equatable, Sendable {
     var completedStaleThreshold: IslandCompletedStaleThreshold = .fiveMinutes
 }
 
-enum IslandUsageDisplay: String, CaseIterable, Identifiable, Sendable {
+enum IslandUsageDisplay: String, CaseIterable, Identifiable, Sendable, Codable {
     case hidden
     case compact
     case detailed

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -74,9 +74,10 @@
 "settings.appearance.profile.macbook.title" = "MacBook notch";
 "settings.appearance.profile.macbook.note" = "Built-in notch surface with notch-aware geometry.";
 "settings.appearance.usageDisplay.title" = "02 · Usage";
-"settings.appearance.usageDisplay.note" = "Controls whether the opened island shows compact agent usage.";
+"settings.appearance.usageDisplay.note" = "Controls how much agent usage the opened island shows.";
 "settings.appearance.usageDisplay.hidden" = "Hidden";
 "settings.appearance.usageDisplay.compact" = "Compact";
+"settings.appearance.usageDisplay.detailed" = "Detailed";
 "settings.appearance.stateIndicator.title" = "03 · Session state";
 "settings.appearance.stateIndicator.note" = "How rows show running, waiting, and completed state.";
 "settings.appearance.stateIndicator.animatedDot" = "Animated dot";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -74,9 +74,10 @@
 "settings.appearance.profile.macbook.title" = "MacBook 刘海屏";
 "settings.appearance.profile.macbook.note" = "内置刘海屏布局，保留刘海感知几何。";
 "settings.appearance.usageDisplay.title" = "02 · 用量";
-"settings.appearance.usageDisplay.note" = "控制展开后的 Island 是否显示紧凑的代理用量。";
+"settings.appearance.usageDisplay.note" = "控制展开后的 Island 显示多少代理用量信息。";
 "settings.appearance.usageDisplay.hidden" = "隐藏";
 "settings.appearance.usageDisplay.compact" = "紧凑";
+"settings.appearance.usageDisplay.detailed" = "详细";
 "settings.appearance.stateIndicator.title" = "03 · 会话状态";
 "settings.appearance.stateIndicator.note" = "控制列表行如何呈现运行、等待和完成状态。";
 "settings.appearance.stateIndicator.animatedDot" = "动效点";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -74,9 +74,10 @@
 "settings.appearance.profile.macbook.title" = "MacBook 凹槽螢幕";
 "settings.appearance.profile.macbook.note" = "內建凹槽螢幕布局，保留凹槽感知幾何。";
 "settings.appearance.usageDisplay.title" = "02 · 用量";
-"settings.appearance.usageDisplay.note" = "控制展開後的 Island 是否顯示緊湊的代理用量。";
+"settings.appearance.usageDisplay.note" = "控制展開後的 Island 顯示多少代理用量資訊。";
 "settings.appearance.usageDisplay.hidden" = "隱藏";
 "settings.appearance.usageDisplay.compact" = "緊湊";
+"settings.appearance.usageDisplay.detailed" = "詳細";
 "settings.appearance.stateIndicator.title" = "03 · 會話狀態";
 "settings.appearance.stateIndicator.note" = "控制列表列如何呈現執行、等待和完成狀態。";
 "settings.appearance.stateIndicator.animatedDot" = "動效點";

--- a/Sources/OpenIslandApp/Views/AppearanceSettingsPane.swift
+++ b/Sources/OpenIslandApp/Views/AppearanceSettingsPane.swift
@@ -1422,10 +1422,10 @@ private struct UsageDisplayPreview: View {
         HStack(spacing: 6) {
             switch option {
             case .compact:
-                usageChip("Cl", windows: [("5h", 42)], color: Color(hex: AgentTool.claudeCode.brandColorHex) ?? .orange)
-                usageChip("Cx", windows: [("7d", 13)], color: Color(hex: AgentTool.codex.brandColorHex) ?? .blue)
+                usageChip("Cl", windows: [("5h", 42)])
+                usageChip("Cx", windows: [("7d", 13)])
             case .detailed:
-                usageChip("Cl", windows: [("5h", 42), ("7d", 13)], color: Color(hex: AgentTool.claudeCode.brandColorHex) ?? .orange)
+                usageChip("Cl", windows: [("5h", 42), ("7d", 13)])
             case .hidden:
                 RoundedRectangle(cornerRadius: 2, style: .continuous)
                     .fill(V6Palette.paper.opacity(0.18))
@@ -1435,7 +1435,7 @@ private struct UsageDisplayPreview: View {
         .frame(width: 104, alignment: .center)
     }
 
-    private func usageChip(_ title: String, windows: [(label: String, value: Int)], color: Color) -> some View {
+    private func usageChip(_ title: String, windows: [(label: String, value: Int)]) -> some View {
         HStack(spacing: 6) {
             Text(title)
                 .font(.system(size: 9.5, weight: .semibold))
@@ -1447,13 +1447,23 @@ private struct UsageDisplayPreview: View {
                         .foregroundStyle(V6Palette.paper.opacity(0.42))
                     Text("\(window.value)%")
                         .font(.system(size: 9.5, weight: .bold, design: .monospaced))
-                        .foregroundStyle(color)
+                        .foregroundStyle(usageColor(for: window.value))
                 }
             }
         }
         .padding(.horizontal, 6)
         .padding(.vertical, 3)
         .background(.white.opacity(0.055), in: Capsule())
+    }
+
+    /// Mirrors the thresholds `IslandPanelView` applies to live usage chips so
+    /// the preview reads the same as the island it is previewing.
+    private func usageColor(for percentage: Int) -> Color {
+        switch percentage {
+        case 90...: .red.opacity(0.95)
+        case 70..<90: .orange.opacity(0.95)
+        default: .green.opacity(0.95)
+        }
     }
 }
 

--- a/Sources/OpenIslandApp/Views/AppearanceSettingsPane.swift
+++ b/Sources/OpenIslandApp/Views/AppearanceSettingsPane.swift
@@ -591,8 +591,9 @@ struct AppearanceSettingsPane: View {
 
     private func title(for option: IslandUsageDisplay) -> String {
         switch option {
-        case .hidden:  lang.t("settings.appearance.usageDisplay.hidden")
-        case .compact: lang.t("settings.appearance.usageDisplay.compact")
+        case .hidden:   lang.t("settings.appearance.usageDisplay.hidden")
+        case .compact:  lang.t("settings.appearance.usageDisplay.compact")
+        case .detailed: lang.t("settings.appearance.usageDisplay.detailed")
         }
     }
 
@@ -1419,10 +1420,13 @@ private struct UsageDisplayPreview: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            if option == .compact {
-                usageChip("Cl", window: "5h", value: 42, color: Color(hex: AgentTool.claudeCode.brandColorHex) ?? .orange)
-                usageChip("Cx", window: "7d", value: 13, color: Color(hex: AgentTool.codex.brandColorHex) ?? .blue)
-            } else {
+            switch option {
+            case .compact:
+                usageChip("Cl", windows: [("5h", 42)], color: Color(hex: AgentTool.claudeCode.brandColorHex) ?? .orange)
+                usageChip("Cx", windows: [("7d", 13)], color: Color(hex: AgentTool.codex.brandColorHex) ?? .blue)
+            case .detailed:
+                usageChip("Cl", windows: [("5h", 42), ("7d", 13)], color: Color(hex: AgentTool.claudeCode.brandColorHex) ?? .orange)
+            case .hidden:
                 RoundedRectangle(cornerRadius: 2, style: .continuous)
                     .fill(V6Palette.paper.opacity(0.18))
                     .frame(width: 72, height: 5)
@@ -1431,17 +1435,21 @@ private struct UsageDisplayPreview: View {
         .frame(width: 104, alignment: .center)
     }
 
-    private func usageChip(_ title: String, window: String, value: Int, color: Color) -> some View {
-        HStack(spacing: 4) {
+    private func usageChip(_ title: String, windows: [(label: String, value: Int)], color: Color) -> some View {
+        HStack(spacing: 6) {
             Text(title)
                 .font(.system(size: 9.5, weight: .semibold))
                 .foregroundStyle(V6Palette.paper.opacity(0.66))
-            Text(window)
-                .font(.system(size: 9, weight: .semibold, design: .monospaced))
-                .foregroundStyle(V6Palette.paper.opacity(0.42))
-            Text("\(value)%")
-                .font(.system(size: 9.5, weight: .bold, design: .monospaced))
-                .foregroundStyle(color)
+            ForEach(Array(windows.enumerated()), id: \.offset) { _, window in
+                HStack(spacing: 4) {
+                    Text(window.label)
+                        .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(V6Palette.paper.opacity(0.42))
+                    Text("\(window.value)%")
+                        .font(.system(size: 9.5, weight: .bold, design: .monospaced))
+                        .foregroundStyle(color)
+                }
+            }
         }
         .padding(.horizontal, 6)
         .padding(.vertical, 3)

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -849,17 +849,27 @@ struct IslandPanelView: View {
         let providers = openedUsageProviders
 
         if providers.isEmpty == false {
-            ViewThatFits(in: .horizontal) {
-                compactUsageSummaryView(providers, usesShortTitles: false)
-                compactUsageSummaryView(providers, usesShortTitles: true)
-            }
+            usageSummaryThatFits(providers)
         } else {
             Color.clear
         }
     }
 
+    /// Renders the widest usage summary that fits, degrading from every window
+    /// down to the busiest one before falling back to abbreviated provider names.
+    private func usageSummaryThatFits(_ providers: [UsageProviderPresentation]) -> some View {
+        let showsAllWindows = model.islandUsageDisplay.showsAllWindows
+
+        return ViewThatFits(in: .horizontal) {
+            compactUsageSummaryView(providers, usesShortTitles: false, showsAllWindows: showsAllWindows)
+            compactUsageSummaryView(providers, usesShortTitles: true, showsAllWindows: showsAllWindows)
+            compactUsageSummaryView(providers, usesShortTitles: false, showsAllWindows: false)
+            compactUsageSummaryView(providers, usesShortTitles: true, showsAllWindows: false)
+        }
+    }
+
     private var openedUsageProviders: [UsageProviderPresentation] {
-        guard model.islandUsageDisplay == .compact else {
+        guard model.islandUsageDisplay.showsUsage else {
             return []
         }
 
@@ -956,11 +966,8 @@ struct IslandPanelView: View {
             Color.clear
                 .frame(maxWidth: .infinity)
         } else {
-            ViewThatFits(in: .horizontal) {
-                compactUsageSummaryView(providers, usesShortTitles: false)
-                compactUsageSummaryView(providers, usesShortTitles: true)
-            }
-            .frame(maxWidth: .infinity, alignment: alignment)
+            usageSummaryThatFits(providers)
+                .frame(maxWidth: .infinity, alignment: alignment)
         }
     }
 
@@ -1019,30 +1026,45 @@ struct IslandPanelView: View {
 
     private func compactUsageSummaryView(
         _ providers: [UsageProviderPresentation],
-        usesShortTitles: Bool
+        usesShortTitles: Bool,
+        showsAllWindows: Bool
     ) -> some View {
         HStack(spacing: 7) {
             ForEach(providers) { provider in
-                compactUsageChip(provider, usesShortTitle: usesShortTitles)
+                compactUsageChip(
+                    provider,
+                    usesShortTitle: usesShortTitles,
+                    showsAllWindows: showsAllWindows
+                )
             }
         }
         .lineLimit(1)
         .fixedSize(horizontal: true, vertical: false)
     }
 
-    private func compactUsageChip(_ provider: UsageProviderPresentation, usesShortTitle: Bool) -> some View {
+    private func compactUsageChip(
+        _ provider: UsageProviderPresentation,
+        usesShortTitle: Bool,
+        showsAllWindows: Bool
+    ) -> some View {
         HStack(spacing: 5) {
             Text(usesShortTitle ? provider.shortTitle : provider.title)
                 .font(.system(size: 11, weight: .semibold))
                 .foregroundStyle(.white.opacity(0.74))
 
-            Text(provider.peakWindowLabel)
-                .font(.system(size: 10.5, weight: .semibold, design: .monospaced))
-                .foregroundStyle(.white.opacity(0.42))
+            HStack(spacing: 7) {
+                ForEach(provider.displayedWindows(showingAllWindows: showsAllWindows)) { window in
+                    HStack(spacing: 5) {
+                        Text(window.label)
+                            .font(.system(size: 10.5, weight: .semibold, design: .monospaced))
+                            .foregroundStyle(.white.opacity(0.42))
 
-            Text("\(provider.peakUsagePercentage)%")
-                .font(.system(size: 11.5, weight: .bold, design: .monospaced))
-                .foregroundStyle(usageColor(for: provider.peakUsedPercentage))
+                        Text("\(window.roundedUsedPercentage)%")
+                            .font(.system(size: 11.5, weight: .bold, design: .monospaced))
+                            .foregroundStyle(usageColor(for: window.usedPercentage))
+                    }
+                }
+            }
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
@@ -1121,16 +1143,10 @@ private struct UsageProviderPresentation: Identifiable {
         }
     }
 
-    var peakWindowLabel: String {
-        peakWindow?.label ?? ""
-    }
-
-    var peakUsedPercentage: Double {
-        peakWindow?.usedPercentage ?? 0
-    }
-
-    var peakUsagePercentage: Int {
-        peakWindow?.roundedUsedPercentage ?? 0
+    /// Windows to render in a chip: every window in detailed mode, otherwise
+    /// only the busiest one so the compact chip keeps its original footprint.
+    func displayedWindows(showingAllWindows: Bool) -> [UsageWindowPresentation] {
+        showingAllWindows ? windows : [peakWindow].compactMap { $0 }
     }
 
     var shortTitle: String {


### PR DESCRIPTION
## Problem

The opened island renders one usage chip per provider, but the chip only ever shows `peakWindow` — whichever window has the highest `used_percentage`:

```swift
var peakWindow: UsageWindowPresentation? {
    windows.max { lhs, rhs in lhs.usedPercentage < rhs.usedPercentage }
}
```

Both windows are already parsed into `ClaudeUsageSnapshot` from `/tmp/open-island-rl.json`. So with 5h at 10% and 7d at 16%, the chip reads `Claude 7d 16%` and the 5h window is invisible — even though 5h is the number you watch while a session is burning down, and it is the one that flips first. The full breakdown is only reachable by hovering for the `.help()` tooltip, which is neither discoverable nor readable at a glance.

## Change

Add a third `IslandUsageDisplay` case, `detailed`, that renders every window in the chip.

- `compact` stays the default. Existing users see no change, and the single-window chip keeps its exact previous spacing and footprint.
- The `ViewThatFits` cascade gains two rungs, so a narrow lane degrades detailed → peak-only *before* falling back to abbreviated provider names:
  1. full title + all windows
  2. short title + all windows
  3. full title + peak only *(previously rung 1)*
  4. short title + peak only *(previously rung 2)*
- Each window is coloured by its own `usedPercentage` through the existing `usageColor(for:)` thresholds, instead of every window inheriting the peak window's colour.
- `peakWindowLabel` / `peakUsedPercentage` / `peakUsagePercentage` existed only for the chip and are replaced by `displayedWindows(showingAllWindows:)`. `peakWindow` itself is kept.

The change is provider-agnostic: Codex chips get the same treatment when `showCodexUsage` is on and its snapshot carries more than one window.

## Screenshots

Captured via `scripts/smoke-dev-app.sh` with the `sessionList` scenario against live `rate_limits` data.

**Compact — default, unchanged**

![compact usage chip](https://raw.githubusercontent.com/Kevindic0214/open-vibe-island/assets/usage-detailed-screenshots/docs/assets/usage-compact.png)

**Detailed — new**

![detailed usage chip](https://raw.githubusercontent.com/Kevindic0214/open-vibe-island/assets/usage-detailed-screenshots/docs/assets/usage-detailed.png)

The detailed capture shows the `Cl` short title rather than `Claude`: the harness panel's left lane is too narrow for the full name plus both windows, so rung 2 wins. That is the cascade doing its job.

## Verification

- `swift build` — passes.
- `swift test` — **could not run locally.** This machine has only the Command Line Tools toolchain, which ships no `swift-testing` module; every test file fails with `no such module 'Testing'`. The identical failure reproduces on a pristine `main`, so it is an environment gap on my side, not a regression from this change. CI covers the actual test run.
- Manual — harness smoke in both modes, screenshots above.

## Notes

- #348 also surfaces 5h/7d, but on the **closed** notch pill via a new `ClaudeUsageBadge` overlay. This PR is the **opened** panel chip. Both edit `IslandPanelView.swift` but in different regions (closed-state header overlay vs. `compactUsageChip`), so they address different surfaces and should not conflict semantically.
- New key `settings.appearance.usageDisplay.detailed` added to all three locales (en / zh-Hans / zh-Hant). The section note was reworded from "whether … shows" to "how much … shows", since the setting is no longer binary.

---

### 中文摘要

展開後的島上，用量膠囊只會顯示 `peakWindow`（百分比最高的那個視窗）。所以在 5h 10% / 7d 16% 的情況下只看得到 7d，5h 被整個藏起來 —— 但跑 session 時真正該盯的是 5h，而且它才是先翻掉的那個。兩個視窗的資料本來就都在 snapshot 裡，目前只有 hover 出 tooltip 才看得到完整內容。

本 PR 新增 `IslandUsageDisplay.detailed`，讓膠囊列出所有視窗。`compact` 維持預設、外觀完全不變，所以這是 opt-in、對現有使用者零影響。`ViewThatFits` 階梯多加兩層，空間不足時先退回只顯示 peak，再退到縮寫名稱，凹槽較窄的機種不會溢出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Detailed** usage display option.
  * Detailed mode can show usage across multiple configured time windows.
  * Added adaptive layouts for compact, detailed, and hidden usage previews.
  * Usage displays now prioritize the busiest window when space is limited, while preserving readable provider names.

* **Localization**
  * Updated usage display descriptions and added translations for the new option in English, Simplified Chinese, and Traditional Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->