### PR TITLE
fix: keep appearance preference writes on the active display profile

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -394,11 +394,17 @@ final class AppModel {
         for profile: IslandAppearanceDisplayProfile,
         _ update: (inout IslandAppearancePreferences) -> Void
     ) {
+        // Copy → mutate → assign so `@Observable` + `didSet` always see a full
+        // writeback (inout on a tracked property is not reliable across observers).
         switch profile {
         case .notch:
-            update(&notchAppearancePreferences)
+            var preferences = notchAppearancePreferences
+            update(&preferences)
+            notchAppearancePreferences = preferences
         case .topBar:
-            update(&topBarAppearancePreferences)
+            var preferences = topBarAppearancePreferences
+            update(&preferences)
+            topBarAppearancePreferences = preferences
         }
     }
 
@@ -411,7 +417,21 @@ final class AppModel {
             oldValue.completedStaleThreshold != newValue.completedStaleThreshold {
             _cachedSessionBuckets = nil
         }
-        refreshOverlayPlacementIfVisible()
+
+        // Session list presentation prefs only affect the open list layout —
+        // not closed-island geometry. Repositioning here can establish or flip
+        // `overlayPlacementDiagnostics` mid-update, which changes
+        // `activeAppearanceProfile` and makes later convenience-setter reads
+        // hit a different profile than the one just written.
+        let affectsOverlayChrome =
+            oldValue.rightSlot != newValue.rightSlot
+            || oldValue.centerLabel != newValue.centerLabel
+            || oldValue.usageDisplay != newValue.usageDisplay
+            || oldValue.sessionStateIndicator != newValue.sessionStateIndicator
+
+        if affectsOverlayChrome {
+            refreshOverlayPlacementIfVisible()
+        }
     }
 
     private func persistAppearancePreferences(

--- a/Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift
+++ b/Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift
@@ -6,6 +6,17 @@ import OpenIslandCore
 
 @MainActor
 struct AgentsGridRightSlotTests {
+    init() {
+        // Appearance right-slot is persisted per display profile. Clear both so
+        // suite order / prior tests cannot leave `.agents` (or `.count`) sticky
+        // across instances via UserDefaults.
+        [
+            "appearance.island.v6.rightSlot",
+            "appearance.island.v8.notch.rightSlot",
+            "appearance.island.v8.topBar.rightSlot",
+        ].forEach(UserDefaults.standard.removeObject(forKey:))
+    }
+
     /// At bulk first observation (e.g. app launch) ties are broken by
     /// session.firstSeenAt so historical order is preserved.
     @Test

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -310,6 +310,27 @@ struct AppModelSessionListTests {
         #expect(model.islandListSessions.map(\.id) == ["fresh-completed", "stale-completed"])
     }
 
+    /// Convenience setters must write and read the same active appearance
+    /// profile. A regression used to flip `overlayPlacementDiagnostics` (and
+    /// thus `activeAppearanceProfile`) mid-update when list prefs triggered a
+    /// full overlay reposition, so later gets hit defaults on the other profile.
+    @Test
+    func appearancePreferenceSettersStickOnActiveProfile() {
+        let model = AppModel()
+        let profileBefore = model.activeAppearanceProfile
+
+        model.islandSessionGroup = .state
+        model.islandSessionSort = .lastUpdate
+        model.completedStaleThreshold = .fiveMinutes
+
+        #expect(model.activeAppearanceProfile == profileBefore)
+        #expect(model.islandSessionGroup == .state)
+        #expect(model.islandSessionSort == .lastUpdate)
+        #expect(model.completedStaleThreshold == .fiveMinutes)
+        #expect(model.appearancePreferences(for: profileBefore).sessionGroup == .state)
+        #expect(model.appearancePreferences(for: profileBefore).sessionSort == .lastUpdate)
+    }
+
     @Test
     func islandSessionSectionsGroupStaleCompletedIntoIdle() {
         let now = Date()


### PR DESCRIPTION
## Summary

Fixes #641

Session list appearance convenience setters (`islandSessionGroup`, `islandSessionSort`, `completedStaleThreshold`, …) could **write one display profile and then read another**.

### Root cause

1. In some environments (tests / empty display option list), `refreshOverlayDisplayConfiguration()` left `overlayPlacementDiagnostics == nil`, so `activeAppearanceProfile` defaulted to `.topBar`.
2. Writing list prefs called `appearancePreferencesDidChange` → **always** `refreshOverlayPlacementIfVisible()`, which established diagnostics for the real screen (often `.notch`).
3. Later gets used `.notch` defaults (`.none` group, `.attention` sort) while the write landed on `.topBar` — so sections stayed `["all"]` and sort ignored `lastUpdate`.

That also explained flaky agents-grid tests when `rightSlot` / UserDefaults interacted with a flipped active profile.

### What changed

| Area | Change |
|---|---|
| `OverlayUICoordinator.refreshOverlayDisplayConfiguration` | Always establish placement diagnostics when selection is already automatic (no early return that skips placement) |
| `AppModel.appearancePreferencesDidChange` | Reposition only for closed-island **chrome** prefs (rightSlot / centerLabel / usageDisplay / stateIndicator); list prefs only clear session-bucket cache |
| `AppModel.updateAppearancePreferences` | Copy → mutate → assign for reliable `@Observable` + `didSet` writeback |
| Tests | Regression test for setter stickiness; clear rightSlot UserDefaults in `AgentsGridRightSlotTests` |

### Why this is a product fix (not only tests)

Settings/list grouping and sorting go through the same profile-aware preferences. Flipping `activeAppearanceProfile` mid-update could make the island ignore the profile that was just written.

## How tested

- [x] `swift test --filter 'AppModelSessionListTests|AgentsGridRightSlotTests'` — all pass (incl. previously failing 4)
- [x] `swift test` full suite — **330 tests in 34 suites passed**
- [x] New regression: `appearancePreferenceSettersStickOnActiveProfile`

## AI disclosure

Drafted with AI assistance; reviewed and verified by me (KesleyDavid).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved appearance preference updates so changes are reliably saved and reflected.
  * Prevented unnecessary overlay repositioning when unrelated appearance settings change.
  * Improved stability for session grouping, sorting, notification behavior, and right-slot configuration.

* **Tests**
  * Added regression coverage for preserving the active profile and persisting appearance changes.
  * Expanded test coverage across notch and top-bar layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->