### PR TITLE
fix(kimi): install hooks into ~/.kimi-code/config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Think of it as an open-source [Vibe Island](https://vibeisland.app/) — **free,
 | **CodeBuddy** | Supported | Claude Code fork — same hook format, config at `~/.codebuddy/settings.json` |
 | **Cursor** | Supported | Hook integration via `~/.cursor/hooks.json`, session tracking, workspace jump-back |
 | **Gemini CLI** | Supported | Hook integration via `~/.gemini/settings.json`, session tracking, fire-and-forget events |
-| **Kimi CLI** | Supported | Hook integration via `~/.kimi/config.toml` `[[hooks]]`, session tracking, permission flow (reuses Claude payload) |
+| **Kimi CLI** | Supported | Hook integration via `~/.kimi-code/config.toml` `[[hooks]]`, session tracking, permission flow (reuses Claude payload) |
 
 ### Terminals & IDEs
 
@@ -271,10 +271,10 @@ Developers who already live in the terminal and want a better way to work with c
 - **CodeBuddy** — Claude Code fork. Same hook format and events via `~/.codebuddy/settings.json`. Use `--source codebuddy` with the hooks binary.
 - **Cursor** — Hook-based integration via `~/.cursor/hooks.json`. Receives `beforeSubmitPrompt`, `beforeShellExecution`, `beforeMCPExecution`, `beforeReadFile`, `afterFileEdit`, and `stop` events. Session persistence across app launches. Workspace jump-back via `cursor -r`. Use `--source cursor` with the hooks binary.
 - **Gemini CLI** — Hook-based integration via `~/.gemini/settings.json`. Receives `SessionStart`, `PreToolUse`, `PostToolUse`, `Stop`, and `UserPromptSubmit` events. Fire-and-forget (no block/deny). Use `--source gemini` with the hooks binary.
-- **Kimi CLI** — Hook-based integration via `~/.kimi/config.toml` `[[hooks]]` array (Moonshot AI). Kimi's hook payload is byte-compatible with Claude Code, so Open Island reuses the Claude decode path and adds a dedicated TOML installer. Subscribes to `SessionStart`, `UserPromptSubmit`, `Stop`, `Notification`, `PreToolUse`, and `PostToolUse`. Requires the Kimi CLI Hooks Beta. Use `--source kimi` with the hooks binary. Manage installation from the Settings window, or via CLI:
+- **Kimi CLI** — Hook-based integration via `~/.kimi-code/config.toml` `[[hooks]]` array (Moonshot AI). Kimi's hook payload is byte-compatible with Claude Code, so Open Island reuses the Claude decode path and adds a dedicated TOML installer. Subscribes to `SessionStart`, `UserPromptSubmit`, `Stop`, `Notification`, `PreToolUse`, and `PostToolUse`. Verified against Kimi Code CLI 0.37.2. Use `--source kimi` with the hooks binary. Manage installation from the Settings window, or via CLI:
 
   ```sh
-  swift run OpenIslandSetup installKimi    # write [[hooks]] entries into ~/.kimi/config.toml
+  swift run OpenIslandSetup installKimi    # write [[hooks]] entries into ~/.kimi-code/config.toml
   swift run OpenIslandSetup statusKimi     # report whether managed hooks are present
   swift run OpenIslandSetup uninstallKimi  # remove managed entries, preserve user-authored [[hooks]]
   ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -71,7 +71,7 @@ Open Island 驻留在 Mac 的**刘海区域**（或顶部栏），为你的 AI c
 | **CodeBuddy** | 已支持 | Claude Code 分支——相同 hook 格式，配置位于 `~/.codebuddy/settings.json` |
 | **Cursor** | 已支持 | Hook 集成，通过 `~/.cursor/hooks.json` 配置，会话追踪，工作区跳转 |
 | **Gemini CLI** | 已支持 | Hook 集成，通过 `~/.gemini/settings.json` 配置，会话追踪，fire-and-forget 事件 |
-| **Kimi CLI** | 已支持 | Hook 集成，通过 `~/.kimi/config.toml` 的 `[[hooks]]` 数组配置，会话追踪，复用 Claude payload 协议 |
+| **Kimi CLI** | 已支持 | Hook 集成，通过 `~/.kimi-code/config.toml` 的 `[[hooks]]` 数组配置，会话追踪，复用 Claude payload 协议 |
 
 ### 终端和 IDE
 
@@ -273,10 +273,10 @@ AI coding 正在成为日常开发流程的一部分，但围绕它的控制层�
 - **CodeBuddy** — Claude Code 分支。相同 hook 格式和事件，配置位于 `~/.codebuddy/settings.json`。使用 `--source codebuddy` 调用 hooks binary。
 - **Cursor** — 基于 hook 的集成，通过 `~/.cursor/hooks.json` 配置。接收 `beforeSubmitPrompt`、`beforeShellExecution`、`beforeMCPExecution`、`beforeReadFile`、`afterFileEdit` 和 `stop` 事件。跨应用启动持久化会话。通过 `cursor -r` 跳回工作区。使用 `--source cursor` 调用 hooks binary。
 - **Gemini CLI** — 基于 hook 的集成，通过 `~/.gemini/settings.json` 配置。接收 `SessionStart`、`PreToolUse`、`PostToolUse`、`Stop` 和 `UserPromptSubmit` 事件。Fire-and-forget（无 block/deny）。使用 `--source gemini` 调用 hooks binary。
-- **Kimi CLI** — 基于 hook 的集成，通过 `~/.kimi/config.toml` 的 `[[hooks]]` 数组配置（Moonshot AI）。Kimi 的 hook payload 与 Claude Code 字段兼容，Open Island 复用 Claude 解码路径，仅新增了 TOML installer。订阅 `SessionStart`、`UserPromptSubmit`、`Stop`、`Notification`、`PreToolUse`、`PostToolUse`。需要 Kimi CLI Hooks Beta。使用 `--source kimi` 调用 hooks binary。可以从设置窗口管理安装，或通过 CLI：
+- **Kimi CLI** — 基于 hook 的集成，通过 `~/.kimi-code/config.toml` 的 `[[hooks]]` 数组配置（Moonshot AI）。Kimi 的 hook payload 与 Claude Code 字段兼容，Open Island 复用 Claude 解码路径，仅新增了 TOML installer。订阅 `SessionStart`、`UserPromptSubmit`、`Stop`、`Notification`、`PreToolUse`、`PostToolUse`。已对 Kimi Code CLI 0.37.2 验证。使用 `--source kimi` 调用 hooks binary。可以从设置窗口管理安装，或通过 CLI：
 
   ```sh
-  swift run OpenIslandSetup installKimi    # 把受管 [[hooks]] 条目写入 ~/.kimi/config.toml
+  swift run OpenIslandSetup installKimi    # 把受管 [[hooks]] 条目写入 ~/.kimi-code/config.toml
   swift run OpenIslandSetup statusKimi     # 查看受管 hooks 是否已安装
   swift run OpenIslandSetup uninstallKimi  # 移除受管条目，保留用户自定义的 [[hooks]]
   ```

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -364,7 +364,7 @@ final class HookInstallationCoordinator {
 
     var kimiHookStatusSummary: String {
         guard kimiHookStatus != nil else {
-            return "Reading ~/.kimi/config.toml."
+            return "Reading ~/.kimi-code/config.toml."
         }
 
         if kimiHooksInstalled {

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -600,7 +600,7 @@ struct SetupSettingsPane: View {
                     }
                     Button(lang.t("settings.general.cancel"), role: .cancel) {}
                 } message: {
-                    Text("This will remove Open Island hooks from ~/.kimi/config.toml.")
+                    Text("This will remove Open Island hooks from ~/.kimi-code/config.toml.")
                 }
             }
 

--- a/Sources/OpenIslandCore/KimiHookInstallationManager.swift
+++ b/Sources/OpenIslandCore/KimiHookInstallationManager.swift
@@ -31,7 +31,7 @@ public final class KimiHookInstallationManager: @unchecked Sendable {
     private let fileManager: FileManager
 
     public init(
-        kimiDirectory: URL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".kimi", isDirectory: true),
+        kimiDirectory: URL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".kimi-code", isDirectory: true),
         managedHooksBinaryURL: URL = ManagedHooksBinary.defaultURL(),
         fileManager: FileManager = .default
     ) {

--- a/Sources/OpenIslandCore/KimiHookInstaller.swift
+++ b/Sources/OpenIslandCore/KimiHookInstaller.swift
@@ -25,7 +25,7 @@ public struct KimiHookFileMutation: Equatable, Sendable, Codable {
 }
 
 /// Installs/uninstalls Open Island's managed `[[hooks]]` entries in
-/// `~/.kimi/config.toml`.
+/// `~/.kimi-code/config.toml` (Kimi Code CLI's config directory).
 ///
 /// Kimi CLI's hook protocol is byte-compatible with Claude Code (same stdin
 /// JSON fields, same exit-code semantics), so the runtime side reuses

--- a/Sources/OpenIslandSetup/OpenIslandSetupCLI.swift
+++ b/Sources/OpenIslandSetup/OpenIslandSetupCLI.swift
@@ -47,7 +47,7 @@ private struct SetupCommand {
         var hooksBinary: URL?
         var codexDirectory = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".codex", isDirectory: true)
         var claudeDirectory = ClaudeConfigDirectory.resolved()
-        var kimiDirectory = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".kimi", isDirectory: true)
+        var kimiDirectory = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".kimi-code", isDirectory: true)
 
         var index = 1
         while index < arguments.count {
@@ -270,9 +270,9 @@ private enum SetupError: Error, LocalizedError {
               swift run OpenIslandSetup installClaude [--hooks-binary /abs/path/to/OpenIslandHooks] [--claude-dir /abs/path/to/.claude]
               swift run OpenIslandSetup uninstallClaude [--claude-dir /abs/path/to/.claude]
               swift run OpenIslandSetup statusClaude [--hooks-binary /abs/path/to/OpenIslandHooks] [--claude-dir /abs/path/to/.claude]
-              swift run OpenIslandSetup installKimi [--hooks-binary /abs/path/to/OpenIslandHooks] [--kimi-dir /abs/path/to/.kimi]
-              swift run OpenIslandSetup uninstallKimi [--kimi-dir /abs/path/to/.kimi]
-              swift run OpenIslandSetup statusKimi [--hooks-binary /abs/path/to/OpenIslandHooks] [--kimi-dir /abs/path/to/.kimi]
+              swift run OpenIslandSetup installKimi [--hooks-binary /abs/path/to/OpenIslandHooks] [--kimi-dir /abs/path/to/.kimi-code]
+              swift run OpenIslandSetup uninstallKimi [--kimi-dir /abs/path/to/.kimi-code]
+              swift run OpenIslandSetup statusKimi [--hooks-binary /abs/path/to/OpenIslandHooks] [--kimi-dir /abs/path/to/.kimi-code]
             """
         case let .missingValue(flag):
             "Missing value for \(flag)"

--- a/Tests/OpenIslandCoreTests/KimiHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/KimiHooksTests.swift
@@ -300,6 +300,86 @@ struct KimiHooksTests {
     }
 
     @Test
+    func managerDefaultsToKimiCodeConfigDirectory() {
+        let manager = KimiHookInstallationManager()
+        #expect(manager.kimiDirectory.lastPathComponent == ".kimi-code")
+    }
+
+    @Test
+    func managerInstallStatusUninstallRoundTripPreservesUserHooks() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kimi-hooks-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let kimiDir = root.appendingPathComponent(".kimi-code", isDirectory: true)
+        try FileManager.default.createDirectory(at: kimiDir, withIntermediateDirectories: true)
+        let sourceBinary = root.appendingPathComponent("OpenIslandHooks-source")
+        try "#!/bin/sh\nexit 0\n".write(to: sourceBinary, atomically: true, encoding: .utf8)
+
+        let userToml = """
+        default_model = "kimi-code/kimi-for-coding"
+
+        [[hooks]]
+        event = "PostToolUse"
+        command = "user-hook"
+
+        """
+        let configURL = kimiDir.appendingPathComponent("config.toml")
+        try userToml.write(to: configURL, atomically: true, encoding: .utf8)
+
+        let manager = KimiHookInstallationManager(
+            kimiDirectory: kimiDir,
+            managedHooksBinaryURL: root.appendingPathComponent("managed/OpenIslandHooks")
+        )
+
+        let installed = try manager.install(hooksBinaryURL: sourceBinary)
+        #expect(installed.managedHooksPresent)
+        #expect(installed.hooksBinaryURL != nil)
+
+        let installedContents = try String(contentsOf: configURL, encoding: .utf8)
+        #expect(installedContents.contains("user-hook"))
+        #expect(installedContents.contains("default_model"))
+
+        // Reinstall must not duplicate or rewrite managed blocks.
+        _ = try manager.install(hooksBinaryURL: sourceBinary)
+        let reinstalledContents = try String(contentsOf: configURL, encoding: .utf8)
+        #expect(reinstalledContents == installedContents)
+
+        let uninstalled = try manager.uninstall()
+        #expect(uninstalled.managedHooksPresent == false)
+        let remaining = try String(contentsOf: configURL, encoding: .utf8)
+        #expect(remaining.contains("user-hook"))
+        #expect(remaining.contains("default_model"))
+        #expect(remaining.contains(KimiHookInstaller.markerComment) == false)
+        let manifestURL = kimiDir.appendingPathComponent(KimiHookInstallerManifest.fileName)
+        #expect(FileManager.default.fileExists(atPath: manifestURL.path) == false)
+    }
+
+    @Test
+    func managerUninstallDeletesConfigThatOnlyHadManagedHooks() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kimi-hooks-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let sourceBinary = root.appendingPathComponent("OpenIslandHooks-source")
+        try "#!/bin/sh\nexit 0\n".write(to: sourceBinary, atomically: true, encoding: .utf8)
+
+        let kimiDir = root.appendingPathComponent(".kimi-code", isDirectory: true)
+        let manager = KimiHookInstallationManager(
+            kimiDirectory: kimiDir,
+            managedHooksBinaryURL: root.appendingPathComponent("managed/OpenIslandHooks")
+        )
+
+        _ = try manager.install(hooksBinaryURL: sourceBinary)
+        let configURL = kimiDir.appendingPathComponent("config.toml")
+        #expect(FileManager.default.fileExists(atPath: configURL.path))
+
+        _ = try manager.uninstall()
+        #expect(FileManager.default.fileExists(atPath: configURL.path) == false)
+    }
+
+    @Test
     func resolvedAgentToolMapsKimiSource() {
         var payload = ClaudeHookPayload(
             cwd: "/tmp",

--- a/docs/product.md
+++ b/docs/product.md
@@ -30,7 +30,7 @@ CLI coding agents are powerful, but they pull attention away from the editor and
 | **Factory** | Supported | Claude Code fork — same hook format, config at `~/.factory/settings.json` |
 | **CodeBuddy** | Supported | Claude Code fork — same hook format, config at `~/.codebuddy/settings.json` |
 | **Gemini CLI** | Supported | Hook integration (`SessionStart`, `BeforeAgent`, `AfterAgent`, `SessionEnd`, `Notification`), session tracking, terminal jump metadata, completion-card compatibility handling |
-| **Kimi CLI** | Supported | Hook integration via `~/.kimi/config.toml` `[[hooks]]` (Moonshot AI). Kimi's hook payload is byte-compatible with Claude Code, so runtime reuses the Claude decode path; a dedicated TOML installer preserves user-authored hooks |
+| **Kimi CLI** | Supported | Hook integration via `~/.kimi-code/config.toml` `[[hooks]]` (Moonshot AI). Kimi's hook payload is byte-compatible with Claude Code, so runtime reuses the Claude decode path; a dedicated TOML installer preserves user-authored hooks |
 
 ## Supported Terminals
 


### PR DESCRIPTION
## Problem

The Kimi hook installer targets `~/.kimi/config.toml`, but the current official Kimi Code CLI (verified with 0.37.2) reads managed `[[hooks]]` from `~/.kimi-code/config.toml`. Installs silently took no effect: hooks were written to a file the CLI never reads.

References: Kimi Code CLI hooks documentation — all hook rules live in the `[[hooks]]` array of `~/.kimi-code/config.toml` (`event`/`matcher`/`command`/`timeout` only). All six events Open Island subscribes to (`SessionStart`, `UserPromptSubmit`, `Stop`, `Notification`, `PreToolUse`, `PostToolUse`) exist in 0.37.2, and the payload/exit-code semantics remain Claude-compatible, so the shared decode path is unchanged.

## Changes

- `KimiHookInstallationManager` and `OpenIslandSetup` CLI default the Kimi config directory to `~/.kimi-code`
- Settings copy, coordinator status string, and docs (README / README.zh-CN / docs/product.md) updated to the real path; the stale "requires Hooks Beta" note now states the verified CLI version
- New manager-level tests: default directory is `.kimi-code`; install → status → reinstall (idempotent) → uninstall preserves user-authored hooks in a temp directory; uninstall removes a config that only held managed entries

## Verification

- `swift test --filter OpenIslandCoreTests`: 216/216 pass (Xcode toolchain; covers the shared Claude-family decode path)
- Real install against a live `~/.kimi-code/config.toml`: automatic backup created, only managed blocks added (diff-verified), reinstall byte-identical, `kimi doctor` passes
- Real `kimi -p` session runs normally with hooks installed; hook delivery to the running app confirmed (island session count incremented on a synthetic `SessionStart`)
- Fail-open: with the island app quit, `kimi -p` completes normally
- Real uninstall leaves user config byte-identical to the pre-install backup

Note: five pre-existing `OpenIslandAppTests` failures (`AppModelSessionListTests`, `AgentsGridRightSlotTests`) reproduce identically on clean `origin/main` in this environment and are unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Kimi Code CLI setup instructions to use `~/.kimi-code/config.toml`.
  * Clarified supported CLI version and removed the Hooks Beta requirement.
  * Updated installation, status, and removal guidance.

* **Bug Fixes**
  * Kimi integration now consistently detects and manages configuration in the new directory.

* **Tests**
  * Added coverage for installation, status checks, uninstalling, configuration preservation, and duplicate hook prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->