### PR TITLE
fix: make "keep open until decision" opt-in and scope it to visible sessions

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -248,10 +248,12 @@ final class AppModel {
             UserDefaults.standard.set(hapticFeedbackEnabled, forKey: Self.hapticFeedbackEnabledDefaultsKey)
         }
     }
-    /// Prefer keeping the island open until the user acts on pending
-    /// approval / question surfaces (Settings → Behavior). Default on so
-    /// accidental clicks outside the notch do not dismiss unread decisions.
-    var keepNotchOpenUntilDecision: Bool = true {
+    /// Keep the island open until the user acts on a pending approval /
+    /// question surface (Settings → General). Opt-in: permission and
+    /// question cards never auto-collapse, so with this on the only way to
+    /// get rid of one is to answer it — clicking into the terminal to type
+    /// the answer no longer dismisses the card.
+    var keepNotchOpenUntilDecision: Bool = false {
         didSet {
             guard hasFinishedInit, keepNotchOpenUntilDecision != oldValue else { return }
             UserDefaults.standard.set(keepNotchOpenUntilDecision, forKey: Self.keepNotchOpenUntilDecisionDefaultsKey)
@@ -604,7 +606,7 @@ final class AppModel {
         UserDefaults.standard.register(defaults: [
             Self.showDockIconDefaultsKey: true,
             Self.hapticFeedbackEnabledDefaultsKey: false,
-            Self.keepNotchOpenUntilDecisionDefaultsKey: true,
+            Self.keepNotchOpenUntilDecisionDefaultsKey: false,
             Self.completionReplyEnabledDefaultsKey: false,
             Self.suppressFrontmostNotificationsDefaultsKey: true,
         ])
@@ -1234,7 +1236,9 @@ final class AppModel {
     var shouldBlockDismissWhileAwaitingDecision: Bool {
         guard keepNotchOpenUntilDecision else { return false }
         guard notchStatus == .opened else { return false }
-        return state.sessions.contains { session in
+        // Only sessions the island actually shows can pin it open; a hidden
+        // subagent waiting on its parent must not block dismissal.
+        return surfacedSessions.contains { session in
             session.phase.requiresAttention
         }
     }

--- a/Tests/OpenIslandAppTests/KeepNotchOpenUntilDecisionTests.swift
+++ b/Tests/OpenIslandAppTests/KeepNotchOpenUntilDecisionTests.swift
@@ -10,31 +10,66 @@ struct KeepNotchOpenUntilDecisionTests {
         UserDefaults.standard.removeObject(forKey: "app.keepNotchOpenUntilDecision")
     }
 
-    @Test
-    func blocksClickOutsideDismissWhileAwaitingApprovalByDefault() {
-        let model = AppModel()
-        #expect(model.keepNotchOpenUntilDecision == true)
-
-        model.state = SessionState(sessions: [
-            AgentSession(
-                id: "approval-session",
-                title: "Codex · project",
-                tool: .codex,
-                attachmentState: .attached,
-                phase: .waitingForApproval,
-                summary: "Approve command",
-                updatedAt: .now,
-                permissionRequest: PermissionRequest(
-                    title: "Approve",
-                    summary: "Allow edit?",
-                    affectedPath: "/tmp/file.swift"
-                )
+    private static func approvalSession(
+        id: String = "approval-session",
+        transcriptPath: String? = nil
+    ) -> AgentSession {
+        AgentSession(
+            id: id,
+            title: "Codex · project",
+            tool: .codex,
+            attachmentState: .attached,
+            phase: .waitingForApproval,
+            summary: "Approve command",
+            updatedAt: .now,
+            permissionRequest: PermissionRequest(
+                title: "Approve",
+                summary: "Allow edit?",
+                affectedPath: "/tmp/file.swift"
             ),
-        ])
+            claudeMetadata: transcriptPath.map { ClaudeSessionMetadata(transcriptPath: $0) }
+        )
+    }
+
+    @Test
+    func preferenceIsOffByDefaultSoClickOutsideStillDismisses() {
+        let model = AppModel()
+        #expect(model.keepNotchOpenUntilDecision == false)
+
+        model.state = SessionState(sessions: [Self.approvalSession()])
+        model.notchStatus = .opened
+        model.notchOpenReason = .notification
+
+        #expect(model.shouldBlockDismissWhileAwaitingDecision == false)
+    }
+
+    @Test
+    func blocksClickOutsideDismissWhileAwaitingApprovalWhenEnabled() {
+        let model = AppModel()
+        model.keepNotchOpenUntilDecision = true
+
+        model.state = SessionState(sessions: [Self.approvalSession()])
         model.notchStatus = .opened
         model.notchOpenReason = .notification
 
         #expect(model.shouldBlockDismissWhileAwaitingDecision == true)
+    }
+
+    @Test
+    func hiddenSubagentAwaitingApprovalDoesNotPinTheIsland() {
+        let model = AppModel()
+        model.keepNotchOpenUntilDecision = true
+
+        model.state = SessionState(sessions: [
+            Self.approvalSession(
+                id: "subagent",
+                transcriptPath: "/tmp/.claude/projects/p/subagents/agent-1.jsonl"
+            ),
+        ])
+        model.notchStatus = .opened
+
+        #expect(model.surfacedSessions.isEmpty)
+        #expect(model.shouldBlockDismissWhileAwaitingDecision == false)
     }
 
     @Test
@@ -83,8 +118,9 @@ struct KeepNotchOpenUntilDecisionTests {
     }
 
     @Test
-    func blocksWhileAwaitingQuestionAnswer() {
+    func blocksWhileAwaitingQuestionAnswerWhenEnabled() {
         let model = AppModel()
+        model.keepNotchOpenUntilDecision = true
         model.state = SessionState(sessions: [
             AgentSession(
                 id: "question-session",


### PR DESCRIPTION
Follow-up to #646.

## Problem

Dogfooding 1.1.8+#646: while Claude Code was asking a question, the island's question card stayed on screen for the whole exchange and could not be dismissed.

Permission and question notification cards never auto-collapse — `IslandSurface.autoDismissesWhenPresentedAsNotification` only returns true for completed sessions — so before #646 the two ways to get rid of one were answering it or clicking outside the island. #646 defaulted `keepNotchOpenUntilDecision` to **on**, which blocks the outside click, so clicking into the terminal to type the answer no longer dismisses the card.

## Change

- `keepNotchOpenUntilDecision` now defaults to **off**. The setting stays in Settings → General for people who want accidental clicks ignored (#547), and existing users who already toggled it keep their value (same UserDefaults key).
- `shouldBlockDismissWhileAwaitingDecision` evaluates `surfacedSessions` instead of `state.sessions`, so a hidden subagent waiting on its parent cannot pin the island with nothing visible to act on (CodeRabbit's point on #646).

## Tests

`KeepNotchOpenUntilDecisionTests`: default-off no longer blocks; enabled blocks for approvals and questions; hidden subagent awaiting approval does not block. `zsh scripts/test-clt.sh`: 393 tests in 42 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nYyiSpPzYGe9R9MFS3QB3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The island now dismisses by clicking outside by default while awaiting a decision.
  * An opt-in setting keeps the island open during pending approvals or questions.
  * Hidden subagents no longer prevent the island from being dismissed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->