### PR TITLE
fix(claude): clear completed background subagents

### DIFF
--- a/Sources/OpenIslandCore/BridgeServer.swift
+++ b/Sources/OpenIslandCore/BridgeServer.swift
@@ -28,6 +28,12 @@ public final class BridgeServer: @unchecked Sendable {
         let tempID: String
     }
 
+    private struct ClaudeTranscriptCursor {
+        var transcriptPath: String
+        var readOffset: UInt64
+        var pendingData = Data()
+    }
+
     private struct PendingClaudeInteraction {
         enum Kind {
             case permission(ClaudeHookPayload)
@@ -74,6 +80,9 @@ public final class BridgeServer: @unchecked Sendable {
     private var pendingAgentDescriptions: [String: String] = [:]
     /// Maps toolUseID → temporary task ID for TaskCreate, so postToolUse can update with real ID.
     private var pendingTaskCreations: [String: PendingTaskCreation] = [:]
+    /// Tracks the portion of each live Claude transcript already inspected for
+    /// terminal background-agent task notifications.
+    private var claudeTranscriptCursors: [String: ClaudeTranscriptCursor] = [:]
     private var stateSnapshot = SessionState()
     /// Local working state: tracks sessions emitted by this server between
     /// snapshot pushes from AppModel. This is NOT a duplicate of AppModel's
@@ -622,8 +631,10 @@ public final class BridgeServer: @unchecked Sendable {
             return
         }
 
+        reconcileCompletedClaudeSubagents(for: payload)
+
         // On every event from the parent session, opportunistically clean up
-        // subagents whose SubagentStop was never received.
+        // subagents whose SubagentStop and task notification were never received.
         cleanUpStaleSubagents(forSession: payload.sessionID)
 
         switch payload.hookEventName {
@@ -2109,12 +2120,17 @@ public final class BridgeServer: @unchecked Sendable {
     }
 
     private func removeSubagent(agentID: String, fromSession sessionID: String) {
+        removeSubagents(agentIDs: [agentID], fromSession: sessionID)
+    }
+
+    private func removeSubagents(agentIDs: Set<String>, fromSession sessionID: String) {
+        guard !agentIDs.isEmpty else { return }
         guard var metadata = localState.session(id: sessionID)?.claudeMetadata else {
             return
         }
 
         let previousCount = metadata.activeSubagents.count
-        metadata.activeSubagents.removeAll { $0.agentID == agentID }
+        metadata.activeSubagents.removeAll { agentIDs.contains($0.agentID) }
         guard metadata.activeSubagents.count != previousCount else {
             return
         }
@@ -2128,6 +2144,90 @@ public final class BridgeServer: @unchecked Sendable {
                 )
             )
         )
+    }
+
+    private func reconcileCompletedClaudeSubagents(for payload: ClaudeHookPayload) {
+        let notifications = readNewClaudeTaskNotifications(
+            sessionID: payload.sessionID,
+            transcriptPath: payload.transcriptPath
+        )
+        let completedAgentIDs = Set(notifications.compactMap(\.taskID))
+        removeSubagents(agentIDs: completedAgentIDs, fromSession: payload.sessionID)
+    }
+
+    private func readNewClaudeTaskNotifications(
+        sessionID: String,
+        transcriptPath: String?
+    ) -> [ClaudeTaskNotification] {
+        guard let transcriptPath,
+              !transcriptPath.isEmpty,
+              let fileSize = fileSize(atPath: transcriptPath) else {
+            return []
+        }
+
+        guard var cursor = claudeTranscriptCursors[sessionID],
+              cursor.transcriptPath == transcriptPath else {
+            claudeTranscriptCursors[sessionID] = ClaudeTranscriptCursor(
+                transcriptPath: transcriptPath,
+                readOffset: fileSize
+            )
+            return []
+        }
+
+        if fileSize < cursor.readOffset {
+            cursor.readOffset = fileSize
+            cursor.pendingData.removeAll(keepingCapacity: false)
+            claudeTranscriptCursors[sessionID] = cursor
+            return []
+        }
+
+        guard fileSize > cursor.readOffset,
+              let fileHandle = try? FileHandle(forReadingFrom: URL(fileURLWithPath: transcriptPath)) else {
+            return []
+        }
+        defer { try? fileHandle.close() }
+
+        do {
+            try fileHandle.seek(toOffset: cursor.readOffset)
+        } catch {
+            cursor.readOffset = fileSize
+            cursor.pendingData.removeAll(keepingCapacity: false)
+            claudeTranscriptCursors[sessionID] = cursor
+            return []
+        }
+
+        var bytesRead: UInt64 = 0
+        while let chunk = try? fileHandle.read(upToCount: 64 * 1_024),
+              !chunk.isEmpty {
+            cursor.pendingData.append(chunk)
+            bytesRead += UInt64(chunk.count)
+        }
+        cursor.readOffset += bytesRead
+
+        var notifications: [ClaudeTaskNotification] = []
+        let newline = UInt8(ascii: "\n")
+        while let newlineIndex = cursor.pendingData.firstIndex(of: newline) {
+            let lineData = cursor.pendingData.prefix(upTo: newlineIndex)
+            cursor.pendingData.removeSubrange(...newlineIndex)
+            guard !lineData.isEmpty,
+                  let object = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any] else {
+                continue
+            }
+            notifications.append(
+                contentsOf: ClaudeTaskNotificationParser.terminalNotifications(in: object)
+            )
+        }
+
+        claudeTranscriptCursors[sessionID] = cursor
+        return notifications
+    }
+
+    private func fileSize(atPath path: String) -> UInt64? {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: path),
+              let size = attributes[.size] as? NSNumber else {
+            return nil
+        }
+        return size.uint64Value
     }
 
     /// Removes subagents that have been inactive for too long.
@@ -2205,6 +2305,7 @@ public final class BridgeServer: @unchecked Sendable {
     /// Called when the session's turn ends (`stop`, `stopFailure`, `sessionEnd`)
     /// to ensure no stale subagent indicators linger.
     private func clearAllActiveSubagents(fromSession sessionID: String) {
+        claudeTranscriptCursors.removeValue(forKey: sessionID)
         guard var metadata = localState.session(id: sessionID)?.claudeMetadata,
               !metadata.activeSubagents.isEmpty else {
             return

--- a/Sources/OpenIslandCore/ClaudeTaskNotification.swift
+++ b/Sources/OpenIslandCore/ClaudeTaskNotification.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+struct ClaudeTaskNotification: Equatable {
+    let taskID: String?
+    let toolUseID: String?
+    let status: String
+}
+
+enum ClaudeTaskNotificationParser {
+    private static let terminalStatuses: Set<String> = [
+        "completed",
+        "failed",
+        "cancelled",
+        "canceled",
+    ]
+
+    static func terminalNotifications(in transcriptObject: [String: Any]) -> [ClaudeTaskNotification] {
+        notificationTexts(in: transcriptObject).flatMap(terminalNotifications(in:))
+    }
+
+    private static func notificationTexts(in transcriptObject: [String: Any]) -> [String] {
+        var texts: [String] = []
+
+        if transcriptObject["type"] as? String == "queue-operation",
+           let content = transcriptObject["content"] as? String {
+            texts.append(content)
+        }
+
+        let origin = transcriptObject["origin"] as? [String: Any]
+        guard origin?["kind"] as? String == "task-notification" else {
+            return texts
+        }
+
+        guard let message = transcriptObject["message"] as? [String: Any] else {
+            return texts
+        }
+
+        if let content = message["content"] as? String {
+            texts.append(content)
+        } else if let blocks = message["content"] as? [[String: Any]] {
+            texts.append(contentsOf: blocks.compactMap { block in
+                guard block["type"] as? String == "text" else { return nil }
+                return block["text"] as? String
+            })
+        }
+
+        return texts
+    }
+
+    private static func terminalNotifications(in text: String) -> [ClaudeTaskNotification] {
+        let openingTag = "<task-notification>"
+        let closingTag = "</task-notification>"
+        var notifications: [ClaudeTaskNotification] = []
+        var searchStart = text.startIndex
+
+        while let openingRange = text.range(
+            of: openingTag,
+            range: searchStart..<text.endIndex
+        ), let closingRange = text.range(
+            of: closingTag,
+            range: openingRange.upperBound..<text.endIndex
+        ) {
+            let body = text[openingRange.upperBound..<closingRange.lowerBound]
+            searchStart = closingRange.upperBound
+
+            guard let status = tagValue("status", in: body)?.lowercased(),
+                  terminalStatuses.contains(status) else {
+                continue
+            }
+
+            let taskID = tagValue("task-id", in: body)
+            let toolUseID = tagValue("tool-use-id", in: body)
+            guard taskID != nil || toolUseID != nil else { continue }
+
+            notifications.append(
+                ClaudeTaskNotification(
+                    taskID: taskID,
+                    toolUseID: toolUseID,
+                    status: status
+                )
+            )
+        }
+
+        return notifications
+    }
+
+    private static func tagValue(_ tag: String, in body: Substring) -> String? {
+        let openingTag = "<\(tag)>"
+        let closingTag = "</\(tag)>"
+        guard let openingRange = body.range(of: openingTag),
+              let closingRange = body.range(
+                  of: closingTag,
+                  range: openingRange.upperBound..<body.endIndex
+              ) else {
+            return nil
+        }
+
+        let value = body[openingRange.upperBound..<closingRange.lowerBound]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+}

--- a/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
@@ -118,6 +118,21 @@ struct ClaudeHooksTests {
     }
 
     @Test
+    func claudeTaskNotificationParserIgnoresUserAuthoredMarkup() throws {
+        let object = try jsonObject(from: Data("""
+        {
+          "type": "user",
+          "message": {
+            "role": "user",
+            "content": "Explain <task-notification><task-id>agent-1</task-id><tool-use-id>toolu_agent_1</tool-use-id><status>completed</status></task-notification>"
+          }
+        }
+        """.utf8))
+
+        #expect(ClaudeTaskNotificationParser.terminalNotifications(in: object).isEmpty)
+    }
+
+    @Test
     func claudeTranscriptDiscoveryStreamsTranscriptsLargerThanReadChunk() throws {
         // Pins streaming behavior across read-chunk boundaries. The
         // pre-fix `parseSession` used `String(contentsOf:)` which on
@@ -665,6 +680,102 @@ struct ClaudeHooksTests {
     }
 
     @Test
+    func claudeParentHookRemovesSubagentCompletedByTaskNotification() async throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-claude-live-completed-subagent-\(UUID().uuidString)", isDirectory: true)
+        let transcriptURL = rootURL.appendingPathComponent("session-live.jsonl")
+        let socketURL = BridgeSocketLocation.uniqueTestURL()
+        let server = BridgeServer(socketURL: socketURL)
+
+        defer {
+            server.stop()
+            try? FileManager.default.removeItem(at: rootURL)
+        }
+
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        try """
+        {"cwd":"/tmp/worktree","sessionId":"session-live","type":"user","message":{"role":"user","content":"Launch background agent."},"timestamp":"2026-04-03T03:20:00Z"}
+        """.write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+        try server.start()
+        let observer = LocalBridgeClient(socketURL: socketURL)
+        let stream = try observer.connect()
+        defer { observer.disconnect() }
+
+        let collector = AgentEventCollector()
+        let collectionTask = Task {
+            do {
+                for try await event in stream {
+                    await collector.append(event)
+                }
+            } catch {}
+        }
+        defer { collectionTask.cancel() }
+
+        try await observer.send(.registerClient(role: .observer))
+
+        let sessionID = "claude-live-completed-subagent"
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processClaudeHook(
+                ClaudeHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .userPromptSubmit,
+                    sessionID: sessionID,
+                    transcriptPath: transcriptURL.path,
+                    prompt: "Launch background agent."
+                )
+            )
+        )
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processClaudeHook(
+                ClaudeHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .subagentStart,
+                    sessionID: sessionID,
+                    transcriptPath: transcriptURL.path,
+                    agentID: "agent-1",
+                    agentType: "general-purpose"
+                )
+            )
+        )
+
+        let completionLine = """
+        {"cwd":"/tmp/worktree","sessionId":"session-live","type":"user","message":{"role":"user","content":"<task-notification><task-id>agent-1</task-id><tool-use-id>toolu_agent_1</tool-use-id><status>completed</status><summary>Agent finished</summary></task-notification>"},"origin":{"kind":"task-notification"},"timestamp":"2026-04-03T03:25:00Z"}
+        """.appending("\n")
+        let transcriptHandle = try FileHandle(forWritingTo: transcriptURL)
+        try transcriptHandle.seekToEnd()
+        try transcriptHandle.write(contentsOf: Data(completionLine.utf8))
+        try transcriptHandle.close()
+
+        _ = try BridgeCommandClient(socketURL: socketURL).send(
+            .processClaudeHook(
+                ClaudeHookPayload(
+                    cwd: "/tmp/worktree",
+                    hookEventName: .preToolUse,
+                    sessionID: sessionID,
+                    transcriptPath: transcriptURL.path,
+                    toolName: "Bash",
+                    toolUseID: "toolu_parent_1"
+                )
+            )
+        )
+
+        let events = await waitForActivityEvent(
+            sessionID: sessionID,
+            summary: "Running Bash",
+            collector: collector
+        )
+        var state = SessionState()
+        for event in events {
+            state.apply(event)
+        }
+
+        let session = try #require(state.session(id: sessionID))
+        #expect(session.phase == .running)
+        #expect(session.claudeMetadata?.activeSubagents == [])
+    }
+
+    @Test
     func questionPromptAlwaysAppendsOtherFreeformOption() throws {
         let payload = ClaudeHookPayload(
             cwd: "/tmp",
@@ -792,6 +903,28 @@ private func waitForCompletedSessionEvent(
         if events.contains(where: { event in
             if case let .sessionCompleted(payload) = event {
                 return payload.sessionID == sessionID && payload.summary == "OK"
+            }
+            return false
+        }) {
+            return events
+        }
+
+        try? await Task.sleep(for: .milliseconds(10))
+    }
+
+    return await collector.snapshot()
+}
+
+private func waitForActivityEvent(
+    sessionID: String,
+    summary: String,
+    collector: AgentEventCollector
+) async -> [AgentEvent] {
+    for _ in 0..<100 {
+        let events = await collector.snapshot()
+        if events.contains(where: { event in
+            if case let .activityUpdated(payload) = event {
+                return payload.sessionID == sessionID && payload.summary == summary
             }
             return false
         }) {


### PR DESCRIPTION
## Summary

- inspect newly appended Claude transcript lines for terminal background-task notifications
- remove the matching active subagent when Claude reports `completed`, `failed`, or cancelled
- ignore task-notification-like markup from ordinary user messages
- retain `SubagentStop` and stale-timeout cleanup as existing fallback paths

## Root Cause

Claude background agents do not always deliver a matching `SubagentStop` hook. In the reproduced flow, Claude instead appends an `origin.kind = task-notification` transcript entry containing the task ID and `<status>completed</status>`.

The bridge tracked `SubagentStart`, but it did not inspect these transcript notifications. The finished agent therefore remained in `activeSubagents` until another cleanup path happened to remove it.

## Fix

The bridge now maintains a per-session transcript cursor and reads only bytes appended since the previous parent hook. Complete JSONL records are parsed for trusted task-notification records, and terminal task IDs are removed from active subagent metadata before the parent hook is processed.

The cursor handles partial lines, file truncation, and transcript path changes without rescanning the full transcript.

## Reproduction

The same live bridge reproducer was run against current `origin/main` and this branch:

```text
origin/main:
parentPhase=running
activeSubagentCount=1
REPRODUCED: completed subagent remains active after parent event

this branch:
parentPhase=running
activeSubagentCount=0
NOT REPRODUCED
```

## Validation

- `swift test --filter ClaudeHooksTests` - 24 tests passed
- `zsh scripts/harness.sh ci` - Claude and core tests passed; four unrelated AppModel preference tests fail locally on a notch Mac and reproduce unchanged against a clean `origin/main` export
- package build and local app smoke launch were previously verified with this fix

Related to #579, which covers preserving still-running Claude subagents after the parent `Stop` hook. This PR handles the complementary terminal transition so genuinely completed subagents are removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved live transcript tracking for more accurate task and subagent status updates.
  * Added support for recognizing completed, failed, and cancelled task notifications.
  * Supports cleanup of multiple completed subagents.

* **Bug Fixes**
  * Prevents user-authored task-notification markup from being treated as system events.
  * Improves reconciliation of task completions before removing stale subagents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->