### PR TITLE
feat: add idle session visibility preference

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -377,6 +377,11 @@ final class AppModel {
         set { updateAppearancePreferences(for: activeAppearanceProfile) { $0.completedStaleThreshold = newValue } }
     }
 
+    var showIdleSessions: Bool {
+        get { appearancePreferences(for: activeAppearanceProfile).showIdleSessions }
+        set { updateAppearancePreferences(for: activeAppearanceProfile) { $0.showIdleSessions = newValue } }
+    }
+
     @ObservationIgnored
     var openSettingsWindow: (() -> Void)?
 
@@ -408,7 +413,8 @@ final class AppModel {
     ) {
         if oldValue.sessionGroup != newValue.sessionGroup ||
             oldValue.sessionSort != newValue.sessionSort ||
-            oldValue.completedStaleThreshold != newValue.completedStaleThreshold {
+            oldValue.completedStaleThreshold != newValue.completedStaleThreshold ||
+            oldValue.showIdleSessions != newValue.showIdleSessions {
             _cachedSessionBuckets = nil
         }
         refreshOverlayPlacementIfVisible()
@@ -426,6 +432,7 @@ final class AppModel {
         defaults.set(preferences.sessionGroup.rawValue, forKey: Self.appearanceDefaultsKey(profile, "sessionGroup"))
         defaults.set(preferences.sessionSort.rawValue, forKey: Self.appearanceDefaultsKey(profile, "sessionSort"))
         defaults.set(preferences.completedStaleThreshold.rawValue, forKey: Self.appearanceDefaultsKey(profile, "completedStaleThreshold"))
+        defaults.set(preferences.showIdleSessions, forKey: Self.appearanceDefaultsKey(profile, "showIdleSessions"))
     }
 
     // MARK: - Watch Notification
@@ -576,7 +583,8 @@ final class AppModel {
                 rawValue: defaults.string(forKey: appearanceDefaultsKey(profile, "completedStaleThreshold"))
                     ?? defaults.string(forKey: legacyCompletedStaleThresholdDefaultsKey)
                     ?? ""
-            ) ?? .fiveMinutes
+            ) ?? .fiveMinutes,
+            showIdleSessions: defaults.bool(forKey: appearanceDefaultsKey(profile, "showIdleSessions"))
         )
     }
 
@@ -711,7 +719,7 @@ final class AppModel {
     }
 
     var allSessions: [AgentSession] {
-        state.sessions
+        visibleIslandSessions(from: state.sessions)
     }
 
     /// Measured by SwiftUI GeometryReader in notification mode. Used by panel controller for sizing.
@@ -739,7 +747,7 @@ final class AppModel {
     }
 
     var islandSessionSections: [IslandSessionSection] {
-        let sessions = sortIslandSessions(surfacedSessions)
+        let sessions = sortIslandSessions(visibleIslandSessions(from: surfacedSessions))
         switch islandSessionGroup {
         case .none:
             return [
@@ -774,15 +782,27 @@ final class AppModel {
     }
 
     var liveSessionCount: Int {
-        surfacedSessions.count
+        islandListSessions.count
     }
 
     var liveAttentionCount: Int {
-        surfacedSessions.filter { $0.phase.requiresAttention }.count
+        islandListSessions.filter { $0.phase.requiresAttention }.count
     }
 
     var liveRunningCount: Int {
-        surfacedSessions.filter { $0.phase == .running }.count
+        islandListSessions.filter { $0.phase == .running }.count
+    }
+
+    private func visibleIslandSessions(from sessions: [AgentSession], now: Date = .now) -> [AgentSession] {
+        guard !showIdleSessions else { return sessions }
+        return sessions.filter { session in
+            guard session.phase == .completed else { return true }
+            let isIdle = session.isStaleCompletedForIsland(
+                at: now,
+                threshold: completedStaleThreshold.seconds
+            ) || session.islandPresence(at: now) == .inactive
+            return !isIdle
+        }
     }
 
     private func sortIslandSessions(_ sessions: [AgentSession]) -> [AgentSession] {
@@ -842,7 +862,7 @@ final class AppModel {
     /// running; everything else is idle. Completed sessions are absorbed
     /// directly into idle so the pill never stops on a tick glyph.
     var islandClosedMode: UnifiedBars.Mode {
-        let sessions = surfacedSessions
+        let sessions = visibleIslandSessions(from: surfacedSessions)
         if sessions.contains(where: { $0.phase.requiresAttention }) { return .waiting }
         if sessions.contains(where: { $0.phase == .running })       { return .running }
         return .idle
@@ -852,9 +872,10 @@ final class AppModel {
     /// sessions first, then the most recent running one, then whatever's
     /// first.
     var islandClosedSpotlight: AgentSession? {
-        surfacedSessions.first(where: { $0.phase.requiresAttention })
-            ?? surfacedSessions.first(where: { $0.phase == .running })
-            ?? surfacedSessions.first
+        let sessions = visibleIslandSessions(from: surfacedSessions)
+        return sessions.first(where: { $0.phase.requiresAttention })
+            ?? sessions.first(where: { $0.phase == .running })
+            ?? sessions.first
     }
 
     /// Text to show in the closed island's center label. Respects the
@@ -883,7 +904,7 @@ final class AppModel {
     /// preference and current live state. Returns nil when the preference
     /// is `.none` or there's nothing meaningful to show.
     func islandClosedRightSlotContent() -> IslandRightSlotContent? {
-        let sessions = surfacedSessions
+        let sessions = visibleIslandSessions(from: surfacedSessions)
         switch islandRightSlot {
         case .none:
             return nil

--- a/Sources/OpenIslandApp/AppModelTypes.swift
+++ b/Sources/OpenIslandApp/AppModelTypes.swift
@@ -25,7 +25,7 @@ enum TrackedEventIngress {
 
 /// What the closed island renders in the right slot. Chosen in the
 /// Personalization tab; the pill layout only varies by content width.
-enum IslandRightSlot: String, CaseIterable, Identifiable, Sendable {
+enum IslandRightSlot: String, CaseIterable, Identifiable, Codable, Sendable {
     case count   // "×N" badge
     case agents  // colored dot stack, one per active agent tool
     case none    // pill collapses — useful if you just want the bars
@@ -36,7 +36,7 @@ enum IslandRightSlot: String, CaseIterable, Identifiable, Sendable {
 /// What the closed island renders in the center label (external displays
 /// only — on MacBook the physical notch covers this space so we suppress
 /// the label regardless).
-enum IslandCenterLabel: String, CaseIterable, Identifiable, Sendable {
+enum IslandCenterLabel: String, CaseIterable, Identifiable, Codable, Sendable {
     case sessionName  // e.g. "open-island"
     case agentAction  // e.g. "Claude · editing"
     case off
@@ -46,14 +46,19 @@ enum IslandCenterLabel: String, CaseIterable, Identifiable, Sendable {
 
 // MARK: - v8 island preferences
 
-enum IslandAppearanceDisplayProfile: String, CaseIterable, Identifiable, Sendable {
+/// The display context that owns an independent island appearance preference.
+enum IslandAppearanceDisplayProfile: String, CaseIterable, Identifiable, Codable, Sendable {
     case notch
     case topBar
 
     var id: String { rawValue }
 }
 
-struct IslandAppearancePreferences: Equatable, Sendable {
+/// Persisted appearance choices for one island display profile.
+///
+/// All fields are codable so profile preferences can be stored or transferred
+/// as one stable value in addition to the current per-key defaults storage.
+struct IslandAppearancePreferences: Equatable, Codable, Sendable {
     var rightSlot: IslandRightSlot = .count
     var centerLabel: IslandCenterLabel = .agentAction
     var usageDisplay: IslandUsageDisplay = .compact
@@ -61,16 +66,19 @@ struct IslandAppearancePreferences: Equatable, Sendable {
     var sessionGroup: IslandSessionGroup = .none
     var sessionSort: IslandSessionSort = .attention
     var completedStaleThreshold: IslandCompletedStaleThreshold = .fiveMinutes
+    var showIdleSessions: Bool = false
 }
 
-enum IslandUsageDisplay: String, CaseIterable, Identifiable, Sendable {
+/// Controls whether the compact Codex usage indicator is visible.
+enum IslandUsageDisplay: String, CaseIterable, Identifiable, Codable, Sendable {
     case hidden
     case compact
 
     var id: String { rawValue }
 }
 
-enum IslandSessionStateIndicator: String, CaseIterable, Identifiable, Sendable {
+/// Selects the visual treatment for a session's state in the island.
+enum IslandSessionStateIndicator: String, CaseIterable, Identifiable, Codable, Sendable {
     case animatedDot
     case bar
     case glyph
@@ -84,7 +92,8 @@ enum IslandSessionStateIndicator: String, CaseIterable, Identifiable, Sendable {
     }
 }
 
-enum IslandSessionGroup: String, CaseIterable, Identifiable, Sendable {
+/// Defines how sessions are grouped in the expanded island list.
+enum IslandSessionGroup: String, CaseIterable, Identifiable, Codable, Sendable {
     case none
     case state
     case agent
@@ -93,14 +102,16 @@ enum IslandSessionGroup: String, CaseIterable, Identifiable, Sendable {
     var id: String { rawValue }
 }
 
-enum IslandSessionSort: String, CaseIterable, Identifiable, Sendable {
+/// Defines the ordering of sessions within an island list group.
+enum IslandSessionSort: String, CaseIterable, Identifiable, Codable, Sendable {
     case attention
     case lastUpdate
 
     var id: String { rawValue }
 }
 
-enum IslandCompletedStaleThreshold: String, CaseIterable, Identifiable, Sendable {
+/// Defines when a completed session is treated as idle by the island.
+enum IslandCompletedStaleThreshold: String, CaseIterable, Identifiable, Codable, Sendable {
     case twoMinutes
     case fiveMinutes
     case tenMinutes

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -93,7 +93,10 @@
 "settings.appearance.sessionSort.note" = "Choose the default order inside the expanded list.";
 "settings.appearance.sessionSort.attention" = "Attention";
 "settings.appearance.sessionSort.lastUpdate" = "Last update";
-"settings.appearance.staleThreshold.title" = "06 · Done timeout";
+"settings.appearance.showIdle.title" = "06 · Idle sessions";
+"settings.appearance.showIdle.note" = "When off, idle sessions are removed from the list and overview counts.";
+"settings.appearance.showIdle.option" = "Show idle sessions";
+"settings.appearance.staleThreshold.title" = "07 · Done timeout";
 "settings.appearance.staleThreshold.note" = "Completed sessions move to the low-priority idle presentation after this time.";
 "settings.appearance.staleThreshold.twoMinutes" = "2 min";
 "settings.appearance.staleThreshold.fiveMinutes" = "5 min";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -93,7 +93,10 @@
 "settings.appearance.sessionSort.note" = "选择展开列表里的默认排序。";
 "settings.appearance.sessionSort.attention" = "优先级";
 "settings.appearance.sessionSort.lastUpdate" = "最近更新";
-"settings.appearance.staleThreshold.title" = "06 · 完成超时";
+"settings.appearance.showIdle.title" = "06 · 空闲会话";
+"settings.appearance.showIdle.note" = "关闭后，空闲会话不会出现在列表和顶部统计中。";
+"settings.appearance.showIdle.option" = "显示空闲会话";
+"settings.appearance.staleThreshold.title" = "07 · 完成超时";
 "settings.appearance.staleThreshold.note" = "完成会话经过这段时间后会降到低优先级空闲展示。";
 "settings.appearance.staleThreshold.twoMinutes" = "2 分钟";
 "settings.appearance.staleThreshold.fiveMinutes" = "5 分钟";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -93,7 +93,10 @@
 "settings.appearance.sessionSort.note" = "選擇展開列表中的預設排序。";
 "settings.appearance.sessionSort.attention" = "優先級";
 "settings.appearance.sessionSort.lastUpdate" = "最近更新";
-"settings.appearance.staleThreshold.title" = "06 · 完成逾時";
+"settings.appearance.showIdle.title" = "06 · 閒置會話";
+"settings.appearance.showIdle.note" = "關閉後，閒置會話不會出現在清單和頂部統計中。";
+"settings.appearance.showIdle.option" = "顯示閒置會話";
+"settings.appearance.staleThreshold.title" = "07 · 完成逾時";
 "settings.appearance.staleThreshold.note" = "完成會話經過這段時間後會降到低優先級閒置展示。";
 "settings.appearance.staleThreshold.twoMinutes" = "2 分鐘";
 "settings.appearance.staleThreshold.fiveMinutes" = "5 分鐘";

--- a/Sources/OpenIslandApp/Views/AppearanceSettingsPane.swift
+++ b/Sources/OpenIslandApp/Views/AppearanceSettingsPane.swift
@@ -139,6 +139,7 @@ struct AppearanceSettingsPane: View {
             stateIndicatorSection
             sessionGroupSection
             sessionSortSection
+            idleVisibilitySection
             staleThresholdSection
         }
     }
@@ -465,7 +466,31 @@ struct AppearanceSettingsPane: View {
         }
     }
 
-    // MARK: - 06 · Done timeout
+    // MARK: - 06 · Idle sessions
+
+    @ViewBuilder
+    private var idleVisibilitySection: some View {
+        sectionHeader(
+            title: lang.t("settings.appearance.showIdle.title"),
+            note: lang.t("settings.appearance.showIdle.note")
+        )
+
+        Toggle(
+            lang.t("settings.appearance.showIdle.option"),
+            isOn: Binding(
+                get: { editingPreferences.showIdleSessions },
+                set: { value in
+                    model.updateAppearancePreferences(for: editingProfile) {
+                        $0.showIdleSessions = value
+                    }
+                }
+            )
+        )
+        .toggleStyle(.switch)
+        .tint(V6Palette.paper.opacity(0.85))
+    }
+
+    // MARK: - 07 · Done timeout
 
     @ViewBuilder
     private var staleThresholdSection: some View {

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -24,6 +24,8 @@ struct AppModelSessionListTests {
             "appearance.island.v8.topBar.sessionGroup",
             "appearance.island.v8.topBar.sessionSort",
             "appearance.island.v8.topBar.completedStaleThreshold",
+            "appearance.island.v8.notch.showIdleSessions",
+            "appearance.island.v8.topBar.showIdleSessions",
             "app.suppressFrontmostNotifications",
             "feature.completionReply.enabled",
             "overlay.sound.muted",
@@ -349,6 +351,57 @@ struct AppModelSessionListTests {
 
         #expect(model.islandSessionSections.map(\.id) == ["state-done"])
         #expect(model.islandSessionSections.first?.sessions.first?.id == "old-done")
+    }
+
+    @Test
+    func idleSessionsAreHiddenByDefaultAndCanBeEnabledPerDisplayProfile() {
+        let now = Date()
+        let model = AppModel()
+        var running = listSession(id: "running", phase: .running, updatedAt: now)
+        var idle = listSession(id: "idle", phase: .completed, updatedAt: now.addingTimeInterval(-360))
+        running.isProcessAlive = true
+        idle.isProcessAlive = true
+        model.state = SessionState(sessions: [idle, running])
+        model.overlayPlacementDiagnostics = placementDiagnostics(mode: .topBar)
+        model.islandRightSlot = .count
+
+        #expect(model.islandListSessions.map(\.id) == ["running"])
+        #expect(model.islandClosedSpotlight?.id == "running")
+        if case let .count(count)? = model.islandClosedRightSlotContent() {
+            #expect(count == 1)
+        } else {
+            Issue.record("Expected a closed-island count with idle sessions filtered out")
+        }
+
+        model.updateAppearancePreferences(for: .topBar) { $0.showIdleSessions = true }
+        #expect(model.showIdleSessions)
+        #expect(Set(model.islandListSessions.map(\.id)) == Set(["running", "idle"]))
+        if case let .count(count)? = model.islandClosedRightSlotContent() {
+            #expect(count == 2)
+        } else {
+            Issue.record("Expected a closed-island count with idle sessions enabled")
+        }
+
+        let reloaded = AppModel()
+        reloaded.overlayPlacementDiagnostics = placementDiagnostics(mode: .topBar)
+        #expect(reloaded.showIdleSessions)
+    }
+
+    @Test
+    func appearancePreferencesRoundTripAsCodable() throws {
+        let preferences = IslandAppearancePreferences(
+            rightSlot: .agents,
+            centerLabel: .sessionName,
+            usageDisplay: .hidden,
+            sessionStateIndicator: .glyph,
+            sessionGroup: .project,
+            sessionSort: .lastUpdate,
+            completedStaleThreshold: .tenMinutes,
+            showIdleSessions: true
+        )
+
+        let encoded = try JSONEncoder().encode(preferences)
+        #expect(try JSONDecoder().decode(IslandAppearancePreferences.self, from: encoded) == preferences)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- add a per-display-profile setting to show or hide idle completed sessions
- apply the preference to the expanded list, overview counts, and closed-island content
- make the persisted appearance preference model and its enum fields `Codable`
- document the persisted preference API and add a Codable round-trip regression test

## Why

This separates the idle-session preference from the broad Codex session PR and addresses the remaining review request that persisted appearance preferences conform to `Codable`.

## Validation

- `swiftc -parse` for the changed Swift source and test files
- `plutil -lint` for English, Simplified Chinese, and Traditional Chinese localization files
- `git diff --check`

The local Command Line Tools installation provides Swift 6.1 and no XCTest module, while this project requires Swift 6.2. A temporary compatibility build compiled the changed OpenIslandApp source module, but could not build the test target. Please use CI for the new `AppModelSessionListTests` regression tests.
