### PR TITLE
feat: option to show remaining usage instead of used

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -24,6 +24,7 @@ final class AppModel {
     private static let islandRightSlotDefaultsKey = "appearance.island.v6.rightSlot"
     private static let islandCenterLabelDefaultsKey = "appearance.island.v6.centerLabel"
     private static let showCodexUsageDefaultsKey = "app.showCodexUsage"
+    private static let usageShowsRemainingDefaultsKey = "app.usageShowsRemaining"
     private static let completionReplyEnabledDefaultsKey = "feature.completionReply.enabled"
     private static let suppressFrontmostNotificationsDefaultsKey = "app.suppressFrontmostNotifications"
     private static let legacyIslandSessionStateIndicatorDefaultsKey = "appearance.island.v8.stateIndicator"
@@ -261,6 +262,13 @@ final class AppModel {
         didSet {
             guard hasFinishedInit, showCodexUsage != oldValue else { return }
             UserDefaults.standard.set(showCodexUsage, forKey: Self.showCodexUsageDefaultsKey)
+        }
+    }
+    /// Renders usage windows as headroom left rather than quota consumed.
+    var usageShowsRemaining: Bool = false {
+        didSet {
+            guard hasFinishedInit, usageShowsRemaining != oldValue else { return }
+            UserDefaults.standard.set(usageShowsRemaining, forKey: Self.usageShowsRemainingDefaultsKey)
         }
     }
     var completionReplyEnabled: Bool = false {
@@ -621,6 +629,7 @@ final class AppModel {
                 atPath: CodexRolloutDiscovery.defaultRootURL.path
             )
         }
+        usageShowsRemaining = UserDefaults.standard.bool(forKey: Self.usageShowsRemainingDefaultsKey)
         completionReplyEnabled = UserDefaults.standard.bool(forKey: Self.completionReplyEnabledDefaultsKey)
         launchAtLoginEnabled = LaunchAtLoginService.shared.isEnabled
         appearanceSettingsProfile = IslandAppearanceDisplayProfile(

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -21,6 +21,7 @@ final class AppModel {
     private static let islandRightSlotDefaultsKey = "appearance.island.v6.rightSlot"
     private static let islandCenterLabelDefaultsKey = "appearance.island.v6.centerLabel"
     private static let showCodexUsageDefaultsKey = "app.showCodexUsage"
+    private static let usageShowsRemainingDefaultsKey = "app.usageShowsRemaining"
     private static let completionReplyEnabledDefaultsKey = "feature.completionReply.enabled"
     private static let suppressFrontmostNotificationsDefaultsKey = "app.suppressFrontmostNotifications"
     private static let legacyIslandSessionStateIndicatorDefaultsKey = "appearance.island.v8.stateIndicator"
@@ -250,6 +251,13 @@ final class AppModel {
         didSet {
             guard hasFinishedInit, showCodexUsage != oldValue else { return }
             UserDefaults.standard.set(showCodexUsage, forKey: Self.showCodexUsageDefaultsKey)
+        }
+    }
+    /// Renders usage windows as headroom left rather than quota consumed.
+    var usageShowsRemaining: Bool = false {
+        didSet {
+            guard hasFinishedInit, usageShowsRemaining != oldValue else { return }
+            UserDefaults.standard.set(usageShowsRemaining, forKey: Self.usageShowsRemainingDefaultsKey)
         }
     }
     var completionReplyEnabled: Bool = false {
@@ -608,6 +616,7 @@ final class AppModel {
                 atPath: CodexRolloutDiscovery.defaultRootURL.path
             )
         }
+        usageShowsRemaining = UserDefaults.standard.bool(forKey: Self.usageShowsRemainingDefaultsKey)
         completionReplyEnabled = UserDefaults.standard.bool(forKey: Self.completionReplyEnabledDefaultsKey)
         launchAtLoginEnabled = LaunchAtLoginService.shared.isEnabled
         appearanceSettingsProfile = IslandAppearanceDisplayProfile(

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -28,6 +28,7 @@
 "settings.general.hapticFeedback" = "Haptic feedback on hover";
 "settings.general.suppressFrontmostNotifications" = "Suppress notifications for focused sessions";
 "settings.general.showCodexUsage" = "Show Codex usage";
+"settings.general.usageShowsRemaining" = "Show remaining quota instead of used";
 "settings.general.completionReply" = "Reply from completion card";
 "settings.general.cliHooks" = "CLI Hooks";
 "settings.general.activated" = "Activated";
@@ -199,6 +200,7 @@
 "island.section.idle" = "Idle";
 "island.showAll" = "Show all %lld sessions";
 "island.collapseList" = "Collapse list";
+"island.usageWindowRemaining" = "%@ %d%% left";
 "island.usageWaiting" = "Usage waiting";
 
 /* Island Panel - Approval */

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -200,7 +200,7 @@
 "island.section.idle" = "Idle";
 "island.showAll" = "Show all %lld sessions";
 "island.collapseList" = "Collapse list";
-"island.usageWindowRemaining" = "%@ %d%% left";
+"island.usageWindowRemaining" = "%@ %lld%% left";
 "island.usageWaiting" = "Usage waiting";
 
 /* Island Panel - Approval */

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -28,7 +28,7 @@
 "settings.general.hapticFeedback" = "Haptic feedback on hover";
 "settings.general.suppressFrontmostNotifications" = "Suppress notifications for focused sessions";
 "settings.general.showCodexUsage" = "Show Codex usage";
-"settings.general.usageShowsRemaining" = "Show remaining quota instead of used";
+"settings.general.usageShowsRemaining" = "Show remaining quota instead of used quota";
 "settings.general.completionReply" = "Reply from completion card";
 "settings.general.cliHooks" = "CLI Hooks";
 "settings.general.activated" = "Activated";

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -27,7 +27,7 @@
 "settings.general.hapticFeedback" = "Haptic feedback on hover";
 "settings.general.suppressFrontmostNotifications" = "Suppress notifications for focused sessions";
 "settings.general.showCodexUsage" = "Show Codex usage";
-"settings.general.usageShowsRemaining" = "Show remaining quota instead of used";
+"settings.general.usageShowsRemaining" = "Show remaining quota instead of used quota";
 "settings.general.completionReply" = "Reply from completion card";
 "settings.general.cliHooks" = "CLI Hooks";
 "settings.general.activated" = "Activated";

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -27,6 +27,7 @@
 "settings.general.hapticFeedback" = "Haptic feedback on hover";
 "settings.general.suppressFrontmostNotifications" = "Suppress notifications for focused sessions";
 "settings.general.showCodexUsage" = "Show Codex usage";
+"settings.general.usageShowsRemaining" = "Show remaining quota instead of used";
 "settings.general.completionReply" = "Reply from completion card";
 "settings.general.cliHooks" = "CLI Hooks";
 "settings.general.activated" = "Activated";
@@ -198,6 +199,7 @@
 "island.section.idle" = "Idle";
 "island.showAll" = "Show all %lld sessions";
 "island.collapseList" = "Collapse list";
+"island.usageWindowRemaining" = "%@ %d%% left";
 "island.usageWaiting" = "Usage waiting";
 
 /* Island Panel - Approval */

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -200,7 +200,7 @@
 "island.section.idle" = "空闲";
 "island.showAll" = "显示全部 %lld 个会话";
 "island.collapseList" = "收起列表";
-"island.usageWindowRemaining" = "%@ 剩余 %d%%";
+"island.usageWindowRemaining" = "%@ 剩余 %lld%%";
 "island.usageWaiting" = "等待用量数据";
 
 /* Island Panel - Approval */

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -28,6 +28,7 @@
 "settings.general.hapticFeedback" = "悬停时震动反馈";
 "settings.general.suppressFrontmostNotifications" = "前台会话不弹出通知";
 "settings.general.showCodexUsage" = "显示 Codex 用量";
+"settings.general.usageShowsRemaining" = "显示剩余额度而非已用额度";
 "settings.general.completionReply" = "在完成卡片中回复";
 "settings.general.cliHooks" = "CLI Hooks";
 "settings.general.activated" = "已激活";
@@ -199,6 +200,7 @@
 "island.section.idle" = "空闲";
 "island.showAll" = "显示全部 %lld 个会话";
 "island.collapseList" = "收起列表";
+"island.usageWindowRemaining" = "%@ 剩余 %d%%";
 "island.usageWaiting" = "等待用量数据";
 
 /* Island Panel - Approval */

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -27,6 +27,7 @@
 "settings.general.hapticFeedback" = "悬停时震动反馈";
 "settings.general.suppressFrontmostNotifications" = "前台会话不弹出通知";
 "settings.general.showCodexUsage" = "显示 Codex 用量";
+"settings.general.usageShowsRemaining" = "显示剩余额度而非已用额度";
 "settings.general.completionReply" = "在完成卡片中回复";
 "settings.general.cliHooks" = "CLI Hooks";
 "settings.general.activated" = "已激活";
@@ -198,6 +199,7 @@
 "island.section.idle" = "空闲";
 "island.showAll" = "显示全部 %lld 个会话";
 "island.collapseList" = "收起列表";
+"island.usageWindowRemaining" = "%@ 剩余 %d%%";
 "island.usageWaiting" = "等待用量数据";
 
 /* Island Panel - Approval */

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -200,7 +200,7 @@
 "island.section.idle" = "閒置";
 "island.showAll" = "顯示全部 %lld 個工作階段";
 "island.collapseList" = "收起清單";
-"island.usageWindowRemaining" = "%@ 剩餘 %d%%";
+"island.usageWindowRemaining" = "%@ 剩餘 %lld%%";
 "island.usageWaiting" = "等待用量資料";
 
 /* Island Panel - Approval */

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -28,6 +28,7 @@
 "settings.general.hapticFeedback" = "懸停時震動回饋";
 "settings.general.suppressFrontmostNotifications" = "前台工作階段不彈出通知";
 "settings.general.showCodexUsage" = "顯示 Codex 用量";
+"settings.general.usageShowsRemaining" = "顯示剩餘額度而非已用額度";
 "settings.general.completionReply" = "在完成卡片中回覆";
 "settings.general.cliHooks" = "CLI Hooks";
 "settings.general.activated" = "已啟用";
@@ -199,6 +200,7 @@
 "island.section.idle" = "閒置";
 "island.showAll" = "顯示全部 %lld 個工作階段";
 "island.collapseList" = "收起清單";
+"island.usageWindowRemaining" = "%@ 剩餘 %d%%";
 "island.usageWaiting" = "等待用量資料";
 
 /* Island Panel - Approval */

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -27,6 +27,7 @@
 "settings.general.hapticFeedback" = "懸停時震動回饋";
 "settings.general.suppressFrontmostNotifications" = "前台工作階段不彈出通知";
 "settings.general.showCodexUsage" = "顯示 Codex 用量";
+"settings.general.usageShowsRemaining" = "顯示剩餘額度而非已用額度";
 "settings.general.completionReply" = "在完成卡片中回覆";
 "settings.general.cliHooks" = "CLI Hooks";
 "settings.general.activated" = "已啟用";
@@ -198,6 +199,7 @@
 "island.section.idle" = "閒置";
 "island.showAll" = "顯示全部 %lld 個工作階段";
 "island.collapseList" = "收起清單";
+"island.usageWindowRemaining" = "%@ 剩餘 %d%%";
 "island.usageWaiting" = "等待用量資料";
 
 /* Island Panel - Approval */

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1180,7 +1180,7 @@ struct IslandPanelView: View {
 
 /// One rung of the usage-chip detail ladder. `adaptiveUsageSummaryView` walks
 /// these from richest to sparsest and renders the first that fits the lane.
-private struct UsageChipLayout {
+private struct UsageChipLayout: Sendable, Codable {
     let usesShortTitle: Bool
     let showsAllWindows: Bool
     let showsRemaining: Bool

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1072,7 +1072,7 @@ struct IslandPanelView: View {
                         .font(.system(size: 10.5, weight: .semibold, design: .monospaced))
                         .foregroundStyle(.white.opacity(0.42))
 
-                    Text("\(window.roundedUsedPercentage)%")
+                    Text(usagePercentageText(for: window, layout: layout))
                         .font(.system(size: 11.5, weight: .bold, design: .monospaced))
                         .foregroundStyle(usageColor(for: window.usedPercentage))
 
@@ -1096,9 +1096,21 @@ struct IslandPanelView: View {
         .help(usageHelpText(for: provider))
     }
 
+    /// Percentage rendered inside a window's chip. Colour is derived
+    /// separately from `window.usedPercentage`, so it keeps meaning "nearly
+    /// spent" even while this flips to headroom.
+    private func usagePercentageText(for window: UsageWindowPresentation, layout: UsageChipLayout) -> String {
+        guard model.usageShowsRemaining else {
+            return "\(window.roundedUsedPercentage)%"
+        }
+
+        let percentage = "\(window.roundedRemainingPercentage)%"
+        return layout.usesShortTitle ? percentage : "\(percentage) left"
+    }
+
     private func usageHelpText(for provider: UsageProviderPresentation) -> String {
         provider.windows.map { window in
-            var parts = ["\(window.label) \(window.roundedUsedPercentage)%"]
+            var parts = [usageWindowSummary(for: window)]
             if let resetsAt = window.resetsAt,
                let remaining = remainingDurationString(until: resetsAt) {
                 parts.append(remaining)
@@ -1106,6 +1118,20 @@ struct IslandPanelView: View {
             return parts.joined(separator: " ")
         }
         .joined(separator: " · ")
+    }
+
+    /// The compact chip has no room to say which direction it counts, so the
+    /// tooltip always spells it out: "5h 84% left" against a bare "5h 16%".
+    private func usageWindowSummary(for window: UsageWindowPresentation) -> String {
+        guard model.usageShowsRemaining else {
+            return "\(window.label) \(window.roundedUsedPercentage)%"
+        }
+
+        return lang.t(
+            "island.usageWindowRemaining",
+            window.label,
+            window.roundedRemainingPercentage
+        )
     }
 
     private func headerPill(_ title: String, tint: Color) -> some View {
@@ -1179,10 +1205,6 @@ private struct UsageProviderPresentation: Identifiable {
         peakWindow?.usedPercentage ?? 0
     }
 
-    var peakUsagePercentage: Int {
-        peakWindow?.roundedUsedPercentage ?? 0
-    }
-
     var shortTitle: String {
         switch id {
         case "claude":
@@ -1203,6 +1225,12 @@ private struct UsageWindowPresentation: Identifiable {
 
     var roundedUsedPercentage: Int {
         Int(usedPercentage.rounded())
+    }
+
+    /// Headroom left in the window. Clamped because providers occasionally
+    /// report over 100% once a window is exhausted.
+    var roundedRemainingPercentage: Int {
+        Int(min(100, max(0, 100 - usedPercentage)).rounded())
     }
 }
 

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -1040,7 +1040,7 @@ struct IslandPanelView: View {
                 .font(.system(size: 10.5, weight: .semibold, design: .monospaced))
                 .foregroundStyle(.white.opacity(0.42))
 
-            Text("\(provider.peakUsagePercentage)%")
+            Text("\(provider.peakPercentage(showingRemaining: model.usageShowsRemaining))%")
                 .font(.system(size: 11.5, weight: .bold, design: .monospaced))
                 .foregroundStyle(usageColor(for: provider.peakUsedPercentage))
         }
@@ -1056,7 +1056,7 @@ struct IslandPanelView: View {
 
     private func usageHelpText(for provider: UsageProviderPresentation) -> String {
         provider.windows.map { window in
-            var parts = ["\(window.label) \(window.roundedUsedPercentage)%"]
+            var parts = [usageWindowSummary(for: window)]
             if let resetsAt = window.resetsAt,
                let remaining = remainingDurationString(until: resetsAt) {
                 parts.append(remaining)
@@ -1064,6 +1064,20 @@ struct IslandPanelView: View {
             return parts.joined(separator: " ")
         }
         .joined(separator: " · ")
+    }
+
+    /// The chip itself has no room to say which direction it counts, so the
+    /// tooltip spells it out: "5h 84% left" against a bare "5h 16%".
+    private func usageWindowSummary(for window: UsageWindowPresentation) -> String {
+        guard model.usageShowsRemaining else {
+            return "\(window.label) \(window.roundedUsedPercentage)%"
+        }
+
+        return lang.t(
+            "island.usageWindowRemaining",
+            window.label,
+            window.roundedRemainingPercentage
+        )
     }
 
     private func headerPill(_ title: String, tint: Color) -> some View {
@@ -1129,8 +1143,13 @@ private struct UsageProviderPresentation: Identifiable {
         peakWindow?.usedPercentage ?? 0
     }
 
-    var peakUsagePercentage: Int {
-        peakWindow?.roundedUsedPercentage ?? 0
+    /// Percentage rendered in the chip, counting either direction. Colour still
+    /// derives from `peakUsedPercentage`, so red keeps meaning "nearly spent".
+    func peakPercentage(showingRemaining: Bool) -> Int {
+        guard let peakWindow else { return 0 }
+        return showingRemaining
+            ? peakWindow.roundedRemainingPercentage
+            : peakWindow.roundedUsedPercentage
     }
 
     var shortTitle: String {
@@ -1153,6 +1172,12 @@ private struct UsageWindowPresentation: Identifiable {
 
     var roundedUsedPercentage: Int {
         Int(usedPercentage.rounded())
+    }
+
+    /// Headroom left in the window. Clamped because providers occasionally
+    /// report over 100% once a window is exhausted.
+    var roundedRemainingPercentage: Int {
+        Int(min(100, max(0, 100 - usedPercentage)).rounded())
     }
 }
 

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -646,6 +646,11 @@ struct SetupSettingsPane: View {
                     get: { model.showCodexUsage },
                     set: { model.showCodexUsage = $0 }
                 ))
+
+                Toggle(lang.t("settings.general.usageShowsRemaining"), isOn: Binding(
+                    get: { model.usageShowsRemaining },
+                    set: { model.usageShowsRemaining = $0 }
+                ))
             } header: {
                 HStack(spacing: 4) {
                     Text(lang.t("setup.section.usage"))

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -639,6 +639,11 @@ struct SetupSettingsPane: View {
                     get: { model.showCodexUsage },
                     set: { model.showCodexUsage = $0 }
                 ))
+
+                Toggle(lang.t("settings.general.usageShowsRemaining"), isOn: Binding(
+                    get: { model.usageShowsRemaining },
+                    set: { model.usageShowsRemaining = $0 }
+                ))
             } header: {
                 HStack(spacing: 4) {
                     Text(lang.t("setup.section.usage"))


### PR DESCRIPTION
## Problem

Usage chips and their tooltips report consumption: a fresh 7-day window reads `7d 16%`. But a quota is watched for its **headroom**, not its consumption — the question at a glance is "how much do I have left before this window caps me", and today that means subtracting from 100 in your head every time you look at the notch.

## Change

Add an app-level toggle, **Show remaining quota instead of used**, in the Usage Bridge section of General settings — right beside the existing *Show Codex usage* toggle, which is the same kind of app-wide usage preference.

Off by default. Nothing changes for anyone who does not turn it on.

Two details worth calling out:

**Colour stays anchored to consumption.** `usageColor(for:)` keeps receiving `usedPercentage`, not the rendered number. Inverting the thresholds alongside the figure would make red mean "plenty left" and green mean "nearly capped" — exactly backwards. So a window at 95% used still shows red while displaying `5%`.

**The tooltip disambiguates.** The chip has no room to state which direction it counts, so `usageHelpText` does it: `5h 84% left` in remaining mode against a bare `5h 16%` in the default. New format key `island.usageWindowRemaining`.

`roundedRemainingPercentage` clamps to `0...100`: providers can report past 100% once a window is exhausted, which would otherwise render as a negative remainder.

This is provider-agnostic — Codex windows flip along with Claude's.

## Screenshots

Captured via `scripts/smoke-dev-app.sh` (`sessionList` scenario) against live `rate_limits` data — the same window, both directions.

**Default — used**

![used](https://raw.githubusercontent.com/Kevindic0214/open-vibe-island/assets/usage-detailed-screenshots/docs/assets/remaining-used.png)

**Toggle on — remaining**

![remaining](https://raw.githubusercontent.com/Kevindic0214/open-vibe-island/assets/usage-detailed-screenshots/docs/assets/remaining-remaining.png)

Note the colour stays green in both: 16% used is plenty of headroom either way you print it.

## Verification

- `swift build` — passes.
- `scripts/lint-strings.sh` — passes (all three locales carry both new keys).
- `scripts/check-docs.sh` — passes.
- Manual — harness smoke in both directions, screenshots above.
- `swift test` — **could not run locally.** This machine has only the Command Line Tools toolchain, which ships no `swift-testing` module; every test file fails with `no such module 'Testing'`. The identical failure reproduces on a pristine `main`, so it is an environment gap on my side rather than a regression. CI covers the actual test run.

## Notes

- Independent of #635 (detailed usage display) — that one changes *which windows* a chip lists, this one changes *which direction* a window counts. Both touch `compactUsageChip`, so whichever lands second will want a trivial rebase, but neither depends on the other.

---

### 中文摘要

用量膠囊顯示的是「已用」，所以 7 天視窗會讀成 `7d 16%`。但看額度時真正在意的是「還剩多少」，現在每次瞄一眼凹槽都得自己心算 100 減掉。

本 PR 在 General 設定的 Usage Bridge 區塊加一個 app 層級開關「顯示剩餘額度而非已用額度」，就放在既有的 Codex 用量開關旁邊。預設關閉，不開就完全不影響。

兩個刻意的取捨：顏色仍然由 `usedPercentage` 決定，不跟著數字一起翻 —— 否則紅色會變成「還很多」，語意整個顛倒。另外膠囊本身沒有空間標示方向，所以由 tooltip 講清楚：剩餘模式顯示 `5h 剩餘 84%`，預設模式維持 `5h 16%`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Settings toggle to display remaining Codex usage quota.
  * The island panel now shows remaining usage percentages when enabled.
  * Usage details adapt to available space by simplifying content as needed.
  * Session badges remain on a single line for improved readability.
  * Added English, Simplified Chinese, and Traditional Chinese translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->