### PR TITLE
feat: opt-out compact usage display, keep detailed as default

### DIFF
--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -567,7 +567,7 @@ final class AppModel {
             usageDisplay: IslandUsageDisplay(
                 rawValue: defaults.string(forKey: appearanceDefaultsKey(profile, "usageDisplay"))
                     ?? ""
-            ) ?? .compact,
+            ) ?? .detailed,
             sessionStateIndicator: IslandSessionStateIndicator(
                 rawValue: defaults.string(forKey: appearanceDefaultsKey(profile, "stateIndicator"))
                     ?? defaults.string(forKey: legacyIslandSessionStateIndicatorDefaultsKey)

--- a/Sources/OpenIslandApp/AppModelTypes.swift
+++ b/Sources/OpenIslandApp/AppModelTypes.swift
@@ -56,7 +56,7 @@ enum IslandAppearanceDisplayProfile: String, CaseIterable, Identifiable, Sendabl
 struct IslandAppearancePreferences: Equatable, Sendable {
     var rightSlot: IslandRightSlot = .count
     var centerLabel: IslandCenterLabel = .agentAction
-    var usageDisplay: IslandUsageDisplay = .compact
+    var usageDisplay: IslandUsageDisplay = .detailed
     var sessionStateIndicator: IslandSessionStateIndicator = .animatedDot
     var sessionGroup: IslandSessionGroup = .none
     var sessionSort: IslandSessionSort = .attention
@@ -66,6 +66,7 @@ struct IslandAppearancePreferences: Equatable, Sendable {
 enum IslandUsageDisplay: String, CaseIterable, Identifiable, Sendable {
     case hidden
     case compact
+    case detailed
 
     var id: String { rawValue }
 }

--- a/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/en.lproj/Localizable.strings
@@ -75,9 +75,10 @@
 "settings.appearance.profile.macbook.title" = "MacBook notch";
 "settings.appearance.profile.macbook.note" = "Built-in notch surface with notch-aware geometry.";
 "settings.appearance.usageDisplay.title" = "02 · Usage";
-"settings.appearance.usageDisplay.note" = "Controls whether the opened island shows compact agent usage.";
+"settings.appearance.usageDisplay.note" = "Controls how much agent usage the opened island shows.";
 "settings.appearance.usageDisplay.hidden" = "Hidden";
 "settings.appearance.usageDisplay.compact" = "Compact";
+"settings.appearance.usageDisplay.detailed" = "Detailed";
 "settings.appearance.stateIndicator.title" = "03 · Session state";
 "settings.appearance.stateIndicator.note" = "How rows show running, waiting, and completed state.";
 "settings.appearance.stateIndicator.animatedDot" = "Animated dot";

--- a/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -75,9 +75,10 @@
 "settings.appearance.profile.macbook.title" = "MacBook 刘海屏";
 "settings.appearance.profile.macbook.note" = "内置刘海屏布局，保留刘海感知几何。";
 "settings.appearance.usageDisplay.title" = "02 · 用量";
-"settings.appearance.usageDisplay.note" = "控制展开后的 Island 是否显示紧凑的代理用量。";
+"settings.appearance.usageDisplay.note" = "控制展开后的 Island 显示多少代理用量。";
 "settings.appearance.usageDisplay.hidden" = "隐藏";
 "settings.appearance.usageDisplay.compact" = "紧凑";
+"settings.appearance.usageDisplay.detailed" = "详细";
 "settings.appearance.stateIndicator.title" = "03 · 会话状态";
 "settings.appearance.stateIndicator.note" = "控制列表行如何呈现运行、等待和完成状态。";
 "settings.appearance.stateIndicator.animatedDot" = "动效点";

--- a/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/OpenIslandApp/Resources/zh-Hant.lproj/Localizable.strings
@@ -75,9 +75,10 @@
 "settings.appearance.profile.macbook.title" = "MacBook 凹槽螢幕";
 "settings.appearance.profile.macbook.note" = "內建凹槽螢幕布局，保留凹槽感知幾何。";
 "settings.appearance.usageDisplay.title" = "02 · 用量";
-"settings.appearance.usageDisplay.note" = "控制展開後的 Island 是否顯示緊湊的代理用量。";
+"settings.appearance.usageDisplay.note" = "控制展開後的 Island 顯示多少代理用量。";
 "settings.appearance.usageDisplay.hidden" = "隱藏";
 "settings.appearance.usageDisplay.compact" = "緊湊";
+"settings.appearance.usageDisplay.detailed" = "詳細";
 "settings.appearance.stateIndicator.title" = "03 · 會話狀態";
 "settings.appearance.stateIndicator.note" = "控制列表列如何呈現執行、等待和完成狀態。";
 "settings.appearance.stateIndicator.animatedDot" = "動效點";

--- a/Sources/OpenIslandApp/Views/AppearanceSettingsPane.swift
+++ b/Sources/OpenIslandApp/Views/AppearanceSettingsPane.swift
@@ -591,8 +591,9 @@ struct AppearanceSettingsPane: View {
 
     private func title(for option: IslandUsageDisplay) -> String {
         switch option {
-        case .hidden:  lang.t("settings.appearance.usageDisplay.hidden")
-        case .compact: lang.t("settings.appearance.usageDisplay.compact")
+        case .hidden:   lang.t("settings.appearance.usageDisplay.hidden")
+        case .compact:  lang.t("settings.appearance.usageDisplay.compact")
+        case .detailed: lang.t("settings.appearance.usageDisplay.detailed")
         }
     }
 
@@ -1423,29 +1424,34 @@ private struct UsageDisplayPreview: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            if option == .compact {
-                usageChip("Cl", window: "5h", value: 42, color: Color(hex: AgentTool.claudeCode.brandColorHex) ?? .orange)
-                usageChip("Cx", window: "7d", value: 13, color: Color(hex: AgentTool.codex.brandColorHex) ?? .blue)
-            } else {
+            switch option {
+            case .hidden:
                 RoundedRectangle(cornerRadius: 2, style: .continuous)
                     .fill(V6Palette.paper.opacity(0.18))
                     .frame(width: 72, height: 5)
+            case .compact:
+                usageChip("Cl", windows: [("5h", 42, Color(hex: AgentTool.claudeCode.brandColorHex) ?? .orange)])
+                usageChip("Cx", windows: [("7d", 13, Color(hex: AgentTool.codex.brandColorHex) ?? .blue)])
+            case .detailed:
+                usageChip("Cl", windows: [("5h", 42, .green.opacity(0.95)), ("7d", 84, .orange.opacity(0.95))])
             }
         }
         .frame(width: 104, alignment: .center)
     }
 
-    private func usageChip(_ title: String, window: String, value: Int, color: Color) -> some View {
+    private func usageChip(_ title: String, windows: [(label: String, value: Int, color: Color)]) -> some View {
         HStack(spacing: 4) {
             Text(title)
                 .font(.system(size: 9.5, weight: .semibold))
                 .foregroundStyle(V6Palette.paper.opacity(0.66))
-            Text(window)
-                .font(.system(size: 9, weight: .semibold, design: .monospaced))
-                .foregroundStyle(V6Palette.paper.opacity(0.42))
-            Text("\(value)%")
-                .font(.system(size: 9.5, weight: .bold, design: .monospaced))
-                .foregroundStyle(color)
+            ForEach(windows, id: \.label) { window in
+                Text(window.label)
+                    .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(V6Palette.paper.opacity(0.42))
+                Text("\(window.value)%")
+                    .font(.system(size: 9.5, weight: .bold, design: .monospaced))
+                    .foregroundStyle(window.color)
+            }
         }
         .padding(.horizontal, 6)
         .padding(.vertical, 3)

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -856,9 +856,10 @@ struct IslandPanelView: View {
     }
 
     /// Renders the usage chips at the richest layout that fits the available
-    /// width, shedding detail one step at a time: reset countdowns first, then
-    /// the secondary windows, with the provider title abbreviated at each step
-    /// before anything is dropped.
+    /// width. In `.detailed` that ladder starts with every window and its
+    /// reset countdown, shedding detail one step at a time — countdowns
+    /// first, then the secondary windows, then the full provider title.
+    /// `.compact` skips straight to the peak-window rungs.
     @ViewBuilder
     private func adaptiveUsageSummaryView(
         _ providers: [UsageProviderPresentation]
@@ -874,18 +875,26 @@ struct IslandPanelView: View {
     private func usageSummaryLadder(
         _ providers: [UsageProviderPresentation]
     ) -> some View {
-        ViewThatFits(in: .horizontal) {
-            compactUsageSummaryView(providers, layout: .init(usesShortTitle: false, showsAllWindows: true, showsRemaining: true))
-            compactUsageSummaryView(providers, layout: .init(usesShortTitle: true, showsAllWindows: true, showsRemaining: true))
-            compactUsageSummaryView(providers, layout: .init(usesShortTitle: false, showsAllWindows: true, showsRemaining: false))
-            compactUsageSummaryView(providers, layout: .init(usesShortTitle: true, showsAllWindows: true, showsRemaining: false))
-            compactUsageSummaryView(providers, layout: .init(usesShortTitle: false, showsAllWindows: false, showsRemaining: false))
-            compactUsageSummaryView(providers, layout: .init(usesShortTitle: true, showsAllWindows: false, showsRemaining: false))
+        switch model.islandUsageDisplay {
+        case .detailed:
+            ViewThatFits(in: .horizontal) {
+                compactUsageSummaryView(providers, layout: .init(usesShortTitle: false, showsAllWindows: true, showsRemaining: true))
+                compactUsageSummaryView(providers, layout: .init(usesShortTitle: true, showsAllWindows: true, showsRemaining: true))
+                compactUsageSummaryView(providers, layout: .init(usesShortTitle: false, showsAllWindows: true, showsRemaining: false))
+                compactUsageSummaryView(providers, layout: .init(usesShortTitle: true, showsAllWindows: true, showsRemaining: false))
+                compactUsageSummaryView(providers, layout: .init(usesShortTitle: false, showsAllWindows: false, showsRemaining: false))
+                compactUsageSummaryView(providers, layout: .init(usesShortTitle: true, showsAllWindows: false, showsRemaining: false))
+            }
+        case .compact, .hidden:
+            ViewThatFits(in: .horizontal) {
+                compactUsageSummaryView(providers, layout: .init(usesShortTitle: false, showsAllWindows: false, showsRemaining: false))
+                compactUsageSummaryView(providers, layout: .init(usesShortTitle: true, showsAllWindows: false, showsRemaining: false))
+            }
         }
     }
 
     private var openedUsageProviders: [UsageProviderPresentation] {
-        guard model.islandUsageDisplay == .compact else {
+        guard model.islandUsageDisplay != .hidden else {
             return []
         }
 

--- a/Sources/OpenIslandApp/Views/IslandPanelView.swift
+++ b/Sources/OpenIslandApp/Views/IslandPanelView.swift
@@ -857,9 +857,10 @@ struct IslandPanelView: View {
 
     /// Renders the usage chips at the richest layout that fits the available
     /// width. In `.detailed` that ladder starts with every window and its
-    /// reset countdown, shedding detail one step at a time — countdowns
-    /// first, then the secondary windows, then the full provider title.
-    /// `.compact` skips straight to the peak-window rungs.
+    /// reset countdown, shedding detail one step at a time — the provider
+    /// title abbreviates first, then the countdown drops, then the
+    /// secondary windows disappear, leaving only the peak window.
+    /// `.compact` skips straight to those peak-only rungs.
     @ViewBuilder
     private func adaptiveUsageSummaryView(
         _ providers: [UsageProviderPresentation]


### PR DESCRIPTION
## Problem

#675 replaced the opened island's peak-only usage chip with one that always shows every window (5h + 7d, with reset countdowns). There's no way back to a lighter, peak-only chip for people who preferred the smaller footprint.

## Change

Follow-up suggested on #635 / #636: split `IslandUsageDisplay` into `.compact` and `.detailed`.

- `.detailed` is the new default and keeps #675's behavior exactly: the full `ViewThatFits` ladder (all windows + reset countdown, degrading to short titles, then to peak-only as a last-resort space fallback).
- `.compact` is the new opt-out: it skips straight to the peak-only rungs (full title / short title, single window, no countdown) — the pre-#675 chip.
- `openedUsageProviders` now only excludes usage when `.hidden`, not specifically `.compact`.
- Settings preview updated to match: `.compact` still shows one window per provider (unchanged), `.detailed` shows one provider with both windows, each colored independently by its own `usedPercentage` threshold.

`#675` hasn't shipped in a release yet (main is past v1.1.8), so there's no persisted-preference migration concern — flipping the default to `.detailed` costs existing installs nothing since they haven't seen the old behavior in a release.

## Verification

- `swift build` — passes.
- `scripts/lint-strings.sh`, `scripts/check-docs.sh` — pass.
- `swift test` — could not run locally (no `swift-testing` module on this toolchain; same environment gap noted on #635/#636, reproduces on a pristine main). CI covers the test run.
- Manual — harness smoke (`sessionList` scenario) with a temporary fake usage snapshot, confirming:
  - `.compact` → `Claude 7d 84%` (peak window only, no countdown)
  - `.detailed` → `Cl 5h 42% 7d 84%` (both windows, colored independently, short title kicking in at the same narrow width as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Detailed** usage display option for the expanded Island.
  * Detailed mode shows additional usage windows, countdowns, and provider information.
  * Usage information is available in Compact and Detailed modes; Hidden mode continues to conceal it.
  * The default usage display is now Detailed.

* **Documentation**
  * Updated appearance setting descriptions and translations to explain the available usage display levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->