### PR TITLE
perf: move session status pulse to Core Animation

### DIFF
--- a/Sources/OpenIslandApp/AppModelTypes.swift
+++ b/Sources/OpenIslandApp/AppModelTypes.swift
@@ -79,8 +79,11 @@ enum IslandSessionStateIndicator: String, CaseIterable, Identifiable, Sendable {
     var id: String { rawValue }
 
     func timelineInterval(presence: IslandSessionPresence, isActionable: Bool) -> TimeInterval? {
-        guard self == .animatedDot else { return nil }
-        return presence == .running || isActionable ? 1.0 / 15.0 : nil
+        nil
+    }
+
+    func usesLayerAnimation(presence: IslandSessionPresence, isActionable: Bool) -> Bool {
+        self == .animatedDot && (presence == .running || isActionable)
     }
 }
 

--- a/Sources/OpenIslandApp/AppModelTypes.swift
+++ b/Sources/OpenIslandApp/AppModelTypes.swift
@@ -78,10 +78,12 @@ enum IslandSessionStateIndicator: String, CaseIterable, Identifiable, Sendable {
 
     var id: String { rawValue }
 
+    /// Returns no SwiftUI timeline because active dots animate in Core Animation.
     func timelineInterval(presence: IslandSessionPresence, isActionable: Bool) -> TimeInterval? {
         nil
     }
 
+    /// Whether this state needs the isolated Core Animation pulse view.
     func usesLayerAnimation(presence: IslandSessionPresence, isActionable: Bool) -> Bool {
         self == .animatedDot && (presence == .running || isActionable)
     }

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -78,18 +78,6 @@ private let closeAnimation = Animation.smooth(duration: 0.3)
 private let popAnimation = Animation.spring(response: 0.3, dampingFraction: 0.5)
 private let openedSurfaceUnmountDelay: TimeInterval = 0.36
 
-private struct ConditionalDrawingGroup: ViewModifier {
-    let enabled: Bool
-
-    func body(content: Content) -> some View {
-        if enabled {
-            content.drawingGroup()
-        } else {
-            content
-        }
-    }
-}
-
 // MARK: - Main island view
 
 struct IslandPanelView: View {
@@ -582,7 +570,6 @@ struct IslandPanelView: View {
                     stateIndicator: model.islandSessionStateIndicator,
                     completedStaleThreshold: model.completedStaleThreshold.seconds,
                     isActionable: true,
-                    useDrawingGroup: model.notchStatus == .opened,
                     isInteractive: model.notchStatus == .opened,
                     presentation: .notification,
                     sideInset: sessionListSideInset,
@@ -624,7 +611,6 @@ struct IslandPanelView: View {
                                 stateIndicator: model.islandSessionStateIndicator,
                                 completedStaleThreshold: model.completedStaleThreshold.seconds,
                                 isActionable: session.phase.requiresAttention || session.id == actionableSessionID,
-                                useDrawingGroup: model.notchStatus == .opened,
                                 isInteractive: model.notchStatus == .opened,
                                 sideInset: sessionListSideInset,
                                 lang: model.lang,
@@ -661,8 +647,8 @@ struct IslandPanelView: View {
 
     @ViewBuilder
     private func sessionRowsContent(referenceDate: Date) -> some View {
-        ForEach(model.islandSessionSections) { section in
-            VStack(alignment: .leading, spacing: 0) {
+        LazyVStack(alignment: .leading, spacing: 0) {
+            ForEach(model.islandSessionSections) { section in
                 if model.islandSessionGroup != .none {
                     sessionSectionHeader(section)
                 }
@@ -674,7 +660,6 @@ struct IslandPanelView: View {
                         stateIndicator: model.islandSessionStateIndicator,
                         completedStaleThreshold: model.completedStaleThreshold.seconds,
                         isActionable: session.phase.requiresAttention || session.id == actionableSessionID,
-                        useDrawingGroup: model.notchStatus == .opened,
                         isInteractive: model.notchStatus == .opened,
                         sideInset: sessionListSideInset,
                         lang: model.lang,
@@ -1184,7 +1169,6 @@ private struct IslandSessionRow: View {
     var stateIndicator: IslandSessionStateIndicator = .animatedDot
     var completedStaleThreshold: TimeInterval = AgentSession.staleCompletedDisplayThreshold
     var isActionable: Bool = false
-    var useDrawingGroup: Bool = true
     var isInteractive: Bool = true
     var presentation: IslandSessionRowPresentation = .list
     var sideInset: CGFloat = 16
@@ -1244,7 +1228,6 @@ private struct IslandSessionRow: View {
             }
         }
         .opacity(isStaleCompleted ? 0.7 : 1)
-        .modifier(ConditionalDrawingGroup(enabled: useDrawingGroup && !isActionable))
         .contentShape(Rectangle())
         .animation(.easeInOut(duration: 0.15), value: isHighlighted)
         .onTapGesture(perform: handlePrimaryTap)
@@ -1868,11 +1851,8 @@ private struct IslandSessionRow: View {
         let tint = statusTint(for: presence)
         switch stateIndicator {
         case .animatedDot:
-            if let interval = stateIndicator.timelineInterval(presence: presence, isActionable: isActionable) {
-                TimelineView(.periodic(from: .now, by: interval)) { context in
-                    let pulse = (sin(context.date.timeIntervalSinceReferenceDate * 3.2) + 1) / 2
-                    statusDot(tint: tint, presence: presence, pulse: pulse)
-                }
+            if stateIndicator.usesLayerAnimation(presence: presence, isActionable: isActionable) {
+                PulsingStatusDot(tint: tint)
                 .frame(width: 10, height: 24, alignment: .top)
             } else {
                 statusDot(tint: tint, presence: presence, pulse: 0)

--- a/Sources/OpenIslandApp/Views/PulsingStatusDot.swift
+++ b/Sources/OpenIslandApp/Views/PulsingStatusDot.swift
@@ -18,6 +18,7 @@ struct PulsingStatusDot: NSViewRepresentable {
         nsView.update(tint: NSColor(tint))
     }
 
+    /// Hosts the animating layers without invalidating the enclosing SwiftUI row.
     final class LayerView: NSView {
         private let dotLayer = CAShapeLayer()
         private var tintColor = NSColor.white
@@ -38,6 +39,7 @@ struct PulsingStatusDot: NSViewRepresentable {
             fatalError("init(coder:) has not been implemented")
         }
 
+        /// Updates the visible tint while preserving an existing pulse animation.
         func update(tint: NSColor) {
             tintColor = tint
             updateColors()

--- a/Sources/OpenIslandApp/Views/PulsingStatusDot.swift
+++ b/Sources/OpenIslandApp/Views/PulsingStatusDot.swift
@@ -1,0 +1,110 @@
+import AppKit
+import SwiftUI
+
+/// A status pulse rendered entirely by Core Animation.
+///
+/// Keeping the pulse below SwiftUI prevents a running session from invalidating
+/// its full row many times per second while the session list is being scrolled.
+struct PulsingStatusDot: NSViewRepresentable {
+    let tint: Color
+
+    func makeNSView(context: Context) -> LayerView {
+        let view = LayerView()
+        view.update(tint: NSColor(tint))
+        return view
+    }
+
+    func updateNSView(_ nsView: LayerView, context: Context) {
+        nsView.update(tint: NSColor(tint))
+    }
+
+    final class LayerView: NSView {
+        private let dotLayer = CAShapeLayer()
+        private var tintColor = NSColor.white
+
+        override init(frame frameRect: NSRect) {
+            super.init(frame: frameRect)
+            wantsLayer = true
+            layer = CALayer()
+            layer?.masksToBounds = false
+
+            dotLayer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
+            dotLayer.masksToBounds = false
+            layer?.addSublayer(dotLayer)
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        func update(tint: NSColor) {
+            tintColor = tint
+            updateColors()
+            needsLayout = true
+            startAnimationIfNeeded()
+        }
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            if window == nil {
+                dotLayer.removeAllAnimations()
+            } else {
+                dotLayer.contentsScale = window?.backingScaleFactor ?? 2
+                startAnimationIfNeeded()
+            }
+        }
+
+        override func layout() {
+            super.layout()
+            let diameter: CGFloat = 9
+            let dotBounds = CGRect(x: 0, y: 0, width: diameter, height: diameter)
+
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            dotLayer.bounds = dotBounds
+            dotLayer.position = CGPoint(x: bounds.midX, y: bounds.maxY - 6 - diameter / 2)
+            dotLayer.path = CGPath(ellipseIn: dotBounds, transform: nil)
+            dotLayer.shadowPath = dotLayer.path
+            CATransaction.commit()
+
+            startAnimationIfNeeded()
+        }
+
+        private func updateColors() {
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            dotLayer.fillColor = tintColor.cgColor
+            dotLayer.shadowColor = tintColor.cgColor
+            dotLayer.shadowOpacity = 0.36
+            dotLayer.shadowRadius = 4
+            dotLayer.shadowOffset = .zero
+            CATransaction.commit()
+        }
+
+        private func startAnimationIfNeeded() {
+            guard window != nil, dotLayer.animation(forKey: "statusPulse") == nil else { return }
+
+            let scale = CABasicAnimation(keyPath: "transform.scale")
+            scale.fromValue = 1
+            scale.toValue = 1.18
+
+            let shadowOpacity = CABasicAnimation(keyPath: "shadowOpacity")
+            shadowOpacity.fromValue = 0.36
+            shadowOpacity.toValue = 0.62
+
+            let shadowRadius = CABasicAnimation(keyPath: "shadowRadius")
+            shadowRadius.fromValue = 4
+            shadowRadius.toValue = 7
+
+            let group = CAAnimationGroup()
+            group.animations = [scale, shadowOpacity, shadowRadius]
+            group.duration = 0.98
+            group.autoreverses = true
+            group.repeatCount = .infinity
+            group.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            group.isRemovedOnCompletion = false
+            dotLayer.add(group, forKey: "statusPulse")
+        }
+    }
+}

--- a/Tests/OpenIslandAppTests/PerformancePolicyTests.swift
+++ b/Tests/OpenIslandAppTests/PerformancePolicyTests.swift
@@ -74,7 +74,7 @@ struct PerformancePolicyTests {
     }
 
     @Test
-    func inactiveSessionDotDoesNotRequireAnimationTimeline() {
+    func sessionDotDoesNotRequireSwiftUIAnimationTimeline() {
         #expect(IslandSessionStateIndicator.animatedDot.timelineInterval(
             presence: .inactive,
             isActionable: false
@@ -86,10 +86,30 @@ struct PerformancePolicyTests {
         #expect(IslandSessionStateIndicator.animatedDot.timelineInterval(
             presence: .running,
             isActionable: false
-        ) == 1.0 / 15.0)
+        ) == nil)
         #expect(IslandSessionStateIndicator.animatedDot.timelineInterval(
             presence: .inactive,
             isActionable: true
-        ) == 1.0 / 15.0)
+        ) == nil)
+    }
+
+    @Test
+    func activeSessionDotUsesCoreAnimationLayerAnimation() {
+        #expect(!IslandSessionStateIndicator.animatedDot.usesLayerAnimation(
+            presence: .inactive,
+            isActionable: false
+        ))
+        #expect(IslandSessionStateIndicator.animatedDot.usesLayerAnimation(
+            presence: .running,
+            isActionable: false
+        ))
+        #expect(IslandSessionStateIndicator.animatedDot.usesLayerAnimation(
+            presence: .inactive,
+            isActionable: true
+        ))
+        #expect(!IslandSessionStateIndicator.bar.usesLayerAnimation(
+            presence: .running,
+            isActionable: false
+        ))
     }
 }


### PR DESCRIPTION
## Summary

- render active session status pulses in an `NSViewRepresentable` backed by Core Animation
- stop using a SwiftUI animation timeline for active session rows
- preserve static indicators for inactive dots and other indicator styles
- document the timeline and layer-view ownership decisions

## Why

This separates the session-list redraw optimization from the broad Codex session PR. Core Animation keeps the pulse running without repeatedly invalidating the surrounding SwiftUI session row while scrolling.

## Validation

- `swiftc -parse` for the changed Swift source and policy tests
- `git diff --check`

Local Command Line Tools Swift is 6.1 and lacks XCTest, while the project requires Swift 6.2. CI should run `PerformancePolicyTests` before this draft is marked ready for review.
