### PR TITLE
fix: distinguish Cursor from VS Code and fail closed on unknown hosts

### DIFF
--- a/Sources/OpenIslandApp/TerminalJumpService.swift
+++ b/Sources/OpenIslandApp/TerminalJumpService.swift
@@ -1199,7 +1199,10 @@ struct TerminalJumpService {
             return exact
         }
 
-        return Self.knownApps.first(where: isInstalled(descriptor:))
+        // Fail closed when the reported host is unknown. Falling back to the
+        // first installed known app made multi-terminal setups always jump to
+        // whichever terminal happened to appear first in `knownApps` (#511).
+        return nil
     }
 
     private func normalizeTerminalAppName(_ preferredName: String) -> String {

--- a/Sources/OpenIslandCore/ClaudeHooks.swift
+++ b/Sources/OpenIslandCore/ClaudeHooks.swift
@@ -1220,12 +1220,8 @@ public extension ClaudeHookPayload {
             case "wezterm":
                 return "WezTerm"
             case "vscode":
-                // Cursor also sets TERM_PROGRAM=vscode; check its unique
-                // env var first.
-                if environment["CURSOR_TRACE_ID"] != nil {
-                    return "Cursor"
-                }
-                return "VS Code"
+                // Cursor (and other forks) also set TERM_PROGRAM=vscode.
+                return TerminalAppInference.resolveVSCodeFamilyHost(from: environment)
             case "vscode-insiders":
                 return "VS Code Insiders"
             case "windsurf":

--- a/Sources/OpenIslandCore/CodexHooks.swift
+++ b/Sources/OpenIslandCore/CodexHooks.swift
@@ -711,7 +711,8 @@ public extension CodexHookPayload {
             case "kaku":
                 return "Kaku"
             case "vscode":
-                return "VS Code"
+                // Cursor also sets TERM_PROGRAM=vscode; disambiguate like Claude hooks (#511).
+                return TerminalAppInference.resolveVSCodeFamilyHost(from: environment)
             case "vscode-insiders":
                 return "VS Code Insiders"
             case "windsurf":

--- a/Sources/OpenIslandCore/GeminiHooks.swift
+++ b/Sources/OpenIslandCore/GeminiHooks.swift
@@ -365,7 +365,8 @@ public extension GeminiHookPayload {
         case .some("kaku"):
             return "Kaku"
         case .some("vscode"):
-            return "VS Code"
+            // Cursor also sets TERM_PROGRAM=vscode; disambiguate like Claude hooks (#511).
+            return TerminalAppInference.resolveVSCodeFamilyHost(from: environment)
         case .some("vscode-insiders"):
             return "VS Code Insiders"
         case .some("windsurf"):

--- a/Sources/OpenIslandCore/TerminalAppInference.swift
+++ b/Sources/OpenIslandCore/TerminalAppInference.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Shared host-terminal classification used by Claude / Codex / Gemini hooks.
+///
+/// VS Code forks (Cursor, Windsurf, Trae, …) often set `TERM_PROGRAM=vscode`.
+/// Classifying them as plain VS Code breaks badge labels and jump targets (#511).
+public enum TerminalAppInference: Sendable {
+    /// Resolve the VS Code family host for a hook environment.
+    /// Prefer Cursor when any Cursor-specific signal is present.
+    public static func resolveVSCodeFamilyHost(from environment: [String: String]) -> String {
+        if isCursorEnvironment(environment) {
+            return "Cursor"
+        }
+        return "VS Code"
+    }
+
+    /// Whether this environment is Cursor rather than stock VS Code.
+    ///
+    /// Cursor sets `TERM_PROGRAM=vscode` like other VS Code forks. Prefer
+    /// explicit Cursor signals; never guess from `TERM_PROGRAM` alone.
+    public static func isCursorEnvironment(_ environment: [String: String]) -> Bool {
+        if environment["CURSOR_TRACE_ID"] != nil {
+            return true
+        }
+
+        // Cursor injects several CURSOR_* variables into its integrated terminal.
+        if environment.keys.contains(where: { key in
+            key.hasPrefix("CURSOR_") && key != "CURSOR_"
+        }) {
+            return true
+        }
+
+        if let bundleID = environment["__CFBundleIdentifier"]?.lowercased() {
+            // Official Cursor bundle id (ToDesktop packaging).
+            if bundleID == "com.todesktop.230313mzl4w4u92" || bundleID.contains("todesktop") {
+                return true
+            }
+            if bundleID.contains("cursor") {
+                return true
+            }
+        }
+
+        // VS Code family often points askpass / node helpers at the host .app.
+        let pathKeys = [
+            "VSCODE_GIT_ASKPASS_NODE",
+            "VSCODE_GIT_ASKPASS_MAIN",
+            "VSCODE_GIT_IPC_HANDLE",
+            "VSCODE_NLS_CONFIG",
+        ]
+        for key in pathKeys {
+            if let value = environment[key], value.localizedCaseInsensitiveContains("Cursor.app") {
+                return true
+            }
+        }
+
+        return false
+    }
+}

--- a/Tests/OpenIslandAppTests/TerminalJumpServiceTests.swift
+++ b/Tests/OpenIslandAppTests/TerminalJumpServiceTests.swift
@@ -357,6 +357,42 @@ struct TerminalJumpServiceTests {
         )
     }
 
+    /// #511: unmatched host names (not just the "Unknown" sentinel) must not
+    /// silently activate the first installed known terminal.
+    @Test
+    func unrecognizedTerminalAppNameFallsBackToFinderInsteadOfFirstInstalled() throws {
+        let openedArguments = OpenedArgumentsBox()
+        let service = TerminalJumpService(
+            applicationResolver: { bundleIdentifier in
+                bundleIdentifier == "com.googlecode.iterm2" ? URL(fileURLWithPath: "/Applications/iTerm.app") : nil
+            },
+            appRunningChecker: { _ in false },
+            openAction: { arguments in
+                openedArguments.values.append(arguments)
+            },
+            appleScriptRunner: { _ in "" }
+        )
+
+        let result = try service.jump(
+            to: JumpTarget(
+                terminalApp: "SomeWeirdTerminal",
+                workspaceName: "my-project",
+                paneTitle: "",
+                workingDirectory: "/tmp"
+            )
+        )
+
+        #expect(openedArguments.values == [["/tmp"]])
+        #expect(
+            !openedArguments.values.contains(where: { $0.contains("-b") }),
+            "must not open -b for an unmatched terminal host"
+        )
+        #expect(
+            result.contains("Finder"),
+            "Expected Finder fallback, got: \(result)"
+        )
+    }
+
     @Test
     func traeJumpActivatesRunningTraeCNApp() throws {
         let openedArguments = OpenedArgumentsBox()

--- a/Tests/OpenIslandCoreTests/TerminalAppInferenceTests.swift
+++ b/Tests/OpenIslandCoreTests/TerminalAppInferenceTests.swift
@@ -1,0 +1,49 @@
+import Testing
+@testable import OpenIslandCore
+
+struct TerminalAppInferenceTests {
+    @Test
+    func vscodeTermProgramWithoutCursorSignalsIsVSCode() {
+        let host = TerminalAppInference.resolveVSCodeFamilyHost(from: [
+            "TERM_PROGRAM": "vscode",
+        ])
+        #expect(host == "VS Code")
+        #expect(TerminalAppInference.isCursorEnvironment(["TERM_PROGRAM": "vscode"]) == false)
+    }
+
+    @Test
+    func cursorTraceIdDisambiguatesCursorFromVSCode() {
+        let host = TerminalAppInference.resolveVSCodeFamilyHost(from: [
+            "TERM_PROGRAM": "vscode",
+            "CURSOR_TRACE_ID": "abc-123",
+        ])
+        #expect(host == "Cursor")
+    }
+
+    @Test
+    func cursorBundleIdentifierDisambiguatesCursorFromVSCode() {
+        let host = TerminalAppInference.resolveVSCodeFamilyHost(from: [
+            "TERM_PROGRAM": "vscode",
+            "__CFBundleIdentifier": "com.todesktop.230313mzl4w4u92",
+        ])
+        #expect(host == "Cursor")
+    }
+
+    @Test
+    func cursorAppPathInVSCodeHelperEnvDisambiguatesCursor() {
+        let host = TerminalAppInference.resolveVSCodeFamilyHost(from: [
+            "TERM_PROGRAM": "vscode",
+            "VSCODE_GIT_ASKPASS_NODE": "/Applications/Cursor.app/Contents/Resources/app/resources/helpers/node",
+        ])
+        #expect(host == "Cursor")
+    }
+
+    @Test
+    func plainVSCodeAskpassPathStaysVSCode() {
+        let host = TerminalAppInference.resolveVSCodeFamilyHost(from: [
+            "TERM_PROGRAM": "vscode",
+            "VSCODE_GIT_ASKPASS_NODE": "/Applications/Visual Studio Code.app/Contents/Resources/app/resources/helpers/node",
+        ])
+        #expect(host == "VS Code")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #511 (multiple IDE jump / Cursor mislabeled as VS Code).

### Root causes

1. **Cursor → VS Code mislabel:** Cursor’s integrated terminal sets `TERM_PROGRAM=vscode`. Claude hooks already checked `CURSOR_TRACE_ID`, but **Codex** and **Gemini** always returned `"VS Code"`. Sessions then jumped with the VS Code bundle/CLI instead of Cursor.
2. **Wrong terminal on unmatched host:** `TerminalJumpService.resolveTerminalApp` fell through to the **first installed** known app when the reported name didn’t match, so multi-terminal setups often “always switched to one terminal”.

### Changes

- New `TerminalAppInference` helper (shared Cursor signals: `CURSOR_*`, Cursor bundle id, `Cursor.app` in VS Code helper paths).
- Claude / Codex / Gemini hooks use the shared VS Code-family disambiguation.
- `resolveTerminalApp` fails closed (returns `nil`) for unmatched names → Finder/cwd fallback instead of a random terminal.
- Tests for inference + unmatched host jump behavior.

### Verification

```bash
swift test --filter 'TerminalAppInferenceTests|TerminalJumpServiceTests'
```

All targeted tests passed (Ghostty live integration remains skipped without env flag).

Drafted with AI assistance; reviewed by me (KesleyDavid).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for detecting Zed as a terminal host.
  * Improved identification of VS Code-family terminals, including Cursor, using available environment and application signals.

* **Bug Fixes**
  * Unrecognized terminal names now open the working directory in Finder instead of selecting an unrelated installed terminal.
  * Preserved accurate classification for standard VS Code environments.
  * Improved error details when terminal automation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->