### PR TITLE
perf: scroll expanded island immediately for wheel input

### DIFF
--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -692,6 +692,89 @@ final class OverlayPanelController {
 private final class NotchPanel: NSPanel {
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { false }
+
+    override func sendEvent(_ event: NSEvent) {
+        if event.type == .scrollWheel,
+           ImmediateWheelScrollPolicy.shouldHandleImmediately(
+               phase: event.phase,
+               momentumPhase: event.momentumPhase
+           ),
+           scrollImmediately(with: event) {
+            return
+        }
+        super.sendEvent(event)
+    }
+
+    private func scrollImmediately(with event: NSEvent) -> Bool {
+        guard abs(event.scrollingDeltaY) >= abs(event.scrollingDeltaX),
+              let contentView else {
+            return false
+        }
+
+        let contentPoint = contentView.convert(event.locationInWindow, from: nil)
+        var hitView = contentView.hitTest(contentPoint)
+        var foundScrollView = false
+        while let view = hitView {
+            if let scrollView = view as? NSScrollView {
+                foundScrollView = true
+                if scrollImmediately(scrollView, with: event) {
+                    return true
+                }
+            }
+            hitView = view.superview
+        }
+        // Consume an event that reached a scroll view but is already at the
+        // outer boundary, avoiding the slow elastic animation.
+        return foundScrollView
+    }
+
+    private func scrollImmediately(_ scrollView: NSScrollView, with event: NSEvent) -> Bool {
+        let clipView = scrollView.contentView
+        guard let documentView = scrollView.documentView else {
+            return false
+        }
+
+        let documentHeight = documentView.bounds.height
+        let viewportHeight = clipView.bounds.height
+        let maximumOriginY = max(0, documentHeight - viewportHeight)
+        guard maximumOriginY > 0 else {
+            return false
+        }
+
+        let targetOriginY = ImmediateWheelScrollPolicy.targetVerticalOrigin(
+            currentOriginY: clipView.bounds.origin.y,
+            scrollingDeltaY: event.scrollingDeltaY,
+            hasPreciseScrollingDeltas: event.hasPreciseScrollingDeltas,
+            maximumOriginY: maximumOriginY
+        )
+        guard targetOriginY != clipView.bounds.origin.y else { return false }
+
+        clipView.scroll(to: CGPoint(x: clipView.bounds.origin.x, y: targetOriginY))
+        scrollView.reflectScrolledClipView(clipView)
+        return true
+    }
+}
+
+enum ImmediateWheelScrollPolicy {
+    private static let lineScrollMultiplier: CGFloat = 18
+
+    static func shouldHandleImmediately(
+        phase: NSEvent.Phase,
+        momentumPhase: NSEvent.Phase
+    ) -> Bool {
+        phase.isEmpty && momentumPhase.isEmpty
+    }
+
+    static func targetVerticalOrigin(
+        currentOriginY: CGFloat,
+        scrollingDeltaY: CGFloat,
+        hasPreciseScrollingDeltas: Bool,
+        maximumOriginY: CGFloat
+    ) -> CGFloat {
+        let multiplier = hasPreciseScrollingDeltas ? 1 : lineScrollMultiplier
+        let proposedOriginY = currentOriginY - (scrollingDeltaY * multiplier)
+        return min(max(0, proposedOriginY), maximumOriginY)
+    }
 }
 
 // MARK: - NotchHostingView

--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -755,9 +755,14 @@ private final class NotchPanel: NSPanel {
     }
 }
 
+/// Converts discrete wheel input into immediate bounded scroll positions.
+///
+/// Trackpad gestures and momentum continue through AppKit so their native
+/// deceleration remains intact.
 enum ImmediateWheelScrollPolicy {
     private static let lineScrollMultiplier: CGFloat = 18
 
+    /// Returns whether an event is a discrete wheel step rather than a gesture.
     static func shouldHandleImmediately(
         phase: NSEvent.Phase,
         momentumPhase: NSEvent.Phase
@@ -765,6 +770,7 @@ enum ImmediateWheelScrollPolicy {
         phase.isEmpty && momentumPhase.isEmpty
     }
 
+    /// Clamps a wheel delta to the scroll view's valid vertical range.
     static func targetVerticalOrigin(
         currentOriginY: CGFloat,
         scrollingDeltaY: CGFloat,

--- a/Tests/OpenIslandAppTests/OverlayPanelControllerTests.swift
+++ b/Tests/OpenIslandAppTests/OverlayPanelControllerTests.swift
@@ -4,6 +4,44 @@ import Testing
 
 struct OverlayPanelControllerTests {
     @Test
+    func standaloneWheelEventsUseImmediateScrolling() {
+        #expect(ImmediateWheelScrollPolicy.shouldHandleImmediately(
+            phase: [],
+            momentumPhase: []
+        ))
+        #expect(!ImmediateWheelScrollPolicy.shouldHandleImmediately(
+            phase: .changed,
+            momentumPhase: []
+        ))
+        #expect(!ImmediateWheelScrollPolicy.shouldHandleImmediately(
+            phase: [],
+            momentumPhase: .changed
+        ))
+    }
+
+    @Test
+    func immediateWheelScrollingScalesLinesAndClampsPreciseDeltas() {
+        #expect(ImmediateWheelScrollPolicy.targetVerticalOrigin(
+            currentOriginY: 20,
+            scrollingDeltaY: -3,
+            hasPreciseScrollingDeltas: false,
+            maximumOriginY: 200
+        ) == 74)
+        #expect(ImmediateWheelScrollPolicy.targetVerticalOrigin(
+            currentOriginY: 20,
+            scrollingDeltaY: -190,
+            hasPreciseScrollingDeltas: true,
+            maximumOriginY: 200
+        ) == 200)
+        #expect(ImmediateWheelScrollPolicy.targetVerticalOrigin(
+            currentOriginY: 20,
+            scrollingDeltaY: 190,
+            hasPreciseScrollingDeltas: true,
+            maximumOriginY: 200
+        ) == 0)
+    }
+
+    @Test
     func closedSurfaceRectCentersOnNotch() {
         let notchRect = NSRect(x: 200, y: 900, width: 200, height: 38)
         let closedWidth: CGFloat = 320


### PR DESCRIPTION
## Summary

- bypass AppKit's delayed elastic animation for discrete mouse-wheel events in the expanded island
- preserve native trackpad gesture and momentum handling
- clamp manual scroll positions to the document bounds
- add policy tests and document the input-routing boundary

## Why

This separates the wheel-scroll responsiveness improvement from the broad Codex session changes, making the panel behavior independently reviewable.

## Validation

- `swiftc -parse` for the changed controller and tests
- `git diff --check`

The local toolchain is Swift 6.1 without XCTest; CI should run `OverlayPanelControllerTests` before this draft is marked ready for review.
