### PR TITLE
fix: resolve VS Code forks so jump-back targets the real editor

### DIFF
--- a/Sources/OpenIslandApp/TerminalJumpService.swift
+++ b/Sources/OpenIslandApp/TerminalJumpService.swift
@@ -477,7 +477,37 @@ struct TerminalJumpService {
         guard let cli = Self.vscodeFamilyCLI[bundleIdentifier] else {
             return false
         }
+
+        // Prefer the launcher shipped inside the app bundle. A GUI-launched app
+        // inherits the LaunchServices PATH (/usr/bin:/bin:/usr/sbin:/sbin),
+        // which contains neither /usr/local/bin nor Homebrew, so resolving the
+        // CLI by bare name fails for most installs and the jump silently
+        // degrades to plain app activation.
+        if let bundledCLI = bundledVSCodeFamilyCLIPath(for: bundleIdentifier, cli: cli),
+           processRunner(bundledCLI, ["-r", workspacePath]) {
+            return true
+        }
+
         return processRunner(cli, ["-r", workspacePath])
+    }
+
+    /// Path to a VS Code family editor's `Contents/Resources/app/bin/<cli>`
+    /// launcher, when the app is installed and ships one.
+    private func bundledVSCodeFamilyCLIPath(for bundleIdentifier: String, cli: String) -> String? {
+        guard let appURL = applicationResolver(bundleIdentifier) else {
+            return nil
+        }
+
+        let cliPath = appURL
+            .appendingPathComponent("Contents/Resources/app/bin")
+            .appendingPathComponent(cli)
+            .path
+
+        guard FileManager.default.isExecutableFile(atPath: cliPath) else {
+            return nil
+        }
+
+        return cliPath
     }
 
     // MARK: - JetBrains IDE family

--- a/Sources/OpenIslandCore/ClaudeHooks.swift
+++ b/Sources/OpenIslandCore/ClaudeHooks.swift
@@ -1220,14 +1220,14 @@ public extension ClaudeHookPayload {
             case "wezterm":
                 return "WezTerm"
             case "vscode":
-                // Cursor also sets TERM_PROGRAM=vscode; check its unique
-                // env var first.
-                if environment["CURSOR_TRACE_ID"] != nil {
-                    return "Cursor"
-                }
-                return "VS Code"
+                // Cursor and the other VS Code forks all inherit
+                // TERM_PROGRAM=vscode; narrow it down to the actual fork.
+                return VSCodeFamilyHost.displayName(from: environment)
             case "vscode-insiders":
-                return "VS Code Insiders"
+                return VSCodeFamilyHost.displayName(
+                    from: environment,
+                    default: "VS Code Insiders"
+                )
             case "windsurf":
                 return "Windsurf"
             case "trae":

--- a/Sources/OpenIslandCore/CodexHooks.swift
+++ b/Sources/OpenIslandCore/CodexHooks.swift
@@ -711,9 +711,14 @@ public extension CodexHookPayload {
             case "kaku":
                 return "Kaku"
             case "vscode":
-                return "VS Code"
+                // Cursor and the other VS Code forks all inherit
+                // TERM_PROGRAM=vscode; narrow it down to the actual fork.
+                return VSCodeFamilyHost.displayName(from: environment)
             case "vscode-insiders":
-                return "VS Code Insiders"
+                return VSCodeFamilyHost.displayName(
+                    from: environment,
+                    default: "VS Code Insiders"
+                )
             case "windsurf":
                 return "Windsurf"
             case "trae":

--- a/Sources/OpenIslandCore/GeminiHooks.swift
+++ b/Sources/OpenIslandCore/GeminiHooks.swift
@@ -365,9 +365,14 @@ public extension GeminiHookPayload {
         case .some("kaku"):
             return "Kaku"
         case .some("vscode"):
-            return "VS Code"
+            // Cursor and the other VS Code forks all inherit
+            // TERM_PROGRAM=vscode; narrow it down to the actual fork.
+            return VSCodeFamilyHost.displayName(from: environment)
         case .some("vscode-insiders"):
-            return "VS Code Insiders"
+            return VSCodeFamilyHost.displayName(
+                from: environment,
+                default: "VS Code Insiders"
+            )
         case .some("windsurf"):
             return "Windsurf"
         case .some("trae"):

--- a/Sources/OpenIslandCore/VSCodeFamilyHost.swift
+++ b/Sources/OpenIslandCore/VSCodeFamilyHost.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Resolves which VS Code family editor hosted a shell.
+///
+/// Every fork of VS Code inherits `TERM_PROGRAM=vscode` from upstream, so that
+/// variable alone identifies the family but not the member. Cursor, Windsurf,
+/// Trae, and Qoder all land on the same value, and only some builds export a
+/// fork-specific marker such as `CURSOR_TRACE_ID`. Tagging those sessions as
+/// "VS Code" sends the jump to `com.microsoft.VSCode`, which then fails
+/// outright on machines where upstream VS Code is not installed.
+///
+/// Callers should consult this only once `TERM_PROGRAM` has already placed the
+/// host in the VS Code family. The corroborating signals below (`__CFBundleIdentifier`,
+/// the bundled git askpass paths) are injected by the hosting GUI app and can
+/// leak across apps through macOS environment inheritance, so they are safe for
+/// picking a family member but not for identifying the family itself.
+public enum VSCodeFamilyHost {
+    /// Bundle identifiers of VS Code family editors, lowercased for matching.
+    private static let displayNamesByBundleIdentifier: [String: String] = [
+        "com.todesktop.230313mzl4w4u92": "Cursor",
+        "com.exafunction.windsurf": "Windsurf",
+        "com.trae.app": "Trae",
+        "cn.trae.app": "Trae",
+        "com.qoder.qoder": "Qoder",
+        "com.microsoft.vscodeinsiders": "VS Code Insiders",
+        "com.microsoft.vscode": "VS Code",
+    ]
+
+    /// Application bundle path fragments, checked against env vars that carry
+    /// an absolute path into the hosting app bundle.
+    private static let displayNamesByBundlePathFragment: [(fragment: String, displayName: String)] = [
+        ("/cursor.app/", "Cursor"),
+        ("/windsurf.app/", "Windsurf"),
+        ("/trae.app/", "Trae"),
+        ("/qoder.app/", "Qoder"),
+        ("/visual studio code - insiders.app/", "VS Code Insiders"),
+        ("/visual studio code.app/", "VS Code"),
+    ]
+
+    /// Env vars whose values point into the hosting editor's app bundle. VS
+    /// Code and every fork export these for the bundled git extension.
+    private static let bundlePathEnvironmentKeys = [
+        "VSCODE_GIT_ASKPASS_NODE",
+        "VSCODE_GIT_ASKPASS_MAIN",
+        "GIT_ASKPASS",
+    ]
+
+    /// Returns the display name of the VS Code family editor hosting the shell,
+    /// falling back to `defaultDisplayName` when no fork can be identified.
+    public static func displayName(
+        from environment: [String: String],
+        default defaultDisplayName: String = "VS Code"
+    ) -> String {
+        // Cursor's own marker, when the build exports it.
+        if environment["CURSOR_TRACE_ID"] != nil {
+            return "Cursor"
+        }
+
+        if let bundleIdentifier = environment["__CFBundleIdentifier"]?.lowercased(),
+           let displayName = displayNamesByBundleIdentifier[bundleIdentifier] {
+            return displayName
+        }
+
+        for key in bundlePathEnvironmentKeys {
+            guard let value = environment[key]?.lowercased(), !value.isEmpty else {
+                continue
+            }
+
+            if let match = displayNamesByBundlePathFragment.first(where: { value.contains($0.fragment) }) {
+                return match.displayName
+            }
+        }
+
+        return defaultDisplayName
+    }
+}

--- a/Tests/OpenIslandAppTests/TerminalJumpServiceTests.swift
+++ b/Tests/OpenIslandAppTests/TerminalJumpServiceTests.swift
@@ -158,6 +158,49 @@ struct TerminalJumpServiceTests {
         #expect(openedArguments.values == [["-b", "com.todesktop.230313mzl4w4u92"]])
     }
 
+    /// The app inherits the LaunchServices PATH, which has neither
+    /// /usr/local/bin nor Homebrew on it, so the bare `cursor` name cannot be
+    /// resolved from a GUI launch. Prefer the launcher inside the app bundle.
+    @Test
+    func vscodeFamilyJumpPrefersTheLauncherInsideTheAppBundle() throws {
+        let invocations = ProcessInvocationBox()
+        let appURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("Cursor-\(UUID().uuidString).app")
+        let binDirectory = appURL.appendingPathComponent("Contents/Resources/app/bin")
+        try FileManager.default.createDirectory(at: binDirectory, withIntermediateDirectories: true)
+        let cliURL = binDirectory.appendingPathComponent("cursor")
+        try Data().write(to: cliURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cliURL.path)
+        defer { try? FileManager.default.removeItem(at: appURL) }
+
+        let service = TerminalJumpService(
+            applicationResolver: { bundleIdentifier in
+                bundleIdentifier == "com.todesktop.230313mzl4w4u92" ? appURL : nil
+            },
+            appRunningChecker: { _ in true },
+            openAction: { _ in },
+            appleScriptRunner: { _ in "" },
+            processRunner: { executable, arguments in
+                invocations.values.append((executable, arguments))
+                return true
+            }
+        )
+
+        let result = try service.jump(
+            to: JumpTarget(
+                terminalApp: "Cursor",
+                workspaceName: "open-vibe-island",
+                paneTitle: "Cursor abc123",
+                workingDirectory: "/Users/test/open-vibe-island"
+            )
+        )
+
+        #expect(result == "Focused the matching Cursor workspace.")
+        #expect(invocations.values.count == 1)
+        #expect(invocations.values.first?.0 == cliURL.path)
+        #expect(invocations.values.first?.1 == ["-r", "/Users/test/open-vibe-island"])
+    }
+
     @Test
     func cursorJumpFallsBackToWorkspaceWhenAppNotRunning() throws {
         let openedArguments = OpenedArgumentsBox()

--- a/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeHooksTests.swift
@@ -345,6 +345,43 @@ struct ClaudeHooksTests {
         #expect(payload.defaultJumpTarget.terminalApp == "Zed")
     }
 
+    /// Regression: Cursor builds that export no `CURSOR_TRACE_ID` fell through
+    /// to the plain "VS Code" branch, so the jump targeted
+    /// `com.microsoft.VSCode` and failed on machines without upstream VS Code.
+    @Test
+    func claudeInferTerminalAppRecognizesCursorWithoutTraceMarker() {
+        let payload = ClaudeHookPayload(
+            cwd: "/tmp/demo", hookEventName: .sessionStart, sessionID: "s1"
+        ).withRuntimeContext(
+            environment: [
+                "TERM_PROGRAM": "vscode",
+                "__CFBundleIdentifier": "com.todesktop.230313mzl4w4u92",
+                "VSCODE_GIT_ASKPASS_MAIN": "/Applications/Cursor.app/Contents/Resources/app/extensions/git/dist/askpass-main.js",
+            ],
+            currentTTYProvider: { nil },
+            terminalLocatorProvider: { _ in (sessionID: nil, tty: nil, title: nil) }
+        )
+
+        #expect(payload.terminalApp == "Cursor")
+        #expect(payload.defaultJumpTarget.terminalApp == "Cursor")
+    }
+
+    @Test
+    func claudeInferTerminalAppKeepsUpstreamVSCodeWhenNoForkSignalIsPresent() {
+        let payload = ClaudeHookPayload(
+            cwd: "/tmp/demo", hookEventName: .sessionStart, sessionID: "s1"
+        ).withRuntimeContext(
+            environment: [
+                "TERM_PROGRAM": "vscode",
+                "__CFBundleIdentifier": "com.microsoft.VSCode",
+            ],
+            currentTTYProvider: { nil },
+            terminalLocatorProvider: { _ in (sessionID: nil, tty: nil, title: nil) }
+        )
+
+        #expect(payload.terminalApp == "VS Code")
+    }
+
     @Test
     func claudeInferTerminalAppRecognizesZedViaBundleIdentifier() {
         let payload = ClaudeHookPayload(

--- a/Tests/OpenIslandCoreTests/VSCodeFamilyHostTests.swift
+++ b/Tests/OpenIslandCoreTests/VSCodeFamilyHostTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import OpenIslandCore
+
+struct VSCodeFamilyHostTests {
+    @Test
+    func resolvesCursorFromItsOwnTraceMarker() {
+        let displayName = VSCodeFamilyHost.displayName(from: ["CURSOR_TRACE_ID": "abc123"])
+
+        #expect(displayName == "Cursor")
+    }
+
+    /// Regression: Cursor builds that ship no `CURSOR_TRACE_ID` were tagged as
+    /// "VS Code", so the jump targeted `com.microsoft.VSCode` and failed
+    /// outright on machines without upstream VS Code installed.
+    @Test
+    func resolvesCursorFromBundleIdentifierWhenTraceMarkerIsAbsent() {
+        let displayName = VSCodeFamilyHost.displayName(
+            from: [
+                "TERM_PROGRAM": "vscode",
+                "__CFBundleIdentifier": "com.todesktop.230313mzl4w4u92",
+            ]
+        )
+
+        #expect(displayName == "Cursor")
+    }
+
+    @Test
+    func resolvesCursorFromGitAskpassBundlePath() {
+        let displayName = VSCodeFamilyHost.displayName(
+            from: [
+                "TERM_PROGRAM": "vscode",
+                "GIT_ASKPASS": "/Applications/Cursor.app/Contents/Resources/app/extensions/git/dist/askpass.sh",
+            ]
+        )
+
+        #expect(displayName == "Cursor")
+    }
+
+    @Test
+    func resolvesWindsurfFromBundleIdentifier() {
+        let displayName = VSCodeFamilyHost.displayName(
+            from: ["__CFBundleIdentifier": "com.exafunction.windsurf"]
+        )
+
+        #expect(displayName == "Windsurf")
+    }
+
+    @Test
+    func fallsBackToUpstreamVSCodeWhenNoForkSignalIsPresent() {
+        #expect(VSCodeFamilyHost.displayName(from: ["TERM_PROGRAM": "vscode"]) == "VS Code")
+        #expect(
+            VSCodeFamilyHost.displayName(
+                from: ["__CFBundleIdentifier": "com.microsoft.VSCode"]
+            ) == "VS Code"
+        )
+    }
+
+    @Test
+    func keepsCallerSuppliedDefaultForInsiders() {
+        let displayName = VSCodeFamilyHost.displayName(
+            from: ["TERM_PROGRAM": "vscode-insiders"],
+            default: "VS Code Insiders"
+        )
+
+        #expect(displayName == "VS Code Insiders")
+    }
+}


### PR DESCRIPTION
## Problem

Clicking a session row does nothing for Claude Code sessions run inside Cursor.

Every VS Code fork inherits `TERM_PROGRAM=vscode`, and `inferTerminalApp` only separated Cursor from upstream VS Code via `CURSOR_TRACE_ID`. Cursor 3.18.9 doesn't export that variable, so the session is tagged `VS Code`, the jump resolves `com.microsoft.VSCode`, and on a machine with no upstream VS Code installed every branch fails:

- `jumpToVSCodeFamilyWorkspace` runs `code -r <dir>` → no such CLI
- `appIsRunning` is false → no activation
- the working-directory fallback runs `open -b com.microsoft.VSCode <dir>` → throws

The user sees a row that swallows clicks.

## Changes

**`VSCodeFamilyHost`** (new, `OpenIslandCore`) narrows an already-identified VS Code family host to the actual fork, using `__CFBundleIdentifier` and then the bundled git askpass paths (`VSCODE_GIT_ASKPASS_NODE` / `GIT_ASKPASS`, which point into the hosting app bundle). Wired into the Claude, Codex, and Gemini hook detectors, all three of which had the same `case "vscode": return "VS Code"`.

Those signals leak across apps through macOS GUI environment inheritance, which is exactly what the existing `TERM_PROGRAM` comments warn about — so they are consulted *only* after `TERM_PROGRAM` has already placed the host in the VS Code family. They pick a family member; they never pick the family.

**Bundled CLI resolution** in `TerminalJumpService`: `jumpToVSCodeFamilyWorkspace` now prefers `<App>.app/Contents/Resources/app/bin/<cli>` before falling back to the bare name. A GUI-launched app inherits the LaunchServices `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`), which contains neither `/usr/local/bin` nor Homebrew, so `cursor -r <dir>` could not be resolved even with the right editor identified — the jump silently degraded to plain app activation and lost the workspace targeting.

## Verification

- `swift test` — new `VSCodeFamilyHostTests`, two `ClaudeHooksTests` regressions (Cursor without the trace marker; upstream VS Code still resolves to VS Code), and a `TerminalJumpServiceTests` case asserting the in-bundle launcher is preferred with the right arguments. Full suite (376 tests) passes.
- `zsh scripts/harness.sh lint docs` passes.
- The environment in the new Cursor fixtures was captured from a real Cursor 3.18.9 integrated-terminal shell on macOS 26.2: `TERM_PROGRAM=vscode`, no `CURSOR_TRACE_ID`, `__CFBundleIdentifier=com.todesktop.230313mzl4w4u92`, `GIT_ASKPASS=/Applications/Cursor.app/...`. That machine has no upstream VS Code installed, which is where the jump failure was originally observed.
- Not yet exercised end-to-end on the other two hook sources (Codex, Gemini); the change there is the same one-line call.

Not fixed here: VS Code family editors expose no way to focus a specific integrated terminal from outside, so the jump lands on the workspace window, not the exact terminal tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved detection of VS Code-family editors, including Cursor, Windsurf, and other compatible forks.
  * Terminal sessions now display the specific editor hosting them instead of a generic VS Code label.
  * Workspace jumping now prefers the editor’s bundled command-line launcher for more reliable navigation.

* **Bug Fixes**
  * Improved workspace focus behavior when launched from graphical applications with limited PATH settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->