### PR TITLE
feat(qoder-cn): add QoderCN (Chinese distribution) adapter

### DIFF
--- a/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
+++ b/Sources/OpenIslandApp/ActiveAgentProcessDiscovery.swift
@@ -565,6 +565,9 @@ struct ActiveAgentProcessDiscovery {
         if lowered.contains("/qoder.app/") {
             return "Qoder"
         }
+        if lowered.contains("/qoder cn.app/") {
+            return "QoderCN"
+        }
         if lowered.contains("/codebuddy.app/") {
             return "CodeBuddy"
         }

--- a/Sources/OpenIslandApp/AgentSession+Presentation.swift
+++ b/Sources/OpenIslandApp/AgentSession+Presentation.swift
@@ -218,6 +218,8 @@ extension AgentSession {
             return "OpenCode"
         case .qoder:
             return "Qoder"
+        case .qoderCN:
+            return "QoderCN"
         case .qwenCode:
             return "Qwen Code"
         case .factory:

--- a/Sources/OpenIslandApp/AppModel.swift
+++ b/Sources/OpenIslandApp/AppModel.swift
@@ -98,14 +98,17 @@ final class AppModel {
     var codexHooksInstalled: Bool { hooks.codexHooksInstalled }
     var claudeHooksInstalled: Bool { hooks.claudeHooksInstalled }
     var qoderHooksInstalled: Bool { hooks.qoderHooksInstalled }
+    var qoderCNHooksInstalled: Bool { hooks.qoderCNHooksInstalled }
     var qwenCodeHooksInstalled: Bool { hooks.qwenCodeHooksInstalled }
     var factoryHooksInstalled: Bool { hooks.factoryHooksInstalled }
     var codebuddyHooksInstalled: Bool { hooks.codebuddyHooksInstalled }
     var qoderHookStatus: ClaudeHookInstallationStatus? { hooks.qoderHookStatus }
+    var qoderCNHookStatus: ClaudeHookInstallationStatus? { hooks.qoderCNHookStatus }
     var qwenCodeHookStatus: ClaudeHookInstallationStatus? { hooks.qwenCodeHookStatus }
     var factoryHookStatus: ClaudeHookInstallationStatus? { hooks.factoryHookStatus }
     var codebuddyHookStatus: ClaudeHookInstallationStatus? { hooks.codebuddyHookStatus }
     var isQoderHookSetupBusy: Bool { hooks.isQoderHookSetupBusy }
+    var isQoderCNHookSetupBusy: Bool { hooks.isQoderCNHookSetupBusy }
     var isQwenCodeHookSetupBusy: Bool { hooks.isQwenCodeHookSetupBusy }
     var isFactoryHookSetupBusy: Bool { hooks.isFactoryHookSetupBusy }
     var isCodebuddyHookSetupBusy: Bool { hooks.isCodebuddyHookSetupBusy }
@@ -170,6 +173,7 @@ final class AppModel {
             || hooks.codexHooksInstalled
             || hooks.cursorHooksInstalled
             || hooks.qoderHooksInstalled
+            || hooks.qoderCNHooksInstalled
             || hooks.qwenCodeHooksInstalled
             || hooks.factoryHooksInstalled
             || hooks.codebuddyHooksInstalled
@@ -192,6 +196,8 @@ final class AppModel {
     func uninstallClaudeHooks() { hooks.uninstallClaudeHooks() }
     func installQoderHooks() { hooks.installQoderHooks() }
     func uninstallQoderHooks() { hooks.uninstallQoderHooks() }
+    func installQoderCNHooks() { hooks.installQoderCNHooks() }
+    func uninstallQoderCNHooks() { hooks.uninstallQoderCNHooks() }
     func installQwenCodeHooks() { hooks.installQwenCodeHooks() }
     func uninstallQwenCodeHooks() { hooks.uninstallQwenCodeHooks() }
     func installFactoryHooks() { hooks.installFactoryHooks() }
@@ -1712,6 +1718,7 @@ final class AppModel {
             if self.hooks.shouldAutoInstall(.claudeCode) { self.installClaudeHooks() }
             if self.hooks.shouldAutoInstall(.codex) { self.installCodexHooks() }
             if self.hooks.shouldAutoInstall(.qoder) { self.installQoderHooks() }
+            if self.hooks.shouldAutoInstall(.qoderCN) { self.installQoderCNHooks() }
             if self.hooks.shouldAutoInstall(.qwenCode) { self.installQwenCodeHooks() }
             if self.hooks.shouldAutoInstall(.factory) { self.installFactoryHooks() }
             if self.hooks.shouldAutoInstall(.codebuddy) { self.installCodebuddyHooks() }

--- a/Sources/OpenIslandApp/HookInstallationCoordinator.swift
+++ b/Sources/OpenIslandApp/HookInstallationCoordinator.swift
@@ -21,6 +21,7 @@ final class HookInstallationCoordinator {
     var codexHookStatus: CodexHookInstallationStatus?
     var claudeHookStatus: ClaudeHookInstallationStatus?
     var qoderHookStatus: ClaudeHookInstallationStatus?
+    var qoderCNHookStatus: ClaudeHookInstallationStatus?
     var qwenCodeHookStatus: ClaudeHookInstallationStatus?
     var factoryHookStatus: ClaudeHookInstallationStatus?
     var codebuddyHookStatus: ClaudeHookInstallationStatus?
@@ -38,6 +39,7 @@ final class HookInstallationCoordinator {
     var isCodexSetupBusy = false
     var isClaudeHookSetupBusy = false
     var isQoderHookSetupBusy = false
+    var isQoderCNHookSetupBusy = false
     var isQwenCodeHookSetupBusy = false
     var isFactoryHookSetupBusy = false
     var isCodebuddyHookSetupBusy = false
@@ -65,6 +67,12 @@ final class HookInstallationCoordinator {
     private let qoderHookInstallationManager = ClaudeHookInstallationManager(
         claudeDirectory: FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".qoder", isDirectory: true),
         hookSource: "qoder"
+    )
+
+    @ObservationIgnored
+    private let qoderCNHookInstallationManager = ClaudeHookInstallationManager(
+        claudeDirectory: FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".qoder-cn", isDirectory: true),
+        hookSource: "qodercn"
     )
 
     @ObservationIgnored
@@ -134,6 +142,10 @@ final class HookInstallationCoordinator {
 
     var qoderHooksInstalled: Bool {
         qoderHookStatus?.managedHooksPresent == true
+    }
+
+    var qoderCNHooksInstalled: Bool {
+        qoderCNHookStatus?.managedHooksPresent == true
     }
 
     var qwenCodeHooksInstalled: Bool {
@@ -648,6 +660,7 @@ final class HookInstallationCoordinator {
 
     func refreshCCForkHookStatuses() {
         refreshCCForkHookStatus(manager: qoderHookInstallationManager, name: "Qoder") { [weak self] in self?.qoderHookStatus = $0 }
+        refreshCCForkHookStatus(manager: qoderCNHookInstallationManager, name: "QoderCN") { [weak self] in self?.qoderCNHookStatus = $0 }
         refreshCCForkHookStatus(manager: qwenCodeHookInstallationManager, name: "Qwen Code") { [weak self] in self?.qwenCodeHookStatus = $0 }
         refreshCCForkHookStatus(manager: factoryHookInstallationManager, name: "Factory") { [weak self] in self?.factoryHookStatus = $0 }
         refreshCCForkHookStatus(manager: codebuddyHookInstallationManager, name: "CodeBuddy") { [weak self] in self?.codebuddyHookStatus = $0 }
@@ -719,6 +732,7 @@ final class HookInstallationCoordinator {
                 guard let self else { return }
                 for (manager, name, apply) in [
                     (self.qoderHookInstallationManager, "Qoder", { [weak self] (s: ClaudeHookInstallationStatus) in self?.qoderHookStatus = s }),
+                    (self.qoderCNHookInstallationManager, "QoderCN", { [weak self] (s: ClaudeHookInstallationStatus) in self?.qoderCNHookStatus = s }),
                     (self.qwenCodeHookInstallationManager, "Qwen Code", { [weak self] (s: ClaudeHookInstallationStatus) in self?.qwenCodeHookStatus = s }),
                     (self.factoryHookInstallationManager, "Factory", { [weak self] (s: ClaudeHookInstallationStatus) in self?.factoryHookStatus = s }),
                     (self.codebuddyHookInstallationManager, "CodeBuddy", { [weak self] (s: ClaudeHookInstallationStatus) in self?.codebuddyHookStatus = s }),
@@ -925,6 +939,7 @@ final class HookInstallationCoordinator {
         case .codex: return !codexHooksInstalled
         case .cursor: return !cursorHooksInstalled
         case .qoder: return !qoderHooksInstalled
+        case .qoderCN: return !qoderCNHooksInstalled
         case .qwenCode: return !qwenCodeHooksInstalled
         case .factory: return !factoryHooksInstalled
         case .codebuddy: return !codebuddyHooksInstalled
@@ -952,6 +967,7 @@ final class HookInstallationCoordinator {
             case .codex: return codexHooksInstalled
             case .cursor: return cursorHooksInstalled
             case .qoder: return qoderHooksInstalled
+            case .qoderCN: return qoderCNHooksInstalled
             case .qwenCode: return qwenCodeHooksInstalled
             case .factory: return factoryHooksInstalled
             case .codebuddy: return codebuddyHooksInstalled
@@ -1008,6 +1024,14 @@ final class HookInstallationCoordinator {
 
     func uninstallQoderHooks() {
         updateCCForkHooks(manager: qoderHookInstallationManager, name: "Qoder", agent: .qoder, isBusySetter: { [weak self] in self?.isQoderHookSetupBusy = $0 }, statusSetter: { [weak self] in self?.qoderHookStatus = $0 }, install: false)
+    }
+
+    func installQoderCNHooks() {
+        updateCCForkHooks(manager: qoderCNHookInstallationManager, name: "QoderCN", agent: .qoderCN, isBusySetter: { [weak self] in self?.isQoderCNHookSetupBusy = $0 }, statusSetter: { [weak self] in self?.qoderCNHookStatus = $0 }, install: true)
+    }
+
+    func uninstallQoderCNHooks() {
+        updateCCForkHooks(manager: qoderCNHookInstallationManager, name: "QoderCN", agent: .qoderCN, isBusySetter: { [weak self] in self?.isQoderCNHookSetupBusy = $0 }, statusSetter: { [weak self] in self?.qoderCNHookStatus = $0 }, install: false)
     }
 
     func installQwenCodeHooks() {

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -1515,6 +1515,11 @@ final class ProcessMonitoringCoordinator {
             return "WezTerm"
         case "zellij":
             return "Zellij"
+        // Qoder family (QoderCN is the China distribution)
+        case "qoder":
+            return "Qoder"
+        case "qodercn", "qoder cn":
+            return "QoderCN"
         // VS Code family
         case "vscode", "code", "visual studio code":
             return "VS Code"

--- a/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
+++ b/Sources/OpenIslandApp/ProcessMonitoringCoordinator.swift
@@ -1579,6 +1579,8 @@ final class ProcessMonitoringCoordinator {
             return "OpenCode \(session.id.prefix(8))"
         case .qoder:
             return "Qoder \(session.id.prefix(8))"
+        case .qoderCN:
+            return "QoderCN \(session.id.prefix(8))"
         case .qwenCode:
             return "Qwen Code \(session.id.prefix(8))"
         case .factory:

--- a/Sources/OpenIslandApp/TerminalJumpService.swift
+++ b/Sources/OpenIslandApp/TerminalJumpService.swift
@@ -142,6 +142,12 @@ struct TerminalJumpService {
             isTerminalHost: false
         ),
         TerminalAppDescriptor(
+            displayName: "Qoder",
+            bundleIdentifier: "com.qoder.app",
+            aliases: ["qoder"],
+            alternateBundleIdentifiers: ["com.qoder.qoder"]
+        ),
+        TerminalAppDescriptor(
             displayName: "QoderCN",
             bundleIdentifier: "com.qodercn.app",
             aliases: ["qoder cn", "qodercn"]

--- a/Sources/OpenIslandApp/TerminalJumpService.swift
+++ b/Sources/OpenIslandApp/TerminalJumpService.swift
@@ -132,6 +132,11 @@ struct TerminalJumpService {
             aliases: ["conductor"]
         ),
         TerminalAppDescriptor(
+            displayName: "QoderCN",
+            bundleIdentifier: "com.qodercn.app",
+            aliases: ["qoder cn", "qodercn"]
+        ),
+        TerminalAppDescriptor(
             displayName: "IntelliJ IDEA",
             bundleIdentifier: "com.jetbrains.intellij",
             aliases: ["intellij", "idea"]
@@ -363,6 +368,10 @@ struct TerminalJumpService {
                 // No per-session deep link; bring the app forward, like Claude.app.
                 try openAction(["-b", "com.conductor.app"])
                 return "Activated Conductor."
+            case "com.qodercn.app":
+                // QoderCN ships no CLI launcher; bring the app forward, like Conductor.
+                try openAction(["-b", "com.qodercn.app"])
+                return "Activated QoderCN."
             case "com.googlecode.iterm2":
                 if try jumpToITermSession(target) {
                     return "Focused the matching iTerm session."

--- a/Sources/OpenIslandApp/TerminalJumpService.swift
+++ b/Sources/OpenIslandApp/TerminalJumpService.swift
@@ -22,19 +22,26 @@ struct TerminalJumpService {
         let aliases: [String]
         let alternateBundleIdentifiers: [String]
         let preferredBundleIdentifiersByAlias: [String: String]
+        /// Whether this app can host an interactive terminal session. Apps
+        /// that wrap an agent without a terminal (Claude.app, Codex.app,
+        /// Conductor) are excluded from terminal-host fallbacks such as the
+        /// Zellij parent lookup.
+        let isTerminalHost: Bool
 
         init(
             displayName: String,
             bundleIdentifier: String,
             aliases: [String],
             alternateBundleIdentifiers: [String] = [],
-            preferredBundleIdentifiersByAlias: [String: String] = [:]
+            preferredBundleIdentifiersByAlias: [String: String] = [:],
+            isTerminalHost: Bool = true
         ) {
             self.displayName = displayName
             self.bundleIdentifier = bundleIdentifier
             self.aliases = aliases
             self.alternateBundleIdentifiers = alternateBundleIdentifiers
             self.preferredBundleIdentifiersByAlias = preferredBundleIdentifiersByAlias
+            self.isTerminalHost = isTerminalHost
         }
 
         var allBundleIdentifiers: [String] {
@@ -76,12 +83,14 @@ struct TerminalJumpService {
         TerminalAppDescriptor(
             displayName: "Codex.app",
             bundleIdentifier: "com.openai.codex",
-            aliases: ["codex.app"]
+            aliases: ["codex.app"],
+            isTerminalHost: false
         ),
         TerminalAppDescriptor(
             displayName: "Claude.app",
             bundleIdentifier: "com.anthropic.claudefordesktop",
-            aliases: ["claude.app"]
+            aliases: ["claude.app"],
+            isTerminalHost: false
         ),
         TerminalAppDescriptor(
             displayName: "Kaku",
@@ -129,7 +138,8 @@ struct TerminalJumpService {
         TerminalAppDescriptor(
             displayName: "Conductor",
             bundleIdentifier: "com.conductor.app",
-            aliases: ["conductor"]
+            aliases: ["conductor"],
+            isTerminalHost: false
         ),
         TerminalAppDescriptor(
             displayName: "QoderCN",
@@ -195,8 +205,9 @@ struct TerminalJumpService {
     private static let vscodeFamilyBundleIDs: Set<String> = Set(vscodeFamilyCLI.keys)
 
     /// Bundle identifiers of terminal emulators that commonly host Zellij,
-    /// derived from `knownApps` so it stays in sync automatically.
-    private static let zellijParentTerminals = knownApps.map(\.bundleIdentifier)
+    /// derived from `knownApps` so it stays in sync automatically. Standalone
+    /// agent apps without a terminal are excluded.
+    private static let zellijParentTerminals = knownApps.filter(\.isTerminalHost).map(\.bundleIdentifier)
 
     private static let ghosttyFocusSettleDelay = 0.08
     private static let ghosttyWindowActivationDelay = 0.04

--- a/Sources/OpenIslandApp/TerminalJumpService.swift
+++ b/Sources/OpenIslandApp/TerminalJumpService.swift
@@ -211,9 +211,10 @@ struct TerminalJumpService {
     private static let vscodeFamilyBundleIDs: Set<String> = Set(vscodeFamilyCLI.keys)
 
     /// Bundle identifiers of terminal emulators that commonly host Zellij,
-    /// derived from `knownApps` so it stays in sync automatically. Standalone
-    /// agent apps without a terminal are excluded.
-    private static let zellijParentTerminals = knownApps.filter(\.isTerminalHost).map(\.bundleIdentifier)
+    /// derived from `knownApps` so it stays in sync automatically (alternate
+    /// bundle identifiers included, so renamed/forked installs are covered).
+    /// Standalone agent apps without a terminal are excluded.
+    private static let zellijParentTerminals = knownApps.filter(\.isTerminalHost).flatMap(\.allBundleIdentifiers)
 
     private static let ghosttyFocusSettleDelay = 0.08
     private static let ghosttyWindowActivationDelay = 0.04
@@ -506,6 +507,7 @@ struct TerminalJumpService {
         "com.trae.app": "trae",
         "cn.trae.app": "trae",
         "com.qoder.qoder": "qoder",
+        "com.qoder.app": "qoder",
     ]
 
     private func jumpToVSCodeFamilyWorkspace(_ workspacePath: String, bundleIdentifier: String) -> Bool {

--- a/Sources/OpenIslandApp/Views/SettingsView.swift
+++ b/Sources/OpenIslandApp/Views/SettingsView.swift
@@ -419,6 +419,7 @@ struct SetupSettingsPane: View {
     @State private var confirmingUninstallCodex = false
     @State private var confirmingUninstallOpenCode = false
     @State private var confirmingUninstallQoder = false
+    @State private var confirmingUninstallQoderCN = false
     @State private var confirmingUninstallQwenCode = false
     @State private var confirmingUninstallFactory = false
     @State private var confirmingUninstallCodebuddy = false
@@ -508,6 +509,23 @@ struct SetupSettingsPane: View {
                     Button(lang.t("settings.general.cancel"), role: .cancel) {}
                 } message: {
                     Text("This will remove Open Island hooks from ~/.qoder/settings.json.")
+                }
+
+                hookRow(
+                    name: "QoderCN",
+                    installed: model.qoderCNHooksInstalled,
+                    busy: model.isQoderCNHookSetupBusy,
+                    configLocationURL: model.qoderCNHookStatus?.settingsURL,
+                    installAction: { model.installQoderCNHooks() },
+                    uninstallAction: { confirmingUninstallQoderCN = true }
+                )
+                .alert(lang.t("settings.general.uninstallConfirmTitle"), isPresented: $confirmingUninstallQoderCN) {
+                    Button(lang.t("settings.general.uninstallConfirmAction"), role: .destructive) {
+                        model.uninstallQoderCNHooks()
+                    }
+                    Button(lang.t("settings.general.cancel"), role: .cancel) {}
+                } message: {
+                    Text("This will remove Open Island hooks from ~/.qoder-cn/settings.json.")
                 }
 
                 hookRow(
@@ -737,6 +755,7 @@ struct SetupSettingsPane: View {
                     if !model.codexHooksInstalled { model.installCodexHooks() }
                     if !model.openCodePluginInstalled { model.installOpenCodePlugin() }
                     if !model.qoderHooksInstalled { model.installQoderHooks() }
+                    if !model.qoderCNHooksInstalled { model.installQoderCNHooks() }
                     if !model.qwenCodeHooksInstalled { model.installQwenCodeHooks() }
                     if !model.factoryHooksInstalled { model.installFactoryHooks() }
                     if !model.codebuddyHooksInstalled { model.installCodebuddyHooks() }

--- a/Sources/OpenIslandCore/AgentHookIntent.swift
+++ b/Sources/OpenIslandCore/AgentHookIntent.swift
@@ -21,6 +21,7 @@ public enum AgentIdentifier: String, Codable, Sendable, CaseIterable {
     case codex
     case cursor
     case qoder
+    case qoderCN
     case qwenCode
     case factory
     case codebuddy

--- a/Sources/OpenIslandCore/AgentSession.swift
+++ b/Sources/OpenIslandCore/AgentSession.swift
@@ -6,6 +6,7 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
     case geminiCLI
     case openCode
     case qoder
+    case qoderCN
     case qwenCode
     case factory
     case codebuddy
@@ -27,6 +28,8 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
             "OpenCode"
         case .qoder:
             "Qoder"
+        case .qoderCN:
+            "QoderCN"
         case .qwenCode:
             "Qwen Code"
         case .factory:
@@ -58,6 +61,8 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
             "OPENCODE"
         case .qoder:
             "QODER"
+        case .qoderCN:
+            "QODERCN"
         case .qwenCode:
             "QWEN"
         case .factory:
@@ -79,7 +84,7 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
 
     public var isClaudeCodeFork: Bool {
         switch self {
-        case .claudeCode, .qoder, .qwenCode, .factory, .codebuddy, .kimiCLI:
+        case .claudeCode, .qoder, .qoderCN, .qwenCode, .factory, .codebuddy, .kimiCLI:
             true
         default:
             false
@@ -98,6 +103,7 @@ public enum AgentTool: String, CaseIterable, Codable, Sendable {
         case .geminiCLI:  "#42e86b"
         case .openCode:   "#ffb547"
         case .qoder:      "#ff6b9f"
+        case .qoderCN:    "#ff4d6d"
         case .qwenCode:   "#c084fc"
         case .factory:    "#6e9fff"
         case .codebuddy:  "#fca5a5"

--- a/Sources/OpenIslandCore/ClaudeHooks.swift
+++ b/Sources/OpenIslandCore/ClaudeHooks.swift
@@ -884,6 +884,8 @@ public extension ClaudeHookPayload {
         switch hookSource {
         case "qoder":
             return .qoder
+        case "qodercn":
+            return .qoderCN
         case "qwen":
             return .qwenCode
         case "factory", "droid":

--- a/Sources/OpenIslandCore/ClaudeHooks.swift
+++ b/Sources/OpenIslandCore/ClaudeHooks.swift
@@ -688,7 +688,10 @@ public extension ClaudeHookPayload {
     }
 
     var sessionTitle: String {
-        "Claude · \(workspaceName)"
+        if hookSource == "qodercn" {
+            return "QoderCN · \(workspaceName)"
+        }
+        return "Claude · \(workspaceName)"
     }
 
     var defaultJumpTarget: JumpTarget {
@@ -871,6 +874,8 @@ public extension ClaudeHookPayload {
         let title: String
         if questions.count == 1, let firstQuestion = questions.first?.question {
             title = firstQuestion
+        } else if hookSource == "qodercn" {
+            title = "QoderCN has \(questions.count) questions for you."
         } else {
             title = "Claude has \(questions.count) questions for you."
         }
@@ -904,11 +909,11 @@ public extension ClaudeHookPayload {
         case "ExitPlanMode":
             return "Exit plan mode"
         case "AskUserQuestion":
-            return "Answer Claude's questions"
+            return hookSource == "qodercn" ? "Answer QoderCN's questions" : "Answer Claude's questions"
         case let toolName?:
             return "Allow \(toolName)"
         case nil:
-            return "Allow Claude tool"
+            return hookSource == "qodercn" ? "Allow QoderCN tool" : "Allow Claude tool"
         }
     }
 

--- a/Sources/OpenIslandCore/SessionState.swift
+++ b/Sources/OpenIslandCore/SessionState.swift
@@ -274,7 +274,7 @@ public struct SessionState: Equatable, Sendable {
         if resolution.isApproved {
             session.phase = .running
             switch session.tool {
-            case .claudeCode, .geminiCLI, .qoder, .qwenCode, .factory, .codebuddy, .kimiCLI:
+            case .claudeCode, .geminiCLI, .qoder, .qoderCN, .qwenCode, .factory, .codebuddy, .kimiCLI:
                 session.summary = "Permission approved. \(session.tool.displayName) continued the tool."
             case .openCode:
                 session.summary = "Permission approved. OpenCode continued the tool."
@@ -284,7 +284,7 @@ public struct SessionState: Equatable, Sendable {
         } else {
             session.phase = .completed
             switch session.tool {
-            case .claudeCode, .geminiCLI, .qoder, .qwenCode, .factory, .codebuddy, .kimiCLI:
+            case .claudeCode, .geminiCLI, .qoder, .qoderCN, .qwenCode, .factory, .codebuddy, .kimiCLI:
                 session.summary = "Permission denied in Open Island."
             case .openCode:
                 session.summary = "Permission denied in Open Island."

--- a/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
+++ b/Sources/OpenIslandHooks/OpenIslandHooksCLI.swift
@@ -11,6 +11,7 @@ struct OpenIslandHooksCLI {
         case codex
         case claude
         case qoder
+        case qodercn
         case qwen
         case factory
         case droid
@@ -22,7 +23,7 @@ struct OpenIslandHooksCLI {
 
         var isClaudeFormat: Bool {
             switch self {
-            case .claude, .qoder, .qwen, .factory, .droid, .codebuddy, .kimi:
+            case .claude, .qoder, .qodercn, .qwen, .factory, .droid, .codebuddy, .kimi:
                 return true
             case .codex, .cursor, .gemini, .grok:
                 return false
@@ -67,7 +68,7 @@ struct OpenIslandHooksCLI {
                 if let output = try CodexHookOutputEncoder.standardOutput(for: response) {
                     FileHandle.standardOutput.write(output)
                 }
-            case .claude, .qoder, .qwen, .factory, .droid, .codebuddy, .kimi:
+            case .claude, .qoder, .qodercn, .qwen, .factory, .droid, .codebuddy, .kimi:
                 var payload = try decoder
                     .decode(ClaudeHookPayload.self, from: input)
                     .withRuntimeContext(environment: ProcessInfo.processInfo.environment)

--- a/Tests/OpenIslandAppTests/ActiveAgentProcessDiscoveryTests.swift
+++ b/Tests/OpenIslandAppTests/ActiveAgentProcessDiscoveryTests.swift
@@ -380,4 +380,16 @@ struct ActiveAgentProcessDiscoveryTests {
         #expect(!aliveIDs.contains("pi-a"))
         #expect(!aliveIDs.contains("omp-b"))
     }
+
+    @Test
+    @MainActor
+    func supportedTerminalAppPreservesQoderFamilyLabels() {
+        let coordinator = ProcessMonitoringCoordinator()
+        #expect(coordinator.supportedTerminalApp(for: "Qoder") == "Qoder")
+        #expect(coordinator.supportedTerminalApp(for: "QoderCN") == "QoderCN")
+        #expect(coordinator.supportedTerminalApp(for: "qoder cn") == "QoderCN")
+        #expect(coordinator.supportedTerminalApp(for: "qodercn") == "QoderCN")
+        #expect(coordinator.supportedTerminalApp(for: nil) == nil)
+        #expect(coordinator.supportedTerminalApp(for: "SomethingElse") == nil)
+    }
 }

--- a/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
+++ b/Tests/OpenIslandAppTests/AgentSessionPresentationTests.swift
@@ -106,6 +106,7 @@ struct AgentSessionPresentationTests {
             (.geminiCLI, "Gemini"),
             (.openCode, "OpenCode"),
             (.qoder, "Qoder"),
+            (.qoderCN, "QoderCN"),
             (.qwenCode, "Qwen Code"),
             (.factory, "Factory"),
             (.codebuddy, "CodeBuddy"),


### PR DESCRIPTION
Implements #691 — first-class support for QoderCN, the China distribution of Qoder (separate app bundle `Qoder CN.app`, bundle ID `com.qodercn.app`, config directory `~/.qoder-cn/`).

## What's included

- **Agent identity**: new `.qoderCN` case across `AgentIdentifier` / `AgentTool` (display name "QoderCN", short name "QODERCN", brand color `#ff4d6d` — kin to Qoder's `#ff6b9f`), `isClaudeCodeFork`, permission summaries, session naming and completion-recipient coverage.
- **Hooks**: hooks CLI accepts `--source qodercn` (Claude-format payload decode, same as `qoder`); `HookInstallationCoordinator` gains a manager targeting `~/.qoder-cn/settings.json` with full install / uninstall / status / auto-install wiring; Settings gains a QoderCN row (with uninstall confirmation) and install-all coverage.
- **Process discovery**: recognizes processes under `/qoder cn.app/`.
- **Jump-back**: `com.qodercn.app` registered in `knownApps` and handled with app-level activation (`open -b`), since QoderCN ships no CLI launcher — mirroring the Conductor approach proposed in #691. Intentionally **no** `vscodeFamilyCLI` entry, so this PR stays independent of #692.

## Verification

- `swift build` clean
- `swift test` → 447 tests in 48 suites, all passed (macOS 26.5, Xcode 26.6, Swift 6.3.2)
- `AgentSessionPresentationTests` exhaustive-coverage test extended for `.qoderCN`
- Hook display path for QoderCN was already manually verified on this machine (hooks written by hand before this adapter — sessions appear on the island with live status); this PR adds the identity, discovery, jump-back and Settings management around it.

Happy to adjust naming (e.g. `qodercn` source string, "QoderCN" display name) or the jump-back approach per maintainer preference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the QoderCN agent across session detection, status displays, permissions, and approval workflows.
  * Added QoderCN hook installation, uninstallation, status tracking, automatic setup, and migration support.
  * Added QoderCN controls in Settings, including “Install All” support.
  * Added QoderCN app activation and terminal navigation support.
  * Improved terminal selection for fallback navigation.
* **Tests**
  * Expanded coverage for QoderCN detection and agent handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->