### PR TITLE
fix: identify Codex desktop sessions reliably

### DIFF
--- a/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
+++ b/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
@@ -491,17 +491,11 @@ final class SessionDiscoveryCoordinator {
 
     private func applyCodexAppRediscovery(_ records: [CodexTrackedSessionRecord]) {
         let existingCodexSessions = state.sessions.filter { $0.tool == .codex }
-        let existingByID = Dictionary(uniqueKeysWithValues: existingCodexSessions.map { ($0.id, $0) })
-        let existingIDs = Set(existingByID.keys)
-        let existingPaths = Set(state.sessions.compactMap(\.codexMetadata?.transcriptPath))
-
-        let recordsToMerge = records.filter { record in
-            if let existing = existingByID[record.sessionID] {
-                return existing.jumpTarget?.terminalApp.caseInsensitiveCompare("Unknown") == .orderedSame
-                    && record.jumpTarget?.terminalApp == "Codex.app"
-            }
-            return (record.codexMetadata?.transcriptPath).map { !existingPaths.contains($0) } ?? true
-        }
+        let existingIDs = Set(existingCodexSessions.map(\.id))
+        let recordsToMerge = codexAppRediscoveryRecords(
+            from: records,
+            existingSessions: state.sessions
+        )
         guard !recordsToMerge.isEmpty else { return }
 
         let discoveredSessions = recordsToMerge.map { record -> AgentSession in
@@ -522,6 +516,22 @@ final class SessionDiscoveryCoordinator {
             onStatusMessage?("Discovered \(newCount) new Codex session(s) via rollout re-scan.")
         } else if upgradedCount > 0 {
             onStatusMessage?("Identified \(upgradedCount) Codex.app session(s) via rollout re-scan.")
+        }
+    }
+
+    func codexAppRediscoveryRecords(
+        from records: [CodexTrackedSessionRecord],
+        existingSessions: [AgentSession]
+    ) -> [CodexTrackedSessionRecord] {
+        let existingCodexIDs = Set(existingSessions.lazy.filter { $0.tool == .codex }.map(\.id))
+        let existingPaths = Set(existingSessions.compactMap(\.codexMetadata?.transcriptPath))
+
+        return records.filter { record in
+            guard record.jumpTarget?.terminalApp == "Codex.app" else { return false }
+            if existingCodexIDs.contains(record.sessionID) {
+                return true
+            }
+            return (record.codexMetadata?.transcriptPath).map { !existingPaths.contains($0) } ?? true
         }
     }
 

--- a/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
+++ b/Sources/OpenIslandApp/SessionDiscoveryCoordinator.swift
@@ -256,7 +256,13 @@ final class SessionDiscoveryCoordinator {
 
         merged.origin = existing.origin ?? discovered.origin
         merged.attachmentState = mergeAttachmentState(existing.attachmentState, discovered.attachmentState)
-        merged.jumpTarget = existing.jumpTarget ?? discovered.jumpTarget
+        if existing.tool == .codex,
+           existing.jumpTarget?.terminalApp.caseInsensitiveCompare("Unknown") == .orderedSame,
+           discovered.jumpTarget?.terminalApp == "Codex.app" {
+            merged.jumpTarget = discovered.jumpTarget
+        } else {
+            merged.jumpTarget = existing.jumpTarget ?? discovered.jumpTarget
+        }
         merged.codexMetadata = mergeCodexMetadata(existing.codexMetadata, discovered.codexMetadata)
         merged.claudeMetadata = mergeClaudeMetadata(existing.claudeMetadata, discovered.claudeMetadata)
         merged.openCodeMetadata = mergeOpenCodeMetadata(existing.openCodeMetadata, discovered.openCodeMetadata)
@@ -266,6 +272,9 @@ final class SessionDiscoveryCoordinator {
         // (hook or rediscovery), preserve that flag so liveness uses the
         // app-level check instead of subprocess polling.
         merged.isCodexAppSession = existing.isCodexAppSession || discovered.isCodexAppSession
+        if discovered.isCodexAppSession && discovered.isProcessAlive {
+            merged.isProcessAlive = true
+        }
 
         return merged
     }
@@ -481,42 +490,39 @@ final class SessionDiscoveryCoordinator {
     }
 
     private func applyCodexAppRediscovery(_ records: [CodexTrackedSessionRecord]) {
-        let existingIDs = Set(state.sessions.filter { $0.tool == .codex }.map(\.id))
+        let existingCodexSessions = state.sessions.filter { $0.tool == .codex }
+        let existingByID = Dictionary(uniqueKeysWithValues: existingCodexSessions.map { ($0.id, $0) })
+        let existingIDs = Set(existingByID.keys)
         let existingPaths = Set(state.sessions.compactMap(\.codexMetadata?.transcriptPath))
 
-        let newRecords = records.filter { record in
-            !existingIDs.contains(record.sessionID)
-                && (record.codexMetadata?.transcriptPath).map { !existingPaths.contains($0) } ?? true
+        let recordsToMerge = records.filter { record in
+            if let existing = existingByID[record.sessionID] {
+                return existing.jumpTarget?.terminalApp.caseInsensitiveCompare("Unknown") == .orderedSame
+                    && record.jumpTarget?.terminalApp == "Codex.app"
+            }
+            return (record.codexMetadata?.transcriptPath).map { !existingPaths.contains($0) } ?? true
         }
-        guard !newRecords.isEmpty else { return }
+        guard !recordsToMerge.isEmpty else { return }
 
-        let newSessions = newRecords.map { record -> AgentSession in
+        let discoveredSessions = recordsToMerge.map { record -> AgentSession in
             var session = record.session
-            session.isCodexAppSession = true
-            session.isProcessAlive = true
-            // Prefer the discovered record's cwd (sourced from the rollout
-            // file's session_meta) over an empty fallback.
-            let cwd = record.jumpTarget?.workingDirectory ?? ""
-            if session.jumpTarget == nil {
-                session.jumpTarget = JumpTarget(
-                    terminalApp: "Codex.app",
-                    workspaceName: URL(fileURLWithPath: cwd).lastPathComponent,
-                    paneTitle: session.title,
-                    workingDirectory: cwd.isEmpty ? nil : cwd,
-                    codexThreadID: session.id
-                )
-            } else {
-                session.jumpTarget?.terminalApp = "Codex.app"
-                session.jumpTarget?.codexThreadID = session.id
+            if session.isCodexAppSession {
+                session.isProcessAlive = true
             }
             return session
         }
 
-        let merged = mergeDiscoveredSessions(newSessions)
+        let merged = mergeDiscoveredSessions(discoveredSessions)
         state = SessionState(sessions: merged)
         refreshCodexRolloutTracking()
         scheduleCodexSessionPersistence()
-        onStatusMessage?("Discovered \(newRecords.count) new Codex.app session(s) via rollout re-scan.")
+        let newCount = recordsToMerge.count { !existingIDs.contains($0.sessionID) }
+        let upgradedCount = recordsToMerge.count - newCount
+        if newCount > 0 {
+            onStatusMessage?("Discovered \(newCount) new Codex session(s) via rollout re-scan.")
+        } else if upgradedCount > 0 {
+            onStatusMessage?("Identified \(upgradedCount) Codex.app session(s) via rollout re-scan.")
+        }
     }
 
     // MARK: - Persistence scheduling

--- a/Sources/OpenIslandCore/CodexAppServer.swift
+++ b/Sources/OpenIslandCore/CodexAppServer.swift
@@ -204,19 +204,25 @@ public final class CodexAppServerClient: @unchecked Sendable {
     /// List currently loaded threads from the app-server.
     public func listLoadedThreads() async throws -> [CodexThread] {
         struct Params: Encodable {}
-        struct Result: Decodable { let threads: [CodexThread] }
         let data = try await sendRequest(method: "thread/loaded/list", params: Params())
-        let result = try JSONDecoder().decode(Result.self, from: data)
-        return result.threads
+        return try Self.decodeThreadListResponse(data)
     }
 
     /// List all threads (including not-loaded) from the app-server.
     public func listThreads(limit: Int? = nil) async throws -> [CodexThread] {
         struct Params: Encodable { let limit: Int? }
-        struct Result: Decodable { let threads: [CodexThread] }
         let data = try await sendRequest(method: "thread/list", params: Params(limit: limit))
+        return try Self.decodeThreadListResponse(data)
+    }
+
+    static func decodeThreadListResponse(_ data: Data) throws -> [CodexThread] {
+        struct Result: Decodable {
+            let data: [CodexThread]?
+            let threads: [CodexThread]?
+        }
+
         let result = try JSONDecoder().decode(Result.self, from: data)
-        return result.threads
+        return result.data ?? result.threads ?? []
     }
 
     // MARK: - JSON-RPC transport

--- a/Sources/OpenIslandCore/CodexHooks.swift
+++ b/Sources/OpenIslandCore/CodexHooks.swift
@@ -690,6 +690,15 @@ public extension CodexHookPayload {
             return "Codex.app"
         }
 
+        // Newer Codex Desktop builds launch the agent through a sanitized
+        // code-mode host that strips __CFBundleIdentifier. The internal
+        // originator marker survives that boundary and is absent from normal
+        // Codex CLI sessions, so use it as the desktop fallback.
+        if let originator = environment["CODEX_INTERNAL_ORIGINATOR_OVERRIDE"]?.lowercased(),
+           ["codex", "codex desktop", "codex_work_desktop"].contains(originator) {
+            return "Codex.app"
+        }
+
         // TERM_PROGRAM is the only authoritative terminal signal. Each
         // terminal sets it explicitly when it execs the user's shell, so
         // unlike per-app env vars (GHOSTTY_RESOURCES_DIR,

--- a/Sources/OpenIslandCore/CodexSessionTracking.swift
+++ b/Sources/OpenIslandCore/CodexSessionTracking.swift
@@ -368,6 +368,12 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
         var sessionID: String
         var cwd: String
         var timestamp: Date?
+        var originator: String?
+
+        var isCodexDesktop: Bool {
+            guard let originator else { return false }
+            return ["codex desktop", "codex_work_desktop"].contains(originator.lowercased())
+        }
 
         var workspaceName: String {
             let workspace = URL(fileURLWithPath: cwd).lastPathComponent
@@ -641,6 +647,15 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             currentTool: snapshot.currentTool,
             currentCommandPreview: snapshot.currentCommandPreview
         )
+        let jumpTarget = sessionMeta.isCodexDesktop
+            ? JumpTarget(
+                terminalApp: "Codex.app",
+                workspaceName: sessionMeta.workspaceName,
+                paneTitle: sessionMeta.sessionTitle,
+                workingDirectory: sessionMeta.cwd,
+                codexThreadID: sessionMeta.sessionID
+            )
+            : nil
 
         return CodexTrackedSessionRecord(
             sessionID: sessionMeta.sessionID,
@@ -650,6 +665,7 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             summary: summary,
             phase: snapshot.phase,
             updatedAt: updatedAt,
+            jumpTarget: jumpTarget,
             codexMetadata: metadata
         )
     }
@@ -675,7 +691,8 @@ public final class CodexRolloutDiscovery: @unchecked Sendable {
             cwd: cwd,
             timestamp: codexRolloutParseTimestamp(
                 (payload["timestamp"] as? String) ?? (object["timestamp"] as? String)
-            )
+            ),
+            originator: payload["originator"] as? String
         )
     }
 

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -1059,6 +1059,77 @@ struct AppModelSessionListTests {
     }
 
     @Test
+    func codexAppRediscoveryExcludesCLIRecordsWithNewTranscriptPaths() {
+        let model = AppModel()
+        let cliRecord = CodexTrackedSessionRecord(
+            sessionID: "cli-session",
+            title: "Codex · project",
+            summary: "CLI rollout",
+            phase: .running,
+            updatedAt: Date(timeIntervalSince1970: 2_000),
+            codexMetadata: CodexSessionMetadata(transcriptPath: "/tmp/new-cli-rollout.jsonl")
+        )
+
+        let selected = model.discovery.codexAppRediscoveryRecords(
+            from: [cliRecord],
+            existingSessions: []
+        )
+
+        #expect(selected.isEmpty)
+    }
+
+    @Test
+    func codexAppRediscoveryReconcilesAlreadyIdentifiedDesktopSessions() {
+        let model = AppModel()
+        let now = Date(timeIntervalSince1970: 2_000)
+        let existing = AgentSession(
+            id: "desktop-session",
+            title: "Codex · project",
+            tool: .codex,
+            origin: .live,
+            attachmentState: .attached,
+            phase: .running,
+            summary: "Earlier rollout metadata",
+            updatedAt: now,
+            jumpTarget: JumpTarget(
+                terminalApp: "Codex.app",
+                workspaceName: "project",
+                paneTitle: "Codex · project",
+                workingDirectory: "/Users/u/project",
+                codexThreadID: "desktop-session"
+            ),
+            codexMetadata: CodexSessionMetadata(
+                transcriptPath: "/tmp/desktop-rollout.jsonl",
+                lastAssistantMessage: "Earlier response"
+            )
+        )
+        let updatedRecord = CodexTrackedSessionRecord(
+            sessionID: "desktop-session",
+            title: "Codex · project",
+            origin: .live,
+            attachmentState: .stale,
+            summary: "Updated rollout metadata",
+            phase: .running,
+            updatedAt: now.addingTimeInterval(10),
+            jumpTarget: existing.jumpTarget,
+            codexMetadata: CodexSessionMetadata(
+                transcriptPath: "/tmp/desktop-rollout.jsonl",
+                lastAssistantMessage: "Latest response"
+            )
+        )
+
+        let selected = model.discovery.codexAppRediscoveryRecords(
+            from: [updatedRecord],
+            existingSessions: [existing]
+        )
+        let merged = model.discovery.mergeDiscoveredSessions(selected.map(\.session))
+
+        #expect(selected.map(\.sessionID) == ["desktop-session"])
+        #expect(merged.first?.summary == "Updated rollout metadata")
+        #expect(merged.first?.codexMetadata?.lastAssistantMessage == "Latest response")
+    }
+
+    @Test
     func mergedWithSyntheticClaudeSessionsAddsGhosttyClaudeProcessWhenNoTrackedSessionExists() {
         let now = Date(timeIntervalSince1970: 2_000)
         let model = AppModel()

--- a/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
+++ b/Tests/OpenIslandAppTests/AppModelSessionListTests.swift
@@ -1008,6 +1008,57 @@ struct AppModelSessionListTests {
     }
 
     @Test
+    func mergeDiscoveredCodexSessionsUpgradesUnknownDesktopJumpTarget() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let model = AppModel()
+        model.state = SessionState(sessions: [
+            AgentSession(
+                id: "desktop-session",
+                title: "Codex · project",
+                tool: .codex,
+                origin: .live,
+                attachmentState: .attached,
+                phase: .running,
+                summary: "Hook session",
+                updatedAt: now,
+                jumpTarget: JumpTarget(
+                    terminalApp: "Unknown",
+                    workspaceName: "project",
+                    paneTitle: "Codex desktop",
+                    workingDirectory: "/Users/u/project"
+                )
+            ),
+        ])
+
+        var discovered = AgentSession(
+            id: "desktop-session",
+            title: "Codex · project",
+            tool: .codex,
+            origin: .live,
+            attachmentState: .stale,
+            phase: .running,
+            summary: "Rollout session",
+            updatedAt: now,
+            jumpTarget: JumpTarget(
+                terminalApp: "Codex.app",
+                workspaceName: "project",
+                paneTitle: "Codex · project",
+                workingDirectory: "/Users/u/project",
+                codexThreadID: "desktop-session"
+            )
+        )
+        discovered.isCodexAppSession = true
+        discovered.isProcessAlive = true
+
+        let merged = model.discovery.mergeDiscoveredSessions([discovered])
+
+        #expect(merged.first?.jumpTarget?.terminalApp == "Codex.app")
+        #expect(merged.first?.jumpTarget?.codexThreadID == "desktop-session")
+        #expect(merged.first?.isCodexAppSession == true)
+        #expect(merged.first?.isProcessAlive == true)
+    }
+
+    @Test
     func mergedWithSyntheticClaudeSessionsAddsGhosttyClaudeProcessWhenNoTrackedSessionExists() {
         let now = Date(timeIntervalSince1970: 2_000)
         let model = AppModel()

--- a/Tests/OpenIslandCoreTests/CodexAppServerLifecycleTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexAppServerLifecycleTests.swift
@@ -3,6 +3,31 @@ import Testing
 @testable import OpenIslandCore
 
 struct CodexAppServerLifecycleTests {
+    @Test(arguments: ["data", "threads"])
+    func threadListDecodesCurrentAndLegacyResponseKeys(responseKey: String) throws {
+        let response = """
+        {
+          "\(responseKey)": [{
+            "id": "desktop-session",
+            "cwd": "/Users/u/project",
+            "preview": "Fix desktop detection",
+            "modelProvider": "openai",
+            "createdAt": 1,
+            "updatedAt": 2,
+            "ephemeral": false,
+            "status": { "type": "idle" },
+            "source": "vscode"
+          }]
+        }
+        """
+
+        let threads = try CodexAppServerClient.decodeThreadListResponse(Data(response.utf8))
+
+        #expect(threads.count == 1)
+        #expect(threads.first?.id == "desktop-session")
+        #expect(threads.first?.source == .vscode)
+    }
+
     @Test
     func outputHandlersUnregisterAtEndOfFile() async throws {
         let client = CodexAppServerClient()

--- a/Tests/OpenIslandCoreTests/CodexHooksTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexHooksTests.swift
@@ -86,6 +86,45 @@ struct CodexHooksTests {
         #expect(payload.warpPaneUUID == nil)
     }
 
+    @Test(arguments: ["Codex", "Codex Desktop", "codex_work_desktop"])
+    func codexWithRuntimeContextDetectsSanitizedCodexDesktopHost(originator: String) {
+        let payload = CodexHookPayload(
+            cwd: "/Users/u/project",
+            hookEventName: .sessionStart,
+            model: "gpt-5",
+            permissionMode: .default,
+            sessionID: "s1",
+            transcriptPath: nil
+        ).withRuntimeContext(
+            environment: ["CODEX_INTERNAL_ORIGINATOR_OVERRIDE": originator],
+            currentTTYProvider: { nil },
+            terminalLocatorProvider: { _ in (sessionID: nil, tty: nil, title: nil) },
+            warpPaneResolver: { _ in nil }
+        )
+
+        #expect(payload.terminalApp == "Codex.app")
+        #expect(payload.defaultJumpTarget.codexThreadID == "s1")
+    }
+
+    @Test
+    func codexWithRuntimeContextDoesNotTreatUnknownOriginatorAsDesktop() {
+        let payload = CodexHookPayload(
+            cwd: "/Users/u/project",
+            hookEventName: .sessionStart,
+            model: "gpt-5",
+            permissionMode: .default,
+            sessionID: "s1",
+            transcriptPath: nil
+        ).withRuntimeContext(
+            environment: ["CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "third-party"],
+            currentTTYProvider: { nil },
+            terminalLocatorProvider: { _ in (sessionID: nil, tty: nil, title: nil) },
+            warpPaneResolver: { _ in nil }
+        )
+
+        #expect(payload.terminalApp == nil)
+    }
+
     @Test
     func codexPermissionRequestPayloadAcceptsDescriptionOnlyToolInput() throws {
         let data = """

--- a/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
+++ b/Tests/OpenIslandCoreTests/CodexSessionTrackingTests.swift
@@ -1218,6 +1218,49 @@ struct CodexSessionTrackingTests {
     }
 
     @Test
+    func codexRolloutDiscoveryIdentifiesDesktopOriginatorWithoutMisclassifyingCLI() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-island-desktop-origin-\(UUID().uuidString)", isDirectory: true)
+        let rolloutDirectoryURL = rootURL.appendingPathComponent("2026/04/02", isDirectory: true)
+        let desktopURL = rolloutDirectoryURL.appendingPathComponent("rollout-desktop.jsonl")
+        let cliURL = rolloutDirectoryURL.appendingPathComponent("rollout-cli.jsonl")
+        let now = Date(timeIntervalSince1970: 1_743_555_200)
+
+        try FileManager.default.createDirectory(at: rolloutDirectoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        try sessionMetaLine(
+            sessionID: "desktop-session",
+            timestamp: "2026-04-02T04:03:44.000Z",
+            cwd: "/Users/u/desktop-project",
+            originator: "Codex Desktop",
+            source: "vscode"
+        ).appending("\n").write(to: desktopURL, atomically: true, encoding: .utf8)
+        try sessionMetaLine(
+            sessionID: "cli-session",
+            timestamp: "2026-04-02T04:03:45.000Z",
+            cwd: "/Users/u/cli-project"
+        ).appending("\n").write(to: cliURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.modificationDate: now], ofItemAtPath: desktopURL.path)
+        try FileManager.default.setAttributes([.modificationDate: now], ofItemAtPath: cliURL.path)
+
+        let records = CodexRolloutDiscovery(
+            rootURL: rootURL,
+            fileManager: .default,
+            maxAge: 86_400,
+            maxFiles: 10
+        ).discoverRecentSessions(now: now)
+
+        let desktop = records.first { $0.sessionID == "desktop-session" }
+        let cli = records.first { $0.sessionID == "cli-session" }
+        #expect(desktop?.jumpTarget?.terminalApp == "Codex.app")
+        #expect(desktop?.jumpTarget?.codexThreadID == "desktop-session")
+        #expect(desktop?.session.isCodexAppSession == true)
+        #expect(cli?.jumpTarget == nil)
+        #expect(cli?.session.isCodexAppSession == false)
+    }
+
+    @Test
     func codexRolloutDiscoveryStreamsRolloutsLargerThanReadChunk() throws {
         // Pins streaming behavior across read-chunk boundaries. The
         // discovery path used to slurp the whole rollout via
@@ -1675,7 +1718,9 @@ private func rolloutLine(
 private func sessionMetaLine(
     sessionID: String,
     timestamp: String,
-    cwd: String
+    cwd: String,
+    originator: String = "codex-tui",
+    source: String = "cli"
 ) -> String {
     rolloutLine(
         timestamp: timestamp,
@@ -1684,8 +1729,8 @@ private func sessionMetaLine(
             "id": sessionID,
             "timestamp": timestamp,
             "cwd": cwd,
-            "originator": "codex-tui",
-            "source": "cli",
+            "originator": originator,
+            "source": source,
         ]
     )
 }


### PR DESCRIPTION
## Summary

- recognize sanitized Codex Desktop hook environments via the internal originator marker
- classify desktop rollouts from their explicit originator and upgrade existing `Unknown` jump targets without touching CLI sessions
- reconcile existing sessions during periodic rollout scans and accept both current and legacy app-server thread-list response keys


<img width="1704" height="1300" alt="image" src="https://github.com/user-attachments/assets/8051e02a-7028-45ee-b6f1-833893f3e146" />


## Verification

- `swift test --filter 'CodexHooksTests|CodexSessionTrackingTests|CodexAppServerLifecycleTests|AppModelSessionListTests'` (76 tests)\n- `swift test` (452 tests across 48 suites)\n- `git diff --check`

**After fix:**
<img width="950" height="710" alt="image" src="https://github.com/user-attachments/assets/88ef7a3e-17b0-47ba-b758-bd24df3c9edc" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved recognition of Codex Desktop sessions, including newer builds with sanitized origin information.
  - Codex Desktop sessions now provide more accurate navigation targets, including workspace, pane, directory, and thread details.

- **Bug Fixes**
  - Existing sessions are updated correctly when Codex Desktop details become available.
  - Thread lists now load successfully across responses using either `data` or `threads`.
  - Command-line Codex sessions are no longer incorrectly identified as Codex Desktop sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->