### PR TITLE
fix: preserve display preference across hotplug

### DIFF
--- a/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
+++ b/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
@@ -6,6 +6,77 @@ struct OverlayDisplayOption: Identifiable, Equatable {
     let id: String
     let title: String
     let subtitle: String
+    let isAvailable: Bool
+
+    init(id: String, title: String, subtitle: String, isAvailable: Bool = true) {
+        self.id = id
+        self.title = title
+        self.subtitle = subtitle
+        self.isAvailable = isAvailable
+    }
+}
+
+struct OverlayDisplayPreferenceReconciliation: Equatable {
+    let selectionID: String
+    let selectionTitle: String?
+    let displayOptions: [OverlayDisplayOption]
+}
+
+enum OverlayDisplayPreferencePolicy {
+    static let preferenceDefaultsKey = "overlay.display.preference"
+    static let preferenceTitleDefaultsKey = "overlay.display.preference.title"
+    private static let legacyDisplayIDPrefix = "display-"
+
+    /// Legacy preferences stored a transient `CGDirectDisplayID` and cannot
+    /// be matched safely after a hotplug. New preferences use a stable display
+    /// UUID (or the resolver's explicit fallback identifier).
+    static func restoredSelectionID(from storedSelectionID: String?) -> String {
+        guard let storedSelectionID,
+              !storedSelectionID.isEmpty,
+              !storedSelectionID.hasPrefix(legacyDisplayIDPrefix) else {
+            return OverlayDisplayOption.automaticID
+        }
+
+        return storedSelectionID
+    }
+
+    /// Keeps the persisted user preference separate from the currently
+    /// available displays. When the preferred display is disconnected, a
+    /// disabled placeholder keeps the Picker selection intact while placement
+    /// temporarily falls back to another screen.
+    static func reconcile(
+        availableOptions: [OverlayDisplayOption],
+        selectionID: String,
+        rememberedSelectionTitle: String?
+    ) -> OverlayDisplayPreferenceReconciliation {
+        guard selectionID != OverlayDisplayOption.automaticID else {
+            return OverlayDisplayPreferenceReconciliation(
+                selectionID: selectionID,
+                selectionTitle: nil,
+                displayOptions: availableOptions
+            )
+        }
+
+        if let selectedOption = availableOptions.first(where: { $0.id == selectionID }) {
+            return OverlayDisplayPreferenceReconciliation(
+                selectionID: selectionID,
+                selectionTitle: selectedOption.title,
+                displayOptions: availableOptions
+            )
+        }
+
+        let unavailableOption = OverlayDisplayOption(
+            id: selectionID,
+            title: rememberedSelectionTitle ?? selectionID,
+            subtitle: "Unavailable",
+            isAvailable: false
+        )
+        return OverlayDisplayPreferenceReconciliation(
+            selectionID: selectionID,
+            selectionTitle: rememberedSelectionTitle,
+            displayOptions: availableOptions + [unavailableOption]
+        )
+    }
 }
 
 enum OverlayPlacementMode: String, Equatable {
@@ -179,9 +250,10 @@ enum OverlayDisplayResolver {
 
     /// Disambiguates identical displays (e.g. two AirPlay receivers with the
     /// same model name and resolution) by appending the arrangement origin.
-    /// The origin is not stable across display rearrangement, but a mismatched
-    /// preference will self-heal through the existing
-    /// `validSelectionIDs.contains` check in `refreshOverlayDisplayConfiguration()`.
+    /// The origin is not stable across display rearrangement. If it changes,
+    /// the preference remains unavailable until that display is reselected;
+    /// it is not discarded automatically because a temporary disconnect must
+    /// preserve the user's intent.
     private static func fallbackScreenID(for screen: NSScreen) -> String {
         let width = Int(screen.frame.width.rounded())
         let height = Int(screen.frame.height.rounded())

--- a/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
+++ b/Sources/OpenIslandApp/OverlayDisplayConfiguration.swift
@@ -1,6 +1,6 @@
 import AppKit
 
-struct OverlayDisplayOption: Identifiable, Equatable {
+struct OverlayDisplayOption: Identifiable, Equatable, Codable, Sendable {
     static let automaticID = "automatic"
 
     let id: String
@@ -16,7 +16,7 @@ struct OverlayDisplayOption: Identifiable, Equatable {
     }
 }
 
-struct OverlayDisplayPreferenceReconciliation: Equatable {
+struct OverlayDisplayPreferenceReconciliation: Equatable, Codable, Sendable {
     let selectionID: String
     let selectionTitle: String?
     let displayOptions: [OverlayDisplayOption]

--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -52,6 +52,9 @@ final class OverlayUICoordinator {
     private var screenParametersObserver: NSObjectProtocol?
 
     @ObservationIgnored
+    private var overlayDisplaySelectionTitle: String?
+
+    @ObservationIgnored
     private var overlayTransitionGeneration: UInt64 = 0
 
     @ObservationIgnored
@@ -92,9 +95,24 @@ final class OverlayUICoordinator {
     // MARK: - Initialization
 
     func restoreDisplayPreference() {
-        overlayDisplaySelectionID = UserDefaults.standard.string(
-            forKey: "overlay.display.preference"
-        ) ?? OverlayDisplayOption.automaticID
+        let defaults = UserDefaults.standard
+        let storedSelectionID = defaults.string(
+            forKey: OverlayDisplayPreferencePolicy.preferenceDefaultsKey
+        )
+        let restoredSelectionID = OverlayDisplayPreferencePolicy.restoredSelectionID(
+            from: storedSelectionID
+        )
+
+        if storedSelectionID != nil,
+           restoredSelectionID == OverlayDisplayOption.automaticID {
+            defaults.removeObject(forKey: OverlayDisplayPreferencePolicy.preferenceDefaultsKey)
+            defaults.removeObject(forKey: OverlayDisplayPreferencePolicy.preferenceTitleDefaultsKey)
+        }
+
+        overlayDisplaySelectionTitle = defaults.string(
+            forKey: OverlayDisplayPreferencePolicy.preferenceTitleDefaultsKey
+        )
+        overlayDisplaySelectionID = restoredSelectionID
     }
 
     /// Re-syncs the cached display options and the target panel placement
@@ -258,13 +276,15 @@ final class OverlayUICoordinator {
     // MARK: - Display configuration
 
     func refreshOverlayDisplayConfiguration() {
-        overlayDisplayOptions = overlayPanelController.availableDisplayOptions()
-
-        let validSelectionIDs = Set(overlayDisplayOptions.map(\.id))
-        if !validSelectionIDs.contains(overlayDisplaySelectionID) {
-            overlayDisplaySelectionID = OverlayDisplayOption.automaticID
-            return
-        }
+        let reconciliation = OverlayDisplayPreferencePolicy.reconcile(
+            availableOptions: overlayPanelController.availableDisplayOptions(),
+            selectionID: overlayDisplaySelectionID,
+            rememberedSelectionTitle: overlayDisplaySelectionTitle
+        )
+        overlayDisplaySelectionID = reconciliation.selectionID
+        overlayDisplaySelectionTitle = reconciliation.selectionTitle
+        overlayDisplayOptions = reconciliation.displayOptions
+        persistOverlayDisplayPreference()
 
         refreshOverlayPlacement()
     }
@@ -512,9 +532,25 @@ final class OverlayUICoordinator {
     private func persistOverlayDisplayPreference() {
         let defaults = UserDefaults.standard
         if overlayDisplaySelectionID == OverlayDisplayOption.automaticID {
-            defaults.removeObject(forKey: "overlay.display.preference")
+            overlayDisplaySelectionTitle = nil
+            defaults.removeObject(forKey: OverlayDisplayPreferencePolicy.preferenceDefaultsKey)
+            defaults.removeObject(forKey: OverlayDisplayPreferencePolicy.preferenceTitleDefaultsKey)
         } else {
-            defaults.set(overlayDisplaySelectionID, forKey: "overlay.display.preference")
+            if let selectedOption = overlayDisplayOptions.first(where: {
+                $0.id == overlayDisplaySelectionID && $0.isAvailable
+            }) {
+                overlayDisplaySelectionTitle = selectedOption.title
+            }
+            defaults.set(
+                overlayDisplaySelectionID,
+                forKey: OverlayDisplayPreferencePolicy.preferenceDefaultsKey
+            )
+            if let overlayDisplaySelectionTitle {
+                defaults.set(
+                    overlayDisplaySelectionTitle,
+                    forKey: OverlayDisplayPreferencePolicy.preferenceTitleDefaultsKey
+                )
+            }
         }
     }
 }

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -188,7 +188,9 @@ struct GeneralSettingsPane: View {
                 )) {
                     Text(lang.t("settings.general.automatic")).tag(OverlayDisplayOption.automaticID)
                     ForEach(model.overlayDisplayOptions) { option in
-                        Text(option.title).tag(option.id)
+                        Text(option.title)
+                            .tag(option.id)
+                            .disabled(!option.isAvailable)
                     }
                 }
             }
@@ -247,7 +249,9 @@ struct DisplaySettingsPane: View {
                 )) {
                     Text(lang.t("settings.general.automatic")).tag(OverlayDisplayOption.automaticID)
                     ForEach(model.overlayDisplayOptions) { option in
-                        Text(option.title).tag(option.id)
+                        Text(option.title)
+                            .tag(option.id)
+                            .disabled(!option.isAvailable)
                     }
                 }
             }

--- a/Tests/OpenIslandAppTests/OverlayPanelControllerTests.swift
+++ b/Tests/OpenIslandAppTests/OverlayPanelControllerTests.swift
@@ -4,6 +4,93 @@ import Testing
 
 struct OverlayPanelControllerTests {
     @Test
+    func legacyDisplayPreferenceResetsToAutomatic() {
+        #expect(
+            OverlayDisplayPreferencePolicy.restoredSelectionID(from: "display-69733248")
+                == OverlayDisplayOption.automaticID
+        )
+    }
+
+    @Test
+    func missingDisplayPreferenceDefaultsToAutomatic() {
+        #expect(
+            OverlayDisplayPreferencePolicy.restoredSelectionID(from: nil)
+                == OverlayDisplayOption.automaticID
+        )
+        #expect(
+            OverlayDisplayPreferencePolicy.restoredSelectionID(from: "")
+                == OverlayDisplayOption.automaticID
+        )
+    }
+
+    @Test
+    func stableDisplayPreferenceSurvivesRestore() {
+        let displayUUID = "7A4C9F42-40FD-4EB4-B189-27F55385629C"
+
+        #expect(
+            OverlayDisplayPreferencePolicy.restoredSelectionID(from: displayUUID)
+                == displayUUID
+        )
+    }
+
+    @Test
+    func disconnectedDisplayPreferenceRemainsSelected() {
+        let displayUUID = "7A4C9F42-40FD-4EB4-B189-27F55385629C"
+        let builtIn = OverlayDisplayOption(
+            id: "built-in",
+            title: "Built-in Display",
+            subtitle: "Built-in notch"
+        )
+
+        let result = OverlayDisplayPreferencePolicy.reconcile(
+            availableOptions: [builtIn],
+            selectionID: displayUUID,
+            rememberedSelectionTitle: "External Display"
+        )
+
+        #expect(result.selectionID == displayUUID)
+        #expect(result.selectionTitle == "External Display")
+        #expect(result.displayOptions.count == 2)
+        #expect(result.displayOptions.last?.id == displayUUID)
+        #expect(result.displayOptions.last?.title == "External Display")
+        #expect(result.displayOptions.last?.isAvailable == false)
+    }
+
+    @Test
+    func reconnectedDisplayReplacesUnavailablePlaceholder() {
+        let displayUUID = "7A4C9F42-40FD-4EB4-B189-27F55385629C"
+        let external = OverlayDisplayOption(
+            id: displayUUID,
+            title: "External Display",
+            subtitle: "Top-bar fallback"
+        )
+
+        let result = OverlayDisplayPreferencePolicy.reconcile(
+            availableOptions: [external],
+            selectionID: displayUUID,
+            rememberedSelectionTitle: "External Display"
+        )
+
+        #expect(result.selectionID == displayUUID)
+        #expect(result.selectionTitle == "External Display")
+        #expect(result.displayOptions == [external])
+        #expect(result.displayOptions[0].isAvailable)
+    }
+
+    @Test
+    func automaticPreferenceDoesNotCreateUnavailablePlaceholder() {
+        let result = OverlayDisplayPreferencePolicy.reconcile(
+            availableOptions: [],
+            selectionID: OverlayDisplayOption.automaticID,
+            rememberedSelectionTitle: "External Display"
+        )
+
+        #expect(result.selectionID == OverlayDisplayOption.automaticID)
+        #expect(result.selectionTitle == nil)
+        #expect(result.displayOptions.isEmpty)
+    }
+
+    @Test
     func closedSurfaceRectCentersOnNotch() {
         let notchRect = NSRect(x: 200, y: 900, width: 200, height: 38)
         let closedWidth: CGFloat = 320


### PR DESCRIPTION
## Summary

- preserve the user's stable display UUID when the preferred external display is temporarily disconnected
- fall back to an available screen without mutating the persisted preference, then restore the external display after reconnect
- reset legacy `display-<CGDirectDisplayID>` preferences to Automatic on restore
- keep both display pickers valid with a disabled placeholder for the unavailable preferred display

## Root cause

`refreshOverlayDisplayConfiguration()` treated a temporarily unavailable display as an invalid preference. It changed the selection to Automatic, which triggered the selection observer and removed `overlay.display.preference` from `UserDefaults`. Once the external display reconnected, the app no longer knew which display the user had selected.

## User impact

Users who unplug and reconnect an external display no longer need to select it again. While it is disconnected, Open Island temporarily uses the normal fallback screen without changing the setting.

## Validation

- `swift test --filter OverlayPanelControllerTests`: 17 tests passed
- full `swift test`: 334 Swift Testing tests passed; 24 XCTest tests passed with 1 environment-gated integration test skipped
- `sem diff --staged --no-cosmetics -v --file-exts .swift`: no broken callers
- OCR review: 4/4 changed files reviewed, no blocking findings

Physical display unplug/replug verification was not performed in this environment; the preference lifecycle is covered by unit tests.

Closes #603


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved external display selection and preference restoration.
  * Display choices remain visible when temporarily unavailable and are clearly disabled.
  * Overlay placement can automatically fall back when a selected display is disconnected.
  * Preferences are restored when displays reconnect or arrangements change.
  * Display preferences are retained more reliably when display arrangements change.

* **Bug Fixes**
  * Invalid and outdated display selections now safely revert to automatic selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->