### PR TITLE
fix(qoder): map real bundle ID (com.qoder.app) for jump-back

### DIFF
--- a/Sources/OpenIslandApp/TerminalJumpService.swift
+++ b/Sources/OpenIslandApp/TerminalJumpService.swift
@@ -121,6 +121,12 @@ struct TerminalJumpService {
             ]
         ),
         TerminalAppDescriptor(
+            displayName: "Qoder",
+            bundleIdentifier: "com.qoder.app",
+            aliases: ["qoder"],
+            alternateBundleIdentifiers: ["com.qoder.qoder"]
+        ),
+        TerminalAppDescriptor(
             displayName: "Zed",
             bundleIdentifier: "dev.zed.Zed",
             aliases: ["zed"],

--- a/Sources/OpenIslandApp/TerminalJumpService.swift
+++ b/Sources/OpenIslandApp/TerminalJumpService.swift
@@ -480,6 +480,7 @@ struct TerminalJumpService {
         "com.trae.app": "trae",
         "cn.trae.app": "trae",
         "com.qoder.qoder": "qoder",
+        "com.qoder.app": "qoder",
     ]
 
     private func jumpToVSCodeFamilyWorkspace(_ workspacePath: String, bundleIdentifier: String) -> Bool {


### PR DESCRIPTION
## Summary

- `vscodeFamilyCLI` maps the VS Code-family jump-back CLI by bundle identifier, but Qoder's only key was `com.qoder.qoder`. Qoder 0.1.6 (current release) actually reports `com.qoder.app` (read from `/Applications/Qoder.app/Contents/Info.plist`), so the workspace jump-back path never matched and fell through to other handling.
- Adds `com.qoder.app → qoder` alongside the existing key. The old key is kept in case earlier Qoder builds shipped that identifier.

Found while diagnosing #691 (QoderCN support request). QoderCN's separate bundle ID (`com.qodercn.app`) is part of the same map, but that likely deserves its own PR after maintainer input on the jump approach for a CLI-less app.

## Verification

- `swift build` → Build complete
- `swift test` → 447 tests in 48 suites, all passed (macOS 26.5, Xcode 26.6, Swift 6.3.2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing Qoder as a VS Code-family terminal application.
  * Workspace jumps can now open and activate Qoder when it is the selected application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->