### PR TITLE
fix: stop reposting outside clicks that already reached other apps

### DIFF
--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -232,8 +232,8 @@ final class OverlayPanelController {
 
         eventMonitors.start { [weak self] location in
             self?.handleMouseMoved(location)
-        } mouseDownHandler: { [weak self] location in
-            self?.handleMouseDown(location)
+        } mouseDownHandler: { [weak self] location, isLocalEvent in
+            self?.handleMouseDown(location, isLocalEvent: isLocalEvent)
         }
     }
 
@@ -261,7 +261,12 @@ final class OverlayPanelController {
         }
     }
 
-    private func handleMouseDown(_ screenLocation: NSPoint) {
+    /// - Parameter isLocalEvent: Whether the click was delivered to this app
+    ///   (local monitor) or to another app (global monitor). Global monitors
+    ///   only observe — the clicked app already received the event — so the
+    ///   synthetic repost must be skipped there or it lands as a duplicate
+    ///   click (double-click word selection, double activation).
+    private func handleMouseDown(_ screenLocation: NSPoint, isLocalEvent: Bool) {
         guard let model else { return }
 
         let inClosedSurfaceArea = isPointInClosedSurfaceArea(screenLocation)
@@ -277,7 +282,15 @@ final class OverlayPanelController {
                     return
                 }
                 model.notchClose()
-                repostMouseDown(at: screenLocation)
+                // Repost only when our panel actually swallowed the original
+                // click: the event entered this app and landed inside the
+                // panel frame, so nothing under the cursor received it. When
+                // another app got the click (notification opened while the
+                // user works elsewhere), reposting injects a second click on
+                // top of the real one and the user's next click “jumps”.
+                if isLocalEvent, let panel, NSPointInRect(screenLocation, panel.frame) {
+                    repostMouseDown(at: screenLocation)
+                }
             }
         }
     }
@@ -668,6 +681,10 @@ final class OverlayPanelController {
 
     // MARK: - Event reposting
 
+    /// Re-injects a synthetic click after the panel swallowed the original
+    /// one (event delivered to this app inside the panel frame). Callers must
+    /// not invoke this for clicks another app already received — the window
+    /// under the cursor would see two clicks and treat them as a double click.
     private func repostMouseDown(at screenPoint: NSPoint) {
         let flippedY = NSScreen.main.map { $0.frame.height - screenPoint.y } ?? screenPoint.y
 
@@ -815,7 +832,7 @@ final class NotchEventMonitors {
 
     func start(
         mouseMoveHandler: @MainActor @escaping @Sendable (NSPoint) -> Void,
-        mouseDownHandler: @MainActor @escaping @Sendable (NSPoint) -> Void
+        mouseDownHandler: @MainActor @escaping @Sendable (NSPoint, _ isLocalEvent: Bool) -> Void
     ) {
         let throttleInterval: TimeInterval = 0.05
 
@@ -840,12 +857,12 @@ final class NotchEventMonitors {
 
         globalClickMonitor = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseDown) { event in
             let location = NSEvent.mouseLocation
-            Task { @MainActor in mouseDownHandler(location) }
+            Task { @MainActor in mouseDownHandler(location, false) }
         }
 
         localClickMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
             let location = NSEvent.mouseLocation
-            Task { @MainActor in mouseDownHandler(location) }
+            Task { @MainActor in mouseDownHandler(location, true) }
             return event
         }
     }

--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -223,6 +223,9 @@ final class OverlayPanelController {
 
     // MARK: - Mouse event monitoring
 
+    /// Registers the mouse monitors that drive hover-open, auto-collapse,
+    /// and click-outside dismissal. Skipped during deterministic harness
+    /// runs; a no-op while monitors are already active.
     private func startEventMonitoring() {
         if model?.disablesOverlayEventMonitoringDuringHarness == true {
             return
@@ -830,6 +833,10 @@ final class NotchEventMonitors {
 
     var isActive: Bool { globalMoveMonitor != nil }
 
+    /// Registers throttled mouse-move monitors plus click monitors for both
+    /// event destinations. The click handler receives `isLocalEvent: true`
+    /// from the local monitor (event delivered to this app) and `false` from
+    /// the global monitor (event delivered to another app, observe-only).
     func start(
         mouseMoveHandler: @MainActor @escaping @Sendable (NSPoint) -> Void,
         mouseDownHandler: @MainActor @escaping @Sendable (NSPoint, _ isLocalEvent: Bool) -> Void


### PR DESCRIPTION
## Problem

When a notification opens the island, the user's next click anywhere else on screen "jumps" — it lands as if it were a double click. Typical symptoms: clicking once in a terminal or editor selects a whole word, buttons fire twice. It was easy to mistake this for macOS forcing a focus switch when the notification appears.

## Root cause

There is **no** focus switch on the notification path — the panel is a `.nonactivatingPanel` presented with `orderFrontRegardless()`, and `NSApp.activate` only exists in the settings-window path.

The duplicate click came from our own event reposting:

1. A notification opens the island (panel interactive, app stays in the background — correct so far).
2. The user clicks somewhere outside the island. That click is delivered **normally** to the app under the cursor — `NSEvent.addGlobalMonitorForEvents` can only observe events, never consume them.
3. But the global click monitor handler also ran `handleMouseDown`, which called `notchClose()` **and unconditionally `repostMouseDown(at:)`**, injecting a second synthetic `leftMouseDown`/`leftMouseUp` pair via `CGEvent` at the same screen coordinates.
4. The target app receives two full click cycles ~10–30 ms apart → parsed as a double click → the "jump".

The repost is only legitimate when the original click never reached its target — i.e. when it was swallowed by our own panel window (local monitor case).

## Fix

`Sources/OpenIslandApp/OverlayPanelController.swift` (only file changed):

- `NotchEventMonitors` now reports where each click came from: the local monitor (event delivered to this app) passes `isLocalEvent: true`; the global monitor (event delivered to another app) passes `false`.
- `handleMouseDown(_:isLocalEvent:)` reposts **only when `isLocalEvent == true` and the click point lies inside the panel frame** — that is, only when the panel actually consumed the original click and nothing under the cursor received it.
- Doc comments on `handleMouseDown` and `repostMouseDown` now state the precondition explicitly.

This preserves the original purpose of the repost (restoring a click swallowed by the panel window) while eliminating the duplicate in the common notification case.

| Scenario | Before | After |
| --- | --- | --- |
| Island open (notification), click in another app | click **+ duplicate synthetic click** (double-click artifact) | single click, island collapses |
| Click swallowed by the panel frame | synthetic repost restores it | unchanged (still reposted) |

## Verification

- `swift build` — passes.
- `swift test` — 393 tests in 42 suites, all pass.
- Manual, via the real data path: launched the dev app from this branch, injected a synthetic `PermissionRequest` through `OpenIslandHooks --source claude` (Unix-socket bridge), then single-clicked in a text area outside the island — the island collapsed and the click registered exactly once (no word selection).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overlay dismissal handling for mouse clicks.
  * Prevented duplicate clicks from being sent to other applications when interacting with the overlay.
  * Preserved clicks inside the overlay by replaying them only when necessary.
  * Improved click behavior when switching between the overlay and other applications.
  * Ensured clicks outside the overlay continue to reach the intended application without unintended duplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->