### PR TITLE
fix: never wrap Open Island's own status line script

### DIFF
--- a/Sources/OpenIslandCore/ClaudeStatusLineInstallationManager.swift
+++ b/Sources/OpenIslandCore/ClaudeStatusLineInstallationManager.swift
@@ -15,6 +15,10 @@ public struct ClaudeStatusLineInstallationStatus: Equatable, Sendable {
     /// `true` when the managed script is installed in wrapper mode, preserving
     /// the user's existing `statusLine.command` under `_openIslandOriginalStatusLine`.
     public var managedStatusLineIsWrapper: Bool
+    /// `true` when the saved original command or the delegate script points back at
+    /// one of Open Island's own status-line scripts. Running that wrapper would spawn
+    /// itself forever (issue #671); `install()` repairs it by dropping the bad delegate.
+    public var managedStatusLineIsPoisoned: Bool
 
     public init(
         claudeDirectory: URL,
@@ -28,7 +32,8 @@ public struct ClaudeStatusLineInstallationStatus: Equatable, Sendable {
         managedStatusLineInstalled: Bool,
         managedStatusLineNeedsRepair: Bool,
         hasConflictingStatusLine: Bool,
-        managedStatusLineIsWrapper: Bool = false
+        managedStatusLineIsWrapper: Bool = false,
+        managedStatusLineIsPoisoned: Bool = false
     ) {
         self.claudeDirectory = claudeDirectory
         self.settingsURL = settingsURL
@@ -42,6 +47,7 @@ public struct ClaudeStatusLineInstallationStatus: Equatable, Sendable {
         self.managedStatusLineNeedsRepair = managedStatusLineNeedsRepair
         self.hasConflictingStatusLine = hasConflictingStatusLine
         self.managedStatusLineIsWrapper = managedStatusLineIsWrapper
+        self.managedStatusLineIsPoisoned = managedStatusLineIsPoisoned
     }
 }
 
@@ -49,6 +55,7 @@ public enum ClaudeStatusLineInstallationError: LocalizedError, Sendable {
     case existingStatusLineConflict(command: String?)
     case invalidSettingsRoot
     case wrappableCommandMissing
+    case wrapperWouldRecurse(command: String)
 
     public var errorDescription: String? {
         switch self {
@@ -61,6 +68,8 @@ public enum ClaudeStatusLineInstallationError: LocalizedError, Sendable {
             return "Claude Code settings.json must contain a top-level object."
         case .wrappableCommandMissing:
             return "No existing statusLine command was found to wrap."
+        case let .wrapperWouldRecurse(command):
+            return "Refusing to wrap Open Island's own status line script (\(command)); the wrapper would call itself forever."
         }
     }
 }
@@ -72,6 +81,14 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
     public static let wrappedDelegateScriptName = "open-island-statusline-delegate"
     public static let legacyManagedScriptName = "vibe-island-statusline"
     public static let managedCacheURL = ClaudeUsageLoader.defaultCacheURL
+    /// Every script Open Island (or its Vibe Island predecessor) may have installed as a
+    /// status-line command. A `statusLine.command` that runs any of these is ours, however
+    /// the path was spelled.
+    public static let managedScriptNames: Set<String> = [
+        managedScriptName,
+        wrappedDelegateScriptName,
+        legacyManagedScriptName,
+    ]
 
     public let claudeDirectory: URL
     public let scriptDirectoryURL: URL
@@ -99,18 +116,27 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
         let scriptURL = scriptDirectoryURL.appendingPathComponent(Self.managedScriptName)
         let legacyScriptURL = legacyScriptDirectoryURL.appendingPathComponent(Self.legacyManagedScriptName)
 
+        let delegateScriptURL = scriptDirectoryURL.appendingPathComponent(Self.wrappedDelegateScriptName)
+
         let settings = try loadSettings(at: settingsURL)
         let statusLine = settings["statusLine"] as? [String: Any]
         let command = statusLine?["command"] as? String
-        let managedCommands = [scriptURL.path, legacyScriptURL.path]
-        let managedStatusLineConfigured = managedCommands.contains(command ?? "")
-        let managedStatusLineInstalled = managedStatusLineConfigured
-            && (command.map { fileManager.fileExists(atPath: $0) } ?? false)
-        let managedStatusLineNeedsRepair = managedStatusLineConfigured && !managedStatusLineInstalled
+        // Match by normalized path or script name rather than the exact string we wrote:
+        // a `$HOME/...` or `~/...` spelling of our own script must never be mistaken for
+        // a user command, or install-as-wrapper wraps itself (issue #671).
+        let managedScriptPath = managedScriptPath(referencedBy: command)
+        let managedStatusLineConfigured = managedScriptPath != nil
+        let managedStatusLineInstalled = managedScriptPath.map { fileManager.fileExists(atPath: $0) } ?? false
         let hasStatusLine = statusLine != nil
         let hasConflictingStatusLine = hasStatusLine && !managedStatusLineConfigured
-        let managedStatusLineIsWrapper = managedStatusLineConfigured
-            && settings[openIslandOriginalStatusLineKey] != nil
+        let savedOriginal = settings[openIslandOriginalStatusLineKey]
+        let managedStatusLineIsWrapper = managedStatusLineConfigured && savedOriginal != nil
+        let savedOriginalIsPoisoned = savedOriginal != nil
+            && isManagedStatusLineCommand((savedOriginal as? [String: Any])?["command"] as? String)
+        let managedStatusLineIsPoisoned = managedStatusLineConfigured
+            && (savedOriginalIsPoisoned || delegateScriptRunsManagedScript(at: delegateScriptURL))
+        let managedStatusLineNeedsRepair = managedStatusLineConfigured
+            && (!managedStatusLineInstalled || managedStatusLineIsPoisoned)
 
         return ClaudeStatusLineInstallationStatus(
             claudeDirectory: claudeDirectory,
@@ -124,8 +150,67 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
             managedStatusLineInstalled: managedStatusLineInstalled,
             managedStatusLineNeedsRepair: managedStatusLineNeedsRepair,
             hasConflictingStatusLine: hasConflictingStatusLine,
-            managedStatusLineIsWrapper: managedStatusLineIsWrapper
+            managedStatusLineIsWrapper: managedStatusLineIsWrapper,
+            managedStatusLineIsPoisoned: managedStatusLineIsPoisoned
         )
+    }
+
+    /// Whether `command` executes one of Open Island's own status-line scripts.
+    ///
+    /// Tolerates the spellings a user, an older installer, or a shell may have written:
+    /// `~/…`, `$HOME/…`, `${HOME}/…`, quoting, and an interpreter prefix such as
+    /// `bash /path/open-island-statusline`.
+    public func isManagedStatusLineCommand(_ command: String?) -> Bool {
+        managedScriptPath(referencedBy: command) != nil
+    }
+
+    /// The path of the managed script that `command` runs, or `nil` when the command is
+    /// not ours. A bare script name (resolved through `PATH`) maps to the current install
+    /// location so the caller can still check whether the file exists.
+    private func managedScriptPath(referencedBy command: String?) -> String? {
+        guard let command, !command.isEmpty else { return nil }
+        let managedPaths = Set(
+            [
+                scriptDirectoryURL.appendingPathComponent(Self.managedScriptName),
+                scriptDirectoryURL.appendingPathComponent(Self.wrappedDelegateScriptName),
+                legacyScriptDirectoryURL.appendingPathComponent(Self.legacyManagedScriptName),
+            ].map { $0.standardizedFileURL.path }
+        )
+        for rawToken in command.split(whereSeparator: \.isWhitespace) {
+            let token = rawToken.trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+            guard !token.isEmpty else { continue }
+            let expanded = expandingHome(in: token)
+            if Self.managedScriptNames.contains(expanded) {
+                return scriptDirectoryURL.appendingPathComponent(expanded).path
+            }
+            guard expanded.contains("/") else { continue }
+            let url = URL(fileURLWithPath: expanded).standardizedFileURL
+            if managedPaths.contains(url.path) || Self.managedScriptNames.contains(url.lastPathComponent) {
+                return url.path
+            }
+        }
+        return nil
+    }
+
+    private func expandingHome(in token: String) -> String {
+        let home = ProcessInfo.processInfo.environment["HOME"] ?? fileManager.homeDirectoryForCurrentUser.path
+        if token == "~" { return home }
+        for prefix in ["~/", "${HOME}/", "$HOME/"] where token.hasPrefix(prefix) {
+            return home + "/" + token.dropFirst(prefix.count)
+        }
+        return token
+    }
+
+    /// `true` when the delegate script on disk would run one of our managed scripts —
+    /// the corrupted state from issue #671 where the delegate points back at the wrapper.
+    private func delegateScriptRunsManagedScript(at delegateScriptURL: URL) -> Bool {
+        guard let contents = try? String(contentsOf: delegateScriptURL, encoding: .utf8) else {
+            return false
+        }
+        return contents.split(whereSeparator: \.isNewline).contains { line in
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            return !trimmed.isEmpty && !trimmed.hasPrefix("#") && isManagedStatusLineCommand(trimmed)
+        }
     }
 
     @discardableResult
@@ -142,19 +227,46 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
 
         let settingsURL = currentStatus.settingsURL
         let scriptURL = currentStatus.scriptURL
+        let delegateScriptURL = scriptDirectoryURL.appendingPathComponent(Self.wrappedDelegateScriptName)
         let existingSettings = try loadSettings(at: settingsURL)
         var mutatedSettings = existingSettings
         mutatedSettings["statusLine"] = managedStatusLine(for: scriptURL)
+
+        // A saved original that runs our own script is the issue #671 corruption: the
+        // user's real command is already lost, and re-wrapping it would spawn forever.
+        // Drop it and fall back to the plain managed script. A healthy saved original is
+        // kept and its wrapper rebuilt, so repairing never orphans the user's status line.
+        var preservedOriginalCommand: String?
+        if let savedOriginal = mutatedSettings[openIslandOriginalStatusLineKey] {
+            let savedCommand = (savedOriginal as? [String: Any])?["command"] as? String
+            if let savedCommand, !savedCommand.isEmpty, !isManagedStatusLineCommand(savedCommand) {
+                preservedOriginalCommand = savedCommand
+            } else {
+                mutatedSettings.removeValue(forKey: openIslandOriginalStatusLineKey)
+            }
+        }
 
         let settingsData = try serializeSettings(mutatedSettings)
         if fileManager.fileExists(atPath: settingsURL.path) {
             try backupFile(at: settingsURL)
         }
 
-        let scriptContents = Self.managedScript(cacheURL: currentStatus.cacheURL)
         try settingsData.write(to: settingsURL, options: .atomic)
-        try scriptContents.write(to: scriptURL, atomically: true, encoding: .utf8)
-        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+        if let preservedOriginalCommand {
+            try writeWrapperScripts(
+                scriptURL: scriptURL,
+                delegateScriptURL: delegateScriptURL,
+                cacheURL: currentStatus.cacheURL,
+                originalCommand: preservedOriginalCommand
+            )
+        } else {
+            let scriptContents = Self.managedScript(cacheURL: currentStatus.cacheURL)
+            try scriptContents.write(to: scriptURL, atomically: true, encoding: .utf8)
+            try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+            if fileManager.fileExists(atPath: delegateScriptURL.path) {
+                try fileManager.removeItem(at: delegateScriptURL)
+            }
+        }
         let legacyScriptURL = legacyScriptDirectoryURL.appendingPathComponent(Self.legacyManagedScriptName)
         if fileManager.fileExists(atPath: legacyScriptURL.path) {
             try fileManager.removeItem(at: legacyScriptURL)
@@ -174,6 +286,11 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
               !originalCommand.isEmpty
         else {
             throw ClaudeStatusLineInstallationError.wrappableCommandMissing
+        }
+        // `status()` already excludes our own scripts from "conflicting" commands; keep an
+        // explicit guard here so the two can never drift apart and wrap the wrapper.
+        guard !isManagedStatusLineCommand(originalCommand) else {
+            throw ClaudeStatusLineInstallationError.wrapperWouldRecurse(command: originalCommand)
         }
 
         try fileManager.createDirectory(at: claudeDirectory, withIntermediateDirectories: true)
@@ -195,19 +312,29 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
             try backupFile(at: settingsURL)
         }
 
-        let wrapperContents = Self.wrappedScript(
-            cacheURL: currentStatus.cacheURL,
-            delegateScriptURL: delegateScriptURL
-        )
-        let delegateContents = Self.wrappedDelegateScript(originalCommand: originalCommand)
-
         try settingsData.write(to: settingsURL, options: .atomic)
+        try writeWrapperScripts(
+            scriptURL: scriptURL,
+            delegateScriptURL: delegateScriptURL,
+            cacheURL: currentStatus.cacheURL,
+            originalCommand: originalCommand
+        )
+
+        return try status()
+    }
+
+    private func writeWrapperScripts(
+        scriptURL: URL,
+        delegateScriptURL: URL,
+        cacheURL: URL,
+        originalCommand: String
+    ) throws {
+        let wrapperContents = Self.wrappedScript(cacheURL: cacheURL, delegateScriptURL: delegateScriptURL)
+        let delegateContents = Self.wrappedDelegateScript(originalCommand: originalCommand)
         try wrapperContents.write(to: scriptURL, atomically: true, encoding: .utf8)
         try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
         try delegateContents.write(to: delegateScriptURL, atomically: true, encoding: .utf8)
         try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: delegateScriptURL.path)
-
-        return try status()
     }
 
     @discardableResult
@@ -221,7 +348,14 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
             var settings = try loadSettings(at: settingsURL)
             // Restore the user's original statusLine when we were running in wrapper mode.
             if let savedOriginal = settings[openIslandOriginalStatusLineKey] {
-                settings["statusLine"] = savedOriginal
+                let savedCommand = (savedOriginal as? [String: Any])?["command"] as? String
+                if isManagedStatusLineCommand(savedCommand) {
+                    // The backup points at our own script (issue #671); restoring it would
+                    // leave Claude Code running a deleted wrapper. Clear the status line instead.
+                    settings.removeValue(forKey: "statusLine")
+                } else {
+                    settings["statusLine"] = savedOriginal
+                }
                 settings.removeValue(forKey: openIslandOriginalStatusLineKey)
             } else {
                 settings.removeValue(forKey: "statusLine")
@@ -299,6 +433,9 @@ public final class ClaudeStatusLineInstallationManager: @unchecked Sendable {
         # Auto-configured by Open Island.
         # The delegate script holds the user's original statusLine.command.
         # Keep the rate_limits cache line intact — it feeds the notch usage panel.
+        # The re-entry guard stops a delegate that loops back here from forking forever.
+        if [ -n "$OPEN_ISLAND_STATUSLINE_ACTIVE" ]; then exit 0; fi
+        export OPEN_ISLAND_STATUSLINE_ACTIVE=1
         input=$(cat)
         _rl=$(printf '%s' "$input" | jq -c '.rate_limits // empty' 2>/dev/null)
         [ -n "$_rl" ] && printf '%s\n' "$_rl" > "\#(cacheURL.path)"

--- a/Tests/OpenIslandCoreTests/ClaudeUsageTests.swift
+++ b/Tests/OpenIslandCoreTests/ClaudeUsageTests.swift
@@ -394,6 +394,221 @@ struct ClaudeUsageTests {
         #expect(finalStatus.managedStatusLineIsWrapper)
         #expect(finalStatus.managedStatusLineInstalled)
     }
+
+    // MARK: - Issue #671: wrapper must never wrap itself
+
+    private struct StatusLineFixture {
+        let rootURL: URL
+        let claudeDirectory: URL
+        let scriptDirectory: URL
+        let settingsURL: URL
+        let manager: ClaudeStatusLineInstallationManager
+
+        var scriptURL: URL {
+            scriptDirectory.appendingPathComponent(ClaudeStatusLineInstallationManager.managedScriptName)
+        }
+
+        var delegateURL: URL {
+            scriptDirectory.appendingPathComponent(ClaudeStatusLineInstallationManager.wrappedDelegateScriptName)
+        }
+
+        init(_ name: String) throws {
+            rootURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("open-island-claude-\(name)-\(UUID().uuidString)", isDirectory: true)
+            claudeDirectory = rootURL.appendingPathComponent(".claude", isDirectory: true)
+            scriptDirectory = rootURL
+                .appendingPathComponent(".open-island", isDirectory: true)
+                .appendingPathComponent("bin", isDirectory: true)
+            settingsURL = claudeDirectory.appendingPathComponent("settings.json")
+            manager = ClaudeStatusLineInstallationManager(
+                claudeDirectory: claudeDirectory,
+                scriptDirectoryURL: scriptDirectory
+            )
+            try FileManager.default.createDirectory(at: claudeDirectory, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(at: scriptDirectory, withIntermediateDirectories: true)
+        }
+
+        func writeSettings(_ settings: [String: Any]) throws {
+            try JSONSerialization.data(withJSONObject: settings, options: [.prettyPrinted, .sortedKeys])
+                .write(to: settingsURL, options: .atomic)
+        }
+
+        func readSettings() throws -> [String: Any] {
+            try jsonObject(from: Data(contentsOf: settingsURL))
+        }
+
+        /// Reproduces the on-disk state from issue #671: the live statusLine is our wrapper,
+        /// the "original" backup is our wrapper spelled with `$HOME`, and the delegate script
+        /// runs the wrapper — so every status-line refresh spawns an endless chain.
+        func writePoisonedWrapper() throws {
+            try writeSettings([
+                "statusLine": ["type": "command", "command": scriptURL.path, "padding": 2],
+                openIslandOriginalStatusLineKey: [
+                    "type": "command",
+                    "command": "$HOME/.open-island/bin/open-island-statusline",
+                    "padding": 2,
+                ],
+            ])
+            try ClaudeStatusLineInstallationManager
+                .wrappedScript(cacheURL: rootURL.appendingPathComponent("rl.json"), delegateScriptURL: delegateURL)
+                .write(to: scriptURL, atomically: true, encoding: .utf8)
+            try ClaudeStatusLineInstallationManager
+                .wrappedDelegateScript(originalCommand: "$HOME/.open-island/bin/open-island-statusline")
+                .write(to: delegateURL, atomically: true, encoding: .utf8)
+            for url in [scriptURL, delegateURL] {
+                try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+            }
+        }
+    }
+
+    @Test(arguments: [
+        "$HOME/.open-island/bin/open-island-statusline",
+        "${HOME}/.open-island/bin/open-island-statusline",
+        "~/.open-island/bin/open-island-statusline",
+        "bash \"$HOME/.open-island/bin/open-island-statusline\"",
+        "/opt/homebrew/bin/bash ~/.vibe-island/bin/vibe-island-statusline",
+    ])
+    func claudeStatusLineRecognizesOwnScriptHoweverItIsSpelled(command: String) throws {
+        let fixture = try StatusLineFixture("spelling")
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        try fixture.writeSettings(["statusLine": ["type": "command", "command": command]])
+
+        let status = try fixture.manager.status()
+        #expect(fixture.manager.isManagedStatusLineCommand(command))
+        #expect(status.managedStatusLineConfigured)
+        #expect(!status.hasConflictingStatusLine)
+
+        // The pre-#671 failure: a home-relative spelling of our own script was treated as the
+        // user's command and wrapped, so the delegate ended up calling the wrapper.
+        #expect(throws: ClaudeStatusLineInstallationError.self) {
+            try fixture.manager.installAsWrapper()
+        }
+        #expect(!FileManager.default.fileExists(atPath: fixture.delegateURL.path))
+        #expect(try fixture.readSettings()[openIslandOriginalStatusLineKey] == nil)
+    }
+
+    @Test
+    func claudeStatusLineDoesNotMistakeUserCommandsForOwnScript() throws {
+        let fixture = try StatusLineFixture("user-command")
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        for command in ["/usr/local/bin/claude-hud", "~/.claude/statusline-command.sh", "bun run ccstatusline"] {
+            #expect(!fixture.manager.isManagedStatusLineCommand(command), "\(command)")
+        }
+        #expect(!fixture.manager.isManagedStatusLineCommand(nil))
+        #expect(!fixture.manager.isManagedStatusLineCommand(""))
+    }
+
+    @Test
+    func claudeStatusLineInstallRepairsPoisonedWrapper() throws {
+        let fixture = try StatusLineFixture("poisoned")
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        try fixture.writePoisonedWrapper()
+
+        let before = try fixture.manager.status()
+        #expect(before.managedStatusLineIsWrapper)
+        #expect(before.managedStatusLineIsPoisoned)
+        #expect(before.managedStatusLineNeedsRepair)
+
+        // This is the path HookInstallationCoordinator takes when it sees needsRepair.
+        let repaired = try fixture.manager.install()
+        #expect(repaired.managedStatusLineInstalled)
+        #expect(!repaired.managedStatusLineIsWrapper)
+        #expect(!repaired.managedStatusLineIsPoisoned)
+        #expect(!repaired.managedStatusLineNeedsRepair)
+        #expect(!FileManager.default.fileExists(atPath: fixture.delegateURL.path))
+
+        let settings = try fixture.readSettings()
+        #expect(settings[openIslandOriginalStatusLineKey] == nil)
+        #expect((settings["statusLine"] as? [String: Any])?["command"] as? String == fixture.scriptURL.path)
+
+        let script = try String(contentsOf: fixture.scriptURL, encoding: .utf8)
+        #expect(!script.contains(fixture.delegateURL.path))
+        #expect(script.contains("rate_limits"))
+    }
+
+    @Test
+    func claudeStatusLineUninstallDoesNotRestorePoisonedOriginal() throws {
+        let fixture = try StatusLineFixture("poisoned-uninstall")
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        try fixture.writePoisonedWrapper()
+
+        let uninstalled = try fixture.manager.uninstall()
+        #expect(!uninstalled.managedStatusLineInstalled)
+        #expect(!uninstalled.hasStatusLine)
+
+        let settings = try fixture.readSettings()
+        #expect(settings["statusLine"] == nil)
+        #expect(settings[openIslandOriginalStatusLineKey] == nil)
+        #expect(!FileManager.default.fileExists(atPath: fixture.scriptURL.path))
+        #expect(!FileManager.default.fileExists(atPath: fixture.delegateURL.path))
+    }
+
+    @Test
+    func claudeStatusLineInstallRebuildsHealthyWrapperInsteadOfOrphaningIt() throws {
+        let fixture = try StatusLineFixture("wrapper-repair")
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let originalCommand = "/usr/local/bin/custom-status --flag"
+        try fixture.writeSettings(["statusLine": ["type": "command", "command": originalCommand]])
+        let wrapped = try fixture.manager.installAsWrapper()
+        #expect(wrapped.managedStatusLineIsWrapper)
+        #expect(!wrapped.managedStatusLineIsPoisoned)
+
+        // Simulate a lost script (the case that triggers needsRepair → install()).
+        try FileManager.default.removeItem(at: fixture.scriptURL)
+        #expect(try fixture.manager.status().managedStatusLineNeedsRepair)
+
+        let repaired = try fixture.manager.install()
+        #expect(repaired.managedStatusLineInstalled)
+        #expect(repaired.managedStatusLineIsWrapper)
+        #expect(!repaired.managedStatusLineNeedsRepair)
+
+        let script = try String(contentsOf: fixture.scriptURL, encoding: .utf8)
+        #expect(script.contains(fixture.delegateURL.path))
+        let delegate = try String(contentsOf: fixture.delegateURL, encoding: .utf8)
+        #expect(delegate.contains(originalCommand))
+        let saved = try fixture.readSettings()[openIslandOriginalStatusLineKey] as? [String: Any]
+        #expect(saved?["command"] as? String == originalCommand)
+    }
+
+    @Test
+    func claudeStatusLineWrapperScriptStopsReentrantSpawn() throws {
+        // Even with the corrupted files from issue #671 on disk, running the wrapper must
+        // terminate instead of forking wrapper → delegate → wrapper forever.
+        let fixture = try StatusLineFixture("reentry")
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        try fixture.writePoisonedWrapper()
+        // Point the delegate at the *real* wrapper path so the loop would actually run.
+        try ClaudeStatusLineInstallationManager
+            .wrappedDelegateScript(originalCommand: "\"\(fixture.scriptURL.path)\"")
+            .write(to: fixture.delegateURL, atomically: true, encoding: .utf8)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = [fixture.scriptURL.path]
+        var environment = ProcessInfo.processInfo.environment
+        environment.removeValue(forKey: "OPEN_ISLAND_STATUSLINE_ACTIVE")
+        process.environment = environment
+        let stdin = Pipe()
+        process.standardInput = stdin
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try process.run()
+        stdin.fileHandleForWriting.write(Data("{}".utf8))
+        try stdin.fileHandleForWriting.close()
+
+        let deadline = Date().addingTimeInterval(10)
+        while process.isRunning, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        if process.isRunning {
+            process.terminate()
+            Issue.record("wrapper did not terminate: re-entry guard is not working")
+        }
+        #expect(process.terminationStatus == 0)
+    }
 }
 
 private func jsonObject(from data: Data) throws -> [String: Any] {


### PR DESCRIPTION
Fixes #671.

## Problem

With Open Island 1.1.8 a user ended up with 4,000+ `open-island-statusline` / `open-island-statusline-delegate` processes and load 48. The delegate script (which should hold the user's original `statusLine.command`) contained the wrapper itself, and `_openIslandOriginalStatusLine` in `~/.claude/settings.json` pointed at the wrapper too, so every status-line refresh forked wrapper → delegate → wrapper without end.

Root cause: `ClaudeStatusLineInstallationManager.status()` recognised our own script only by an exact string compare against the absolute path we write. A `$HOME/.open-island/bin/open-island-statusline` spelling (as in the report) is therefore classified as a *user* command, i.e. "not installed + conflicting". On launch `AppModel` auto-reinstalls the usage bridge whenever the intent store says "installed" but the status says "missing" (`AppModel.swift:1652`), `install()` throws the conflict, and the coordinator falls back to `installAsWrapper()` (`HookInstallationCoordinator.swift:1059`), which wraps the wrapper. That is also why the issue reports the loop coming back after every upgrade/relaunch.

## Fix

- Recognise our script by normalized path **or** script name, tolerating `~`, `$HOME`, `${HOME}`, quoting and an interpreter prefix (`bash /path/open-island-statusline`), for the current, delegate and legacy `vibe-island-statusline` scripts.
- Detect a poisoned install (saved backup or delegate script runs a managed script), expose it as `managedStatusLineIsPoisoned`, and fold it into `managedStatusLineNeedsRepair`. The coordinator's existing repair path (`readClaudeUsageState(repairManagedBridgeIfNeeded:)`) then heals affected machines on the next refresh: the bad backup and delegate are dropped and the plain managed script is written.
- `install()` on a *healthy* wrapper now rebuilds wrapper + delegate from the saved original instead of orphaning the user's status line (the concern raised in #615).
- `installAsWrapper()` refuses to wrap a managed command (`wrapperWouldRecurse`); `uninstall()` clears a poisoned backup instead of restoring it, and now also uninstalls a `$HOME`-spelled managed command properly instead of leaving it pointing at a deleted script.
- Defense in depth: the wrapper script exports `OPEN_ISLAND_STATUSLINE_ACTIVE` and exits immediately if it is already set, so even the corrupted files on disk cannot fork-bomb the machine.

## Tests

New in `ClaudeUsageTests`:
- parameterised: five spellings of our own script are recognised as managed and `installAsWrapper()` refuses them without writing a delegate
- user commands (`claude-hud`, `~/.claude/statusline-command.sh`, `bun run ccstatusline`) are not mistaken for ours
- a poisoned install reports `isPoisoned` / `needsRepair`, and `install()` repairs it into plain managed mode
- `uninstall()` on a poisoned install clears the status line instead of restoring the loop
- `install()` on a healthy wrapper with a missing script rebuilds the wrapper and keeps the saved original
- the wrapper script, run with the corrupted files from the issue, terminates with status 0 (re-entry guard)

`zsh scripts/test-clt.sh`: 374 tests in 39 suites pass.

## Overlap

#615 adds `installPreservingExisting()` in the same file. It still relies on the exact-path check, so it does not prevent this loop; it should rebase onto this change (its idempotency goal is covered by the new `install()` behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nYyiSpPzYGe9R9MFS3QB3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of managed status-line commands across path formats, aliases, quoting, home-directory expansions, and interpreter-prefixed commands.
  * Prevented status-line wrappers from recursively invoking themselves.
  * Repaired corrupted wrapper configurations and avoided restoring invalid commands during uninstallation.
  * Rebuilt healthy wrappers when corrupted configurations are detected.
  * Installation now rejects commands that would cause recursive wrapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->