### PR TITLE
build: stop re-rendering tracked brand assets on dev launch and packaging

### DIFF
--- a/Assets/Brand/README.md
+++ b/Assets/Brand/README.md
@@ -10,7 +10,9 @@ Structure:
 
 Generation workflow:
 
-- regenerate everything with `python3 scripts/generate_brand_icons.py`
+- the generated assets are committed; `scripts/launch-dev-app.sh` and `scripts/package-app.sh` package the committed `OpenIsland.icns` (and `dmg-background.png`) as-is and do not re-render anything
+- regenerate everything with `python3 scripts/generate_brand_icons.py` (or `zsh scripts/launch-dev-app.sh --regenerate-icons`, or `OPEN_ISLAND_REGENERATE_BRAND_ASSETS=true zsh scripts/package-app.sh`, which also re-renders `dmg-background.png`) only when you deliberately change the brand source, then commit the result
+- PNG bytes differ between Pillow versions even when every pixel is identical, so regenerating on another machine produces a 14-file diff; do not commit that unless the artwork itself changed
 - the script outputs:
   - `AppIcon.appiconset/` for future asset-catalog use
   - `OpenIsland.iconset/` and `OpenIsland.icns` for manual macOS bundle packaging

--- a/scripts/launch-dev-app.sh
+++ b/scripts/launch-dev-app.sh
@@ -4,9 +4,11 @@ set -euo pipefail
 
 
 skip_setup=false
+regenerate_icons=false
 for arg in "$@"; do
   case "$arg" in
     --skip-setup) skip_setup=true ;;
+    --regenerate-icons) regenerate_icons=true ;;
   esac
 done
 
@@ -28,7 +30,18 @@ app_binary="$build_root/OpenIslandApp"
 hooks_binary="$build_root/OpenIslandHooks"
 setup_binary="$build_root/OpenIslandSetup"
 
-python3 "$brand_script"
+# Brand assets are generated artifacts that live in git. Rendering them on
+# every launch rewrote 14 tracked PNGs whenever the local Pillow encoded them
+# differently from the committed bytes, dirtying the worktree and leaking icon
+# churn into unrelated commits. Use the committed .icns; pass
+# --regenerate-icons only when deliberately changing the brand source, and
+# commit the result.
+if [ "$regenerate_icons" = true ]; then
+  python3 "$brand_script"
+elif [ ! -f "$brand_icon" ]; then
+  echo "Missing $brand_icon — run: python3 scripts/generate_brand_icons.py" >&2
+  exit 1
+fi
 if [ "$skip_setup" = false ]; then
   "$setup_binary" install --hooks-binary "$hooks_binary"
 fi

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -40,8 +40,22 @@ hooks_binary="$build_bin_dir/OpenIslandHooks"
 setup_binary="$build_bin_dir/OpenIslandSetup"
 brand_icon="$repo_root/Assets/Brand/OpenIsland.icns"
 
-python3 "$brand_script"
-python3 "$dmg_bg_script"
+# Package the committed brand assets instead of re-rendering them: the icon
+# generator rewrites tracked PNGs whenever the local Pillow encodes them
+# differently, and the DMG background depends on whichever fonts the machine
+# has (see scripts/launch-dev-app.sh). Opt in when the brand source changed.
+dmg_background="$repo_root/Assets/Brand/dmg-background.png"
+if [[ "${OPEN_ISLAND_REGENERATE_BRAND_ASSETS:-false}" == "true" ]]; then
+    python3 "$brand_script"
+    python3 "$dmg_bg_script"
+else
+    for asset in "$brand_icon" "$dmg_background"; do
+        if [[ ! -f "$asset" ]]; then
+            echo "Missing $asset — run scripts/generate_brand_icons.py and scripts/generate_dmg_background.py, or set OPEN_ISLAND_REGENERATE_BRAND_ASSETS=true" >&2
+            exit 1
+        fi
+    done
+fi
 
 rm -rf "$bundle_dir" "$zip_path" "$dmg_path"
 mkdir -p "$bundle_dir/Contents/MacOS" "$bundle_dir/Contents/Helpers" "$bundle_dir/Contents/Resources" "$bundle_dir/Contents/Frameworks"


### PR DESCRIPTION
## Problem

`scripts/launch-dev-app.sh` and `scripts/package-app.sh` run `generate_brand_icons.py` on every invocation and write the result over the committed iconsets. The renderer is deterministic on a given machine, but PNG bytes differ between Pillow versions even when every pixel is identical (verified: max channel difference 0 across all 14 files, only the encoding changed). So on any machine whose Pillow differs from the one that produced the committed files, every dev launch leaves 14 modified PNGs under `Assets/Brand`, which blocks `git pull --ff-only` and gets swept into unrelated commits — #669 carried a churn-and-revert pair, and #678 shipped the 14 re-encoded files (harmless, pixel-identical, but unintended). `package-app.sh` has the same issue with `dmg-background.png`, which additionally depends on the fonts installed on the machine. Open PR #378 targets the same problem with a larger generator refactor (`--output-root` / `--icns-only`).

## Change

- Both scripts package the committed `Assets/Brand/OpenIsland.icns` (and `dmg-background.png` for the DMG) as-is, and fail with a pointer to the generator if either file is missing.
- Re-rendering is opt-in: `zsh scripts/launch-dev-app.sh --regenerate-icons`, or `OPEN_ISLAND_REGENERATE_BRAND_ASSETS=true zsh scripts/package-app.sh`. The generators themselves are unchanged.
- `Assets/Brand/README.md` documents that the generated assets are committed artifacts, how to regenerate deliberately, and that a 14-file diff after regenerating on another machine is expected and should not be committed unless the artwork changed.

CI keeps installing Pillow because `generate_dmg_background.py` still needs it when regeneration is requested; nothing in the default path imports it anymore.

## Verification

- `zsh -n` on both scripts.
- `zsh scripts/launch-dev-app.sh` from a fresh worktree: dev app builds and launches, `git status` shows no changes under `Assets/Brand`.
- `OPEN_ISLAND_PACKAGE_ROOT=<tmp> zsh scripts/package-app.sh` from the same worktree: release build, `.app`, `.zip` and `.dmg` produced, bundle checks pass, worktree still clean.
- No Swift changes; the test suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nYyiSpPzYGe9R9MFS3QB3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Development launches now use the committed brand icon by default; icons are regenerated only when explicitly requested.
  * App packaging now uses committed brand assets by default and reports an error if required assets are missing.
  * Brand asset regeneration can be enabled through documented command-line options or an environment setting.

* **Documentation**
  * Expanded guidance explains asset generation, packaging behavior, regeneration options, and image-rendering differences that may create unnecessary file changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->