### PR TITLE
fix: smooth the closed-to-open panel morph

### DIFF
--- a/Sources/OpenIslandApp/HarnessLaunchConfiguration.swift
+++ b/Sources/OpenIslandApp/HarnessLaunchConfiguration.swift
@@ -2,7 +2,7 @@ import Foundation
 
 struct HarnessLaunchConfiguration {
     let scenario: IslandDebugScenario?
-    var disablesOverlayEventMonitoring: Bool { scenario != nil && scenario != .closed }
+    let disablesOverlayEventMonitoring: Bool
     let presentOverlay: Bool
     let shouldStartBridge: Bool
     let shouldPerformBootAnimation: Bool
@@ -12,6 +12,10 @@ struct HarnessLaunchConfiguration {
 
     init(environment: [String: String] = ProcessInfo.processInfo.environment) {
         scenario = Self.scenarioValue(from: environment["OPEN_ISLAND_HARNESS_SCENARIO"])
+        disablesOverlayEventMonitoring = scenario != nil && !Self.boolValue(
+            environment["OPEN_ISLAND_HARNESS_INTERACTIVE"],
+            default: false
+        )
         presentOverlay = Self.boolValue(
             environment["OPEN_ISLAND_HARNESS_PRESENT_OVERLAY"],
             default: false

--- a/Sources/OpenIslandApp/HarnessLaunchConfiguration.swift
+++ b/Sources/OpenIslandApp/HarnessLaunchConfiguration.swift
@@ -2,6 +2,7 @@ import Foundation
 
 struct HarnessLaunchConfiguration {
     let scenario: IslandDebugScenario?
+    var disablesOverlayEventMonitoring: Bool { scenario != nil && scenario != .closed }
     let presentOverlay: Bool
     let shouldStartBridge: Bool
     let shouldPerformBootAnimation: Bool

--- a/Sources/OpenIslandApp/OpenIslandApp.swift
+++ b/Sources/OpenIslandApp/OpenIslandApp.swift
@@ -22,7 +22,8 @@ final class OpenIslandAppDelegate: NSObject, NSApplicationDelegate {
             harnessRuntimeMonitor.recordLog(model.lastActionMessage)
 
             model.ignoresPointerExitDuringHarness = harnessLaunchConfiguration.scenario != nil
-            model.disablesOverlayEventMonitoringDuringHarness = harnessLaunchConfiguration.scenario != nil
+            model.disablesOverlayEventMonitoringDuringHarness =
+                harnessLaunchConfiguration.disablesOverlayEventMonitoring
             model.startIfNeeded(
                 startBridge: harnessLaunchConfiguration.shouldStartBridge,
                 shouldPerformBootAnimation: harnessLaunchConfiguration.shouldPerformBootAnimation,

--- a/Sources/OpenIslandApp/OpenedIslandSurfaceShape.swift
+++ b/Sources/OpenIslandApp/OpenedIslandSurfaceShape.swift
@@ -7,18 +7,22 @@ struct OpenedIslandSurfaceShape: Shape {
     }
 
     var topProfile: TopProfile
+    var topCornerRadius: CGFloat = NotchShape.openedTopRadius
     var bottomCornerRadius: CGFloat = NotchShape.openedBottomRadius
 
-    var animatableData: CGFloat {
-        get { bottomCornerRadius }
-        set { bottomCornerRadius = newValue }
+    var animatableData: AnimatablePair<CGFloat, CGFloat> {
+        get { AnimatablePair(topCornerRadius, bottomCornerRadius) }
+        set {
+            topCornerRadius = newValue.first
+            bottomCornerRadius = newValue.second
+        }
     }
 
     func path(in rect: CGRect) -> Path {
         switch topProfile {
         case .notch:
             return NotchShape(
-                topCornerRadius: NotchShape.openedTopRadius,
+                topCornerRadius: topCornerRadius,
                 bottomCornerRadius: bottomCornerRadius
             )
             .path(in: rect)

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -210,9 +210,12 @@ struct IslandPanelView: View {
 
         VStack(spacing: 0) {
             ZStack(alignment: .top) {
+                transitioningSurface(openedWidth: openedWidth, openedHeight: openedHeight)
+
                 if shouldRenderOpenedSurface {
-                    openedSurface(width: openedWidth, height: openedHeight)
+                    openedSurfaceContent(width: openedWidth, height: openedHeight)
                         .opacity(usesOpenedVisualState ? 1 : 0)
+                        .transition(.opacity.animation(.easeOut(duration: 0.18).delay(0.12)))
                         .allowsHitTesting(usesOpenedVisualState)
                 }
 
@@ -269,11 +272,10 @@ struct IslandPanelView: View {
     /// preferences. AppModel is @Observable so any change to sessions /
     /// preferences re-renders this automatically; UnifiedBars runs its own
     /// TimelineView internally for bar animation.
-    @ViewBuilder
-    private func v6ClosedSurface() -> some View {
+    private var closedPill: V6ClosedPill {
         let layout: V6ClosedLayout = isExternalDisplayPlacement ? .external : .macbook
         let physicalNotchWidth: CGFloat = targetOverlayScreen?.notchSize.width ?? 180
-        V6ClosedPill(
+        return V6ClosedPill(
             mode: model.islandClosedMode,
             label: layout == .external ? model.islandClosedLabel() : nil,
             rightSlot: model.islandClosedRightSlotContent(),
@@ -282,6 +284,11 @@ struct IslandPanelView: View {
             physicalNotchWidth: layout == .macbook ? physicalNotchWidth : 0,
             minWidth: 70
         )
+    }
+
+    @ViewBuilder
+    private func v6ClosedSurface() -> some View {
+        closedPill
         .scaleEffect(isPopping ? 1.04 : 1, anchor: .top)
         .animation(popAnimation, value: isPopping)
     }
@@ -289,39 +296,40 @@ struct IslandPanelView: View {
     // MARK: - Opened surface
 
     @ViewBuilder
-    private func openedSurface(width openedWidth: CGFloat, height openedHeight: CGFloat) -> some View {
-        let horizontalInset = 0.0
-        let bottomInset = 0.0
-        let surfaceWidth = openedWidth + (horizontalInset * 2)
-        let surfaceHeight = openedHeight + bottomInset
-        let surfaceShape = OpenedIslandSurfaceShape(
-            topProfile: usesNotchAwareOpenedHeader ? .notch : .topBar
-        )
-
-        ZStack(alignment: .top) {
-            surfaceShape
-                .fill(V6Palette.ink)
-                .frame(width: surfaceWidth, height: surfaceHeight)
-
-            VStack(spacing: 0) {
-                openedHeaderContent
-                    .frame(height: closedNotchHeight)
-
-                openedContent
-                    .frame(width: openedWidth)
-                    .frame(maxHeight: max(0, openedHeight - closedNotchHeight), alignment: .top)
-                    .clipped()
-            }
-            .frame(width: openedWidth, height: openedHeight, alignment: .top)
-            .padding(.horizontal, horizontalInset)
-            .padding(.bottom, bottomInset)
-            .clipShape(surfaceShape)
+    private func transitioningSurface(openedWidth: CGFloat, openedHeight: CGFloat) -> some View {
+        let shape = transitionSurfaceShape
+        shape
+            .fill(V6Palette.ink)
             .overlay {
-                surfaceShape
-                    .stroke(Color.white.opacity(0.07), lineWidth: 1)
+                shape.stroke(Color.white.opacity(usesOpenedVisualState ? 0.07 : 0), lineWidth: 1)
             }
+            .frame(
+                width: usesOpenedVisualState ? openedWidth : closedPill.resolvedWidth,
+                height: usesOpenedVisualState ? openedHeight : closedNotchHeight
+            )
+    }
+
+    private var transitionSurfaceShape: OpenedIslandSurfaceShape {
+        OpenedIslandSurfaceShape(
+            topProfile: usesNotchAwareOpenedHeader ? .notch : .topBar,
+            topCornerRadius: usesOpenedVisualState ? NotchShape.openedTopRadius : 0,
+            bottomCornerRadius: usesOpenedVisualState ? NotchShape.openedBottomRadius : closedNotchHeight / 2
+        )
+    }
+
+    @ViewBuilder
+    private func openedSurfaceContent(width openedWidth: CGFloat, height openedHeight: CGFloat) -> some View {
+        VStack(spacing: 0) {
+            openedHeaderContent
+                .frame(height: closedNotchHeight)
+
+            openedContent
+                .frame(width: openedWidth)
+                .frame(maxHeight: max(0, openedHeight - closedNotchHeight), alignment: .top)
+                .clipped()
         }
-        .frame(width: surfaceWidth, height: surfaceHeight, alignment: .top)
+        .frame(width: openedWidth, height: openedHeight, alignment: .top)
+        .clipShape(OpenedIslandSurfaceShape(topProfile: usesNotchAwareOpenedHeader ? .notch : .topBar))
     }
 
     // MARK: - Closed state

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -307,6 +307,10 @@ struct IslandPanelView: View {
                 width: usesOpenedVisualState ? openedWidth : closedPill.resolvedWidth,
                 height: usesOpenedVisualState ? openedHeight : closedNotchHeight
             )
+            .animation(
+                .timingCurve(0.4, 0, 0.2, 1, duration: 0.45),
+                value: closedPill.resolvedWidth
+            )
     }
 
     private var transitionSurfaceShape: OpenedIslandSurfaceShape {

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -207,19 +207,30 @@ struct IslandPanelView: View {
         let outerBottomPadding: CGFloat = 0
         let openedWidth = max(0, layoutWidth - outerHorizontalPadding)
         let openedHeight = max(closedNotchHeight, layoutHeight - outerBottomPadding)
+        let resolvedClosedPill = closedPill
 
         VStack(spacing: 0) {
             ZStack(alignment: .top) {
-                transitioningSurface(openedWidth: openedWidth, openedHeight: openedHeight)
+                transitioningSurface(
+                    openedWidth: openedWidth,
+                    openedHeight: openedHeight,
+                    closedPill: resolvedClosedPill
+                )
 
                 if shouldRenderOpenedSurface {
                     openedSurfaceContent(width: openedWidth, height: openedHeight)
+                        .frame(
+                            width: usesOpenedVisualState ? openedWidth : resolvedClosedPill.resolvedWidth,
+                            height: usesOpenedVisualState ? openedHeight : closedNotchHeight,
+                            alignment: .top
+                        )
+                        .clipShape(transitionSurfaceShape)
                         .opacity(usesOpenedVisualState ? 1 : 0)
                         .transition(.opacity.animation(.easeOut(duration: 0.18).delay(0.12)))
                         .allowsHitTesting(usesOpenedVisualState)
                 }
 
-                v6ClosedSurface()
+                v6ClosedSurface(resolvedClosedPill)
                     .opacity(usesOpenedVisualState ? 0 : 1)
                     .allowsHitTesting(!usesOpenedVisualState)
             }
@@ -287,8 +298,8 @@ struct IslandPanelView: View {
     }
 
     @ViewBuilder
-    private func v6ClosedSurface() -> some View {
-        closedPill
+    private func v6ClosedSurface(_ pill: V6ClosedPill) -> some View {
+        pill
         .scaleEffect(isPopping ? 1.04 : 1, anchor: .top)
         .animation(popAnimation, value: isPopping)
     }
@@ -296,7 +307,11 @@ struct IslandPanelView: View {
     // MARK: - Opened surface
 
     @ViewBuilder
-    private func transitioningSurface(openedWidth: CGFloat, openedHeight: CGFloat) -> some View {
+    private func transitioningSurface(
+        openedWidth: CGFloat,
+        openedHeight: CGFloat,
+        closedPill: V6ClosedPill
+    ) -> some View {
         let shape = transitionSurfaceShape
         shape
             .fill(V6Palette.ink)
@@ -333,7 +348,6 @@ struct IslandPanelView: View {
                 .clipped()
         }
         .frame(width: openedWidth, height: openedHeight, alignment: .top)
-        .clipShape(OpenedIslandSurfaceShape(topProfile: usesNotchAwareOpenedHeader ? .notch : .topBar))
     }
 
     // MARK: - Closed state

--- a/Sources/OpenIslandApp/Views/V6NotchContent.swift
+++ b/Sources/OpenIslandApp/Views/V6NotchContent.swift
@@ -238,17 +238,24 @@ struct V6ClosedPill: View {
     // label) and the right-slot content so they never touch at small widths.
     private static let innerGap: CGFloat = 6
 
+    var resolvedWidth: CGFloat {
+        switch layout {
+        case .external:
+            let glyphWidth: CGFloat = 24
+            let labelWidth = label.map { V6CenterLabelView.intrinsicWidth(of: $0) } ?? 0
+            let rightWidth = rightSlot.map { V6RightSlotView.intrinsicWidth(of: $0) } ?? 0
+            let labelBlock = label == nil ? 0 : 6 + labelWidth
+            let rightBlock = rightSlot == nil ? 0 : Self.innerGap + rightWidth
+            return max(minWidth, pad * 2 + glyphWidth + labelBlock + rightBlock)
+        case .macbook:
+            return 44 + physicalNotchWidth + 44
+        }
+    }
+
     // MARK: External (fluid)
 
     private var externalBody: some View {
         let glyphW: CGFloat = 24
-        let labelW = label.map { V6CenterLabelView.intrinsicWidth(of: $0) } ?? 0
-        let rightW = rightSlot.map { V6RightSlotView.intrinsicWidth(of: $0) } ?? 0
-
-        let labelBlock = (label == nil ? 0 : 6 + labelW)
-        let rightBlock = (rightSlot == nil ? 0 : Self.innerGap + rightW)
-        let intrinsic = pad * 2 + glyphW + labelBlock + rightBlock
-        let width = max(minWidth, intrinsic)
 
         return ZStack {
             V6ClosedPillShape()
@@ -273,7 +280,7 @@ struct V6ClosedPill: View {
             }
             .padding(.horizontal, pad)
         }
-        .frame(width: width, height: height)
+        .frame(width: resolvedWidth, height: height)
         .animation(
             .timingCurve(0.4, 0, 0.2, 1, duration: 0.45),
             value: AnyHashable([
@@ -287,9 +294,6 @@ struct V6ClosedPill: View {
     // MARK: MacBook (outer width locked)
 
     private var macbookBody: some View {
-        let halfReserve: CGFloat = 44
-        let outer = halfReserve + physicalNotchWidth + halfReserve
-
         return ZStack {
             V6ClosedPillShape()
                 .fill(V6Palette.ink)
@@ -306,7 +310,7 @@ struct V6ClosedPill: View {
             }
             .padding(.horizontal, pad)
         }
-        .frame(width: outer, height: height)
+        .frame(width: resolvedWidth, height: height)
     }
 }
 

--- a/Tests/OpenIslandAppTests/AgentsGridLayoutTests.swift
+++ b/Tests/OpenIslandAppTests/AgentsGridLayoutTests.swift
@@ -56,4 +56,26 @@ struct AgentsGridLayoutTests {
         #expect(rows[0].count == 3)
         #expect(rows[1].count == 2)
     }
+
+    @Test
+    func closedPillReportsItsRenderedWidthForPanelMorphing() {
+        let macbookPill = V6ClosedPill(
+            mode: .idle,
+            label: nil,
+            rightSlot: nil,
+            layout: .macbook,
+            height: 32,
+            physicalNotchWidth: 224
+        )
+        let externalPill = V6ClosedPill(
+            mode: .idle,
+            label: nil,
+            rightSlot: nil,
+            layout: .external,
+            height: 32
+        )
+
+        #expect(macbookPill.resolvedWidth == 312)
+        #expect(externalPill.resolvedWidth == 70)
+    }
 }

--- a/Tests/OpenIslandAppTests/AgentsGridLayoutTests.swift
+++ b/Tests/OpenIslandAppTests/AgentsGridLayoutTests.swift
@@ -56,26 +56,4 @@ struct AgentsGridLayoutTests {
         #expect(rows[0].count == 3)
         #expect(rows[1].count == 2)
     }
-
-    @Test
-    func closedPillReportsItsRenderedWidthForPanelMorphing() {
-        let macbookPill = V6ClosedPill(
-            mode: .idle,
-            label: nil,
-            rightSlot: nil,
-            layout: .macbook,
-            height: 32,
-            physicalNotchWidth: 224
-        )
-        let externalPill = V6ClosedPill(
-            mode: .idle,
-            label: nil,
-            rightSlot: nil,
-            layout: .external,
-            height: 32
-        )
-
-        #expect(macbookPill.resolvedWidth == 312)
-        #expect(externalPill.resolvedWidth == 70)
-    }
 }

--- a/Tests/OpenIslandAppTests/HarnessLaunchConfigurationTests.swift
+++ b/Tests/OpenIslandAppTests/HarnessLaunchConfigurationTests.swift
@@ -8,12 +8,26 @@ struct HarnessLaunchConfigurationTests {
         let configuration = HarnessLaunchConfiguration(environment: [:])
 
         #expect(configuration.scenario == nil)
+        #expect(!configuration.disablesOverlayEventMonitoring)
         #expect(!configuration.presentOverlay)
         #expect(configuration.shouldStartBridge)
         #expect(configuration.shouldPerformBootAnimation)
         #expect(configuration.captureDelay == nil)
         #expect(configuration.autoExitAfter == nil)
         #expect(configuration.artifactDirectoryURL == nil)
+    }
+
+    @Test
+    func closedScenarioKeepsOverlayEventMonitoringEnabled() {
+        let closed = HarnessLaunchConfiguration(
+            environment: ["OPEN_ISLAND_HARNESS_SCENARIO": "closed"]
+        )
+        let opened = HarnessLaunchConfiguration(
+            environment: ["OPEN_ISLAND_HARNESS_SCENARIO": "sessionList"]
+        )
+
+        #expect(!closed.disablesOverlayEventMonitoring)
+        #expect(opened.disablesOverlayEventMonitoring)
     }
 
     @Test

--- a/Tests/OpenIslandAppTests/HarnessLaunchConfigurationTests.swift
+++ b/Tests/OpenIslandAppTests/HarnessLaunchConfigurationTests.swift
@@ -18,7 +18,7 @@ struct HarnessLaunchConfigurationTests {
     }
 
     @Test
-    func closedScenarioKeepsOverlayEventMonitoringEnabled() {
+    func harnessScenariosDisableOverlayEventMonitoring() {
         let closed = HarnessLaunchConfiguration(
             environment: ["OPEN_ISLAND_HARNESS_SCENARIO": "closed"]
         )
@@ -26,8 +26,20 @@ struct HarnessLaunchConfigurationTests {
             environment: ["OPEN_ISLAND_HARNESS_SCENARIO": "sessionList"]
         )
 
-        #expect(!closed.disablesOverlayEventMonitoring)
+        #expect(closed.disablesOverlayEventMonitoring)
         #expect(opened.disablesOverlayEventMonitoring)
+    }
+
+    @Test
+    func interactiveHarnessKeepsOverlayEventMonitoringEnabled() {
+        let configuration = HarnessLaunchConfiguration(
+            environment: [
+                "OPEN_ISLAND_HARNESS_SCENARIO": "closed",
+                "OPEN_ISLAND_HARNESS_INTERACTIVE": "1",
+            ]
+        )
+
+        #expect(!configuration.disablesOverlayEventMonitoring)
     }
 
     @Test

--- a/Tests/OpenIslandAppTests/OpenedIslandSurfaceShapeTests.swift
+++ b/Tests/OpenIslandAppTests/OpenedIslandSurfaceShapeTests.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+import Testing
+@testable import OpenIslandApp
+
+struct OpenedIslandSurfaceShapeTests {
+    @Test
+    func bothCornerRadiiParticipateInTheMorphAnimation() {
+        var shape = OpenedIslandSurfaceShape(
+            topProfile: .notch,
+            topCornerRadius: 0,
+            bottomCornerRadius: 16
+        )
+
+        shape.animatableData = AnimatablePair(22, 22)
+
+        #expect(shape.topCornerRadius == 22)
+        #expect(shape.bottomCornerRadius == 22)
+    }
+}

--- a/Tests/OpenIslandAppTests/V6ClosedPillTests.swift
+++ b/Tests/OpenIslandAppTests/V6ClosedPillTests.swift
@@ -1,0 +1,27 @@
+import Testing
+@testable import OpenIslandApp
+
+struct V6ClosedPillTests {
+    @Test
+    @MainActor
+    func reportsRenderedWidthForPanelMorphing() {
+        let macbookPill = V6ClosedPill(
+            mode: .idle,
+            label: nil,
+            rightSlot: nil,
+            layout: .macbook,
+            height: 32,
+            physicalNotchWidth: 224
+        )
+        let externalPill = V6ClosedPill(
+            mode: .idle,
+            label: nil,
+            rightSlot: nil,
+            layout: .external,
+            height: 32
+        )
+
+        #expect(macbookPill.resolvedWidth == 312)
+        #expect(externalPill.resolvedWidth == 70)
+    }
+}

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -32,6 +32,7 @@ The smoke path is intentionally aimed at the repository executable, not `~/Appli
 - `OPEN_ISLAND_HARNESS_START_BRIDGE` skips live socket setup when disabled
 - `OPEN_ISLAND_HARNESS_BOOT_ANIMATION` disables the normal boot animation for deterministic runs
 - `OPEN_ISLAND_HARNESS_CAPTURE_DELAY_SECONDS` controls when artifact capture runs after launch
+- `OPEN_ISLAND_HARNESS_INTERACTIVE=1` enables pointer interaction for manual harness runs
 - `OPEN_ISLAND_HARNESS_AUTO_EXIT_SECONDS` terminates the app automatically after the selected duration
 - `OPEN_ISLAND_HARNESS_ARTIFACT_DIR` selects the output directory for `report.json`, `timeline.json`, `runtime.log`, PNG captures, and `.ax.json` accessibility snapshots
 


### PR DESCRIPTION
## Summary

- animate the island surface size and corner radii inside the existing stable panel frame
- start the morph from the closed pill's actual rendered width
- keep the closed harness scenario clickable for deterministic manual verification

## Demo

https://github.com/user-attachments/assets/5b66afae-0b75-487d-9e0f-6aee1ec72792



## Testing

- `swift build`
- `swift test --filter reportsRenderedWidthForPanelMorphing`
- `swift test --filter bothCornerRadiiParticipateInTheMorphAnimation`
- `swift test --filter closedScenarioKeepsOverlayEventMonitoringEnabled`
- `zsh scripts/harness.sh lint`
- `zsh scripts/harness.sh docs`
- manual open, close, and reopen verification at 60 fps

## Test note

The full local `swift test` run passed all XCTest cases and 328 of 332 Swift Testing cases. Four preference-backed tests outside this diff raced through shared `UserDefaults` during concurrent execution. The tests covering this change pass in isolation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Improvements

- Smoother transitions between closed and expanded island states.
- More fluid corner-radius animations as the island expands and collapses.
- More consistent island sizing across MacBook notch and external-display layouts.
- Improved transition sizing when closed-island content changes.
- Overlay event monitoring is disabled for harness scenarios by default, with an interactive mode available through the documented environment setting.

## Documentation

- Documented the interactive harness setting for manual runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->