### PR TITLE
fix: decode hex-escaped UTF-8 paths in session titles

### DIFF
--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -579,8 +579,9 @@ struct ActiveAgentProcessDiscovery {
             }
 
             let value = String(nextLine.dropFirst()).trimmingCharacters(in: .whitespacesAndNewlines)
-            if value.hasPrefix("/") {
-                return value
+            let decoded = HexEscapedUTF8.decodeIfNeeded(value)
+            if decoded.hasPrefix("/") {
+                return decoded
             }
         }
 

--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -117,7 +117,8 @@ extension AgentSession {
     var spotlightWorkspaceName: String {
         if let workspaceName = jumpTarget?.workspaceName.trimmedForSurface,
            !workspaceName.isEmpty {
-            return workspaceName
+            // Cover already-persisted titles that still contain `\xHH` dumps.
+            return HexEscapedUTF8.decodeIfNeeded(workspaceName)
         }
 
         let trimmedTitle = title.trimmedForSurface
@@ -125,10 +126,10 @@ extension AgentSession {
             String($0).trimmedForSurface
         }
         if pieces.count == 2, !pieces[1].isEmpty {
-            return pieces[1]
+            return HexEscapedUTF8.decodeIfNeeded(pieces[1])
         }
 
-        return trimmedTitle
+        return HexEscapedUTF8.decodeIfNeeded(trimmedTitle)
     }
 
     var spotlightWorktreeBranch: String? {

--- a/Sources/OpenIslandCore/ClaudeTranscriptDiscovery.swift
+++ b/Sources/OpenIslandCore/ClaudeTranscriptDiscovery.swift
@@ -100,7 +100,8 @@ public final class ClaudeTranscriptDiscovery: @unchecked Sendable {
             }
 
             if let value = object["cwd"] as? String, !value.isEmpty {
-                cwd = value
+                // Some transcripts dump non-ASCII cwd as `\xHH` byte escapes.
+                cwd = HexEscapedUTF8.decodeIfNeeded(value)
             }
 
             if let timestampText = object["timestamp"] as? String,

--- a/Sources/OpenIslandCore/HexEscapedUTF8.swift
+++ b/Sources/OpenIslandCore/HexEscapedUTF8.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Decodes C/Python-style `\xHH` byte escapes into UTF-8 text.
+///
+/// Some session sources surface non-ASCII path segments as hex escapes
+/// (e.g. `\xe8\xa8\xba\xe7\x99\x82...` instead of `診療...`). When those
+/// sequences are present, reassemble the bytes and decode as UTF-8 so
+/// island titles stay human-readable.
+public enum HexEscapedUTF8 {
+    /// Returns `input` with `\xHH` sequences decoded when possible; otherwise
+    /// returns `input` unchanged.
+    public static func decodeIfNeeded(_ input: String) -> String {
+        let trimmed = stripPythonBytesLiteral(input)
+        guard trimmed.contains("\\x") || trimmed.contains("\\X") else {
+            return input
+        }
+        guard let decoded = decodeHexEscapes(trimmed), !decoded.isEmpty else {
+            return input
+        }
+        return decoded
+    }
+
+    private static func stripPythonBytesLiteral(_ input: String) -> String {
+        if input.count >= 3,
+           input.hasPrefix("b'"),
+           input.hasSuffix("'") {
+            return String(input.dropFirst(2).dropLast())
+        }
+        if input.count >= 3,
+           input.hasPrefix("b\""),
+           input.hasSuffix("\"") {
+            return String(input.dropFirst(2).dropLast())
+        }
+        return input
+    }
+
+    private static func decodeHexEscapes(_ input: String) -> String? {
+        var bytes: [UInt8] = []
+        bytes.reserveCapacity(input.utf8.count)
+
+        var index = input.startIndex
+        var sawEscape = false
+
+        while index < input.endIndex {
+            if input[index] == "\\",
+               input.distance(from: index, to: input.endIndex) >= 4 {
+                let xIndex = input.index(after: index)
+                if input[xIndex] == "x" || input[xIndex] == "X" {
+                    let firstHex = input.index(after: xIndex)
+                    let secondHex = input.index(after: firstHex)
+                    let hex = String(input[firstHex...secondHex])
+                    if let byte = UInt8(hex, radix: 16) {
+                        bytes.append(byte)
+                        sawEscape = true
+                        index = input.index(after: secondHex)
+                        continue
+                    }
+                }
+            }
+
+            let next = input.index(after: index)
+            bytes.append(contentsOf: input[index..<next].utf8)
+            index = next
+        }
+
+        guard sawEscape else {
+            return nil
+        }
+
+        return String(bytes: bytes, encoding: .utf8)
+    }
+}

--- a/Sources/OpenIslandCore/WorkspaceNameResolver.swift
+++ b/Sources/OpenIslandCore/WorkspaceNameResolver.swift
@@ -4,20 +4,25 @@ public enum WorkspaceNameResolver {
     private static let worktreeMarkers = ["/.claude/worktrees/", "/.git/worktrees/"]
 
     public static func workspaceName(for cwd: String) -> String {
-        let url = URL(fileURLWithPath: cwd)
+        // Decode `\xHH` path dumps (non-ASCII cwd) before taking the last
+        // path component so titles show readable text, not byte escapes.
+        let normalizedCWD = HexEscapedUTF8.decodeIfNeeded(cwd)
+        let url = URL(fileURLWithPath: normalizedCWD)
         let path = url.standardizedFileURL.path
 
         for marker in worktreeMarkers {
             if let range = path.range(of: marker) {
                 let projectPath = String(path[path.startIndex..<range.lowerBound])
-                let projectName = URL(fileURLWithPath: projectPath).lastPathComponent
+                let projectName = HexEscapedUTF8.decodeIfNeeded(
+                    URL(fileURLWithPath: projectPath).lastPathComponent
+                )
                 if !projectName.isEmpty {
                     return projectName
                 }
             }
         }
 
-        let name = url.lastPathComponent
+        let name = HexEscapedUTF8.decodeIfNeeded(url.lastPathComponent)
         return name.isEmpty ? "Workspace" : name
     }
 

--- a/Tests/OpenIslandCoreTests/HexEscapedUTF8Tests.swift
+++ b/Tests/OpenIslandCoreTests/HexEscapedUTF8Tests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+struct HexEscapedUTF8Tests {
+    @Test
+    func decodesPythonStyleUTF8PathSegment() {
+        // UTF-8 for 診療報酬AI研究所
+        let escaped =
+            #"\xe8\xa8\xba\xe7\x99\x82\xe5\xa0\xb1\xe9\x85\xacAI\xe7\xa0\x94\xe7\xa9\xb6\xe6\x89\x80"#
+        #expect(HexEscapedUTF8.decodeIfNeeded(escaped) == "診療報酬AI研究所")
+    }
+
+    @Test
+    func decodesEscapedSegmentInsideAbsolutePath() {
+        let escaped =
+            #"/Users/me/Library/CloudStorage/Drive/\xe8\xa8\xba\xe7\x99\x82\xe5\xa0\xb1\xe9\x85\xacAI\xe7\xa0\x94\xe7\xa9\xb6\xe6\x89\x80"#
+        #expect(
+            HexEscapedUTF8.decodeIfNeeded(escaped)
+                == "/Users/me/Library/CloudStorage/Drive/診療報酬AI研究所"
+        )
+    }
+
+    @Test
+    func stripsPythonBytesLiteralWrapper() {
+        let wrapped =
+            #"b'\xe8\xa8\xba\xe7\x99\x82\xe5\xa0\xb1\xe9\x85\xacAI\xe7\xa0\x94\xe7\xa9\xb6\xe6\x89\x80'"#
+        #expect(HexEscapedUTF8.decodeIfNeeded(wrapped) == "診療報酬AI研究所")
+    }
+
+    @Test
+    func leavesNormalPathsUnchanged() {
+        let path = "/Users/me/Documents/open-island"
+        #expect(HexEscapedUTF8.decodeIfNeeded(path) == path)
+        #expect(HexEscapedUTF8.decodeIfNeeded("診療報酬") == "診療報酬")
+    }
+
+    @Test
+    func workspaceNameUsesDecodedLastComponent() {
+        let cwd =
+            #"/Users/me/Drive/\xe8\xa8\xba\xe7\x99\x82\xe5\xa0\xb1\xe9\x85\xacAI\xe7\xa0\x94\xe7\xa9\xb6\xe6\x89\x80"#
+        #expect(WorkspaceNameResolver.workspaceName(for: cwd) == "診療報酬AI研究所")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #623

Session rows with non-ASCII project paths (e.g. Japanese) could show C/Python-style **hex byte dumps** instead of readable text:

- **Observed:** `\xe8\xa8\xba\xe7\x99\x82\xe5\xa0...`
- **Expected:** `診療報酬AI研究所`

### What changed

| Area | Change |
|---|---|
| `HexEscapedUTF8` (new) | Decode `\xHH` (and optional `b'...'`) sequences into UTF-8 |
| `WorkspaceNameResolver` | Normalize path before taking last component |
| `ClaudeTranscriptDiscovery` | Decode `cwd` when reading JSONL |
| `ActiveAgentProcessDiscovery` | Decode `lsof` cwd if escaped |
| `AgentSession+Presentation` | Decode persisted `workspaceName` / title segments for display |
| Tests | Unit coverage for Japanese path segment + full path + python `b'...'` wrapper |

### Why

Claude’s project **directory** under `~/.claude/projects/` replaces non-alphanumeric chars with `-`, so the readable name must come from `cwd` (transcript / process). When that value arrives as hex-escaped UTF-8 bytes, the island was showing the escape form. Decoding restores human-readable titles for CJK and other non-ASCII paths.

## How tested

- [x] `swift test --filter 'HexEscapedUTF8Tests|WorkspaceNameResolverTests'` — all pass
- [x] Full `swift test`: new tests pass; remaining failures are **pre-existing on `main`** (session list preference profile flip — tracked by #641 / #642), unrelated to path decoding
- [x] Example decode: `\xe8\xa8\xba...` → `診療報酬AI研究所`

### Suggested manual check

1. Open a Claude session whose `cwd` last component is non-ASCII (or inject a session with escaped `workspaceName`).
2. Confirm the session row title shows the readable name, not `\xHH` dumps.

## AI disclosure

Drafted with AI assistance; reviewed and verified by me (KesleyDavid).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of hex-escaped UTF-8 characters in working directories, workspace names, project paths, and session metadata.
  * Workspace and project names now display correctly when sourced from escaped path values.
  * Added support for Python-style byte-string formatting and escaped path segments while preserving invalid or already-readable values.

* **Tests**
  * Added coverage for escaped UTF-8 paths, byte-string wrappers, Unicode text, and workspace-name resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->