### PR TITLE
feat: detect Zed IDE instead of showing Unknown

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Think of it as an open-source [Vibe Island](https://vibeisland.app/) — **free,
 
 **10 agents**: Claude Code, Codex, Cursor, Gemini CLI, Kimi CLI, OpenCode, Qoder, Qwen Code, Factory, CodeBuddy
 
-**15+ terminals & IDEs**: Terminal.app, Ghostty, iTerm2, WezTerm, Zellij, tmux, cmux, Kaku, VS Code, Cursor, Windsurf, Trae, JetBrains IDEs (IDEA, WebStorm, PyCharm, GoLand, CLion, RubyMine, PhpStorm, Rider, RustRover)
+**15+ terminals & IDEs**: Terminal.app, Ghostty, iTerm2, WezTerm, Zellij, tmux, cmux, Kaku, VS Code, Cursor, Windsurf, Trae, Zed, JetBrains IDEs (IDEA, WebStorm, PyCharm, GoLand, CLion, RubyMine, PhpStorm, Rider, RustRover)
 
 <details>
 <summary>Full compatibility table</summary>
@@ -90,6 +90,7 @@ Think of it as an open-source [Vibe Island](https://vibeisland.app/) — **free,
 | **Cursor** | Workspace | Activate workspace via `cursor` CLI |
 | **Windsurf** | Workspace | Activate workspace via `windsurf` CLI |
 | **Trae** | Workspace | Activate workspace via `trae` CLI |
+| **Zed** | Workspace | Detect integrated terminal; activate app / open project folder |
 | **JetBrains IDEs** | Workspace | IDEA, WebStorm, PyCharm, GoLand, CLion, RubyMine, PhpStorm, Rider, RustRover |
 | **Warp** | Full | Precision tab jump via SQLite pane lookup + AX menu click |
 
@@ -282,7 +283,7 @@ Developers who already live in the terminal and want a better way to work with c
 ### Terminal Support
 
 - **Terminal.app**, **Ghostty**, **cmux**, **Kaku**, **WezTerm**, **iTerm2**, and **Zellij** — Full jump-back support with session attachment matching (cmux via Unix socket API, Kaku/WezTerm/Zellij via CLI pane targeting, iTerm2 via AppleScript session/TTY probe)
-- **VS Code**, **VS Code Insiders**, **Cursor**, **Windsurf**, **Trae** — Workspace-level jump via respective CLI (`code -r`, `cursor -r`, etc.)
+- **VS Code**, **VS Code Insiders**, **Cursor**, **Windsurf**, **Trae**, **Zed** — Workspace-level jump via respective CLI / app activation (`code -r`, `cursor -r`, Zed app, etc.)
 - **JetBrains IDEs** (IntelliJ IDEA, WebStorm, PyCharm, GoLand, CLion, RubyMine, PhpStorm, Rider, RustRover) — Workspace-level jump via IDE CLI launcher
 - **Warp** — Precision tab jump via SQLite pane lookup, pid-based sibling-tab disambiguation, and AX menu click
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -52,7 +52,7 @@ Open Island 驻留在 Mac 的**刘海区域**（或顶部栏），为你的 AI c
 
 **10 个 Agents**：Claude Code、Codex、Cursor、Gemini CLI、Kimi CLI、OpenCode、Qoder、Qwen Code、Factory、CodeBuddy
 
-**15+ 终端和 IDE**：Terminal.app、Ghostty、iTerm2、WezTerm、Zellij、tmux、cmux、Kaku、VS Code、Cursor、Windsurf、Trae、JetBrains 全家桶（IDEA、WebStorm、PyCharm、GoLand、CLion、RubyMine、PhpStorm、Rider、RustRover）
+**15+ 终端和 IDE**：Terminal.app、Ghostty、iTerm2、WezTerm、Zellij、tmux、cmux、Kaku、VS Code、Cursor、Windsurf、Trae、Zed、JetBrains 全家桶（IDEA、WebStorm、PyCharm、GoLand、CLion、RubyMine、PhpStorm、Rider、RustRover）
 
 <details>
 <summary>完整兼容列表</summary>
@@ -89,6 +89,7 @@ Open Island 驻留在 Mac 的**刘海区域**（或顶部栏），为你的 AI c
 | **Cursor** | 工作区 | 通过 `cursor` CLI 激活工作区 |
 | **Windsurf** | 工作区 | 通过 `windsurf` CLI 激活工作区 |
 | **Trae** | 工作区 | 通过 `trae` CLI 激活工作区 |
+| **Zed** | 工作区 | 识别集成终端；激活应用 / 打开项目目录 |
 | **JetBrains 全家桶** | 工作区 | IDEA、WebStorm、PyCharm、GoLand、CLion、RubyMine、PhpStorm、Rider、RustRover |
 | **Warp** | 完整支持 | 通过 SQLite pane 查找 + AX 菜单点击精准跳转到目标 tab |
 
@@ -284,7 +285,7 @@ AI coding 正在成为日常开发流程的一部分，但围绕它的控制层�
 ### 终端支持
 
 - **Terminal.app**、**Ghostty**、**cmux**、**Kaku**、**WezTerm**、**iTerm2** 和 **Zellij** — 完整的 jump-back 支持，带会话附着匹配（cmux 通过 Unix socket API，Kaku/WezTerm/Zellij 通过 CLI pane 定位，iTerm2 通过 AppleScript session/TTY 探针）
-- **VS Code**、**VS Code Insiders**、**Cursor**、**Windsurf**、**Trae** — 工作区级跳转，通过对应 CLI（`code -r`、`cursor -r` 等）
+- **VS Code**、**VS Code Insiders**、**Cursor**、**Windsurf**、**Trae**、**Zed** — 工作区级跳转，通过对应 CLI / 激活应用（`code -r`、`cursor -r`、Zed 等）
 - **JetBrains 全家桶**（IntelliJ IDEA、WebStorm、PyCharm、GoLand、CLion、RubyMine、PhpStorm、Rider、RustRover） — 工作区级跳转，通过 IDE CLI launcher
 - **Warp** — 通过 SQLite pane 查找、pid 进程树消歧和 AX 菜单点击实现精准 tab 跳转
 

--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -516,6 +516,12 @@ struct ActiveAgentProcessDiscovery {
         if lowered.contains("/trae.app/") {
             return "Trae"
         }
+        // Zed ships as Zed.app / Zed Preview.app; both live under …/Zed*.app/
+        if lowered.contains("/zed.app/")
+            || lowered.contains("/zed preview.app/")
+            || lowered.hasSuffix("/zed") {
+            return "Zed"
+        }
         if lowered.contains("/qoder.app/") {
             return "Qoder"
         }

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -1381,6 +1381,8 @@ final class ProcessMonitoringCoordinator {
             return "Windsurf"
         case "trae":
             return "Trae"
+        case "zed":
+            return "Zed"
         // JetBrains family
         case "intellij", "idea":
             return "IntelliJ IDEA"

--- a/Sources/OpenIslandApp/TerminalJumpService.swift
+++ b/Sources/OpenIslandApp/TerminalJumpService.swift
@@ -121,6 +121,12 @@ struct TerminalJumpService {
             ]
         ),
         TerminalAppDescriptor(
+            displayName: "Zed",
+            bundleIdentifier: "dev.zed.Zed",
+            aliases: ["zed"],
+            alternateBundleIdentifiers: ["dev.zed.Zed-Preview"]
+        ),
+        TerminalAppDescriptor(
             displayName: "IntelliJ IDEA",
             bundleIdentifier: "com.jetbrains.intellij",
             aliases: ["intellij", "idea"]

--- a/Sources/OpenIslandCore/ClaudeHooks.swift
+++ b/Sources/OpenIslandCore/ClaudeHooks.swift
@@ -1232,6 +1232,8 @@ public extension ClaudeHookPayload {
                 return "Windsurf"
             case "trae":
                 return "Trae"
+            case "zed":
+                return "Zed"
             default:
                 break
             }
@@ -1269,6 +1271,12 @@ public extension ClaudeHookPayload {
                 if bundleID.contains("intellij") { return "IntelliJ IDEA" }
             }
             return "IntelliJ IDEA"  // Fallback for unknown JetBrains IDE
+        }
+
+        // Zed (and Zed Preview) when TERM_PROGRAM is missing.
+        if let bundleID = environment["__CFBundleIdentifier"]?.lowercased(),
+           bundleID == "dev.zed.zed" || bundleID.hasPrefix("dev.zed.zed") {
+            return "Zed"
         }
 
         return nil

--- a/Sources/OpenIslandCore/CodexHooks.swift
+++ b/Sources/OpenIslandCore/CodexHooks.swift
@@ -718,6 +718,8 @@ public extension CodexHookPayload {
                 return "Windsurf"
             case "trae":
                 return "Trae"
+            case "zed":
+                return "Zed"
             default:
                 break
             }

--- a/Sources/OpenIslandCore/GeminiHooks.swift
+++ b/Sources/OpenIslandCore/GeminiHooks.swift
@@ -372,6 +372,8 @@ public extension GeminiHookPayload {
             return "Windsurf"
         case .some("trae"):
             return "Trae"
+        case .some("zed"):
+            return "Zed"
         default:
             break
         }

--- a/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
@@ -316,6 +316,33 @@ struct ClaudeHooksTests {
         #expect(payload.defaultJumpTarget.terminalApp == "Unknown")
     }
 
+    @Test
+    func claudeInferTerminalAppRecognizesZedViaTermProgram() {
+        let payload = ClaudeHookPayload(
+            cwd: "/tmp/demo", hookEventName: .sessionStart, sessionID: "s1"
+        ).withRuntimeContext(
+            environment: ["TERM_PROGRAM": "zed"],
+            currentTTYProvider: { nil },
+            terminalLocatorProvider: { _ in (sessionID: nil, tty: nil, title: nil) }
+        )
+
+        #expect(payload.terminalApp == "Zed")
+        #expect(payload.defaultJumpTarget.terminalApp == "Zed")
+    }
+
+    @Test
+    func claudeInferTerminalAppRecognizesZedViaBundleIdentifier() {
+        let payload = ClaudeHookPayload(
+            cwd: "/tmp/demo", hookEventName: .sessionStart, sessionID: "s1"
+        ).withRuntimeContext(
+            environment: ["__CFBundleIdentifier": "dev.zed.Zed"],
+            currentTTYProvider: { nil },
+            terminalLocatorProvider: { _ in (sessionID: nil, tty: nil, title: nil) }
+        )
+
+        #expect(payload.terminalApp == "Zed")
+    }
+
     /// Verifies a Claude Desktop session is tagged `Claude.app` via the
     /// authoritative `CLAUDE_CODE_ENTRYPOINT=claude-desktop` signal. The
     /// desktop subprocess is TTY-less and invisible to process discovery, so


### PR DESCRIPTION
## Summary

Fixes #634

Sessions running inside **Zed** (integrated terminal) were classified as `Unknown` because Zed was missing from terminal/IDE detection and jump tables.

### What changed

| Layer | Change |
|---|---|
| Hook inference (`ClaudeHooks` / `CodexHooks` / `GeminiHooks`) | `TERM_PROGRAM=zed` → `Zed`; `__CFBundleIdentifier` `dev.zed.Zed*` fallback |
| Process discovery | Recognize `/Zed.app/` / `/Zed Preview.app/` / `…/zed` parents |
| `supportedTerminalApp` | Map `"zed"` → display name `Zed` |
| `TerminalJumpService` | Register Zed (`dev.zed.Zed`, preview alt) for app activation / open folder |
| README (EN + 简体中文) | Document Zed in the terminal/IDE matrix |
| Tests | `TERM_PROGRAM` + bundle-id recognition |

Jump-back is **workspace/app activation** (same tier as VS Code family without a special CLI path in this PR): activate Zed and open the project folder when available. Pane-precise jump is not claimed.

## How tested

- [x] `swift test --filter 'ClaudeHooksTests.claudeInferTerminalAppRecognizesZed|…'` — pass
- [x] `claudeDefaultJumpTargetUsesUnknownSentinelForUnrecognizedTerminal` still passes (rio stays Unknown)
- [ ] Manual: run Claude/Codex inside Zed’s terminal and confirm badge shows `Zed` instead of `Unknown`

## AI disclosure

Drafted with AI assistance; reviewed and verified by me (KesleyDavid).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing Zed and Zed Preview as supported terminal and IDE applications.
  * Enabled workspace navigation and application activation through Zed’s integrated terminal.
  * Added fallback handling for Zed Preview when the standard Zed app is unavailable.
* **Documentation**
  * Updated English and Chinese compatibility documentation to include Zed.
* **Tests**
  * Added coverage for detecting Zed through terminal and application environment details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->