### PR TITLE
fix: repair a closed island that keeps swallowing clicks

### DIFF
--- a/Sources/OpenIslandApp/OverlayPanelController.swift
+++ b/Sources/OpenIslandApp/OverlayPanelController.swift
@@ -1,7 +1,10 @@
 import AppKit
 import Combine
+import OSLog
 import SwiftUI
 import OpenIslandCore
+
+private let overlayLog = Logger(subsystem: "app.openisland", category: "overlay")
 
 @MainActor
 final class OverlayPanelController {
@@ -33,6 +36,7 @@ final class OverlayPanelController {
 
     private var panel: NotchPanel?
     private var eventMonitors = NotchEventMonitors()
+    private var lastStrayClickRepair: Date = .distantPast
     private var hoverTimer: DispatchWorkItem?
     private var hoverCancelGrace: DispatchWorkItem?
     weak var model: AppModel?
@@ -141,6 +145,7 @@ final class OverlayPanelController {
         let hostingView = NotchHostingView(rootView: IslandPanelView(model: model))
         hostingView.notchController = self
         panel.contentView = hostingView
+        panel.notchController = self
 
         computeNotchRect(screen: resolveTargetScreen())
         return panel
@@ -666,6 +671,46 @@ final class OverlayPanelController {
         Array(sessions.prefix(Self.maxVisibleSessionRows))
     }
 
+    // MARK: - Stray clicks on a closed island
+
+    /// Minimum spacing between two repaired stray clicks. If the re-asserted
+    /// pass-through did not take, the reposted click would land on us again;
+    /// the throttle turns that into a dropped click instead of a loop.
+    private static let strayClickRepairInterval: TimeInterval = 0.5
+
+    /// Called by `NotchPanel` for every left mouse down it receives. While the
+    /// island is closed the panel is `ignoresMouseEvents`, so it should never
+    /// see a click outside the pill — yet occasionally it does (macOS keeps
+    /// routing clicks to the panel until it is re-ordered, and the user has to
+    /// expand and collapse the island to "unstick" the desktop underneath).
+    /// Re-assert pass-through, re-order the window so the change takes, and
+    /// forward the click to whatever is below. Returns `true` when the event
+    /// must not reach SwiftUI.
+    func panelReceivedMouseDown(_ event: NSEvent) -> Bool {
+        guard let panel, let model, model.notchStatus != .opened else { return false }
+
+        let screenPoint = NSEvent.mouseLocation
+        // A click on the pill itself is legitimate: the click monitor opens the island.
+        guard !isPointInClosedSurfaceArea(screenPoint) else { return false }
+
+        let now = Date()
+        let repost = now.timeIntervalSince(lastStrayClickRepair) > Self.strayClickRepairInterval
+        overlayLog.error(
+            "Closed island panel received a click at (\(screenPoint.x, privacy: .public), \(screenPoint.y, privacy: .public)); ignoresMouseEvents=\(panel.ignoresMouseEvents, privacy: .public) isKey=\(panel.isKeyWindow, privacy: .public) status=\(String(describing: model.notchStatus), privacy: .public) reason=\(String(describing: model.notchOpenReason), privacy: .public). Re-asserting pass-through\(repost ? " and reposting the click" : "", privacy: .public)."
+        )
+
+        panel.ignoresMouseEvents = false
+        panel.ignoresMouseEvents = true
+        panel.acceptsMouseMovedEvents = false
+        panel.orderFrontRegardless()
+
+        if repost {
+            lastStrayClickRepair = now
+            repostMouseDown(at: screenPoint)
+        }
+        return true
+    }
+
     // MARK: - Event reposting
 
     private func repostMouseDown(at screenPoint: NSPoint) {
@@ -695,6 +740,8 @@ final class OverlayPanelController {
 // MARK: - NotchPanel
 
 private final class NotchPanel: NSPanel {
+    weak var notchController: OverlayPanelController?
+
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { false }
 
@@ -708,8 +755,13 @@ private final class NotchPanel: NSPanel {
     /// it is delivered on the first press, matching click-opened islands
     /// (presented with `makeKeyAndOrderFront`).
     override func sendEvent(_ event: NSEvent) {
-        if event.type == .leftMouseDown, !isKeyWindow, !ignoresMouseEvents {
-            makeKey()
+        if event.type == .leftMouseDown {
+            if notchController?.panelReceivedMouseDown(event) == true {
+                return
+            }
+            if !isKeyWindow, !ignoresMouseEvents {
+                makeKey()
+            }
         }
         super.sendEvent(event)
     }


### PR DESCRIPTION
## Problem

Intermittently, with the island closed (only the pill visible), clicks on whatever sits under the panel's invisible opened-size frame do nothing. Expanding and collapsing the island makes the desktop clickable again. Reported by the maintainer while dogfooding 1.2.0 on a notched MacBook / macOS 26.

## Analysis

The panel keeps a fixed opened-size frame and relies on `ignoresMouseEvents` to be click-through while closed. Every path that toggles the flag is synchronous and paired (`setInteractive`, `show`, `hide`, `ensurePanel`), so the app-side state looks consistent. What expand/collapse actually changes, beyond re-setting the same flag, is re-ordering the window (`orderFrontRegardless` / `makeKeyAndOrderFront`) — which points at the WindowServer not honouring the flag until the window is re-ordered (one plausible trigger: the flag is set while the mouse button is still down, as the outside-click dismissal does). I could not reproduce it on demand, so this PR ships a targeted safety net plus the diagnostics needed to pin the trigger down.

## Change

`NotchPanel.sendEvent` now hands every left mouse down to the controller first. If the island is not opened and the click is outside the pill (a pill click is legitimate and handled by the click monitor), the controller:

1. logs the panel state (`ignoresMouseEvents`, `isKeyWindow`, `notchStatus`, open reason) under `subsystem app.openisland`, `category overlay`;
2. re-asserts `ignoresMouseEvents = true` and re-orders the panel so the change takes;
3. reposts the click at the same location so it reaches the window below, throttled to one repost per 0.5 s so a repost that bounces back becomes a dropped click rather than a loop;
4. swallows the original event so SwiftUI never sees it.

The existing first-click `makeKey()` behaviour for opened islands is unchanged.

## Verification

- `swift build`; `zsh scripts/test-clt.sh`: 447 tests in 48 suites pass. No unit test: the behaviour lives in AppKit event routing.
- Dev app running with the change; when the stuck state recurs, `log show --predicate 'subsystem == "app.openisland"' --last 1h` shows the repair line and the state at that moment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nYyiSpPzYGe9R9MFS3QB3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stray clicks received by the closed island panel.
  * Restored click-through behavior so interactions reach the underlying app as expected.
  * Improved panel focus and ordering after unexpected mouse interactions.
  * Added safeguards to prevent repeated repairs from causing disruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->