### PR TITLE
feat: show every usage window in the island header, with reset countdowns

### DIFF
--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -849,12 +849,38 @@ struct IslandPanelView: View {
         let providers = openedUsageProviders
 
         if providers.isEmpty == false {
-            ViewThatFits(in: .horizontal) {
-                compactUsageSummaryView(providers, usesShortTitles: false)
-                compactUsageSummaryView(providers, usesShortTitles: true)
-            }
+            adaptiveUsageSummaryView(providers)
         } else {
             Color.clear
+        }
+    }
+
+    /// Renders the usage chips at the richest layout that fits the available
+    /// width, shedding detail one step at a time: reset countdowns first, then
+    /// the secondary windows, with the provider title abbreviated at each step
+    /// before anything is dropped.
+    @ViewBuilder
+    private func adaptiveUsageSummaryView(
+        _ providers: [UsageProviderPresentation]
+    ) -> some View {
+        // Re-render on a slow cadence so the reset countdowns stay honest
+        // while the panel is held open.
+        TimelineView(.periodic(from: .now, by: 30)) { _ in
+            usageSummaryLadder(providers)
+        }
+    }
+
+    @ViewBuilder
+    private func usageSummaryLadder(
+        _ providers: [UsageProviderPresentation]
+    ) -> some View {
+        ViewThatFits(in: .horizontal) {
+            compactUsageSummaryView(providers, layout: .init(usesShortTitle: false, showsAllWindows: true, showsRemaining: true))
+            compactUsageSummaryView(providers, layout: .init(usesShortTitle: true, showsAllWindows: true, showsRemaining: true))
+            compactUsageSummaryView(providers, layout: .init(usesShortTitle: false, showsAllWindows: true, showsRemaining: false))
+            compactUsageSummaryView(providers, layout: .init(usesShortTitle: true, showsAllWindows: true, showsRemaining: false))
+            compactUsageSummaryView(providers, layout: .init(usesShortTitle: false, showsAllWindows: false, showsRemaining: false))
+            compactUsageSummaryView(providers, layout: .init(usesShortTitle: true, showsAllWindows: false, showsRemaining: false))
         }
     }
 
@@ -956,11 +982,8 @@ struct IslandPanelView: View {
             Color.clear
                 .frame(maxWidth: .infinity)
         } else {
-            ViewThatFits(in: .horizontal) {
-                compactUsageSummaryView(providers, usesShortTitles: false)
-                compactUsageSummaryView(providers, usesShortTitles: true)
-            }
-            .frame(maxWidth: .infinity, alignment: alignment)
+            adaptiveUsageSummaryView(providers)
+                .frame(maxWidth: .infinity, alignment: alignment)
         }
     }
 
@@ -1019,30 +1042,49 @@ struct IslandPanelView: View {
 
     private func compactUsageSummaryView(
         _ providers: [UsageProviderPresentation],
-        usesShortTitles: Bool
+        layout: UsageChipLayout
     ) -> some View {
         HStack(spacing: 7) {
             ForEach(providers) { provider in
-                compactUsageChip(provider, usesShortTitle: usesShortTitles)
+                compactUsageChip(provider, layout: layout)
             }
         }
         .lineLimit(1)
         .fixedSize(horizontal: true, vertical: false)
     }
 
-    private func compactUsageChip(_ provider: UsageProviderPresentation, usesShortTitle: Bool) -> some View {
-        HStack(spacing: 5) {
-            Text(usesShortTitle ? provider.shortTitle : provider.title)
+    private func compactUsageChip(
+        _ provider: UsageProviderPresentation,
+        layout: UsageChipLayout
+    ) -> some View {
+        let windows = layout.showsAllWindows
+            ? provider.windows
+            : (provider.peakWindow.map { [$0] } ?? [])
+
+        return HStack(spacing: 6) {
+            Text(layout.usesShortTitle ? provider.shortTitle : provider.title)
                 .font(.system(size: 11, weight: .semibold))
                 .foregroundStyle(.white.opacity(0.74))
 
-            Text(provider.peakWindowLabel)
-                .font(.system(size: 10.5, weight: .semibold, design: .monospaced))
-                .foregroundStyle(.white.opacity(0.42))
+            ForEach(windows) { window in
+                HStack(spacing: 4) {
+                    Text(window.label)
+                        .font(.system(size: 10.5, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(.white.opacity(0.42))
 
-            Text("\(provider.peakUsagePercentage)%")
-                .font(.system(size: 11.5, weight: .bold, design: .monospaced))
-                .foregroundStyle(usageColor(for: provider.peakUsedPercentage))
+                    Text("\(window.roundedUsedPercentage)%")
+                        .font(.system(size: 11.5, weight: .bold, design: .monospaced))
+                        .foregroundStyle(usageColor(for: window.usedPercentage))
+
+                    if layout.showsRemaining,
+                       let resetsAt = window.resetsAt,
+                       let remaining = remainingDurationString(until: resetsAt) {
+                        Text("· \(remaining)")
+                            .font(.system(size: 10, weight: .medium, design: .monospaced))
+                            .foregroundStyle(.white.opacity(0.34))
+                    }
+                }
+            }
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
@@ -1108,6 +1150,14 @@ struct IslandPanelView: View {
 
         return formatter.string(from: interval)
     }
+}
+
+/// One rung of the usage-chip detail ladder. `adaptiveUsageSummaryView` walks
+/// these from richest to sparsest and renders the first that fits the lane.
+private struct UsageChipLayout {
+    let usesShortTitle: Bool
+    let showsAllWindows: Bool
+    let showsRemaining: Bool
 }
 
 private struct UsageProviderPresentation: Identifiable {


### PR DESCRIPTION
## Problem

With Claude usage connected, the opened island shows a single number — `Claude 7d 55%` — even though the snapshot carries both windows. `compactUsageChip` renders `provider.peakWindow`, so whichever quota is higher wins and the other is dropped at render time. The 5h window is the one that actually gates the next hour of work, and it disappears exactly when the 7d number creeps above it.

The data was already in `UsageProviderPresentation.windows`; only the chip discarded it (it was visible in the tooltip).

## Changes

The chip renders every window, each with its own `usageColor` threshold, so a hot 5h reads red while the 7d is still green:

```
Claude  5h 51% · 2h 14m   7d 55% · 1d
```

Each window also carries the time left before it resets, formatted with the existing `remainingDurationString`.

The header lanes beside the notch are narrow, so instead of one fallback pair, the chips now walk a detail ladder through `ViewThatFits` — countdowns drop first, then the secondary windows, with the provider title abbreviated (`Claude` → `Cl`) at each step before anything is dropped. The last rung is the old peak-only short-title chip, so nothing regresses on a small display. Both call sites (the notch-aware split lanes and the plain header) share the ladder through `adaptiveUsageSummaryView`.

A `TimelineView(.periodic(by: 30))` wrapper keeps the countdowns honest while the panel is held open.

No new settings: this is what `usageDisplay = .compact` shows now.

## Verification

- `swift build` and the full `swift test` suite (376 tests) pass; `zsh scripts/harness.sh lint docs` passes.
- Running on a locally packaged 1.1.8 bundle with live Claude rate limits (both a 5h and a 7d window present) on a notched built-in display.
- The `ViewThatFits` fallback rungs have not been exercised at every lane width — the narrow-lane behavior is the part most worth a second pair of eyes. The settings-pane `UsageDisplayPreview` is a stylized mock and was deliberately left alone.