### PR TITLE
fix: deterministic tests on notched MacBooks + CLT-compatible test runner

### DIFF
--- a/Sources/OpenIslandApp/OverlayUICoordinator.swift
+++ b/Sources/OpenIslandApp/OverlayUICoordinator.swift
@@ -42,6 +42,12 @@ final class OverlayUICoordinator {
     @ObservationIgnored
     var ignoresPointerExitAccessor: (() -> Bool)?
 
+    /// Overrides the global cursor query so pointer-sensitive behavior stays
+    /// deterministic when the host machine's real cursor happens to hover the
+    /// overlay area (e.g. during unit tests).
+    @ObservationIgnored
+    var pointerLocationProvider: (() -> NSPoint)?
+
     @ObservationIgnored
     var harnessRuntimeMonitor: HarnessRuntimeMonitor?
 
@@ -81,6 +87,10 @@ final class OverlayUICoordinator {
 
     private var ignoresPointerExitDuringHarness: Bool {
         ignoresPointerExitAccessor?() ?? false
+    }
+
+    private var currentPointerLocation: NSPoint {
+        pointerLocationProvider?() ?? NSEvent.mouseLocation
     }
 
     private var preferredOverlayScreenID: String? {
@@ -417,7 +427,7 @@ final class OverlayUICoordinator {
             return
         }
 
-        if overlayPanelController.isPointInExpandedArea(NSEvent.mouseLocation) {
+        if overlayPanelController.isPointInExpandedArea(currentPointerLocation) {
             notePointerInsideIslandSurface()
             return
         }
@@ -448,7 +458,7 @@ final class OverlayUICoordinator {
 
     var shouldDeferTimedNotificationAutoCollapse: Bool {
         isPointerInsideIslandSurface
-            || overlayPanelController.isPointInExpandedArea(NSEvent.mouseLocation)
+            || overlayPanelController.isPointInExpandedArea(currentPointerLocation)
     }
 
     private var shouldTrackPointerInsideIslandSurface: Bool {
@@ -458,7 +468,7 @@ final class OverlayUICoordinator {
 
     private var isPointerInsideCurrentNotificationCard: Bool {
         isPointerInsideIslandSurface
-            || overlayPanelController.isPointInExpandedArea(NSEvent.mouseLocation)
+            || overlayPanelController.isPointInExpandedArea(currentPointerLocation)
     }
 
     // MARK: - Debug snapshots (overlay portion)

--- a/Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift
+++ b/Tests/OpenIslandAppTests/AgentsGridRightSlotTests.swift
@@ -10,8 +10,7 @@ struct AgentsGridRightSlotTests {
     /// session.firstSeenAt so historical order is preserved.
     @Test
     func bulkFirstObservationOrdersByHistoricalFirstSeenAt() {
-        let model = AppModel()
-        model.islandRightSlot = .agents
+        let model = makeAgentsSlotModel()
 
         let now = Date(timeIntervalSince1970: 100_000)
         let sessionA = makeSession(id: "A", firstSeenAt: now,                       updatedAt: now.addingTimeInterval(60))
@@ -45,8 +44,7 @@ struct AgentsGridRightSlotTests {
     /// observation-time.
     @Test
     func newlyObservedSessionAlwaysLandsAtTheEndRegardlessOfHistoricalTime() {
-        let model = AppModel()
-        model.islandRightSlot = .agents
+        let model = makeAgentsSlotModel()
 
         let now = Date(timeIntervalSince1970: 200_000)
         let sessionA = makeSession(id: "A", firstSeenAt: now,                       updatedAt: now)
@@ -78,8 +76,7 @@ struct AgentsGridRightSlotTests {
     /// again — not re-observed as a newcomer.
     @Test
     func returningSessionKeepsItsOriginalSlot() {
-        let model = AppModel()
-        model.islandRightSlot = .agents
+        let model = makeAgentsSlotModel()
 
         let now = Date(timeIntervalSince1970: 300_000)
         let sessionA = makeSession(id: "A", firstSeenAt: now,                       updatedAt: now)
@@ -109,8 +106,7 @@ struct AgentsGridRightSlotTests {
     /// overflow cell showing the remainder count.
     @Test
     func moreThanNineSessionsFoldIntoOverflow() {
-        let model = AppModel()
-        model.islandRightSlot = .agents
+        let model = makeAgentsSlotModel()
         let now = Date(timeIntervalSince1970: 200_000)
 
         var sessions: [AgentSession] = []
@@ -140,8 +136,7 @@ struct AgentsGridRightSlotTests {
     /// everything else (completed, stale) to `.idle`.
     @Test
     func cellStateReflectsSessionPhase() {
-        let model = AppModel()
-        model.islandRightSlot = .agents
+        let model = makeAgentsSlotModel()
         let now = Date(timeIntervalSince1970: 300_000)
 
         let running  = makeSession(id: "r", firstSeenAt: now,                         updatedAt: now, phase: .running)
@@ -176,6 +171,17 @@ struct AgentsGridRightSlotTests {
     }
 
     // MARK: - helpers
+
+    /// The implicit `islandRightSlot` setter resolves the display profile
+    /// against the machine's real screen, which can flip from .topBar to
+    /// .notch mid-test on notched MacBooks. Writing the preference to both
+    /// profiles keeps reads deterministic on every machine.
+    private func makeAgentsSlotModel() -> AppModel {
+        let model = AppModel()
+        model.updateAppearancePreferences(for: .topBar) { $0.rightSlot = .agents }
+        model.updateAppearancePreferences(for: .notch) { $0.rightSlot = .agents }
+        return model
+    }
 
     private static func cellFor(_ session: AgentSession) -> AgentGridCell {
         let color = Color(hex: session.tool.brandColorHex) ?? .gray

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -314,8 +314,13 @@ struct AppModelSessionListTests {
     func islandSessionSectionsGroupStaleCompletedIntoIdle() {
         let now = Date()
         let model = AppModel()
-        model.islandSessionGroup = .state
-        model.completedStaleThreshold = .fiveMinutes
+        // Write and read through an explicit display profile: the implicit
+        // setters resolve against the machine's real screen, which flips from
+        // .topBar to .notch mid-test on notched MacBooks.
+        model.updateAppearancePreferences(for: .topBar) {
+            $0.sessionGroup = .state
+            $0.completedStaleThreshold = .fiveMinutes
+        }
 
         var approval = listSession(id: "approval", phase: .waitingForApproval, updatedAt: now)
         approval.permissionRequest = PermissionRequest(
@@ -331,6 +336,7 @@ struct AppModelSessionListTests {
         stale.isProcessAlive = true
 
         model.state = SessionState(sessions: [stale, done, approval])
+        model.overlayPlacementDiagnostics = placementDiagnostics(mode: .topBar)
 
         #expect(model.islandSessionSections.map(\.id) == ["state-approval", "state-done", "state-idle"])
         #expect(model.islandSessionSections.map(\.sessions.first?.id) == ["approval", "done", "stale"])
@@ -340,12 +346,15 @@ struct AppModelSessionListTests {
     func islandSessionSectionsKeepCompletedInDoneWhenStaleThresholdIsNever() {
         let now = Date()
         let model = AppModel()
-        model.islandSessionGroup = .state
-        model.completedStaleThreshold = .never
+        model.updateAppearancePreferences(for: .topBar) {
+            $0.sessionGroup = .state
+            $0.completedStaleThreshold = .never
+        }
 
         var oldDone = listSession(id: "old-done", phase: .completed, updatedAt: now.addingTimeInterval(-86_400))
         oldDone.isProcessAlive = true
         model.state = SessionState(sessions: [oldDone])
+        model.overlayPlacementDiagnostics = placementDiagnostics(mode: .topBar)
 
         #expect(model.islandSessionSections.map(\.id) == ["state-done"])
         #expect(model.islandSessionSections.first?.sessions.first?.id == "old-done")
@@ -355,7 +364,9 @@ struct AppModelSessionListTests {
     func islandSessionListCanSortByLastUpdate() {
         let now = Date()
         let model = AppModel()
-        model.islandSessionSort = .lastUpdate
+        model.updateAppearancePreferences(for: .topBar) {
+            $0.sessionSort = .lastUpdate
+        }
 
         var olderRunning = listSession(id: "older-running", phase: .running, updatedAt: now.addingTimeInterval(-120))
         var newerCompleted = listSession(id: "newer-completed", phase: .completed, updatedAt: now.addingTimeInterval(-10))
@@ -363,6 +374,7 @@ struct AppModelSessionListTests {
         newerCompleted.isProcessAlive = true
 
         model.state = SessionState(sessions: [olderRunning, newerCompleted])
+        model.overlayPlacementDiagnostics = placementDiagnostics(mode: .topBar)
 
         #expect(model.islandListSessions.map(\.id) == ["newer-completed", "older-running"])
     }
@@ -759,6 +771,7 @@ struct AppModelSessionListTests {
     @Test
     func completionNotificationDefersTimedCollapseWhilePointerIsInside() {
         let model = AppModel()
+        model.overlay.pointerLocationProvider = { NSPoint(x: -10_000, y: -10_000) }
         model.applyTrackedEvent(
             .sessionStarted(SessionStarted(
                 sessionID: "session-1",
@@ -797,6 +810,10 @@ struct AppModelSessionListTests {
     @Test
     func completionNotificationHoverCancelsPendingTimedCollapse() {
         let model = AppModel()
+        // Pin the pointer far outside the overlay: auto-collapse is never
+        // scheduled when the machine's real cursor sits inside the expanded
+        // area, which made this test depend on the host's mouse position.
+        model.overlay.pointerLocationProvider = { NSPoint(x: -10_000, y: -10_000) }
         model.state = SessionState(
             sessions: [
                 AgentSession(

--- a/Tests/OpenIslandAppTests/ForegroundTerminalSessionProbeTests.swift
+++ b/Tests/OpenIslandAppTests/ForegroundTerminalSessionProbeTests.swift
@@ -1,9 +1,11 @@
-import XCTest
+import Testing
 @testable import OpenIslandApp
 import OpenIslandCore
 
-final class ForegroundTerminalSessionProbeTests: XCTestCase {
-    func testMatchesGhosttyFrontmostTerminalBySessionID() async {
+@Suite(.serialized)
+struct ForegroundTerminalSessionProbeTests {
+    @Test
+    func matchesGhosttyFrontmostTerminalBySessionID() async {
         let probe = ForegroundTerminalSessionProbe(
             frontmostBundleIdentifierProvider: { "com.mitchellh.ghostty" },
             appleScriptRunner: { _ in "ghostty-frontmost" }
@@ -18,10 +20,11 @@ final class ForegroundTerminalSessionProbeTests: XCTestCase {
             )
         )
 
-        XCTAssertTrue(matches)
+        #expect(matches)
     }
 
-    func testMatchesTerminalFrontmostTabByTTY() async {
+    @Test
+    func matchesTerminalFrontmostTabByTTY() async {
         let probe = ForegroundTerminalSessionProbe(
             frontmostBundleIdentifierProvider: { "com.apple.Terminal" },
             appleScriptRunner: { _ in "ttys001" }
@@ -36,10 +39,11 @@ final class ForegroundTerminalSessionProbeTests: XCTestCase {
             )
         )
 
-        XCTAssertTrue(matches)
+        #expect(matches)
     }
 
-    func testMatchesITermFrontmostSessionByTTYFallback() async {
+    @Test
+    func matchesITermFrontmostSessionByTTYFallback() async {
         let probe = ForegroundTerminalSessionProbe(
             frontmostBundleIdentifierProvider: { "com.googlecode.iterm2" },
             appleScriptRunner: { _ in "different-session\u{1f}/dev/ttys002" }
@@ -55,10 +59,11 @@ final class ForegroundTerminalSessionProbeTests: XCTestCase {
             )
         )
 
-        XCTAssertTrue(matches)
+        #expect(matches)
     }
 
-    func testReturnsFalseForUnsupportedFrontmostApp() async {
+    @Test
+    func returnsFalseForUnsupportedFrontmostApp() async {
         let probe = ForegroundTerminalSessionProbe(
             frontmostBundleIdentifierProvider: { "com.example.Editor" },
             appleScriptRunner: { _ in "" }
@@ -73,6 +78,6 @@ final class ForegroundTerminalSessionProbeTests: XCTestCase {
             )
         )
 
-        XCTAssertFalse(matches)
+        #expect(!matches)
     }
 }

--- a/Tests/OpenIslandAppTests/KeystrokeInjectorTests.swift
+++ b/Tests/OpenIslandAppTests/KeystrokeInjectorTests.swift
@@ -1,8 +1,10 @@
-import XCTest
+import Testing
 @testable import OpenIslandApp
 
-final class KeystrokeInjectorTests: XCTestCase {
-    func testDefaultInjectorPostsCmdShiftRightBracketWithoutCrashing() {
+@Suite(.serialized)
+struct KeystrokeInjectorTests {
+    @Test
+    func defaultInjectorPostsCmdShiftRightBracketWithoutCrashing() {
         // We can't observe actual OS-level CGEvent delivery in a unit test,
         // but constructing and posting the event without throwing/crashing
         // covers the init-time correctness of the keycode and flags.
@@ -10,11 +12,12 @@ final class KeystrokeInjectorTests: XCTestCase {
         injector.sendCmdShiftRightBracket()  // no XCTAssert — if this crashes the test fails
     }
 
-    func testSpyKeystrokerRecordsCalls() {
+    @Test
+    func spyKeystrokerRecordsCalls() {
         let spy = KeystrokeInjectorSpy()
         spy.sendCmdShiftRightBracket()
         spy.sendCmdShiftRightBracket()
-        XCTAssertEqual(spy.callCount, 2)
+        #expect(spy.callCount == 2)
     }
 }
 

--- a/Tests/OpenIslandAppTests/TerminalJumpServiceTests.swift
+++ b/Tests/OpenIslandAppTests/TerminalJumpServiceTests.swift
@@ -1,9 +1,10 @@
-import XCTest
+import Foundation
+import Testing
 @testable import OpenIslandApp
 import OpenIslandCore
-import Foundation
 
-final class TerminalJumpServiceTests: XCTestCase {
+@Suite(.serialized)
+struct TerminalJumpServiceTests {
     private final class OpenedArgumentsBox: @unchecked Sendable {
         var values: [[String]] = []
     }
@@ -12,7 +13,8 @@ final class TerminalJumpServiceTests: XCTestCase {
         var values: [(String, [String])] = []
     }
 
-    func testGhosttyJumpScriptActivatesWindowAndRetriesFocusUntilItSticks() {
+    @Test
+    func ghosttyJumpScriptActivatesWindowAndRetriesFocusUntilItSticks() {
         let target = JumpTarget(
             terminalApp: "Ghostty",
             workspaceName: "open-island",
@@ -23,20 +25,21 @@ final class TerminalJumpServiceTests: XCTestCase {
 
         let script = TerminalJumpService().ghosttyJumpScript(for: target)
 
-        XCTAssertTrue(script.contains("activate"))
-        XCTAssertTrue(script.contains("activate window targetWindow"))
-        XCTAssertTrue(script.contains("select tab targetTab"))
-        XCTAssertTrue(script.contains("focus targetTerminal"))
-        XCTAssertTrue(script.contains("repeat 3 times"))
-        XCTAssertTrue(script.contains("delay 0.04"))
-        XCTAssertTrue(script.contains("delay 0.08"))
-        XCTAssertTrue(script.contains("focused terminal of selected tab of front window"))
-        XCTAssertTrue(script.contains("repeat with aWindow in windows"))
-        XCTAssertTrue(script.contains("repeat with aTab in tabs of aWindow"))
-        XCTAssertTrue(script.contains("repeat with aTerminal in terminals of aTab"))
+        #expect(script.contains("activate"))
+        #expect(script.contains("activate window targetWindow"))
+        #expect(script.contains("select tab targetTab"))
+        #expect(script.contains("focus targetTerminal"))
+        #expect(script.contains("repeat 3 times"))
+        #expect(script.contains("delay 0.04"))
+        #expect(script.contains("delay 0.08"))
+        #expect(script.contains("focused terminal of selected tab of front window"))
+        #expect(script.contains("repeat with aWindow in windows"))
+        #expect(script.contains("repeat with aTab in tabs of aWindow"))
+        #expect(script.contains("repeat with aTerminal in terminals of aTab"))
     }
 
-    func testGhosttyJumpScriptFallsBackToWorkingDirectoryAndTitle() {
+    @Test
+    func ghosttyJumpScriptFallsBackToWorkingDirectoryAndTitle() {
         let target = JumpTarget(
             terminalApp: "Ghostty",
             workspaceName: "open-island",
@@ -46,19 +49,20 @@ final class TerminalJumpServiceTests: XCTestCase {
 
         let script = TerminalJumpService().ghosttyJumpScript(for: target)
 
-        XCTAssertTrue(script.contains("(working directory of aTerminal as text) is \"/Users/wangruobing/Personal/open-island\""))
-        XCTAssertTrue(script.contains("(name of aTerminal as text) contains \"codex ~/p/open-island\""))
-        XCTAssertTrue(script.contains("if \"\" is \"\" then"))
+        #expect(script.contains("(working directory of aTerminal as text) is \"/Users/wangruobing/Personal/open-island\""))
+        #expect(script.contains("(name of aTerminal as text) contains \"codex ~/p/open-island\""))
+        #expect(script.contains("if \"\" is \"\" then"))
     }
 
-    func testGhosttyJumpIntegrationMatchesFocusedTerminalForLiveSurfaces() throws {
+    @Test
+    func ghosttyJumpIntegrationMatchesFocusedTerminalForLiveSurfaces() throws {
         guard ProcessInfo.processInfo.environment["OPEN_ISLAND_RUN_GHOSTTY_JUMP_INTEGRATION"] == "1" else {
-            throw XCTSkip("Set OPEN_ISLAND_RUN_GHOSTTY_JUMP_INTEGRATION=1 to run live Ghostty jump verification.")
+            try Test.cancel("Set OPEN_ISLAND_RUN_GHOSTTY_JUMP_INTEGRATION=1 to run live Ghostty jump verification.")
         }
 
         let terminals = try liveGhosttyTerminals()
         if terminals.isEmpty {
-            throw XCTSkip("No live Ghostty terminals were found.")
+            try Test.cancel("No live Ghostty terminals were found.")
         }
 
         let service = TerminalJumpService()
@@ -87,14 +91,15 @@ final class TerminalJumpServiceTests: XCTestCase {
                 Thread.sleep(forTimeInterval: 0.25)
             }
 
-            XCTAssertTrue(
+            #expect(
                 matched,
                 "Ghostty jump did not settle on \(terminal.id). lastResult=\(lastResult) lastFocusedID=\(lastFocusedID)"
             )
         }
     }
 
-    func testGhosttyJumpDoesNotOpenNewTabWhenPreciseTargetMissesInRunningApp() throws {
+    @Test
+    func ghosttyJumpDoesNotOpenNewTabWhenPreciseTargetMissesInRunningApp() throws {
         let openedArguments = OpenedArgumentsBox()
         let service = TerminalJumpService(
             applicationResolver: { bundleIdentifier in
@@ -119,11 +124,12 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Activated Ghostty. Exact pane targeting could not find the live terminal.")
-        XCTAssertEqual(openedArguments.values, [["-b", "com.mitchellh.ghostty"]])
+        #expect(result == "Activated Ghostty. Exact pane targeting could not find the live terminal.")
+        #expect(openedArguments.values == [["-b", "com.mitchellh.ghostty"]])
     }
 
-    func testCursorJumpActivatesRunningAppWithoutWorkspaceReuse() throws {
+    @Test
+    func cursorJumpActivatesRunningAppWithoutWorkspaceReuse() throws {
         let openedArguments = OpenedArgumentsBox()
         let service = TerminalJumpService(
             applicationResolver: { bundleIdentifier in
@@ -148,11 +154,12 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Activated Cursor.")
-        XCTAssertEqual(openedArguments.values, [["-b", "com.todesktop.230313mzl4w4u92"]])
+        #expect(result == "Activated Cursor.")
+        #expect(openedArguments.values == [["-b", "com.todesktop.230313mzl4w4u92"]])
     }
 
-    func testCursorJumpFallsBackToWorkspaceWhenAppNotRunning() throws {
+    @Test
+    func cursorJumpFallsBackToWorkspaceWhenAppNotRunning() throws {
         let openedArguments = OpenedArgumentsBox()
         let service = TerminalJumpService(
             applicationResolver: { bundleIdentifier in
@@ -175,11 +182,12 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Focused the matching Cursor workspace.")
-        XCTAssertTrue(openedArguments.values.isEmpty)
+        #expect(result == "Focused the matching Cursor workspace.")
+        #expect(openedArguments.values.isEmpty)
     }
 
-    func testWarpJumpReturnsImmediatelyWhenAlreadyOnTargetPane() throws {
+    @Test
+    func warpJumpReturnsImmediatelyWhenAlreadyOnTargetPane() throws {
         let openedArguments = OpenedArgumentsBox()
         let keystroker = KeystrokeInjectorSpy()
         let targetUUID = "D1A5DF3027E44FC080FE2656FAF2BA2E"
@@ -207,12 +215,13 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Focused the matching Warp tab.")
-        XCTAssertEqual(keystroker.callCount, 0)
-        XCTAssertEqual(openedArguments.values, [["-b", "dev.warp.Warp-Stable"]])
+        #expect(result == "Focused the matching Warp tab.")
+        #expect(keystroker.callCount == 0)
+        #expect(openedArguments.values == [["-b", "dev.warp.Warp-Stable"]])
     }
 
-    func testWarpJumpCyclesThroughTabsUntilTargetIsFocused() throws {
+    @Test
+    func warpJumpCyclesThroughTabsUntilTargetIsFocused() throws {
         let openedArguments = OpenedArgumentsBox()
         let keystroker = KeystrokeInjectorSpy()
         let targetUUID = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
@@ -247,12 +256,13 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Focused the matching Warp tab.")
-        XCTAssertEqual(keystroker.callCount, 2)
-        XCTAssertEqual(openedArguments.values, [["-b", "dev.warp.Warp-Stable"]])
+        #expect(result == "Focused the matching Warp tab.")
+        #expect(keystroker.callCount == 2)
+        #expect(openedArguments.values == [["-b", "dev.warp.Warp-Stable"]])
     }
 
-    func testWarpJumpCapsOutAfterTabCountPlusTwoAndReturnsBestEffortMessage() throws {
+    @Test
+    func warpJumpCapsOutAfterTabCountPlusTwoAndReturnsBestEffortMessage() throws {
         let keystroker = KeystrokeInjectorSpy()
         let service = TerminalJumpService(
             applicationResolver: { id in
@@ -277,11 +287,12 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Activated Warp but could not confirm precision focus.")
-        XCTAssertEqual(keystroker.callCount, 5)  // tabCount (3) + 2
+        #expect(result == "Activated Warp but could not confirm precision focus.")
+        #expect(keystroker.callCount == 5)  // tabCount (3) + 2
     }
 
-    func testWarpJumpWithNilWarpPaneUUIDFallsBackToAppActivation() throws {
+    @Test
+    func warpJumpWithNilWarpPaneUUIDFallsBackToAppActivation() throws {
         let keystroker = KeystrokeInjectorSpy()
         let openedArguments = OpenedArgumentsBox()
         let service = TerminalJumpService(
@@ -307,12 +318,13 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Activated Warp. No precise pane mapping available.")
-        XCTAssertEqual(keystroker.callCount, 0)
-        XCTAssertEqual(openedArguments.values, [["-b", "dev.warp.Warp-Stable"]])
+        #expect(result == "Activated Warp. No precise pane mapping available.")
+        #expect(keystroker.callCount == 0)
+        #expect(openedArguments.values == [["-b", "dev.warp.Warp-Stable"]])
     }
 
-    func testUnknownTerminalAppFallsBackToFinderInsteadOfFirstInstalledTerminal() throws {
+    @Test
+    func unknownTerminalAppFallsBackToFinderInsteadOfFirstInstalledTerminal() throws {
         let openedArguments = OpenedArgumentsBox()
         // Pretend iTerm is installed. Without the "unknown" guard in
         // resolveTerminalApp, the silent "first installed known app" fallback
@@ -338,14 +350,15 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(openedArguments.values, [["/tmp"]])
-        XCTAssertTrue(
+        #expect(openedArguments.values == [["/tmp"]])
+        #expect(
             result.contains("Finder"),
             "Expected Finder fallback, got: \(result)"
         )
     }
 
-    func testTraeJumpActivatesRunningTraeCNApp() throws {
+    @Test
+    func traeJumpActivatesRunningTraeCNApp() throws {
         let openedArguments = OpenedArgumentsBox()
         let service = TerminalJumpService(
             applicationResolver: { bundleIdentifier in
@@ -369,11 +382,12 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Activated Trae.")
-        XCTAssertEqual(openedArguments.values, [["-b", "cn.trae.app"]])
+        #expect(result == "Activated Trae.")
+        #expect(openedArguments.values == [["-b", "cn.trae.app"]])
     }
 
-    func testTraeCNJumpPrefersCNBundleWhenBothTraeVariantsExist() throws {
+    @Test
+    func traeCNJumpPrefersCNBundleWhenBothTraeVariantsExist() throws {
         let openedArguments = OpenedArgumentsBox()
         let service = TerminalJumpService(
             applicationResolver: { bundleIdentifier in
@@ -403,11 +417,12 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Activated Trae. Exact pane targeting is still best-effort.")
-        XCTAssertEqual(openedArguments.values, [["-b", "cn.trae.app"]])
+        #expect(result == "Activated Trae. Exact pane targeting is still best-effort.")
+        #expect(openedArguments.values == [["-b", "cn.trae.app"]])
     }
 
-    func testCodexAppJumpActivatesCodexDesktopApp() throws {
+    @Test
+    func codexAppJumpActivatesCodexDesktopApp() throws {
         let openedArguments = OpenedArgumentsBox()
         let service = TerminalJumpService(
             applicationResolver: { bundleIdentifier in
@@ -431,11 +446,12 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Activated Codex.app.")
-        XCTAssertEqual(openedArguments.values, [["-b", "com.openai.codex"]])
+        #expect(result == "Activated Codex.app.")
+        #expect(openedArguments.values == [["-b", "com.openai.codex"]])
     }
 
-    func testCodexAppJumpOpensSpecificThreadWhenThreadIDProvided() throws {
+    @Test
+    func codexAppJumpOpensSpecificThreadWhenThreadIDProvided() throws {
         let openedArguments = OpenedArgumentsBox()
         let service = TerminalJumpService(
             applicationResolver: { bundleIdentifier in
@@ -461,11 +477,12 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Focused the Codex.app conversation.")
-        XCTAssertEqual(openedArguments.values, [["codex://threads/\(threadID)"]])
+        #expect(result == "Focused the Codex.app conversation.")
+        #expect(openedArguments.values == [["codex://threads/\(threadID)"]])
     }
 
-    func testTraeCNJumpFallsBackToWorkspaceViaTraeCLI() throws {
+    @Test
+    func traeCNJumpFallsBackToWorkspaceViaTraeCLI() throws {
         let openedArguments = OpenedArgumentsBox()
         let processInvocations = ProcessInvocationBox()
         let service = TerminalJumpService(
@@ -492,11 +509,11 @@ final class TerminalJumpServiceTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(result, "Focused the matching Trae workspace.")
-        XCTAssertTrue(openedArguments.values.isEmpty)
-        XCTAssertEqual(processInvocations.values.count, 1)
-        XCTAssertEqual(processInvocations.values.first?.0, "trae")
-        XCTAssertEqual(processInvocations.values.first?.1, ["-r", "/Users/test/open-vibe-island"])
+        #expect(result == "Focused the matching Trae workspace.")
+        #expect(openedArguments.values.isEmpty)
+        #expect(processInvocations.values.count == 1)
+        #expect(processInvocations.values.first?.0 == "trae")
+        #expect(processInvocations.values.first?.1 == ["-r", "/Users/test/open-vibe-island"])
     }
 }
 
@@ -585,8 +602,12 @@ private func runAppleScript(_ script: String) throws -> String {
     guard task.terminationStatus == 0 else {
         let stderr = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        XCTFail(stderr.isEmpty ? "AppleScript command failed." : stderr)
-        throw NSError(domain: "TerminalJumpServiceTests", code: Int(task.terminationStatus))
+        let message = stderr.isEmpty ? "AppleScript command failed." : stderr
+        throw NSError(
+            domain: "TerminalJumpServiceTests",
+            code: Int(task.terminationStatus),
+            userInfo: [NSLocalizedDescriptionKey: message]
+        )
     }
 
     return output

--- a/Tests/OpenIslandCoreTests/OpenCodeSessionRegistryTests.swift
+++ b/Tests/OpenIslandCoreTests/OpenCodeSessionRegistryTests.swift
@@ -1,22 +1,16 @@
-import XCTest
+import Foundation
+import Testing
 import OpenIslandCore
 
-final class OpenCodeSessionRegistryTests: XCTestCase {
-    var tempFileURL: URL!
-
-    override func setUp() {
-        super.setUp()
-        tempFileURL = FileManager.default.temporaryDirectory
+@Suite(.serialized)
+struct OpenCodeSessionRegistryTests {
+    @Test
+    func saveAndLoad() throws {
+        let tempFileURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
             .appendingPathExtension("json")
-    }
+        defer { try? FileManager.default.removeItem(at: tempFileURL) }
 
-    override func tearDown() {
-        try? FileManager.default.removeItem(at: tempFileURL)
-        super.tearDown()
-    }
-
-    func testSaveAndLoad() throws {
         let registry = OpenCodeSessionRegistry(fileURL: tempFileURL)
         let records = [
             OpenCodeTrackedSessionRecord(
@@ -37,14 +31,20 @@ final class OpenCodeSessionRegistryTests: XCTestCase {
         try registry.save(records)
         let loaded = try registry.load()
 
-        XCTAssertEqual(loaded.count, 1)
-        XCTAssertEqual(loaded[0].sessionID, "opencode-1")
-        XCTAssertEqual(loaded[0].openCodeMetadata?.initialUserPrompt, "Hello")
+        #expect(loaded.count == 1)
+        #expect(loaded[0].sessionID == "opencode-1")
+        #expect(loaded[0].openCodeMetadata?.initialUserPrompt == "Hello")
     }
 
-    func testLoadEmpty() throws {
+    @Test
+    func loadEmpty() throws {
+        let tempFileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("json")
+        defer { try? FileManager.default.removeItem(at: tempFileURL) }
+
         let registry = OpenCodeSessionRegistry(fileURL: tempFileURL)
         let loaded = try registry.load()
-        XCTAssertEqual(loaded.count, 0)
+        #expect(loaded.count == 0)
     }
 }

--- a/scripts/harness.sh
+++ b/scripts/harness.sh
@@ -21,7 +21,7 @@ run_step() {
             ;;
         test)
             echo "==> test"
-            swift test
+            zsh "$repo_root/scripts/test-clt.sh"
             ;;
         lint)
             echo "==> lint"

--- a/scripts/test-clt.sh
+++ b/scripts/test-clt.sh
@@ -1,19 +1,21 @@
 #!/bin/zsh
 
+# Runs the test suite with Swift Testing on Command Line Tools-only setups,
+# where plain `swift test` fails with "no such module 'Testing'". Full Xcode
+# toolchains provide Testing natively, so they use plain `swift test`.
+
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 developer_dir="$(xcode-select -p 2>/dev/null || true)"
 testing_frameworks="$developer_dir/Library/Developer/Frameworks"
 
-if [[ -z "$developer_dir" || ! -d "$testing_frameworks/Testing.framework" ]]; then
-    echo "Testing.framework was not found under the selected developer directory:" >&2
-    echo "  ${testing_frameworks:-<unknown>}" >&2
-    echo "Select Apple Command Line Tools or an Xcode installation that provides Swift Testing." >&2
-    exit 1
-fi
-
 cd "$repo_root"
+
+if [[ -z "$developer_dir" || ! -d "$testing_frameworks/Testing.framework" ]]; then
+    # Xcode toolchains bundle Swift Testing into the toolchain itself.
+    exec swift test "$@"
+fi
 
 swift test \
     --enable-swift-testing \

--- a/scripts/test-clt.sh
+++ b/scripts/test-clt.sh
@@ -1,0 +1,27 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+developer_dir="$(xcode-select -p 2>/dev/null || true)"
+testing_frameworks="$developer_dir/Library/Developer/Frameworks"
+
+if [[ -z "$developer_dir" || ! -d "$testing_frameworks/Testing.framework" ]]; then
+    echo "Testing.framework was not found under the selected developer directory:" >&2
+    echo "  ${testing_frameworks:-<unknown>}" >&2
+    echo "Select Apple Command Line Tools or an Xcode installation that provides Swift Testing." >&2
+    exit 1
+fi
+
+cd "$repo_root"
+
+swift test \
+    --enable-swift-testing \
+    -Xswiftc -F \
+    -Xswiftc "$testing_frameworks" \
+    -Xlinker "-F$testing_frameworks" \
+    -Xlinker -rpath \
+    -Xlinker "$testing_frameworks" \
+    -Xlinker -rpath \
+    -Xlinker "$developer_dir/Library/Developer/usr/lib" \
+    "$@"

--- a/scripts/verify-ghostty-jumps.sh
+++ b/scripts/verify-ghostty-jumps.sh
@@ -7,4 +7,4 @@ repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$repo_root"
 
 export OPEN_ISLAND_RUN_GHOSTTY_JUMP_INTEGRATION=1
-swift test --filter TerminalJumpServiceTests
+zsh "$repo_root/scripts/test-clt.sh" --filter TerminalJumpServiceTests


### PR DESCRIPTION
## Summary

Five unit tests fail when run locally on a notched MacBook while passing in CI, because they depend on the host machine's real display and cursor:

- **Display-profile flip**: appearance preferences are keyed by display profile (`.notch`/`.topBar`) resolved from the real screen. The implicit setters (`islandSessionGroup`, `islandSessionSort`, `completedStaleThreshold`, `islandRightSlot`) could write to `.topBar` and then read back from `.notch` after overlay placement resolved against the machine's notch mid-test. Affected: `islandSessionSectionsGroupStaleCompletedIntoIdle`, `islandSessionSectionsKeepCompletedInDoneWhenStaleThresholdIsNever`, `islandSessionListCanSortByLastUpdate`, `moreThanNineSessionsFoldIntoOverflow` (plus four sibling tests in `AgentsGridRightSlotTests` that only passed due to persisted UserDefaults from earlier runs).
- **Real cursor reads**: `updateNotificationAutoCollapse()` reads `NSEvent.mouseLocation`, so the auto-collapse timer is never scheduled when the host's real cursor happens to sit inside the expanded overlay area (top-center of the screen). Affected: `completionNotificationHoverCancelsPendingTimedCollapse`.

## Changes

- Tests write appearance preferences through an explicit profile (`updateAppearancePreferences(for:)`) and pin `overlayPlacementDiagnostics` before asserting, following the existing pattern in `islandAppearancePreferencesPersistPerDisplayProfile`.
- New `pointerLocationProvider` test seam on `OverlayUICoordinator` (defaults to `NSEvent.mouseLocation`); pointer-sensitive tests pin it far outside the overlay.
- Completes the Swift Testing migration: the last four XCTest suites (`ForegroundTerminalSessionProbeTests`, `KeystrokeInjectorTests`, `TerminalJumpServiceTests`, `OpenCodeSessionRegistryTests`) converted to `@Suite`/`#expect`.
- Adds `scripts/test-clt.sh`: on Command Line Tools-only setups (where plain `swift test` fails with *no such module 'Testing'*) it supplies the framework search path and runtime rpaths for `Testing.framework`; on Xcode toolchains it falls back to plain `swift test`, so `harness.sh ci` behaves unchanged on CI runners.

## Verification

- `zsh scripts/test-clt.sh`: **349 tests / 38 suites pass** on a notched MacBook (Apple Silicon, macOS 26, Swift 6.3 CLT-only), across repeated runs.
- Before this change the five tests above failed deterministically on the same machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification auto-collapse behavior by using a reliable pointer location when available, with a fallback to the system cursor position.

* **Tests**
  * Migrated several test suites to Swift Testing.
  * Stabilized tests involving appearance profiles, pointer location, session grouping, and terminal interactions.
  * Improved test handling across supported Xcode and Swift environments.

* **Chores**
  * Updated test and verification scripts to use the enhanced test runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->