### PR TITLE
fix: stop Codex app-server EOF handler spin

### DIFF
--- a/Sources/OpenIslandCore/CodexAppServer.swift
+++ b/Sources/OpenIslandCore/CodexAppServer.swift
@@ -87,6 +87,8 @@ public enum CodexAppServerNotification: Sendable {
 public final class CodexAppServerClient: @unchecked Sendable {
     private let codexPath: String
     private var process: Process?
+    private var stdoutReadHandle: FileHandle?
+    private var stderrReadHandle: FileHandle?
     /// Internal access so tests can inject a discard `Pipe` and drive
     /// the request path without launching a real codex subprocess.
     var stdin: FileHandle?
@@ -135,17 +137,10 @@ public final class CodexAppServerClient: @unchecked Sendable {
         self.stdin = stdinPipe.fileHandleForWriting
         self.process = proc
 
-        // Read stdout in a background thread.
-        stdoutPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
-            let data = handle.availableData
-            guard !data.isEmpty else { return }
-            self?.handleIncomingData(data)
-        }
-
-        // Drain stderr so a full pipe can't block the child process.
-        stderrPipe.fileHandleForReading.readabilityHandler = { handle in
-            _ = handle.availableData
-        }
+        configureOutputHandlers(
+            stdout: stdoutPipe.fileHandleForReading,
+            stderr: stderrPipe.fileHandleForReading
+        )
 
         try proc.run()
 
@@ -163,8 +158,35 @@ public final class CodexAppServerClient: @unchecked Sendable {
         )
     }
 
+    func configureOutputHandlers(stdout: FileHandle, stderr: FileHandle) {
+        stdoutReadHandle = stdout
+        stderrReadHandle = stderr
+
+        // Read stdout in a background thread.
+        stdout.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty else {
+                handle.readabilityHandler = nil
+                return
+            }
+            self?.handleIncomingData(data)
+        }
+
+        // Drain stderr so a full pipe can't block the child process.
+        stderr.readabilityHandler = { handle in
+            let data = handle.availableData
+            if data.isEmpty {
+                handle.readabilityHandler = nil
+            }
+        }
+    }
+
     /// Stop the app-server subprocess.
     public func stop() {
+        stdoutReadHandle?.readabilityHandler = nil
+        stderrReadHandle?.readabilityHandler = nil
+        stdoutReadHandle = nil
+        stderrReadHandle = nil
         process?.terminate()
         process = nil
         stdin = nil

--- a/Tests/OpenIslandCoreTests/CodexAppServerLifecycleTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexAppServerLifecycleTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+struct CodexAppServerLifecycleTests {
+    @Test
+    func outputHandlersUnregisterAtEndOfFile() async throws {
+        let client = CodexAppServerClient()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        defer {
+            try? stdoutPipe.fileHandleForReading.close()
+            try? stderrPipe.fileHandleForReading.close()
+        }
+
+        client.configureOutputHandlers(
+            stdout: stdoutPipe.fileHandleForReading,
+            stderr: stderrPipe.fileHandleForReading
+        )
+
+        try stdoutPipe.fileHandleForWriting.close()
+        try stderrPipe.fileHandleForWriting.close()
+
+        #expect(await waitUntil {
+            stdoutPipe.fileHandleForReading.readabilityHandler == nil
+                && stderrPipe.fileHandleForReading.readabilityHandler == nil
+        })
+    }
+
+    @Test
+    func stopUnregistersOutputHandlers() throws {
+        let client = CodexAppServerClient()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        defer {
+            try? stdoutPipe.fileHandleForWriting.close()
+            try? stderrPipe.fileHandleForWriting.close()
+            try? stdoutPipe.fileHandleForReading.close()
+            try? stderrPipe.fileHandleForReading.close()
+        }
+
+        client.configureOutputHandlers(
+            stdout: stdoutPipe.fileHandleForReading,
+            stderr: stderrPipe.fileHandleForReading
+        )
+
+        client.stop()
+
+        #expect(stdoutPipe.fileHandleForReading.readabilityHandler == nil)
+        #expect(stderrPipe.fileHandleForReading.readabilityHandler == nil)
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        condition: () -> Bool
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if condition() {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return condition()
+    }
+}


### PR DESCRIPTION
## Summary

- Unregister Codex app-server stdout and stderr readability handlers when their pipes reach EOF.
- Clear both output handlers before terminating the subprocess during an explicit stop.
- Add lifecycle regression tests for EOF and explicit shutdown.

## Root cause

`CodexAppServerClient` left each `FileHandle.readabilityHandler` installed after `availableData` returned empty data at EOF. On macOS, an EOF descriptor remains readable, so Foundation repeatedly invoked both the stdout and stderr handlers after the app-server process exited or its pipes closed. Those two hot dispatch sources could keep roughly two CPU cores busy. The existing `stop()` path also terminated the process without unregistering the handlers, allowing the same spin during normal disconnects.

## Verification

- `swift test --disable-sandbox --scratch-path /Users/tanghuaizhe/Dev/open-vibe-island/.build --filter CodexAppServer` — 7 tests passed.
- `swift test --disable-sandbox --scratch-path /Users/tanghuaizhe/Dev/open-vibe-island/.build` — 370 tests passed.
- `git diff --check` — passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of application output streams when the connection ends or the client stops.
  * Prevented lingering output handlers after end-of-file, supporting more reliable shutdown behavior.

* **Tests**
  * Added coverage for output-handler cleanup during normal stream closure and client shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->