### PR TITLE
fix: reap stalled Codex.app sessions and fold idle rows in the island

### DIFF
--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -292,7 +292,7 @@ extension AgentSession {
     }
 
     func spotlightShowsDetailLines(at referenceDate: Date) -> Bool {
-        if phase == .running || phase.requiresAttention {
+        if phase.isActiveTurn {
             return true
         }
 
@@ -304,8 +304,13 @@ extension AgentSession {
     }
 
     var spotlightAgeBadge: String {
-        let age = max(0, Int(Date.now.timeIntervalSince(islandActivityDate)))
+        Self.islandAgeBadge(since: islandActivityDate)
+    }
 
+    /// Compact age badge ("<1m", "5m", "3h", "2d") shared by the session
+    /// row spotlight and the collapsed idle-fold row.
+    static func islandAgeBadge(since date: Date, now: Date = .now) -> String {
+        let age = max(0, Int(now.timeIntervalSince(date)))
         if age < 60 {
             return "<1m"
         }
@@ -437,7 +442,7 @@ extension AgentSession {
     }
 
     private var prefersLivePromptHeadline: Bool {
-        isProcessAlive || phase == .running || phase.requiresAttention
+        isProcessAlive || phase.isActiveTurn
     }
 }
 

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -738,35 +738,60 @@ final class AppModel {
         islandSessionSections.flatMap(\.sessions)
     }
 
+    /// Section id for the collapsed idle row appended to every grouping mode.
+    /// Sessions beyond the completed-stale threshold fold into it instead of
+    /// occupying full rows (see `islandSessionSections`).
+    static let idleFoldSectionID = "idle-fold"
+
     var islandSessionSections: [IslandSessionSection] {
-        let sessions = sortIslandSessions(surfacedSessions)
+        let now = Date.now
+        let threshold = completedStaleThreshold.seconds
+        // `.never` keeps every completed session as a full row.
+        let isFoldable: (AgentSession) -> Bool = { session in
+            session.isStaleCompletedForIsland(at: now, threshold: threshold)
+        }
+        let visibleSessions = sortIslandSessions(surfacedSessions.filter { !isFoldable($0) })
+        let foldedSessions = sortIslandSessions(surfacedSessions.filter(isFoldable))
+
+        var sections: [IslandSessionSection] = []
         switch islandSessionGroup {
         case .none:
-            return [
+            sections = [
                 IslandSessionSection(
                     id: "all",
                     title: "island.section.sessions",
-                    sessions: sessions
+                    sessions: visibleSessions
                 )
             ]
         case .state:
-            return stateGroupedSections(for: sessions)
+            sections = stateGroupedSections(for: visibleSessions)
         case .agent:
-            return AgentTool.allCases.compactMap { tool in
-                let list = sessions.filter { $0.tool == tool }
+            sections = AgentTool.allCases.compactMap { tool in
+                let list = visibleSessions.filter { $0.tool == tool }
                 guard !list.isEmpty else { return nil }
                 return IslandSessionSection(id: "agent-\(tool.rawValue)", title: tool.displayName, sessions: list)
             }
         case .project:
-            let names = Set(sessions.map(projectGroupName(for:))).sorted {
+            let names = Set(visibleSessions.map(projectGroupName(for:))).sorted {
                 $0.localizedStandardCompare($1) == .orderedAscending
             }
-            return names.compactMap { name in
-                let list = sessions.filter { projectGroupName(for: $0) == name }
+            sections = names.compactMap { name in
+                let list = visibleSessions.filter { projectGroupName(for: $0) == name }
                 guard !list.isEmpty else { return nil }
                 return IslandSessionSection(id: "project-\(name)", title: name, sessions: list)
             }
         }
+
+        if !foldedSessions.isEmpty {
+            sections.append(
+                IslandSessionSection(
+                    id: Self.idleFoldSectionID,
+                    title: "island.idleFold.title",
+                    sessions: foldedSessions
+                )
+            )
+        }
+        return sections
     }
 
     var recentSessionCount: Int {
@@ -800,6 +825,8 @@ final class AppModel {
     }
 
     private func stateGroupedSections(for sessions: [AgentSession]) -> [IslandSessionSection] {
+        // Stale-completed sessions are intentionally absent here: they fold
+        // into the collapsed idle row appended by `islandSessionSections`.
         let definitions: [(id: String, title: String, include: (AgentSession) -> Bool)] = [
             ("approval", "island.section.needsApproval", { $0.phase == .waitingForApproval }),
             ("answer", "island.section.needsAnswer", { $0.phase == .waitingForAnswer }),
@@ -807,10 +834,6 @@ final class AppModel {
             ("done", "island.section.justDone", { [completedStaleThreshold] session in
                 session.phase == .completed
                     && !session.isStaleCompletedForIsland(at: .now, threshold: completedStaleThreshold.seconds)
-            }),
-            ("idle", "island.section.idle", { [completedStaleThreshold] session in
-                session.phase == .completed
-                    && session.isStaleCompletedForIsland(at: .now, threshold: completedStaleThreshold.seconds)
             }),
         ]
 
@@ -888,7 +911,10 @@ final class AppModel {
         case .none:
             return nil
         case .count:
-            let n = sessions.count
+            // The badge answers "how many agents need me right now": running
+            // plus waiting states. Idle/folded sessions carry no signal, and
+            // an all-idle island shows no badge at all.
+            let n = sessions.filter { $0.phase == .running || $0.phase.requiresAttention }.count
             guard n > 0 else { return nil }
             return .count(n)
         case .agents:
@@ -1491,10 +1517,14 @@ final class AppModel {
         // back to running. The bridge's sessionCompleted is authoritative; the
         // rollout watcher may have read the JSONL before task_complete was
         // flushed, producing a stale activityUpdated(phase: .running).
+        // Exception: stall-reaped sessions — their completion was inferred
+        // from a quiet rollout file, so a later append IS genuine activity
+        // and must revive the session.
         if ingress == .rollout,
            case let .activityUpdated(payload) = event,
            payload.phase == .running,
-           state.session(id: payload.sessionID)?.phase == .completed {
+           state.session(id: payload.sessionID)?.phase == .completed,
+           state.session(id: payload.sessionID)?.isStallReaped != true {
             return
         }
 

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -749,6 +749,10 @@ final class AppModel {
         // `.never` keeps every completed session as a full row.
         let isFoldable: (AgentSession) -> Bool = { session in
             session.isStaleCompletedForIsland(at: now, threshold: threshold)
+                // Stall reaps carry their pre-timeout last-write time; fold
+                // them straight away even when the user's threshold exceeds
+                // the stall timeout, so they never flash through "Just done".
+                || (threshold.isFinite && session.phase == .completed && session.isStallReaped)
         }
         let visibleSessions = sortIslandSessions(surfacedSessions.filter { !isFoldable($0) })
         let foldedSessions = sortIslandSessions(surfacedSessions.filter(isFoldable))
@@ -914,7 +918,7 @@ final class AppModel {
             // The badge answers "how many agents need me right now": running
             // plus waiting states. Idle/folded sessions carry no signal, and
             // an all-idle island shows no badge at all.
-            let n = sessions.filter { $0.phase == .running || $0.phase.requiresAttention }.count
+            let n = sessions.filter(\.phase.isActiveTurn).count
             guard n > 0 else { return nil }
             return .count(n)
         case .agents:

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -54,12 +54,12 @@ final class ProcessMonitoringCoordinator {
     private static let idlePollInterval: TimeInterval = 300
     private static let cursorStalenessTimeout: TimeInterval = 600  // 10 minutes
     /// Completed Codex.app sessions stay resident while their rollout is
-    /// still inside the discovery window (`CodexRolloutDiscovery.maxAge`)
-    /// so they fold into the idle row instead of churning between eviction
-    /// and rediscovery. Running sessions get no timeout here — they are
-    /// demoted by `CodexAppSessionReconciler.runningStallTimeout` once the
-    /// rollout file goes quiet.
-    private static let codexAppCompletedRetention: TimeInterval = 86_400
+    /// still inside the discovery window so they fold into the idle row
+    /// instead of churning between eviction and rediscovery. Running
+    /// sessions get no timeout here — they are demoted by
+    /// `CodexAppSessionReconciler.runningStallTimeout` once the rollout
+    /// file goes quiet.
+    private static let codexAppCompletedRetention: TimeInterval = CodexRolloutDiscovery.defaultMaxAge
     private static let claudeDesktopStalenessTimeout: TimeInterval = 600  // 10 minutes
 
     static func monitoringPollInterval(

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -53,7 +53,13 @@ final class ProcessMonitoringCoordinator {
     private static let activePollInterval: TimeInterval = 60
     private static let idlePollInterval: TimeInterval = 300
     private static let cursorStalenessTimeout: TimeInterval = 600  // 10 minutes
-    private static let codexAppStalenessTimeout: TimeInterval = 600  // 10 minutes
+    /// Completed Codex.app sessions stay resident while their rollout is
+    /// still inside the discovery window (`CodexRolloutDiscovery.maxAge`)
+    /// so they fold into the idle row instead of churning between eviction
+    /// and rediscovery. Running sessions get no timeout here — they are
+    /// demoted by `CodexAppSessionReconciler.runningStallTimeout` once the
+    /// rollout file goes quiet.
+    private static let codexAppCompletedRetention: TimeInterval = 86_400
     private static let claudeDesktopStalenessTimeout: TimeInterval = 600  // 10 minutes
 
     static func monitoringPollInterval(
@@ -396,7 +402,7 @@ final class ProcessMonitoringCoordinator {
                     continue
                 }
                 let isStale = session.phase == .completed
-                    && session.updatedAt.addingTimeInterval(Self.codexAppStalenessTimeout) < Date.now
+                    && session.updatedAt.addingTimeInterval(Self.codexAppCompletedRetention) < Date.now
                 if isCodexAppRunning, !isStale {
                     aliveIDs.insert(session.id)
                 }

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -196,6 +196,7 @@
 "island.section.inProgress" = "In progress";
 "island.section.justDone" = "Just done";
 "island.section.idle" = "Idle";
+"island.idleFold.title" = "%1$lld idle · last active %2$@";
 "island.showAll" = "Show all %lld sessions";
 "island.collapseList" = "Collapse list";
 "island.usageWaiting" = "Usage waiting";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -196,6 +196,7 @@
 "island.section.inProgress" = "进行中";
 "island.section.justDone" = "刚完成";
 "island.section.idle" = "空闲";
+"island.idleFold.title" = "%1$lld 个空闲 · 最近活跃 %2$@";
 "island.showAll" = "显示全部 %lld 个会话";
 "island.collapseList" = "收起列表";
 "island.usageWaiting" = "等待用量数据";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -196,6 +196,7 @@
 "island.section.inProgress" = "進行中";
 "island.section.justDone" = "剛完成";
 "island.section.idle" = "閒置";
+"island.idleFold.title" = "%1$lld 個閒置 · 最近活躍 %2$@";
 "island.showAll" = "顯示全部 %lld 個工作階段";
 "island.collapseList" = "收起清單";
 "island.usageWaiting" = "等待用量資料";

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -613,19 +613,7 @@ struct IslandPanelView: View {
                 }
             } else {
                 ForEach(model.islandSessionSections) { section in
-                    if section.id == AppModel.idleFoldSectionID {
-                        idleFoldSection(section, referenceDate: referenceDate)
-                    } else {
-                        VStack(alignment: .leading, spacing: 0) {
-                            if model.islandSessionGroup != .none {
-                                sessionSectionHeader(section)
-                            }
-
-                            ForEach(section.sessions) { session in
-                                sessionRow(session, referenceDate: referenceDate)
-                            }
-                        }
-                    }
+                    sectionBody(section, referenceDate: referenceDate)
                 }
             }
 
@@ -651,17 +639,22 @@ struct IslandPanelView: View {
     @ViewBuilder
     private func sessionRowsContent(referenceDate: Date) -> some View {
         ForEach(model.islandSessionSections) { section in
-            if section.id == AppModel.idleFoldSectionID {
-                idleFoldSection(section, referenceDate: referenceDate)
-            } else {
-                VStack(alignment: .leading, spacing: 0) {
-                    if model.islandSessionGroup != .none {
-                        sessionSectionHeader(section)
-                    }
+            sectionBody(section, referenceDate: referenceDate)
+        }
+    }
 
-                    ForEach(section.sessions) { session in
-                        sessionRow(session, referenceDate: referenceDate)
-                    }
+    @ViewBuilder
+    private func sectionBody(_ section: IslandSessionSection, referenceDate: Date) -> some View {
+        if section.id == AppModel.idleFoldSectionID {
+            idleFoldSection(section, referenceDate: referenceDate)
+        } else {
+            VStack(alignment: .leading, spacing: 0) {
+                if model.islandSessionGroup != .none {
+                    sessionSectionHeader(section)
+                }
+
+                ForEach(section.sessions) { session in
+                    sessionRow(session, referenceDate: referenceDate)
                 }
             }
         }
@@ -737,16 +730,8 @@ struct IslandPanelView: View {
         return lang.t(
             "island.idleFold.title",
             section.sessions.count,
-            idleFoldAgeLabel(newestActivity)
+            AgentSession.islandAgeBadge(since: newestActivity)
         )
-    }
-
-    private func idleFoldAgeLabel(_ date: Date) -> String {
-        let age = max(0, Int(Date.now.timeIntervalSince(date)))
-        if age < 60 { return "<1m" }
-        if age < 3_600 { return "\(max(1, age / 60))m" }
-        if age < 86_400 { return "\(max(1, age / 3_600))h" }
-        return "\(max(1, age / 86_400))d"
     }
 
     private func sessionPanelHeader(referenceDate: Date) -> some View {
@@ -879,7 +864,6 @@ struct IslandPanelView: View {
 
     private func sectionTint(for section: IslandSessionSection) -> Color {
         guard let first = section.sessions.first else { return IslandDesignPalette.Status.idle }
-        if section.id == "state-idle" { return IslandDesignPalette.Status.idle }
         return IslandDesignPalette.Status.tint(for: first.phase)
     }
 

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -108,6 +108,7 @@ struct IslandPanelView: View {
     @State private var showingQuitConfirmation = false
     @State private var keepsOpenedSurfaceMounted = false
     @State private var openedSurfaceMountGeneration: UInt64 = 0
+    @State private var isIdleFoldExpanded = false
 
     private var isOpened: Bool {
         model.notchStatus == .opened
@@ -612,29 +613,17 @@ struct IslandPanelView: View {
                 }
             } else {
                 ForEach(model.islandSessionSections) { section in
-                    VStack(alignment: .leading, spacing: 0) {
-                        if model.islandSessionGroup != .none {
-                            sessionSectionHeader(section)
-                        }
+                    if section.id == AppModel.idleFoldSectionID {
+                        idleFoldSection(section, referenceDate: referenceDate)
+                    } else {
+                        VStack(alignment: .leading, spacing: 0) {
+                            if model.islandSessionGroup != .none {
+                                sessionSectionHeader(section)
+                            }
 
-                        ForEach(section.sessions) { session in
-                            IslandSessionRow(
-                                session: session,
-                                referenceDate: referenceDate,
-                                stateIndicator: model.islandSessionStateIndicator,
-                                completedStaleThreshold: model.completedStaleThreshold.seconds,
-                                isActionable: session.phase.requiresAttention || session.id == actionableSessionID,
-                                useDrawingGroup: model.notchStatus == .opened,
-                                isInteractive: model.notchStatus == .opened,
-                                sideInset: sessionListSideInset,
-                                lang: model.lang,
-                                onApprove: { model.approvePermission(for: session.id, action: $0) },
-                                onAnswer: { model.answerQuestion(for: session.id, answer: $0) },
-                                onReply: TerminalTextSender.canReply(to: session, enabled: model.completionReplyEnabled)
-                                    ? { model.replyToSession(session, text: $0) } : nil,
-                                onJump: { model.jumpToSession(session) },
-                                onDismiss: session.isRemote ? { model.dismissSession(session.id) } : nil
-                            )
+                            ForEach(section.sessions) { session in
+                                sessionRow(session, referenceDate: referenceDate)
+                            }
                         }
                     }
                 }
@@ -662,32 +651,102 @@ struct IslandPanelView: View {
     @ViewBuilder
     private func sessionRowsContent(referenceDate: Date) -> some View {
         ForEach(model.islandSessionSections) { section in
-            VStack(alignment: .leading, spacing: 0) {
-                if model.islandSessionGroup != .none {
-                    sessionSectionHeader(section)
-                }
+            if section.id == AppModel.idleFoldSectionID {
+                idleFoldSection(section, referenceDate: referenceDate)
+            } else {
+                VStack(alignment: .leading, spacing: 0) {
+                    if model.islandSessionGroup != .none {
+                        sessionSectionHeader(section)
+                    }
 
-                ForEach(section.sessions) { session in
-                    IslandSessionRow(
-                        session: session,
-                        referenceDate: referenceDate,
-                        stateIndicator: model.islandSessionStateIndicator,
-                        completedStaleThreshold: model.completedStaleThreshold.seconds,
-                        isActionable: session.phase.requiresAttention || session.id == actionableSessionID,
-                        useDrawingGroup: model.notchStatus == .opened,
-                        isInteractive: model.notchStatus == .opened,
-                        sideInset: sessionListSideInset,
-                        lang: model.lang,
-                        onApprove: { model.approvePermission(for: session.id, action: $0) },
-                        onAnswer: { model.answerQuestion(for: session.id, answer: $0) },
-                        onReply: TerminalTextSender.canReply(to: session, enabled: model.completionReplyEnabled)
-                            ? { model.replyToSession(session, text: $0) } : nil,
-                        onJump: { model.jumpToSession(session) },
-                        onDismiss: session.isRemote ? { model.dismissSession(session.id) } : nil
-                    )
+                    ForEach(section.sessions) { session in
+                        sessionRow(session, referenceDate: referenceDate)
+                    }
                 }
             }
         }
+    }
+
+    private func sessionRow(_ session: AgentSession, referenceDate: Date) -> IslandSessionRow {
+        IslandSessionRow(
+            session: session,
+            referenceDate: referenceDate,
+            stateIndicator: model.islandSessionStateIndicator,
+            completedStaleThreshold: model.completedStaleThreshold.seconds,
+            isActionable: session.phase.requiresAttention || session.id == actionableSessionID,
+            useDrawingGroup: model.notchStatus == .opened,
+            isInteractive: model.notchStatus == .opened,
+            sideInset: sessionListSideInset,
+            lang: model.lang,
+            onApprove: { model.approvePermission(for: session.id, action: $0) },
+            onAnswer: { model.answerQuestion(for: session.id, answer: $0) },
+            onReply: TerminalTextSender.canReply(to: session, enabled: model.completionReplyEnabled)
+                ? { model.replyToSession(session, text: $0) } : nil,
+            onJump: { model.jumpToSession(session) },
+            onDismiss: session.isRemote ? { model.dismissSession(session.id) } : nil
+        )
+    }
+
+    /// Collapsed idle row: completed sessions past the stale threshold fold
+    /// into a single line so the active sessions own the list. Click to
+    /// expand back into full rows (jump-to-terminal preserved).
+    private func idleFoldSection(_ section: IslandSessionSection, referenceDate: Date) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button {
+                withAnimation(openAnimation) {
+                    isIdleFoldExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(IslandDesignPalette.Status.idle)
+                        .frame(width: 7, height: 7)
+                    Text(idleFoldTitle(for: section))
+                        .font(.system(size: 10.5, weight: .semibold, design: .monospaced))
+                        .tracking(0.4)
+                        .foregroundStyle(V6Palette.paper.opacity(0.48))
+                    Spacer(minLength: 0)
+                    Image(systemName: isIdleFoldExpanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(V6Palette.paper.opacity(0.36))
+                }
+                .padding(.leading, sessionListSideInset)
+                .padding(.trailing, sessionListSideInset)
+                .padding(.top, 10)
+                .padding(.bottom, 7)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if isIdleFoldExpanded {
+                ForEach(section.sessions) { session in
+                    sessionRow(session, referenceDate: referenceDate)
+                }
+            }
+        }
+        .background(Color.white.opacity(0.008))
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(.white.opacity(0.055))
+                .frame(height: 1)
+        }
+    }
+
+    private func idleFoldTitle(for section: IslandSessionSection) -> String {
+        let newestActivity = section.sessions.map(\.islandActivityDate).max() ?? .now
+        return lang.t(
+            "island.idleFold.title",
+            section.sessions.count,
+            idleFoldAgeLabel(newestActivity)
+        )
+    }
+
+    private func idleFoldAgeLabel(_ date: Date) -> String {
+        let age = max(0, Int(Date.now.timeIntervalSince(date)))
+        if age < 60 { return "<1m" }
+        if age < 3_600 { return "\(max(1, age / 60))m" }
+        if age < 86_400 { return "\(max(1, age / 3_600))h" }
+        return "\(max(1, age / 86_400))d"
     }
 
     private func sessionPanelHeader(referenceDate: Date) -> some View {

--- a/Sources/OpenIslandCore/AgentEvent.swift
+++ b/Sources/OpenIslandCore/AgentEvent.swift
@@ -54,17 +54,24 @@ public struct SessionActivityUpdated: Equatable, Codable, Sendable {
     public var summary: String
     public var phase: SessionPhase
     public var timestamp: Date
+    /// True when `.completed` was inferred from a quiet rollout file by the
+    /// stall reaper rather than observed as a real turn completion. Lets the
+    /// session state mark the completion as revivable by later rollout
+    /// activity.
+    public var isStallReap: Bool?
 
     public init(
         sessionID: String,
         summary: String,
         phase: SessionPhase,
-        timestamp: Date
+        timestamp: Date,
+        isStallReap: Bool? = nil
     ) {
         self.sessionID = sessionID
         self.summary = summary
         self.phase = phase
         self.timestamp = timestamp
+        self.isStallReap = isStallReap
     }
 }
 

--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -401,6 +401,14 @@ public struct AgentSession: Equatable, Identifiable, Codable, Sendable {
     /// is considered gone. This prevents flicker from momentary `ps` gaps.
     public var processNotSeenCount: Int = 0
 
+    /// True when `.completed` was inferred by the stall reaper (a Codex.app
+    /// session whose rollout file went quiet) rather than a real turn
+    /// completion. Transient by design — never persisted — so a later rollout
+    /// write can revive the session back to `.running`. Without this flag the
+    /// "bridge completion is authoritative" guard would treat any subsequent
+    /// rollout `activityUpdated(running)` event as a stale race and drop it.
+    public var isStallReaped: Bool = false
+
     public init(
         id: String,
         title: String,

--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -133,6 +133,13 @@ public enum SessionPhase: String, Codable, Sendable, CaseIterable {
             false
         }
     }
+
+    /// Running, or paused mid-turn waiting on the user (approval / answer).
+    /// Drives the ×N badge, spotlight detail lines, and prompt-headline
+    /// preference — anywhere the question is "is this turn still live".
+    public var isActiveTurn: Bool {
+        self == .running || requiresAttention
+    }
 }
 
 public struct JumpTarget: Equatable, Codable, Sendable {

--- a/Sources/OpenIslandCore/CodexSessionTracking.swift
+++ b/Sources/OpenIslandCore/CodexSessionTracking.swift
@@ -420,6 +420,11 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             .appendingPathComponent(".codex/sessions", isDirectory: true)
     }
 
+    /// Scan window shared with the app layer: completed Codex.app sessions
+    /// stay resident (folded) for the same duration their rollouts remain
+    /// discoverable. Change this and both move together.
+    public static let defaultMaxAge: TimeInterval = 86_400
+
     private let rootURL: URL
     private let fileManager: FileManager
     private let maxAge: TimeInterval
@@ -437,7 +442,7 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
     public init(
         rootURL: URL = CodexRolloutDiscovery.defaultRootURL,
         fileManager: FileManager = .default,
-        maxAge: TimeInterval = 86_400,
+        maxAge: TimeInterval = CodexRolloutDiscovery.defaultMaxAge,
         maxFiles: Int = 40
     ) {
         self.rootURL = rootURL

--- a/Sources/OpenIslandCore/CodexSessionTracking.swift
+++ b/Sources/OpenIslandCore/CodexSessionTracking.swift
@@ -257,6 +257,15 @@ public enum CodexArchivedSessionIndex: Sendable {
 }
 
 public enum CodexAppSessionReconciler {
+    /// How long a `.running` Codex.app session's rollout file may stay quiet
+    /// before the session is demoted to `.completed`. Turns that end on a
+    /// reasoning event never flush `turn_complete`, so without this timeout
+    /// such sessions pin at `.running` forever — inflating the session list,
+    /// the `×N` badge, and any "agents are busy" derived state. `waiting`
+    /// phases are never reaped: a quiet file while waiting on the user is
+    /// expected. A later rollout write revives the session.
+    public static let runningStallTimeout: TimeInterval = 600
+
     public static func reconciliationEvents(
         for sessions: [AgentSession],
         archivedSessionIDs: Set<String>,
@@ -320,12 +329,35 @@ public enum CodexAppSessionReconciler {
                     sessionID: session.id,
                     summary: "Turn stalled.",
                     phase: .completed,
-                    timestamp: now
+                    timestamp: now,
+                    isStallReap: true
+                )
+            )
+        }
+
+        // File exists but has been quiet past the stall timeout. The
+        // timestamp preserves the file's real last-write time so the reaped
+        // session goes straight into the idle bucket instead of flashing
+        // "just done" first.
+        if let modifiedAt = Self.fileModificationDate(transcriptPath, fileManager: fileManager),
+           now.timeIntervalSince(modifiedAt) >= Self.runningStallTimeout {
+            return .activityUpdated(
+                SessionActivityUpdated(
+                    sessionID: session.id,
+                    summary: "Turn stalled.",
+                    phase: .completed,
+                    timestamp: modifiedAt,
+                    isStallReap: true
                 )
             )
         }
 
         return nil
+    }
+
+    private static func fileModificationDate(_ path: String, fileManager: FileManager) -> Date? {
+        let attributes = try? fileManager.attributesOfItem(atPath: path)
+        return attributes?[.modificationDate] as? Date
     }
 
     private static func isArchivedTranscriptPath(_ transcriptPath: String?) -> Bool {

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -90,6 +90,14 @@ public struct SessionState: Equatable, Sendable {
                 return
             }
 
+            // A stall reap marks the completion as inferred (revivable);
+            // any later running activity supersedes that inference.
+            if payload.isStallReap == true {
+                session.isStallReaped = true
+            } else if payload.phase == .running {
+                session.isStallReaped = false
+            }
+
             let keepsPendingApproval = payload.phase == .running
                 && session.phase == .waitingForApproval
                 && session.permissionRequest != nil
@@ -146,6 +154,7 @@ public struct SessionState: Equatable, Sendable {
             session.permissionRequest = nil
             session.questionPrompt = nil
             session.updatedAt = payload.timestamp
+            session.isStallReaped = false
             if payload.isSessionEnd == true {
                 session.isSessionEnded = true
             }

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -364,6 +364,53 @@ struct AppModelSessionListTests {
     }
 
     @Test
+    func stallReapedSessionsFoldImmediatelyEvenWithLargerStaleThreshold() {
+        let now = Date()
+        let model = AppModel()
+        // A 20-min stale threshold exceeds the 10-min stall timeout: a
+        // just-reaped session (quiet for ~11 min) would otherwise sit in
+        // "Just done" for up to 10 minutes before folding.
+        model.updateAppearancePreferences(for: .topBar) {
+            $0.sessionGroup = .state
+            $0.completedStaleThreshold = .twentyMinutes
+        }
+
+        var reaped = listSession(id: "reaped", phase: .completed, updatedAt: now.addingTimeInterval(-660))
+        reaped.isProcessAlive = true
+        reaped.isStallReaped = true
+        var freshDone = listSession(id: "fresh-done", phase: .completed, updatedAt: now.addingTimeInterval(-60))
+        freshDone.isProcessAlive = true
+
+        model.state = SessionState(sessions: [reaped, freshDone])
+        model.overlayPlacementDiagnostics = placementDiagnostics(mode: .topBar)
+
+        #expect(model.islandSessionSections.map(\.id) == ["state-done", AppModel.idleFoldSectionID])
+        #expect(model.islandSessionSections.first?.sessions.first?.id == "fresh-done")
+        #expect(model.islandSessionSections.last?.sessions.first?.id == "reaped")
+    }
+
+    @Test
+    func stallReapedSessionsStayFullRowsWhenStaleThresholdIsNever() {
+        let now = Date()
+        let model = AppModel()
+        model.updateAppearancePreferences(for: .topBar) {
+            $0.completedStaleThreshold = .never
+        }
+
+        var reaped = listSession(id: "reaped", phase: .completed, updatedAt: now.addingTimeInterval(-660))
+        reaped.isProcessAlive = true
+        reaped.isStallReaped = true
+
+        model.state = SessionState(sessions: [reaped])
+        model.overlayPlacementDiagnostics = placementDiagnostics(mode: .topBar)
+
+        // `.never` is an explicit user preference for no folding — it wins
+        // over the reaped-session fast path.
+        #expect(model.islandSessionSections.map(\.id) == ["all"])
+        #expect(model.islandSessionSections.first?.sessions.first?.id == "reaped")
+    }
+
+    @Test
     func closedIslandCountBadgeCountsActiveSessionsOnly() {
         let now = Date()
         let model = AppModel()

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -338,8 +338,101 @@ struct AppModelSessionListTests {
         model.state = SessionState(sessions: [stale, done, approval])
         model.overlayPlacementDiagnostics = placementDiagnostics(mode: .topBar)
 
-        #expect(model.islandSessionSections.map(\.id) == ["state-approval", "state-done", "state-idle"])
+        #expect(model.islandSessionSections.map(\.id) == ["state-approval", "state-done", AppModel.idleFoldSectionID])
         #expect(model.islandSessionSections.map(\.sessions.first?.id) == ["approval", "done", "stale"])
+    }
+
+    @Test
+    func islandSectionsFoldStaleCompletedSessionsInDefaultGrouping() {
+        let now = Date()
+        let model = AppModel()
+
+        var running = listSession(id: "running", phase: .running, updatedAt: now)
+        running.isProcessAlive = true
+        var stale = listSession(id: "stale", phase: .completed, updatedAt: now.addingTimeInterval(-3_600))
+        stale.isProcessAlive = true
+
+        model.state = SessionState(sessions: [running, stale])
+
+        let sections = model.islandSessionSections
+        #expect(sections.map(\.id) == ["all", AppModel.idleFoldSectionID])
+        #expect(sections.first?.sessions.map(\.id) == ["running"])
+        #expect(sections.last?.sessions.map(\.id) == ["stale"])
+        // Folded sessions stay in islandListSessions so the overview totals
+        // (总运行/完成/空闲) keep counting them.
+        #expect(model.islandListSessions.map(\.id) == ["running", "stale"])
+    }
+
+    @Test
+    func closedIslandCountBadgeCountsActiveSessionsOnly() {
+        let now = Date()
+        let model = AppModel()
+        model.updateAppearancePreferences(for: .topBar) {
+            $0.rightSlot = .count
+        }
+        model.overlayPlacementDiagnostics = placementDiagnostics(mode: .topBar)
+
+        var running = listSession(id: "running", phase: .running, updatedAt: now)
+        running.isProcessAlive = true
+        var staleIdle = listSession(id: "idle", phase: .completed, updatedAt: now.addingTimeInterval(-3_600))
+        staleIdle.isProcessAlive = true
+
+        model.state = SessionState(sessions: [running, staleIdle])
+        #expect(model.islandClosedRightSlotContent() == .count(1))
+
+        // All sessions idle → the badge disappears entirely.
+        var finished = listSession(id: "running", phase: .completed, updatedAt: now.addingTimeInterval(-60))
+        finished.isProcessAlive = true
+        model.state = SessionState(sessions: [finished, staleIdle])
+        #expect(model.islandClosedRightSlotContent() == nil)
+    }
+
+    @Test
+    func stallReapedSessionsReviveFromSubsequentRolloutRunningEvents() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let model = AppModel()
+
+        var reaped = listSession(id: "reaped", phase: .completed, updatedAt: now.addingTimeInterval(-3_600))
+        reaped.isProcessAlive = true
+        reaped.isStallReaped = true
+        model.state = SessionState(sessions: [reaped])
+
+        model.applyTrackedEvent(
+            .activityUpdated(
+                SessionActivityUpdated(
+                    sessionID: "reaped",
+                    summary: "Working again.",
+                    phase: .running,
+                    timestamp: now
+                )
+            ),
+            updateLastActionMessage: false,
+            ingress: .rollout
+        )
+
+        #expect(model.state.session(id: "reaped")?.phase == .running)
+        #expect(model.state.session(id: "reaped")?.isStallReaped == false)
+
+        // Control: a genuine completion still wins over stale rollout
+        // running events (the original anti-flapping guard).
+        var genuinelyDone = listSession(id: "done", phase: .completed, updatedAt: now.addingTimeInterval(-60))
+        genuinelyDone.isProcessAlive = true
+        model.state = SessionState(sessions: [genuinelyDone])
+
+        model.applyTrackedEvent(
+            .activityUpdated(
+                SessionActivityUpdated(
+                    sessionID: "done",
+                    summary: "Stale watcher race.",
+                    phase: .running,
+                    timestamp: now.addingTimeInterval(1)
+                )
+            ),
+            updateLastActionMessage: false,
+            ingress: .rollout
+        )
+
+        #expect(model.state.session(id: "done")?.phase == .completed)
     }
 
     @Test

--- a/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
@@ -691,6 +691,67 @@ struct CodexSessionTrackingTests {
     }
 
     @Test
+    func codexAppSessionReconcilerReapsQuietRunningSessions() throws {
+        let quietDate = Date.now.addingTimeInterval(-CodexAppSessionReconciler.runningStallTimeout - 120)
+        let events = try stalledReapEvents(phase: .running, modifiedAt: quietDate)
+
+        #expect(events.count == 1)
+        let payload = events.first?.trackedActivityUpdate
+        #expect(payload?.phase == .completed)
+        #expect(payload?.summary == "Turn stalled.")
+        #expect(payload?.isStallReap == true)
+        // The reap preserves the file's real last-write time so the session
+        // folds into the idle bucket instead of flashing "just done".
+        #expect(abs((payload?.timestamp ?? .distantFuture).timeIntervalSince(quietDate)) < 1)
+    }
+
+    @Test
+    func codexAppSessionReconcilerKeepsRunningSessionsWithFreshRollouts() throws {
+        let events = try stalledReapEvents(phase: .running, modifiedAt: .now.addingTimeInterval(-30))
+        #expect(events.isEmpty)
+    }
+
+    @Test
+    func codexAppSessionReconcilerNeverReapsWaitingSessions() throws {
+        // A quiet file while waiting on the user is expected — approval and
+        // question states must survive an arbitrarily long wait.
+        let quietDate = Date.now.addingTimeInterval(-CodexAppSessionReconciler.runningStallTimeout - 3_600)
+        #expect(try stalledReapEvents(phase: .waitingForApproval, modifiedAt: quietDate).isEmpty)
+        #expect(try stalledReapEvents(phase: .waitingForAnswer, modifiedAt: quietDate).isEmpty)
+    }
+
+    /// Builds a Codex.app session backed by a temp rollout file with the
+    /// given modification date and runs the stall reconciler over it.
+    private func stalledReapEvents(phase: SessionPhase, modifiedAt: Date) throws -> [AgentEvent] {
+        let rolloutURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rollout-stall-\(UUID().uuidString).jsonl")
+        try Data("{}".utf8).write(to: rolloutURL)
+        try FileManager.default.setAttributes([.modificationDate: modifiedAt], ofItemAtPath: rolloutURL.path)
+        defer { try? FileManager.default.removeItem(at: rolloutURL) }
+
+        var session = AgentSession(
+            id: "codex-session-stall",
+            title: "Codex · demo",
+            tool: .codex,
+            origin: .live,
+            attachmentState: .attached,
+            phase: phase,
+            summary: "Thinking.",
+            updatedAt: .now,
+            jumpTarget: JumpTarget(
+                terminalApp: "Codex.app",
+                workspaceName: "demo",
+                paneTitle: "Codex",
+                workingDirectory: "/tmp/demo",
+                codexThreadID: "codex-session-stall"
+            )
+        )
+        session.codexMetadata = CodexSessionMetadata(transcriptPath: rolloutURL.path)
+
+        return CodexAppSessionReconciler.stalledRunningEvents(for: [session])
+    }
+
+    @Test
     func codexRolloutReducerMarksPrimaryRateLimitWhileAwaitingAgentResponse() {
         let initialSnapshot = CodexRolloutReducer.snapshot(for: [
             rolloutLine(

--- a/Tests/OpenIslandCoreTests/SessionStateTests.swift
+++ b/Tests/OpenIslandCoreTests/SessionStateTests.swift
@@ -5,6 +5,77 @@ import Testing
 
 /// Regression coverage for core session lifecycle and visibility behavior.
 struct SessionStateTests {
+    /// Stall-reap completions are revivable: the flag stays set until real
+    /// running activity or a genuine completion supersedes the inference.
+    @Test
+    func stallReapFlagIsSetAndClearedBySubsequentEvents() {
+        let startedAt = Date(timeIntervalSince1970: 5_000)
+        var state = SessionState()
+        state.apply(
+            .sessionStarted(
+                SessionStarted(
+                    sessionID: "codex-stalled",
+                    title: "Codex · demo",
+                    tool: .codex,
+                    origin: .live,
+                    summary: "Thinking.",
+                    timestamp: startedAt
+                )
+            )
+        )
+
+        state.apply(
+            .activityUpdated(
+                SessionActivityUpdated(
+                    sessionID: "codex-stalled",
+                    summary: "Turn stalled.",
+                    phase: .completed,
+                    timestamp: startedAt.addingTimeInterval(600),
+                    isStallReap: true
+                )
+            )
+        )
+        #expect(state.session(id: "codex-stalled")?.phase == .completed)
+        #expect(state.session(id: "codex-stalled")?.isStallReaped == true)
+
+        // Rollout activity resumes → the inferred completion is superseded.
+        state.apply(
+            .activityUpdated(
+                SessionActivityUpdated(
+                    sessionID: "codex-stalled",
+                    summary: "Working again.",
+                    phase: .running,
+                    timestamp: startedAt.addingTimeInterval(700)
+                )
+            )
+        )
+        #expect(state.session(id: "codex-stalled")?.phase == .running)
+        #expect(state.session(id: "codex-stalled")?.isStallReaped == false)
+
+        // A real turn completion clears any lingering reap inference.
+        state.apply(
+            .activityUpdated(
+                SessionActivityUpdated(
+                    sessionID: "codex-stalled",
+                    summary: "Turn stalled.",
+                    phase: .completed,
+                    timestamp: startedAt.addingTimeInterval(1_400),
+                    isStallReap: true
+                )
+            )
+        )
+        state.apply(
+            .sessionCompleted(
+                SessionCompleted(
+                    sessionID: "codex-stalled",
+                    summary: "Turn finished for real.",
+                    timestamp: startedAt.addingTimeInterval(1_500)
+                )
+            )
+        )
+        #expect(state.session(id: "codex-stalled")?.isStallReaped == false)
+    }
+
     /// Completed Codex CLI sessions outside Codex.app should age out even while Codex.app is running.
     @Test
     func completedCodexCLISessionEndsEvenWhenCodexAppIsRunning() {

--- a/docs/session-state-refactor.md
+++ b/docs/session-state-refactor.md
@@ -83,6 +83,29 @@ REMOVAL:
 
 The "2 consecutive polls" requirement prevents flicker from momentary `ps` gaps.
 
+### Codex.app Deviation: App-Level Liveness + Stall Reaping
+
+Codex.app threads have no per-session subprocess visible to `ps`, so their
+liveness is app-level (Codex.app running). Two rules keep that exemption
+honest:
+
+- **Stall reaping** (`CodexAppSessionReconciler.runningStallTimeout`, 10 min):
+  a `.running` Codex.app session whose rollout file has been quiet past the
+  timeout is demoted to `.completed` *silently* (an `activityUpdated` event
+  produces no notification card or sound) and keeps the file's real
+  last-write time as its activity date, so it goes straight into the idle
+  fold. Turns that end on a reasoning event never flush `turn_complete`;
+  without this rule they pin at `.running` forever. `waiting` phases are
+  never reaped — a quiet file while waiting on the user is expected.
+- **Revival**: reaped completions are marked (`AgentSession.isStallReaped`,
+  transient, never persisted), so a later rollout append may demote them
+  back to `.running` — the "bridge completion is authoritative" guard lets
+  rollout running-events through for reaped sessions only.
+
+Completed Codex.app sessions stay resident while their rollout is inside the
+24h discovery window (`ProcessMonitoringCoordinator.codexAppCompletedRetention`)
+and fold into the collapsed idle row instead of occupying full list rows.
+
 ### State Model Changes
 
 **Remove:**


### PR DESCRIPTION
## Problem

Codex.app turns that end on a reasoning event (`agent_reasoning`) never flush `turn_complete` to their rollout file. Those sessions pinned at `.running` forever, and the Codex.app keep-alive exemption had **no timeout for running sessions** — only completed ones aged out. With the desktop app running, every such zombie stayed visible indefinitely. Three symptoms, one root:

1. **Session list flooded** — 30+ dead sessions drowned out the real ones (32 observed on a real machine, most stuck on a final "Thinking." record).
2. **×N badge meaningless** — the collapsed-island count included every zombie.
3. **Keep-awake pinned** — any "agents are busy" derived state (e.g. `PreventUserIdleSystemSleep` while a session runs) was held permanently by dead sessions.

## Fix

**Stall reaping** (`CodexAppSessionReconciler`) — a `.running` Codex.app session whose rollout file has been quiet past `runningStallTimeout` (10 min, matching the previous completed-session staleness window) is demoted to `.completed`:

- **File activity is the primary signal** — a genuinely running turn keeps writing rollout events; a dead one's file goes quiet. Time is only the fallback bound.
- **Waiting phases are never reaped** — approval/question waits commonly outlive any timeout; that's the user's decision pending, not a stall.
- **Revivable** — reaped completions carry a transient `isStallReaped` marker (never persisted) that lets a later rollout append demote the session back to `.running`, bypassing the existing "bridge completion is authoritative" anti-flap guard. A real completion still wins over stale watcher races.
- **Silent** — the reap is an `activityUpdated` event, which produces no notification card or sound, and keeps the file's last-write time so the session goes straight to the idle bucket without flashing "Just done".

**Idle folding** — completed sessions beyond the existing `completedStaleThreshold` preference (default 5 min) collapse into a single bottom row ("20 idle · last active 14h"), click to expand, jump-to-terminal preserved, effective in all grouping modes; `.never` disables folding entirely. Completed Codex.app sessions stay resident for the discovery window (`CodexRolloutDiscovery.defaultMaxAge`, 24 h) instead of being evicted after 10 minutes and re-discovered 10 seconds later.

**Badge** — ×N now counts running + waiting sessions only; an all-idle island shows no badge.

## Verification

Targeted tests: 121 passing across `SessionStateTests`, `CodexSessionTrackingTests`, `AppModelSessionListTests`, `AgentSessionPresentationTests`, including new coverage for reap / no-reap-of-waiting / revival (with a genuine-completion control) / fold bucketing / badge semantics. Harness `sessionList` scenario renders the fold row ("7 个空闲 · 最近活跃 27m" visible in the AX snapshot). Two-axis code review (standards + spec) findings addressed in 06e0628.

Real-machine (merged with `feat/keep-awake-while-agents-busy`, dev bundle):

- List converged from ~32 zombie rows to the true active count within the first reconcile pass (~15 s); persisted registry shows 20 sessions, **all `completed`, 0 `running`** — including previously stuck "Thinking." zombies (reaped, summary `Turn stalled.`, timestamps preserved from file mtime).
- Fold row rendered "20 个空闲 · 最近活跃 14h" and expanded on click into full rows with jump targets.
- `pmset -g assertions`: with no real running session, OpenIslandApp holds **no** `PreventUserIdleSystemSleep` (previously permanent); with a real `claude -p` session it holds it within 4 s and releases within 2 s of completion.
- Badge: all-idle island shows no badge; one real running session shows `×1` alongside the blue keep-awake coffee cup.

## Notes

- `docs/session-state-refactor.md` documents the stall-reap semantics under the Codex.app deviation section.
- The settings-pane grouping preview still shows the legacy "Idle" group chip; harmless demo data, can be updated separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a collapsible idle section for stale or inactive sessions, showing count and last-active time.
  * Active sessions now display consistently across running and attention-required states.
  * Quiet running sessions are automatically marked idle after 10 minutes and can revive when activity resumes.
  * Closed-island badges now count active sessions only.
* **Bug Fixes**
  * Preserved completed sessions during the rollout discovery window.
  * Improved handling of sessions that resume after being marked idle.
* **Localization**
  * Added idle-session labels in English, Simplified Chinese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->