### PR TITLE
feat: keep notch open until approve or deny when pending

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -18,6 +18,9 @@ final class AppModel {
     private static let soundMutedDefaultsKey = "overlay.sound.muted"
     private static let showDockIconDefaultsKey = "app.showDockIcon"
     private static let hapticFeedbackEnabledDefaultsKey = "app.hapticFeedbackEnabled"
+    /// When true, click-outside does not dismiss the notch while any session
+    /// is waiting for approval or an answer (#547).
+    private static let keepNotchOpenUntilDecisionDefaultsKey = "app.keepNotchOpenUntilDecision"
     private static let islandRightSlotDefaultsKey = "appearance.island.v6.rightSlot"
     private static let islandCenterLabelDefaultsKey = "appearance.island.v6.centerLabel"
     private static let showCodexUsageDefaultsKey = "app.showCodexUsage"
@@ -244,6 +247,15 @@ final class AppModel {
         didSet {
             guard hasFinishedInit, hapticFeedbackEnabled != oldValue else { return }
             UserDefaults.standard.set(hapticFeedbackEnabled, forKey: Self.hapticFeedbackEnabledDefaultsKey)
+        }
+    }
+    /// Prefer keeping the island open until the user acts on pending
+    /// approval / question surfaces (Settings → Behavior). Default on so
+    /// accidental clicks outside the notch do not dismiss unread decisions.
+    var keepNotchOpenUntilDecision: Bool = true {
+        didSet {
+            guard hasFinishedInit, keepNotchOpenUntilDecision != oldValue else { return }
+            UserDefaults.standard.set(keepNotchOpenUntilDecision, forKey: Self.keepNotchOpenUntilDecisionDefaultsKey)
         }
     }
     var showCodexUsage: Bool = false {
@@ -593,6 +605,7 @@ final class AppModel {
         UserDefaults.standard.register(defaults: [
             Self.showDockIconDefaultsKey: true,
             Self.hapticFeedbackEnabledDefaultsKey: false,
+            Self.keepNotchOpenUntilDecisionDefaultsKey: true,
             Self.completionReplyEnabledDefaultsKey: false,
             Self.suppressFrontmostNotificationsDefaultsKey: true,
         ])
@@ -600,6 +613,7 @@ final class AppModel {
         selectedSoundName = NotificationSoundService.selectedSoundName
         showDockIcon = UserDefaults.standard.bool(forKey: Self.showDockIconDefaultsKey)
         hapticFeedbackEnabled = UserDefaults.standard.bool(forKey: Self.hapticFeedbackEnabledDefaultsKey)
+        keepNotchOpenUntilDecision = UserDefaults.standard.bool(forKey: Self.keepNotchOpenUntilDecisionDefaultsKey)
         suppressFrontmostNotifications = UserDefaults.standard.bool(forKey: Self.suppressFrontmostNotificationsDefaultsKey)
         if UserDefaults.standard.object(forKey: Self.showCodexUsageDefaultsKey) != nil {
             showCodexUsage = UserDefaults.standard.bool(forKey: Self.showCodexUsageDefaultsKey)
@@ -1215,6 +1229,16 @@ final class AppModel {
     func toggleOverlay() { overlay.toggleOverlay() }
     func notchOpen(reason: NotchOpenReason, surface: IslandSurface = .sessionList()) { overlay.notchOpen(reason: reason, surface: surface) }
     func notchClose() { overlay.notchClose() }
+
+    /// Whether click-outside (and similar accidental dismissals) should be
+    /// ignored because a session still needs an approve/deny or answer.
+    var shouldBlockDismissWhileAwaitingDecision: Bool {
+        guard keepNotchOpenUntilDecision else { return false }
+        guard notchStatus == .opened else { return false }
+        return state.sessions.contains { session in
+            session.phase.requiresAttention
+        }
+    }
     func notchPop() { overlay.notchPop() }
     func performBootAnimation() { overlay.performBootAnimation() }
     func ensureOverlayPanel() { overlay.ensureOverlayPanel() }

--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -271,6 +271,11 @@ final class OverlayPanelController {
             model.notchOpen(reason: .click)
         } else if model.notchStatus == .opened {
             if !isPointInExpandedArea(screenLocation) {
+                // Keep the island open while a permission/question is pending
+                // when the user opted into “keep open until decision” (#547).
+                if model.shouldBlockDismissWhileAwaitingDecision {
+                    return
+                }
                 model.notchClose()
                 repostMouseDown(at: screenLocation)
             }

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -23,6 +23,7 @@
 "settings.general.hideFullscreen" = "Hide in fullscreen";
 "settings.general.autoHideNoSessions" = "Auto-hide without active sessions";
 "settings.general.autoCollapse" = "Auto-collapse on mouse exit";
+"settings.general.keepOpenUntilDecision" = "Keep open until approve or deny";
 "settings.general.showDockIcon" = "Show icon in Dock";
 "settings.general.hapticFeedback" = "Haptic feedback on hover";
 "settings.general.suppressFrontmostNotifications" = "Suppress notifications for focused sessions";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -23,6 +23,7 @@
 "settings.general.hideFullscreen" = "全屏时隐藏";
 "settings.general.autoHideNoSessions" = "无活跃会话时自动隐藏";
 "settings.general.autoCollapse" = "鼠标离开时自动收起";
+"settings.general.keepOpenUntilDecision" = "未审批前不关闭刘海";
 "settings.general.showDockIcon" = "在 Dock 中显示图标";
 "settings.general.hapticFeedback" = "悬停时震动反馈";
 "settings.general.suppressFrontmostNotifications" = "前台会话不弹出通知";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -23,6 +23,7 @@
 "settings.general.hideFullscreen" = "全螢幕時隱藏";
 "settings.general.autoHideNoSessions" = "無活躍工作階段時自動隱藏";
 "settings.general.autoCollapse" = "滑鼠離開時自動收起";
+"settings.general.keepOpenUntilDecision" = "未審批前不關閉瀏海";
 "settings.general.showDockIcon" = "在 Dock 中顯示圖示";
 "settings.general.hapticFeedback" = "懸停時震動回饋";
 "settings.general.suppressFrontmostNotifications" = "前台工作階段不彈出通知";

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -208,7 +208,10 @@ struct GeneralSettingsPane: View {
             }
 
             Section(lang.t("settings.general.behavior")) {
-                Toggle(lang.t("settings.general.autoCollapse"), isOn: .constant(true))
+                Toggle(lang.t("settings.general.keepOpenUntilDecision"), isOn: Binding(
+                    get: { model.keepNotchOpenUntilDecision },
+                    set: { model.keepNotchOpenUntilDecision = $0 }
+                ))
                 Toggle(lang.t("settings.general.showDockIcon"), isOn: Binding(
                     get: { model.showDockIcon },
                     set: { model.showDockIcon = $0 }

--- a/Tests/OpenIslandAppTests/KeepNotchOpenUntilDecisionTests.swift
+++ b/Tests/OpenIslandAppTests/KeepNotchOpenUntilDecisionTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+@testable import OpenIslandApp
+import OpenIslandCore
+
+@MainActor
+@Suite(.serialized)
+struct KeepNotchOpenUntilDecisionTests {
+    init() {
+        UserDefaults.standard.removeObject(forKey: "app.keepNotchOpenUntilDecision")
+    }
+
+    @Test
+    func blocksClickOutsideDismissWhileAwaitingApprovalByDefault() {
+        let model = AppModel()
+        #expect(model.keepNotchOpenUntilDecision == true)
+
+        model.state = SessionState(sessions: [
+            AgentSession(
+                id: "approval-session",
+                title: "Codex · project",
+                tool: .codex,
+                attachmentState: .attached,
+                phase: .waitingForApproval,
+                summary: "Approve command",
+                updatedAt: .now,
+                permissionRequest: PermissionRequest(
+                    title: "Approve",
+                    summary: "Allow edit?",
+                    affectedPath: "/tmp/file.swift"
+                )
+            ),
+        ])
+        model.notchStatus = .opened
+        model.notchOpenReason = .notification
+
+        #expect(model.shouldBlockDismissWhileAwaitingDecision == true)
+    }
+
+    @Test
+    func doesNotBlockWhenPreferenceDisabled() {
+        let model = AppModel()
+        model.keepNotchOpenUntilDecision = false
+
+        model.state = SessionState(sessions: [
+            AgentSession(
+                id: "approval-session",
+                title: "Codex · project",
+                tool: .codex,
+                attachmentState: .attached,
+                phase: .waitingForApproval,
+                summary: "Approve command",
+                updatedAt: .now,
+                permissionRequest: PermissionRequest(
+                    title: "Approve",
+                    summary: "Allow edit?",
+                    affectedPath: "/tmp/file.swift"
+                )
+            ),
+        ])
+        model.notchStatus = .opened
+
+        #expect(model.shouldBlockDismissWhileAwaitingDecision == false)
+    }
+
+    @Test
+    func doesNotBlockWhenOnlyRunningSessions() {
+        let model = AppModel()
+        model.state = SessionState(sessions: [
+            AgentSession(
+                id: "running",
+                title: "Claude · project",
+                tool: .claudeCode,
+                attachmentState: .attached,
+                phase: .running,
+                summary: "Working",
+                updatedAt: .now
+            ),
+        ])
+        model.notchStatus = .opened
+
+        #expect(model.shouldBlockDismissWhileAwaitingDecision == false)
+    }
+
+    @Test
+    func blocksWhileAwaitingQuestionAnswer() {
+        let model = AppModel()
+        model.state = SessionState(sessions: [
+            AgentSession(
+                id: "question-session",
+                title: "Codex · project",
+                tool: .codex,
+                attachmentState: .attached,
+                phase: .waitingForAnswer,
+                summary: "Which env?",
+                updatedAt: .now,
+                questionPrompt: QuestionPrompt(
+                    title: "Environment",
+                    options: ["Prod", "Staging"]
+                )
+            ),
+        ])
+        model.notchStatus = .opened
+
+        #expect(model.shouldBlockDismissWhileAwaitingDecision == true)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #547: accidental click outside the expanded notch closed the island while a **permission / question** was still pending, so users could dismiss without approving and not know the outcome.

### Changes

- **Settings → Behavior → “Keep open until approve or deny”** (`keepNotchOpenUntilDecision`, default **on**)
- Click-outside dismiss is **blocked** while any session is in `waitingForApproval` / `waitingForAnswer` (and the setting is on)
- User can still turn the setting off to restore previous click-outside close
- Localized en / zh-Hans / zh-Hant
- Replaces the non-functional placeholder auto-collapse toggle in General settings

### Verification

```bash
swift test --filter KeepNotchOpenUntilDecisionTests
```

All 4 new tests passed.

Drafted with AI assistance; reviewed by me (KesleyDavid).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a setting to keep the Island open until pending approvals or questions are answered.
  * The setting is enabled by default and available in General settings.
  * Added English, Simplified Chinese, and Traditional Chinese translations.

* **Bug Fixes**
  * Improved dismissal behavior so the Island remains open while a decision is pending when enabled.
  * Unavailable overlay display options are now disabled in Settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->